### PR TITLE
Remove get_ prefix from getter methods.

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -12,7 +12,7 @@ use log::LogLevel::Debug;
 
 /// Takes a fully formed and signed request and executes it.
 pub fn send_request(signed_request: &SignedRequest) -> Response {
-    let hyper_method = match signed_request.get_method().as_ref() {
+    let hyper_method = match signed_request.method().as_ref() {
         "POST" => Method::Post,
         "PUT" => Method::Put,
         "DELETE" => Method::Delete,
@@ -22,18 +22,18 @@ pub fn send_request(signed_request: &SignedRequest) -> Response {
 
     // translate the headers map to a format Hyper likes
     let mut hyper_headers = Headers::new();
-    for h in signed_request.get_headers().iter() {
+    for h in signed_request.headers().iter() {
         hyper_headers.set_raw(h.0.to_owned(), h.1.to_owned());
     }
 
-    let mut final_uri = format!("https://{}{}", signed_request.get_hostname(), signed_request.get_canonical_uri());
-    if signed_request.get_canonical_query_string().len() > 0 {
-        final_uri = final_uri + &format!("?{}", signed_request.get_canonical_query_string());
+    let mut final_uri = format!("https://{}{}", signed_request.hostname(), signed_request.canonical_uri());
+    if signed_request.canonical_query_string().len() > 0 {
+        final_uri = final_uri + &format!("?{}", signed_request.canonical_query_string());
     }
 
     if log_enabled!(Debug) {
         debug!("Full request: \n method: {}\n final_uri: {}\n payload: {:?}\nHeaders:\n",
-        	hyper_method, final_uri, signed_request.get_payload());
+            hyper_method, final_uri, signed_request.payload());
         for h in hyper_headers.iter() {
             debug!("{}:{}", h.name(), h.value_string());
         }
@@ -42,7 +42,7 @@ pub fn send_request(signed_request: &SignedRequest) -> Response {
     let mut client = Client::new();
     client.set_redirect_policy(RedirectPolicy::FollowNone);
 
-    match signed_request.get_payload() {
+    match signed_request.payload() {
         None => client.request(hyper_method, &final_uri).headers(hyper_headers).body("").send().unwrap(),
         Some(payload_contents) => client.request(hyper_method, &final_uri).headers(hyper_headers).body(payload_contents).send().unwrap(),
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -80,27 +80,27 @@ impl <'a> SignedRequest <'a> {
 		self.payload = payload;
 	}
 
-	pub fn get_method(&self) -> &str {
+	pub fn method(&self) -> &str {
 		&self.method
 	}
 
-	pub fn get_canonical_uri(&self) -> &str {
+	pub fn canonical_uri(&self) -> &str {
 		&self.canonical_uri
 	}
 
-	pub fn get_canonical_query_string(&self) -> &str {
+	pub fn canonical_query_string(&self) -> &str {
 		&self.canonical_query_string
 	}
 
-	pub fn get_payload(&self) -> Option<&'a [u8]> {
+	pub fn payload(&self) -> Option<&'a [u8]> {
 		self.payload
 	}
 
-	pub fn get_headers(&'a self) -> &'a BTreeMap<String, Vec<Vec<u8>>> {
+	pub fn headers(&'a self) -> &'a BTreeMap<String, Vec<Vec<u8>>> {
 		&self.headers
 	}
 
-	pub fn get_hostname(&self) -> String {
+	pub fn hostname(&self) -> String {
 		match self.hostname {
 			Some(ref h) => h.to_string(),
 			None => build_hostname(&self.service, &self.region)
@@ -428,7 +428,7 @@ mod tests {
 	fn get_hostname_none_present() {
 		let region = Region::UsEast1;
 		let request = SignedRequest::new("POST", "sqs", &region, "/");
-		assert_eq!("sqs.us-east-1.amazonaws.com", request.get_hostname());
+		assert_eq!("sqs.us-east-1.amazonaws.com", request.hostname());
 	}
 
 	#[test]
@@ -436,7 +436,7 @@ mod tests {
 		let region = Region::UsEast1;
 		let mut request = SignedRequest::new("POST", "sqs", &region, "/");
 		request.set_hostname(Some("test-hostname".to_string()));
-		assert_eq!("test-hostname", request.get_hostname());
+		assert_eq!("test-hostname", request.hostname());
 	}
 
 	#[test]


### PR DESCRIPTION
Removes the "get_" prefix from getter methods according to the [style guidelines for getters and setters](https://doc.rust-lang.org/style/style/naming/README.html#gettersetter-methods-rfc-344). There are other methods that need to be changed as well in the credentials module, but I have another PR coming that overhauls that module once #181 is resolved.