### PR TITLE
Update serde_codegen and syntex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ exclude = [".gitignore", ".travis.yml", "docgen.sh"]
 build = "build.rs"
 
 [build-dependencies]
-serde_codegen = "^0.6.7"
-syntex = "^0.25.0"
+serde_codegen = "^0.6.9"
+syntex = "^0.26.0"
 
 [dependencies]
 xml-rs = "^0.1.26"


### PR DESCRIPTION
I can't build the latest master because of syntex again. This patch updates us to the latest versions of both which work.