### PR TITLE
Use a Cargo feature for each API.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ Check out code from github.
 
 `pip install --user -r codegen/requirements.txt` to install Python codegen required libraries.
 
-If you're on OSX, you'll probably need a new version of openssl.  Run `brew install openssl`.  
+If you're on OSX, you'll probably need a new version of openssl.  Run `brew install openssl`.
 
-If using pre-El Capitan OSX, run `brew link --force openssl`.  
+If using pre-El Capitan OSX, run `brew link --force openssl`.
 
 For El Capitan, these environment variables need to be set whenever building the openssl crate.
 This includes rebuilding Rusoto after a `cargo clean`.
@@ -39,10 +39,12 @@ Initial setup is now complete, the above shouldn't be needed again unless you ne
 
 Build the project with `cargo build`.
 
-Integration tests can be executed by running `cargo test --verbose --features aws_integration`.
+Integration tests can be executed by running `cargo test --features FEATURE`, where FEATURE is one or more space-separated Cargo features to test as defined in `Cargo.toml`.
+Each AWS service has a Cargo feature to enable it.
+The feature "all" can be used to test all supported services.
 This will create real AWS resources and you may be charged.
 
-For more verbose test output, you can run `cargo test --verbose --features aws_integration -- --nocapture`.
+For more verbose test output, you can run `cargo test --verbose --features FEATURE -- --nocapture`.
 
 ### Rust code generation from boto core service definitions:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ build = "build.rs"
 [features]
 default = ["serde_codegen"]
 nightly = ["serde_macros"]
-aws_integration = ["dynamodb", "ecs", "kms", "s3", "sqs", "dynamodb"]
+all = ["dynamodb", "ecs", "kms", "s3", "sqs"]
+dynamodb = []
 ecs = []
+kms = []
 s3 = []
 sqs = []
-dynamodb = []
-kms = []
 
 [build-dependencies]
 regex = "^0.1.51"

