### PR TITLE
Allow configuration of profile credentials with the default chain

### DIFF
--- a/AWS-CREDENTIALS.md
+++ b/AWS-CREDENTIALS.md
@@ -2,7 +2,7 @@
 
 Rusoto has the ability to source AWS access credentials in a few different ways:
 
-1. Environment variables via `rusoto::credentials::EnvironmentCredentialsProvider`
+1. Environment variables via `rusoto::credentials::EnvironmentCredentialsProvider` (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
 2. AWS credentials file via `rusoto::credentials::ProfileCredentialsProvider`
 3. IAM instance profile via `rusoto::credentials::IAMRoleCredentialsProvider`
 

--- a/AWS-CREDENTIALS.md
+++ b/AWS-CREDENTIALS.md
@@ -1,24 +1,35 @@
 ### Credentials
 
-Rusoto will search for credentials in this order:
+Rusoto has the ability to source AWS access credentials in a few different ways:
 
-1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. AWS Credentials file: `~/.aws/credentials`.  It will use `aws_access_key_id` and `aws_secret_access_key` fields.
-Profiles are supported.
-3. IAM instance profile.  Rusoto will query the metadata service for an instance profile/role and fetch the access key, secret access key and token to supply those for requests.
+1. Environment variables via `rusoto::credentials::EnvironmentCredentialsProvider`
+2. AWS credentials file via `rusoto::credentials::ProfileCredentialsProvider`
+3. IAM instance profile via `rusoto::credentials::IAMRoleCredentialsProvider`
 
-If Rusoto exhausts all three options it will return an error.
+There is also `rusoto::credentials::DefaultAWSCredentialsProviderChain`, which is a convenience for attempting to source access credentials using the methods above in order.
+If credentials cannot be obtained through one method, it falls back to the next.
+If all possibilites are exhausted, an error will be returned.
+
+`ProfileCredentialsProvider` (and `DefaultAWSCredentialsProviderChain`) also allow you to specify a custom path to the credentials file and the name of the profile to use.
+If not specified, the profile "default" is used.
+
+It's also possible to implement your own credentials sourcing mechanism by creating a type that implements `rusoto::credentials::AWSCredentialsProvider`.
 
 #### Credential refreshing
 
-Credentials obtained from environment variables and credential files expire ten minutes after being acquired, and are refreshed on subsequent calls to `get_credentials()`.
+Credentials obtained from environment variables and credential files expire ten minutes after being acquired and are refreshed on subsequent calls to `get_credentials()` (a method from the `AWSCredentialsProvider` trait).
 
-IAM instance profile credentials are refreshed as needed.  Upon calling `get_credentials()` it will see if they are expired or not.  If expired, it attempts to get new credentials from the metadata service.  If that fails it will return an error.  IAM credentials expiration time comes from the IAM metadata response.
+IAM instance profile credentials are refreshed as needed.
+Upon calling `get_credentials()` it will see if they are expired or not.
+If expired, it attempts to get new credentials from the metadata service.
+If that fails it will return an error.
+IAM credentials expiration time comes from the IAM metadata response.
 
 #### Local integration testing of IAM credentials
 
-Edit the `address` location in [src/credentials.rs](src/credentials.rs).  For local testing, I use [moe](https://github.com/matthewkmayer/moe) and set the string to this:
+Edit the `address` location in [src/credentials.rs](src/credentials.rs).
+For local testing, you can use [moe](https://github.com/matthewkmayer/moe) and set the string to this:
 
 ```rust
-let mut address : String = "http://localhost:8080/latest/meta-data/iam/security-credentials".to_string();
+let mut address: String = "http://localhost:8080/latest/meta-data/iam/security-credentials".to_owned();
 ```


### PR DESCRIPTION
Adds a new constructor (and a new getter and setter) to DefaultAWSCredentialsProviderChain to allow you to change the path of the configuration file.

Also removes an extra impl block and fixes indentation in some of the existing tests.