### PR TITLE
Move build code into rusoto_codegen sub-crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ documentation = "http://rusoto.github.io/rusoto/rusoto/index.html"
 exclude = [".gitignore", ".travis.yml", "docgen.sh"]
 build = "build.rs"
 
-[build-dependencies]
-serde_codegen = "^0.6.7"
-syntex = "^0.24.0"
+[build-dependencies.rusoto_codegen]
+path = "codegen"
 
 [dependencies]
 xml-rs = "^0.1.26"

--- a/build.rs
+++ b/build.rs
@@ -1,84 +1,23 @@
-extern crate serde_codegen;
-extern crate syntex;
+extern crate rusoto_codegen;
 
-use std::env::var_os;
-use std::fs::File;
-use std::io::copy;
-use std::path::Path;
-use std::process::Command;
-
-use serde_codegen::register;
-use syntex::Registry;
-
-const BOTOCORE_DIR: &'static str = "codegen/botocore/botocore/data/";
-
-struct Service {
-    name: String,
-    type_name: String, 
-    protocol_date: String
-}
+use rusoto_codegen::{Generator, Service};
 
 fn main() {
-    let out_dir = var_os("OUT_DIR").expect("OUT_DIR not specified");
-    let out_path = Path::new(&out_dir);
-
-    let botocore_dir = var_os("BOTOCORE_DIR");
-    let botocore_path = match botocore_dir {
-        Some(ref dirname) => Path::new(dirname),
-        None => Path::new(BOTOCORE_DIR)
-    };
-    
-    let services = vec![
+    let services = [
         Service::new("dynamodb", "DynamoDBClient", "2012-08-10"),
         Service::new("kms", "KMSClient", "2014-11-01"),
-        Service::new("sqs", "SQSClient", "2012-11-05")
+        Service::new("sqs", "SQSClient", "2012-11-05"),
     ];
 
-    for service in services {        
-        generate(service, botocore_path, out_path);
-    }
-}
+    let generator = match Generator::new() {
+        Ok(generator) => generator,
+        Err(error) => {
+            println!("Error: {}", error);
+            return;
+        }
+    };
 
-fn botocore_generate(input: &str, type_name: &str, destination: &Path) {
-    let mut command = Command::new("codegen/botocore_parser.py");
-
-    command.args(&[input, type_name]);
-
-    let output = command.output().expect("couldn't get output of child process");
-
-    if !output.status.success() {
-        println!("{}", String::from_utf8_lossy(&output.stderr[..]));
-        panic!("child process was unsuccessful");
-    }
-
-    let mut file = File::create(destination).expect("couldn't open file for writing");
-    copy(&mut &output.stdout[..], &mut file).expect("failed to write generated code to file");
-}
-
-fn generate(
-    service: Service,
-    botocore_path: &Path,
-    base_destination: &Path,
-) {
-    let botocore_destination = base_destination.join(format!("{}_botocore.rs", service.name));
-    let serde_destination = base_destination.join(format!("{}.rs", service.name));
-    let input_location = botocore_path.join(format!("{}/{}/service-2.json", service.name, service.protocol_date));
-
-    let input = input_location.to_str().expect(&format!("Invalid service definition path for {} {}", service.protocol_date, service.name));
-
-    botocore_generate(input, &service.type_name, botocore_destination.as_path());
-    serde_generate(botocore_destination.as_path(), serde_destination.as_path());
-}
-
-fn serde_generate(source: &Path, destination: &Path) {
-    let mut registry = Registry::new();
-
-    register(&mut registry);
-    registry.expand("", source, destination).expect("failed to generate code with Serde");
-}
-
-impl Service {
-    fn new<S: ToString>(name: S, type_name: S, protocol_date: S) -> Service {
-        Service { name: name.to_string(), type_name: type_name.to_string(), protocol_date: protocol_date.to_string() }
+    if let Err(error) = generator.generate(&services) {
+        println!("Error: {}", error);
     }
 }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rusoto_codegen"
+version = "0.1.0"
+authors = ["Anthony DiMarco <anthony.dimarco@dualspark.com>", "Matthew Mayer <matthewkmayer@gmail.com>"]
+description = "Code generation library for Rusoto."
+license = "MIT"
+repository = "https://github.com/rusoto/rusoto"
+
+[dependencies]
+serde_codegen = "0.6.9"
+syntex = "0.26.0"

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,0 +1,120 @@
+extern crate serde_codegen;
+extern crate syntex;
+
+use std::env::var_os;
+use std::fs::File;
+use std::io::copy;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_codegen::register;
+use syntex::Registry;
+
+const BOTOCORE_DIR: &'static str = "codegen/botocore/botocore/data/";
+
+pub struct Generator {
+    botocore_path: PathBuf,
+    out_path: PathBuf,
+}
+
+impl Generator {
+    pub fn new() -> Result<Generator, String> {
+        let out_dir = try!(var_os("OUT_DIR").ok_or("OUT_DIR not specified"));
+        let out_path = PathBuf::from(&out_dir);
+
+        let botocore_dir = var_os("BOTOCORE_DIR");
+        let botocore_path = match botocore_dir {
+            Some(ref dirname) => PathBuf::from(dirname),
+            None => PathBuf::from(BOTOCORE_DIR)
+        };
+
+        Ok(Generator {
+            botocore_path: botocore_path,
+            out_path: out_path,
+        })
+    }
+
+    pub fn generate(&self, services: &[Service]) -> Result<(), String> {
+        for service in services {
+            try!(generate(service, self.botocore_path.as_path(), self.out_path.as_path()));
+        }
+
+        Ok(())
+    }
+}
+
+pub struct Service {
+    name: String,
+    type_name: String,
+    protocol_date: String
+}
+
+impl Service {
+    pub fn new<S: ToString>(name: S, type_name: S, protocol_date: S) -> Service {
+        Service {
+            name: name.to_string(),
+            type_name: type_name.to_string(),
+            protocol_date: protocol_date.to_string(),
+        }
+    }
+}
+
+fn botocore_generate(input: &str, type_name: &str, destination: &Path) -> Result<(), String> {
+    let mut command = Command::new("codegen/botocore_parser.py");
+
+    command.args(&[input, type_name]);
+
+    let output = try!(command.output().or(Err("Couldn't get output of child process".to_owned())));
+
+    if !output.status.success() {
+        println!("{}", String::from_utf8_lossy(&output.stderr[..]));
+        return Err("child process was unsuccessful".to_owned());
+    }
+
+    let mut file = try!(
+        File::create(destination).or(Err("Couldn't open file for writing".to_owned()))
+    );
+
+    try!(
+        copy(&mut &output.stdout[..], &mut file).or(
+            Err("Failed to write generated code to file".to_owned())
+        )
+    );
+
+    Ok(())
+}
+
+fn generate(service: &Service, botocore_path: &Path, base_destination: &Path) -> Result<(), String> {
+    let botocore_destination = base_destination.join(format!("{}_botocore.rs", service.name));
+    let serde_destination = base_destination.join(format!("{}.rs", service.name));
+    let input_location = botocore_path.join(
+        format!("{}/{}/service-2.json", service.name, service.protocol_date)
+    );
+
+    let input = try!(
+        input_location.to_str().ok_or(
+            format!(
+                "Invalid service definition path for {} {}",
+                service.protocol_date,
+                service.name,
+            )
+        )
+    );
+
+    try!(botocore_generate(input, &service.type_name, botocore_destination.as_path()));
+    serde_generate(botocore_destination.as_path(), serde_destination.as_path())
+}
+
+fn serde_generate(source: &Path, destination: &Path) -> Result<(), String> {
+    let mut registry = Registry::new();
+
+    register(&mut registry);
+
+    try!(
+        registry.expand("", source, destination).or(
+            Err("Failed to generate code with Serde".to_owned())
+        )
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Building on the work @adimarco started in the feature-split-crates branch, this gets us another step of the way closer to having our code generation written in Rust by turning the "codegen" directory into a sub-crate used only as a build dependency by the top-level crate. Now rusoto's `build.rs` just uses this other crate and invokes a generator with each service to generate as arguments. From this point we can move the Python logic piece by piece into the "rusoto_codegen" crate and the interface from `build.rs` won't change.