--- a/README.md
+++ b/README.md
@@ -2,59 +2,105 @@
 
 [![Build Status](https://travis-ci.org/rusoto/rusoto.svg?branch=master)](https://travis-ci.org/rusoto/rusoto)
 
-AWS SDK for Rust.  [Documentation](http://rusoto.github.io/rusoto/rusoto/index.html).
+AWS SDK for Rust. [Documentation](http://rusoto.github.io/rusoto/rusoto/index.html).
 
 IRC: #rusoto on irc.freenode.net.
 
-### Installation
+## Installation
 
 Rusoto is available on [crates.io](https://crates.io/crates/rusoto).
+To use Rusoto in your Rust program built with Cargo, add it as a dependency and enable the Cargo features for any AWS service you want to use.
 
-### Use
+For example:
 
-Examples are available in [tests](tests) directory.
+``` toml
+[dependencies.rusoto]
+features = ["dynamodb", "s3"]
+version = "x.y.z"
+```
 
-[SQS example](tests/sqs.rs):
+You can use the Cargo feature "all" to build Rusoto with support for every available service.
+
+## Usage
+
+Rusoto includes a public module for each AWS service it is compiled for containing Rust types for that service's API.
+A full list of these services and their Cargo feature names are included at the end of this document.
+Other public modules in the crate include types common between AWS APIs, such as credentials management, AWS regions, and API request signing.
+Consult the rustdoc documenation for full details by running `cargo doc`.
+
+A simple example of using the Rusoto's DynamoDB API to list the names of all tables in a database:
 
 ```rust
-let provider = DefaultAWSCredentialsProviderChain::new();
-let region = Region::UsEast1;
+extern crate rusoto;
 
-let mut sqs = SQSHelper::new(provider, &region);
+use default::Default;
 
-let response = try!(sqs.list_queues());
-for q in response.queue_urls {
-    println!("Existing queue url: {}", q);
+use rusoto::credentials::DefaultAWSCredentialsProviderChain;
+use rusoto::dynamodb::{DynamoDBClient, ListTablesInput};
+use rusoto:regions::Region;
+
+fn main() {
+  let provider = DefaultAWSCredentialsProviderChain::new();
+  let region = Region::UsEast1;
+  let mut client = DynamoDBClient::new(provider, &region);
+  let list_tables_input: ListTablesInput = Default::default();
+
+  match client.list_tables(&list_tables_input) {
+    Ok(output) => {
+      match output.TableNames {
+        Some(table_name_list) {
+          println!("Tables in database:");
+
+          for table_name in table_name_list {
+            println!("{}", table_name);
+          }
+        }
+        None => println!("No tables in database!"),
+      }
+    }
+    Err(error) => {
+      println!("Error: {}", error);
+    }
+  }
 }
 ```
 
-#### Credentials
+Rusoto exposes relatively low level types for AWS's APIs.
+It may be convenient to use higher level types, which can be found in the [rusoto_helpers](https://github.com/rusoto/rusoto_helpers) crate.
+
+### Credentials
 
 For more information on Rusoto's use of AWS credentials such as priority and refreshing, see [AWS Credentials](AWS-CREDENTIALS.md).
 
-#### Debugging
+### Debugging
 
-Rusoto uses the [log](https://crates.io/crates/log/) logging facade.  For tests it uses [env_logger](https://crates.io/crates/env_logger/).
+Rusoto uses the [log](https://crates.io/crates/log/) logging facade.
+For tests it uses [env_logger](https://crates.io/crates/env_logger/).
 To see output of logging from integration tests, run:
 
 `RUST_LOG=info cargo test --features aws_integration`
 
-### Semantic versioning
+## Semantic versioning
 
-Rusoto complies with [semantic versioning 2.0.0](http://semver.org/).  Until reaching 1.0.0 the API is to be considered unstable.  See [Cargo.toml](Cargo.toml) or [rusoto on crates.io](https://crates.io/crates/rusoto) for current version.
+Rusoto complies with [semantic versioning 2.0.0](http://semver.org/).
+Until reaching 1.0.0 the API is to be considered unstable.
+See [Cargo.toml](Cargo.toml) or [rusoto on crates.io](https://crates.io/crates/rusoto) for current version.
 
-### Releases
+## Releases
 
 Information on release schedules and procedures are in [RELEASING](RELEASING.md).
 
-#### Currently implemented
+## Supported AWS services
 
-* DynamoDB
-* [ECS](https://aws.amazon.com/ecs/)
-* KMS
-* S3
-* SQS
+Service | Cargo feature
+--------|--------------
+All supported services | all
+[DynamoDB](https://aws.amazon.com/dynamodb/) | dynamodb
+[ECS](https://aws.amazon.com/ecs/) | ecs
+[KMS](https://aws.amazon.com/kms/) | kms
+[S3](https://aws.amazon.com/s3/) | s3
+[SQS](https://aws.amazon.com/sqs/) | sqs
 
-### Contributing
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md).

--- a/docgen.sh
+++ b/docgen.sh
@@ -3,7 +3,7 @@
 echo "Requires ghp-import in PATH.  pip install ghp-import if you don't have it.\n"
 
 echo "Generating docs via cargo."
-cargo doc --no-deps
+cargo doc --no-deps --features all
 echo '<meta http-equiv=refresh content=0;url=rusoto/index.html>' > target/doc/index.html
 
 echo "Firing off ghp-import."

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,11 +1,10 @@
-//! AWS credentials: sourcing and supplying for signed requests
+//! Types for loading and managing AWS access credentials for API requests.
 //!
 //! ## Priority order
 //!
 //! 1. Environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
 //! 2. AWS credentials file.  Usually located at ~/.aws/credentials .
 //! 3. IAM instance profile.  Will only work if running on an EC2 instance with an instance profile/role.
-//!
 
 use std::env::*;
 use std::env;

--- a/src/dynamodb.rs
+++ b/src/dynamodb.rs
@@ -1,4 +1,4 @@
-//! DynamoDB bindings for Rust.
+//! The AWS DynamoDB API.
 
 #![allow(non_snake_case)]
 

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -1,4 +1,4 @@
-//! [ECS](https://aws.amazon.com/ecs/) bindings for Rust.
+//! The AWS ECS API.
 
 #![allow(non_snake_case)]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,4 @@
-//! Errors during AWS communication or parsing
-//!
-//! Wrapper around String to store the error.
-//!
+//! Error and result types.
 
 use std::fmt;
 use std::io::Error as IoError;

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -1,4 +1,4 @@
-//! KMS bindings for Rust.
+//! The AWS KMS API.
 
 #![allow(non_snake_case)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,28 +4,8 @@
 
 //! # Rusoto
 //!
-//! Rusoto is a Rust SDK for [Amazon Web Services](http://aws.amazon.com/).  It follows best practices
-//! for [AWS Credentials](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs).
-//!
-//! The library interacts with AWS in the same fashion as Python's [boto3](https://github.com/boto/boto3) SDK.
-//!
-//! ## Credentials
-//!
-//! Credentials are sourced from environment variables, AWS credentials file and IAM instance profiles,
-//! in that order.  IAM instance profile credentials are refreshed automatically as needed.
-//!
-//! ## Supported services
-//!
-//! * DynamoDB
-//! * [ECS](https://aws.amazon.com/ecs/)
-//! * KMS
-//! * S3
-//! * SQS
-//!
-//! ## Requests and request signing
-//!
-//! Rusoto uses [AWS Signature 4](http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
-//! to sign requests.
+//! Rusoto is an AWS SDK for Rust.
+//! A high level overview is available in `README.md` at https://github.com/rusoto/rusoto.
 
 extern crate time;
 extern crate xml;
@@ -45,12 +25,18 @@ extern crate log;
 #[macro_use] pub mod params;
 #[macro_use] pub mod signature;
 pub mod credentials;
-pub mod dynamodb;
-pub mod ecs;
 pub mod error;
-pub mod kms;
-pub mod sqs;
-pub mod s3;
 pub mod xmlutil;
 pub mod regions;
 pub mod request;
+
+#[cfg(feature = "dynamodb")]
+pub mod dynamodb;
+#[cfg(feature = "ecs")]
+pub mod ecs;
+#[cfg(feature = "kms")]
+pub mod kms;
+#[cfg(feature = "s3")]
+pub mod s3;
+#[cfg(feature = "sqs")]
+pub mod sqs;

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,4 +1,4 @@
-//! Parameters for talking to SQS
+//! Parameters for talking to SQS.
 //!
 //! Key-value pairs for SQS requests.
 //!

--- a/src/regions.rs
+++ b/src/regions.rs
@@ -1,8 +1,8 @@
-//! AWS Regions and helper functions
+//! AWS Regions and helper functions.
 //!
 //! Mostly used for translating the Region enum to a string AWS accepts.
 //!
-//! EG: UsEast1 to "us-east-1"
+//! For example: UsEast1 to "us-east-1"
 
 use std::str::FromStr;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,6 @@
-//! A request to AWS, pre-signed
+//! AWS API requests.
 //!
 //! Wraps the Hyper library to send PUT, POST, DELETE and GET requests.
-//!
 
 use hyper::Client;
 use hyper::client::Response;

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -1,8 +1,4 @@
-//! S3 bindings for Rust
-//!
-//! Not all functions are yet implemented.  Check [S3Helper](http://dualspark.github.io/rusoto/rusoto/s3/struct.S3Helper.html)
-//! for implemented functions and convenience functions.
-//!
+//! The AWS S3 API.
 
 #![allow(unused_variables, unused_mut)]
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,4 +1,4 @@
-//! Tools for signing a request to AWS
+//! AWS API request signatures.
 //!
 //! Follows [AWS Signature 4](http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
 //! algorithm.

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -1,7 +1,4 @@
-//! SQS bindings for Rust
-//!
-//! Check [SQSHelper](http://dualspark.github.io/rusoto/rusoto/sqs/struct.SQSHelper.html) for convenience functions.
-//!
+//! The AWS SQS API.
 
 #![allow(unused_variables, unused_mut)]
 

--- a/src/xmlutil.rs
+++ b/src/xmlutil.rs
@@ -1,8 +1,7 @@
-//! Tools for handling XML from AWS with helper functions for testing
+//! Tools for handling XML from AWS with helper functions for testing.
 //!
-//! Wraps an XML stack via traits.  Also provides a method of supplying an XML stack from a file
-//! for testing purposes.
-//!
+//! Wraps an XML stack via traits.
+//! Also provides a method of supplying an XML stack from a file for testing purposes.
 
 use std::iter::Peekable;
 use std::num::ParseIntError;


### PR DESCRIPTION
This patch puts each AWS API under a Cargo feature so that users can enable only the features they need when building the library. I also cleaned up a bunch of documentation that was at least somewhat related to this change and the module layout.