### PR TITLE
Revise credentials API.

### DIFF
--- a/AWS-CREDENTIALS.md
+++ b/AWS-CREDENTIALS.md
@@ -2,25 +2,25 @@
 
 Rusoto has the ability to source AWS access credentials in a few different ways:
 
-1. Environment variables via `rusoto::credentials::EnvironmentCredentialsProvider` (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
-2. AWS credentials file via `rusoto::credentials::ProfileCredentialsProvider`
-3. IAM instance profile via `rusoto::credentials::IAMRoleCredentialsProvider`
+1. Environment variables via `rusoto::credentials::EnvironmentProvider` (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
+2. AWS credentials file via `rusoto::credentials::ProfileProvider`
+3. IAM instance profile via `rusoto::credentials::IAMProvider`
 
-There is also `rusoto::credentials::DefaultAWSCredentialsProviderChain`, which is a convenience for attempting to source access credentials using the methods above in order.
+There is also `rusoto::credentials::ChainProvider`, which is a convenience for attempting to source access credentials using the methods above in order.
 If credentials cannot be obtained through one method, it falls back to the next.
 If all possibilites are exhausted, an error will be returned.
 
-`ProfileCredentialsProvider` (and `DefaultAWSCredentialsProviderChain`) also allow you to specify a custom path to the credentials file and the name of the profile to use.
+`ProfileProvider` (and `ChainProvider`) also allow you to specify a custom path to the credentials file and the name of the profile to use.
 If not specified, the profile "default" is used.
 
-It's also possible to implement your own credentials sourcing mechanism by creating a type that implements `rusoto::credentials::AWSCredentialsProvider`.
+It's also possible to implement your own credentials sourcing mechanism by creating a type that implements `rusoto::credentials::ProvideAWSCredentials`.
 
 #### Credential refreshing
 
-Credentials obtained from environment variables and credential files expire ten minutes after being acquired and are refreshed on subsequent calls to `get_credentials()` (a method from the `AWSCredentialsProvider` trait).
+Credentials obtained from environment variables and credential files expire ten minutes after being acquired and are refreshed on subsequent calls to `credentials()` (a method from the `ProvideAWSCredentials` trait).
 
 IAM instance profile credentials are refreshed as needed.
-Upon calling `get_credentials()` it will see if they are expired or not.
+Upon calling `credentials()` it will see if they are expired or not.
 If expired, it attempts to get new credentials from the metadata service.
 If that fails it will return an error.
 IAM credentials expiration time comes from the IAM metadata response.

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ extern crate rusoto;
 
 use default::Default;
 
-use rusoto::credentials::DefaultAWSCredentialsProviderChain;
+use rusoto::credentials::ChainProvider;
 use rusoto::dynamodb::{DynamoDBClient, ListTablesInput};
 use rusoto:regions::Region;
 
 fn main() {
-  let provider = DefaultAWSCredentialsProviderChain::new();
+  let provider = ChainProvider::new().unwrap();
   let region = Region::UsEast1;
   let mut client = DynamoDBClient::new(provider, &region);
   let list_tables_input: ListTablesInput = Default::default();

--- a/codegen/CODEGEN.md
+++ b/codegen/CODEGEN.md
@@ -26,17 +26,17 @@ This is a guide to how SQS was added to Rusoto.
 
     ```rust
     fn main() {
-      // ...
+        // ...
 
-      // SQS
-      generate(
-          "codegen/botocore/botocore/data/sqs/2012-11-05/service-2.json",
-          "SQSClient",
-          out_path,
-          "sqs",
-      )
+        // SQS
+        generate(
+            "codegen/botocore/botocore/data/sqs/2012-11-05/service-2.json",
+            "SQSClient",
+            out_path,
+            "sqs",
+        )
 
-      // ...
+        // ...
     }
     ```
 
@@ -62,7 +62,7 @@ This is a guide to how SQS was added to Rusoto.
 
     use xml::EventReader;
 
-    use credentials::AWSCredentialsProvider;
+    use credentials::ProvideAWSCredentials;
     use error::AWSError;
     use params::{Params, SQSParams};
     use regions::Region;
@@ -87,21 +87,21 @@ This is a guide to how SQS was added to Rusoto.
     ```rust
     /// High level SQS client that wraps the generated SQSClient.
     pub struct SQSHelper<'a> {
-      client: SQSClient<'a>
+        client: SQSClient<'a>
     }
 
     impl<'a> SQSHelper<'a> {
-      /// Creates a new SQS helper
-      pub fn new<P: AWSCredentialsProvider + 'a>(credentials: P, region:&'a Region) -> SQSHelper<'a> {
-        SQSHelper { client: SQSClient::new(credentials, region) }
-      }
+        /// Creates a new SQS helper
+        pub fn new<P: ProvideAWSCredentials + 'a>(credentials: P, region:&'a Region) -> SQSHelper<'a> {
+          SQSHelper { client: SQSClient::new(credentials, region) }
+        }
 
-      /// Lists queues
-      pub fn list_queues(&mut self) -> Result<ListQueuesResult, AWSError> {
-        self.client.list_queues(&ListQueuesRequest::default())
-      }
+        /// Lists queues
+        pub fn list_queues(&mut self) -> Result<ListQueuesResult, AWSError> {
+          self.client.list_queues(&ListQueuesRequest::default())
+        }
 
-      // ...
+        // ...
     }
     ```
 

--- a/codegen/jsonprotocol.py
+++ b/codegen/jsonprotocol.py
@@ -70,7 +70,7 @@ class JsonProtocolParser(ParserBase):
         self.append('\t\trequest.add_header("x-amz-target", "' + self.metadata('targetPrefix') + '.' + operation[
             'name'] + '");')
         self.append('\t\trequest.set_payload(Some(encoded.as_bytes()));')
-        self.append('\t\tlet mut result = request.sign_and_execute(try!(self.creds.get_credentials()));')
+        self.append('\t\tlet mut result = request.sign_and_execute(try!(self.creds.credentials()));')
         self.append('\t\tlet status = result.status.to_u16();')
         self.append('\t\tlet mut body = String::new();')
         self.append('\t\tresult.read_to_string(&mut body).unwrap();')

--- a/codegen/parserbase.py
+++ b/codegen/parserbase.py
@@ -68,7 +68,7 @@ class ParserBase(object):
 
     def rust_struct(self, name, shape):
         """
-        generate a rust declaration for a botocore structure shape        
+        generate a rust declaration for a botocore structure shape
         """
         pass
 
@@ -78,13 +78,13 @@ class ParserBase(object):
         """
 
         self.append("pub struct " + self.client_name + "<'a> {")
-        self.append("\tcreds: Box<AWSCredentialsProvider + 'a>,")
+        self.append("\tcreds: Box<ProvideAWSCredentials + 'a>,")
         self.append("\tregion: &'a Region")
         self.append("}\n")
 
         self.append("impl<'a> " + self.client_name + "<'a> { ")
         self.append(
-            "\tpub fn new<P: AWSCredentialsProvider + 'a>(creds: P, region: &'a Region) -> " + self.client_name + "<'a> {")
+            "\tpub fn new<P: ProvideAWSCredentials + 'a>(creds: P, region: &'a Region) -> " + self.client_name + "<'a> {")
         self.append("\t\t" + self.client_name + " { creds: Box::new(creds), region: region }")
         self.append("\t}")
 

--- a/codegen/queryprotocol.py
+++ b/codegen/queryprotocol.py
@@ -243,9 +243,9 @@ class QueryProtocolParser(ParserBase):
             self.append('\t\t' + input_name + 'Writer::write_params(&mut params, \"\", &input);')
 
         self.append('\t\trequest.set_params(params);')
-        self.append('\t\tlet mut result = request.sign_and_execute(try!(self.creds.get_credentials()));')
+        self.append('\t\tlet mut result = request.sign_and_execute(try!(self.creds.credentials()));')
         self.append('\t\tlet status = result.status.to_u16();')
-        #	self.append('\t\tprintln!("{}", output);'
+        #   self.append('\t\tprintln!("{}", output);'
         self.append('\t\tlet mut reader = EventReader::new(result);')
         self.append('\t\tlet mut stack = XmlResponseFromAws::new(reader.events().peekable());')
         self.append('\t\tstack.next(); // xml start tag')

--- a/codegen/s3.rs
+++ b/codegen/s3.rs
@@ -10998,12 +10998,12 @@ impl MaxPartsWriter {
 	}
 }
 pub struct S3Client<'a> {
-	creds: Box<AWSCredentialsProvider + 'a>,
+	creds: Box<ProvideAWSCredentials + 'a>,
 	region: &'a Region
 }
 
 impl<'a> S3Client<'a> {
-	pub fn new<P: AWSCredentialsProvider + 'a>(creds: P, region: &'a Region) -> S3Client<'a> {
+	pub fn new<P: ProvideAWSCredentials + 'a>(creds: P, region: &'a Region) -> S3Client<'a> {
 		S3Client { creds: Box::new(creds), region: region }
 	}
 	/// Returns metadata about all of the versions of objects in a bucket.
@@ -11013,7 +11013,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "ListObjectVersions");
 		ListObjectVersionsRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11034,7 +11034,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketPolicy");
 		PutBucketPolicyRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11056,7 +11056,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "ListObjects");
 		ListObjectsRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11076,7 +11076,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketWebsite");
 		PutBucketWebsiteRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11096,7 +11096,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketNotification");
 		PutBucketNotificationRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11118,7 +11118,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketLogging");
 		PutBucketLoggingRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11139,7 +11139,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketReplication");
 		PutBucketReplicationRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11175,7 +11175,7 @@ impl<'a> S3Client<'a> {
 		params.put("uploadId", &format!("{}", upload_id));
 		request.set_params(params);
 
-		let mut result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let mut result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 
 		match status {
@@ -11233,7 +11233,7 @@ impl<'a> S3Client<'a> {
 		request.set_hostname(Some(hostname));
 		request.set_payload(input.body);
 
-		let mut result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let mut result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 
 		match status {
@@ -11259,7 +11259,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "DeleteBucketCors");
 		DeleteBucketCorsRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11280,7 +11280,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketVersioning");
 		PutBucketVersioningRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11300,7 +11300,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketCors");
 		GetBucketCorsRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11321,7 +11321,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketLifecycle");
 		PutBucketLifecycleRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11341,7 +11341,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketAcl");
 		GetBucketAclRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11362,7 +11362,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketLogging");
 		GetBucketLoggingRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11383,7 +11383,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "HeadBucket");
 		HeadBucketRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11402,7 +11402,7 @@ impl<'a> S3Client<'a> {
 		let mut params = Params::new();
 		params.put("Action", "PutBucketAcl");
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11422,7 +11422,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "DeleteBucketWebsite");
 		DeleteBucketWebsiteRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11442,7 +11442,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "DeleteBucketPolicy");
 		DeleteBucketPolicyRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11462,7 +11462,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketNotificationConfiguration");
 		GetBucketNotificationConfigurationRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11489,7 +11489,7 @@ impl<'a> S3Client<'a> {
 		// params.put("Action", "DeleteObjects");
 		// DeleteObjectsRequestWriter::write_params(&mut params, "", &input);
 		// request.set_params(params);
-		// let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		// let result = request.sign_and_execute(try!(self.creds.credentials()));
 		// let status = result.status.to_u16();
 		// match status {
 		// 	200 => {
@@ -11505,7 +11505,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "DeleteBucketReplication");
 		DeleteBucketReplicationRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11525,7 +11525,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "CopyObject");
 		CopyObjectRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11545,7 +11545,7 @@ impl<'a> S3Client<'a> {
 		let mut params = Params::new();
 		params.put("Action", "ListBuckets");
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11572,7 +11572,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketRequestPayment");
 		PutBucketRequestPaymentRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11592,7 +11592,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketNotificationConfiguration");
 		PutBucketNotificationConfigurationRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11614,7 +11614,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "HeadObject");
 		HeadObjectRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11634,7 +11634,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "DeleteBucketTagging");
 		DeleteBucketTaggingRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11654,7 +11654,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetObjectTorrent");
 		GetObjectTorrentRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11674,7 +11674,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketLifecycle");
 		GetBucketLifecycleRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11706,7 +11706,7 @@ impl<'a> S3Client<'a> {
 			Some(ref canned_acl) => request.add_header("x-amz-acl", &canned_acl_in_aws_format(&canned_acl)),
 		}
 
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 
 		match status {
@@ -11737,7 +11737,7 @@ impl<'a> S3Client<'a> {
 
 		request.set_payload(input.multipart_upload);
 
-		let mut result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let mut result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 
 		match status {
@@ -11762,7 +11762,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketWebsite");
 		GetBucketWebsiteRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11789,7 +11789,7 @@ impl<'a> S3Client<'a> {
 		let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
 		request.set_hostname(Some(hostname));
 
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 
 		let mut reader = EventReader::new(result);
@@ -11811,7 +11811,7 @@ impl<'a> S3Client<'a> {
 		let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
 		request.set_hostname(Some(hostname));
 
-		let mut result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let mut result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		match status {
 			204 => {
@@ -11926,7 +11926,7 @@ impl<'a> S3Client<'a> {
 		GetObjectRequestWriter::write_params(&mut params, "", &input);
 
 		request.set_params(params);
-		let mut result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let mut result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 
 		match status {
@@ -11952,7 +11952,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketPolicy");
 		GetBucketPolicyRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11972,7 +11972,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketVersioning");
 		GetBucketVersioningRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -11996,7 +11996,7 @@ impl<'a> S3Client<'a> {
 		let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
 		request.set_hostname(Some(hostname));
 
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12018,7 +12018,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketRequestPayment");
 		GetBucketRequestPaymentRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12038,7 +12038,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketTagging");
 		PutBucketTaggingRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12058,7 +12058,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketTagging");
 		GetBucketTaggingRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12085,7 +12085,7 @@ impl<'a> S3Client<'a> {
 		let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
 		request.set_hostname(Some(hostname));
 
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12106,7 +12106,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutObjectAcl");
 		PutObjectAclRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12126,7 +12126,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketLocation");
 		GetBucketLocationRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12146,7 +12146,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "PutBucketCors");
 		PutBucketCorsRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12166,7 +12166,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "DeleteBucketLifecycle");
 		DeleteBucketLifecycleRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12186,7 +12186,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketNotification");
 		GetBucketNotificationConfigurationRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12210,7 +12210,7 @@ impl<'a> S3Client<'a> {
 		let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
 		request.set_hostname(Some(hostname));
 
-		let mut result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let mut result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 
 		match status {
@@ -12237,7 +12237,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetObjectAcl");
 		GetObjectAclRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12258,7 +12258,7 @@ impl<'a> S3Client<'a> {
 	// 	let mut request = SignedRequest::new("PUT", "s3", &self.region, &format!("/{}?partNumber={}&uploadId={}",
 	// 		object_id, part_number, upload_id));
 	//
-	// 	let result = request.sign_and_execute(&self.creds.get_credentials());
+	// 	let result = request.sign_and_execute(&self.creds.credentials());
 	// 	let status = result.status.to_u16();
 	//
 	// 	match status {
@@ -12283,7 +12283,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "DeleteObject");
 		DeleteObjectRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 
 		match status {
@@ -12301,7 +12301,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "RestoreObject");
 		RestoreObjectRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());
@@ -12320,7 +12320,7 @@ impl<'a> S3Client<'a> {
 		params.put("Action", "GetBucketReplication");
 		GetBucketReplicationRequestWriter::write_params(&mut params, "", &input);
 		request.set_params(params);
-		let result = request.sign_and_execute(try!(self.creds.get_credentials()));
+		let result = request.sign_and_execute(try!(self.creds.credentials()));
 		let status = result.status.to_u16();
 		let mut reader = EventReader::new(result);
 		let mut stack = XmlResponseFromAws::new(reader.events().peekable());

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -58,7 +58,7 @@ use std::result;
 
 use serde_json;
 
-use credentials::AWSCredentialsProvider;
+use credentials::ProvideAWSCredentials;
 use error::AWSError;
 use regions::Region;
 use signature::SignedRequest;
@@ -100,7 +100,7 @@ fn parse_error(body: &str) -> {error_type_name} {{
 use hyper::header::Headers;
 use xml::reader::EventReader;
 
-use credentials::AWSCredentialsProvider;
+use credentials::ProvideAWSCredentials;
 use error::AWSError;
 use regions::Region;
 use signature::SignedRequest;
@@ -123,13 +123,13 @@ pub enum ArgumentLocation {
 
     // generate the service client struct
     source.push_str(&format!("pub struct {}<'a> {{", type_name));
-    source.push_str("\tcreds: Box<AWSCredentialsProvider + 'a>,");
+    source.push_str("\tcreds: Box<ProvideAWSCredentials + 'a>,");
     source.push_str("\tregion: &'a Region");
     source.push_str("}\n");
 
     // implement each botocore operation as function for the client
     source.push_str(&format!("impl<'a> {}<'a> {{ ", type_name));
-    source.push_str(&format!("\tpub fn new<P: AWSCredentialsProvider + 'a>(creds: P, region: &'a Region) -> {}<'a> {{", type_name));
+    source.push_str(&format!("\tpub fn new<P: ProvideAWSCredentials + 'a>(creds: P, region: &'a Region) -> {}<'a> {{", type_name));
     source.push_str(&format!("\t\t{} {{ creds: Box::new(creds), region: region }}", type_name));
     source.push_str("\t}");
 
@@ -210,7 +210,7 @@ fn json_operations(service: &Service) -> String {
         src.push_str("\t\trequest.set_content_type(\"application/x-amz-json-1.0\".to_string());\n");
         src.push_str(&format!("\t\trequest.add_header(\"x-amz-target\", \"{}.{}\");\n", target_prefix, operation.name));
         src.push_str("\t\trequest.set_payload(Some(encoded.as_bytes()));\n");
-        src.push_str("\t\tlet mut result = request.sign_and_execute(try!(self.creds.get_credentials()));\n");
+        src.push_str("\t\tlet mut result = request.sign_and_execute(try!(self.creds.credentials()));\n");
         src.push_str("\t\tlet status = result.status.to_u16();\n");
         src.push_str("\t\tlet mut body = String::new();\n");
         src.push_str("\t\tresult.read_to_string(&mut body).unwrap();\n");

--- a/src/s3.rs.old
+++ b/src/s3.rs.old
@@ -42,7 +42,7 @@ pub enum CannedAcl {
 impl<'a> S3Helper<'a> {
 
 	/// Creates a new S3 helper
-	pub fn new<CP: AWSCredentialsProvider + 'a>(credentials: CP, region:&'a Region) -> S3Helper<'a> {
+	pub fn new<CP: ProvideAWSCredentials + 'a>(credentials: CP, region:&'a Region) -> S3Helper<'a> {
 		S3Helper { client: S3Client::new(credentials, region) }
 	}
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -37,258 +37,258 @@ const HTTP_TEMPORARY_REDIRECT: StatusCode = StatusCode::TemporaryRedirect;
 /// the Amazon Signature Version 4 signing process
 #[derive(Debug)]
 pub struct SignedRequest<'a> {
-	method: String,
-	service: String,
-	region: &'a Region,
-	path: String,
-	headers: BTreeMap<String, Vec<Vec<u8>>>,
-	params: Params,
-	hostname: Option<String>,
-	payload: Option<&'a [u8]>,
-	content_type: Option<String>,
-	canonical_query_string: String,
-	canonical_uri: String,
+    method: String,
+    service: String,
+    region: &'a Region,
+    path: String,
+    headers: BTreeMap<String, Vec<Vec<u8>>>,
+    params: Params,
+    hostname: Option<String>,
+    payload: Option<&'a [u8]>,
+    content_type: Option<String>,
+    canonical_query_string: String,
+    canonical_uri: String,
 }
 
 impl <'a> SignedRequest <'a> {
-	/// Default constructor
-	pub fn new<'b>(method: &str, service: &str, region: &'a Region, path: &str) -> SignedRequest<'a> {
-		SignedRequest {
-			method: method.to_string(),
-			service: service.to_string(),
-			region: region,
-			path: path.to_string(),
-			headers: BTreeMap::new(),
-			params: Params::new(),
-			hostname: None,
-			payload: None,
-			content_type: None,
-			canonical_query_string: String::new(),
-			canonical_uri: String::new(),
-		 }
-	}
+    /// Default constructor
+    pub fn new<'b>(method: &str, service: &str, region: &'a Region, path: &str) -> SignedRequest<'a> {
+        SignedRequest {
+            method: method.to_string(),
+            service: service.to_string(),
+            region: region,
+            path: path.to_string(),
+            headers: BTreeMap::new(),
+            params: Params::new(),
+            hostname: None,
+            payload: None,
+            content_type: None,
+            canonical_query_string: String::new(),
+            canonical_uri: String::new(),
+         }
+    }
 
-	pub fn set_content_type(&mut self, content_type: String) {
-		self.content_type = Some(content_type);
-	}
+    pub fn set_content_type(&mut self, content_type: String) {
+        self.content_type = Some(content_type);
+    }
 
-	pub fn set_hostname(&mut self, hostname: Option<String>) {
-		self.hostname = hostname;
-	}
+    pub fn set_hostname(&mut self, hostname: Option<String>) {
+        self.hostname = hostname;
+    }
 
-	pub fn set_payload(&mut self, payload: Option<&'a [u8]>) {
-		self.payload = payload;
-	}
+    pub fn set_payload(&mut self, payload: Option<&'a [u8]>) {
+        self.payload = payload;
+    }
 
-	pub fn method(&self) -> &str {
-		&self.method
-	}
+    pub fn method(&self) -> &str {
+        &self.method
+    }
 
-	pub fn canonical_uri(&self) -> &str {
-		&self.canonical_uri
-	}
+    pub fn canonical_uri(&self) -> &str {
+        &self.canonical_uri
+    }
 
-	pub fn canonical_query_string(&self) -> &str {
-		&self.canonical_query_string
-	}
+    pub fn canonical_query_string(&self) -> &str {
+        &self.canonical_query_string
+    }
 
-	pub fn payload(&self) -> Option<&'a [u8]> {
-		self.payload
-	}
+    pub fn payload(&self) -> Option<&'a [u8]> {
+        self.payload
+    }
 
-	pub fn headers(&'a self) -> &'a BTreeMap<String, Vec<Vec<u8>>> {
-		&self.headers
-	}
+    pub fn headers(&'a self) -> &'a BTreeMap<String, Vec<Vec<u8>>> {
+        &self.headers
+    }
 
-	pub fn hostname(&self) -> String {
-		match self.hostname {
-			Some(ref h) => h.to_string(),
-			None => build_hostname(&self.service, &self.region)
-		}
-	}
+    pub fn hostname(&self) -> String {
+        match self.hostname {
+            Some(ref h) => h.to_string(),
+            None => build_hostname(&self.service, &self.region)
+        }
+    }
 
-	// If the key exists in headers, set it to blank/unoccupied:
-	pub fn remove_header(&mut self, key: &str) {
-		let key_lower = key.to_ascii_lowercase().to_string();
-		self.headers.remove(&key_lower);
-	}
+    // If the key exists in headers, set it to blank/unoccupied:
+    pub fn remove_header(&mut self, key: &str) {
+        let key_lower = key.to_ascii_lowercase().to_string();
+        self.headers.remove(&key_lower);
+    }
 
-	/// Add a value to the array of headers for the specified key.
-	/// Headers are kept sorted by key name for use at signing (BTreeMap)
-	pub fn add_header(&mut self, key: &str, value: &str) {
-		let key_lower = key.to_ascii_lowercase().to_string();
-		let value_vec = value.as_bytes().to_vec();
+    /// Add a value to the array of headers for the specified key.
+    /// Headers are kept sorted by key name for use at signing (BTreeMap)
+    pub fn add_header(&mut self, key: &str, value: &str) {
+        let key_lower = key.to_ascii_lowercase().to_string();
+        let value_vec = value.as_bytes().to_vec();
 
-		match self.headers.entry(key_lower) {
-			Entry::Vacant(entry) => {
-				let mut values = Vec::new();
-				values.push(value_vec);
-				entry.insert(values);
-			}
-			Entry::Occupied(entry) => {
-				entry.into_mut().push(value_vec);
-			}
-		}
-	}
+        match self.headers.entry(key_lower) {
+            Entry::Vacant(entry) => {
+                let mut values = Vec::new();
+                values.push(value_vec);
+                entry.insert(values);
+            }
+            Entry::Occupied(entry) => {
+                entry.into_mut().push(value_vec);
+            }
+        }
+    }
 
-	pub fn add_param<S>(&mut self, key: S, value: S)  where S: Into<String> {
-		self.params.insert(key.into(), value.into());
-	}
+    pub fn add_param<S>(&mut self, key: S, value: S)  where S: Into<String> {
+        self.params.insert(key.into(), value.into());
+    }
 
-	pub fn set_params(&mut self, params: Params){
-		self.params = params;
-	}
+    pub fn set_params(&mut self, params: Params){
+        self.params = params;
+    }
 
-	/// Calculate the signature from the credentials provided and the request data
-	/// Add the calculated signature to the request headers and execute it
-	/// Return the hyper HTTP response
-	pub fn sign_and_execute(&mut self, creds: &AWSCredentials) -> Response {
-		debug!("Creating request to send to AWS.");
-		let hostname = match self.hostname {
-			Some(ref h) => h.to_string(),
-			None => build_hostname(&self.service, &self.region)
-		};
+    /// Calculate the signature from the credentials provided and the request data
+    /// Add the calculated signature to the request headers and execute it
+    /// Return the hyper HTTP response
+    pub fn sign_and_execute(&mut self, creds: &AWSCredentials) -> Response {
+        debug!("Creating request to send to AWS.");
+        let hostname = match self.hostname {
+            Some(ref h) => h.to_string(),
+            None => build_hostname(&self.service, &self.region)
+        };
 
-		// Gotta remove and re-add headers since by default they append the value.  If we're following
-		// a 307 redirect we end up with Three Stooges in the headers with duplicate values.
-		self.remove_header("host");
-		self.add_header("host", &hostname);
+        // Gotta remove and re-add headers since by default they append the value.  If we're following
+        // a 307 redirect we end up with Three Stooges in the headers with duplicate values.
+        self.remove_header("host");
+        self.add_header("host", &hostname);
 
-		if let Some(ref token) = *creds.get_token() {
-			self.remove_header("X-Amz-Security-Token");
-			self.add_header("X-Amz-Security-Token", token);
-		}
+        if let Some(ref token) = *creds.token() {
+            self.remove_header("X-Amz-Security-Token");
+            self.add_header("X-Amz-Security-Token", token);
+        }
 
-		self.canonical_query_string = build_canonical_query_string(&self.params);
+        self.canonical_query_string = build_canonical_query_string(&self.params);
 
-		let date = now_utc();
-		self.remove_header("x-amz-date");
-		self.add_header("x-amz-date", &date.strftime("%Y%m%dT%H%M%SZ").unwrap().to_string());
+        let date = now_utc();
+        self.remove_header("x-amz-date");
+        self.add_header("x-amz-date", &date.strftime("%Y%m%dT%H%M%SZ").unwrap().to_string());
 
-		// build the canonical request
-		let signed_headers = signed_headers(&self.headers);
-		self.canonical_uri = canonical_uri(&self.path);
-		let canonical_headers = canonical_headers(&self.headers);
+        // build the canonical request
+        let signed_headers = signed_headers(&self.headers);
+        self.canonical_uri = canonical_uri(&self.path);
+        let canonical_headers = canonical_headers(&self.headers);
 
-		let canonical_request : String;
+        let canonical_request : String;
 
-		match self.payload {
-			None => {
-				canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
-					&self.method,
-					self.canonical_uri,
-					self.canonical_query_string,
-					canonical_headers,
-					signed_headers,
-					&to_hexdigest_from_string(""));
-				self.remove_header("x-amz-content-sha256");
-				self.add_header("x-amz-content-sha256", &to_hexdigest_from_string(""));
-			}
-			Some(payload) => {
-				// This is hashing the payload twice, booo:
-				canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
-					&self.method,
-					self.canonical_uri,
-					self.canonical_query_string,
-					canonical_headers,
-					signed_headers,
-					&to_hexdigest_from_bytes(payload));
-				self.remove_header("x-amz-content-sha256");
-				self.add_header("x-amz-content-sha256", &to_hexdigest_from_bytes(payload));
-				self.remove_header("content-length");
-				self.add_header("content-length", &format!("{}", payload.len()));
-			}
-		}
+        match self.payload {
+            None => {
+                canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
+                    &self.method,
+                    self.canonical_uri,
+                    self.canonical_query_string,
+                    canonical_headers,
+                    signed_headers,
+                    &to_hexdigest_from_string(""));
+                self.remove_header("x-amz-content-sha256");
+                self.add_header("x-amz-content-sha256", &to_hexdigest_from_string(""));
+            }
+            Some(payload) => {
+                // This is hashing the payload twice, booo:
+                canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
+                    &self.method,
+                    self.canonical_uri,
+                    self.canonical_query_string,
+                    canonical_headers,
+                    signed_headers,
+                    &to_hexdigest_from_bytes(payload));
+                self.remove_header("x-amz-content-sha256");
+                self.add_header("x-amz-content-sha256", &to_hexdigest_from_bytes(payload));
+                self.remove_header("content-length");
+                self.add_header("content-length", &format!("{}", payload.len()));
+            }
+        }
 
-		self.remove_header("content-type");
-		let ct = match self.content_type {
-			Some(ref h) => h.to_string(),
-			None => String::from("application/octet-stream")
-		};
+        self.remove_header("content-type");
+        let ct = match self.content_type {
+            Some(ref h) => h.to_string(),
+            None => String::from("application/octet-stream")
+        };
 
-		self.add_header("content-type", &ct);
+        self.add_header("content-type", &ct);
 
-		// use the hashed canonical request to build the string to sign
-		let hashed_canonical_request = to_hexdigest_from_string(&canonical_request);
-		let scope = format!("{}/{}/{}/aws4_request", date.strftime("%Y%m%d").unwrap(), region_in_aws_format(&self.region), &self.service);
-		let string_to_sign = string_to_sign(date, &hashed_canonical_request, &scope);
+        // use the hashed canonical request to build the string to sign
+        let hashed_canonical_request = to_hexdigest_from_string(&canonical_request);
+        let scope = format!("{}/{}/{}/aws4_request", date.strftime("%Y%m%d").unwrap(), region_in_aws_format(&self.region), &self.service);
+        let string_to_sign = string_to_sign(date, &hashed_canonical_request, &scope);
 
-		// construct the signing key and sign the string with it
-		let signing_key = signing_key(&creds.get_aws_secret_key(), date, &region_in_aws_format(&self.region), &self.service);
-		let signature = signature(&string_to_sign, signing_key);
+        // construct the signing key and sign the string with it
+        let signing_key = signing_key(&creds.aws_secret_access_key(), date, &region_in_aws_format(&self.region), &self.service);
+        let signature = signature(&string_to_sign, signing_key);
 
-		// build the actual auth header
-		let auth_header = format!("AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
-	               &creds.get_aws_access_key_id(), scope, signed_headers, signature);
-	    self.remove_header("authorization");
-		self.add_header("authorization", &auth_header);
+        // build the actual auth header
+        let auth_header = format!("AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
+                   &creds.aws_access_key_id(), scope, signed_headers, signature);
+        self.remove_header("authorization");
+        self.add_header("authorization", &auth_header);
 
-		let response = send_request(&self);
-		debug!("Sent request to AWS");
+        let response = send_request(&self);
+        debug!("Sent request to AWS");
 
-		if response.status == HTTP_TEMPORARY_REDIRECT {
-			debug!("Got a redirect response, resending request.");
-			// extract location from response, modify request and re-sign and resend.
-			let new_hostname = extract_s3_redirect_location(response).unwrap();
-			self.set_hostname(Some(new_hostname.to_string()));
+        if response.status == HTTP_TEMPORARY_REDIRECT {
+            debug!("Got a redirect response, resending request.");
+            // extract location from response, modify request and re-sign and resend.
+            let new_hostname = extract_s3_redirect_location(response).unwrap();
+            self.set_hostname(Some(new_hostname.to_string()));
 
-			// This does a lot of appending and not clearing/creation, so we'll have to do that ourselves:
-			return self.sign_and_execute(creds);
-		}
+            // This does a lot of appending and not clearing/creation, so we'll have to do that ourselves:
+            return self.sign_and_execute(creds);
+        }
 
-		response
-	}
+        response
+    }
 }
 
 fn signature(string_to_sign: &str, signing_key: Vec<u8>) -> String {
-	hmac(SHA256, &signing_key, string_to_sign.as_bytes()).to_hex().to_string()
+    hmac(SHA256, &signing_key, string_to_sign.as_bytes()).to_hex().to_string()
 }
 
 fn signing_key(secret: &str, date: Tm, region: &str, service: &str) -> Vec<u8> {
-	let k_date = hmac(SHA256, format!("AWS4{}", secret).as_bytes(), date.strftime("%Y%m%d").unwrap().to_string().as_bytes());
-	let k_region = hmac(SHA256, &k_date, region.as_bytes());
-	let k_service = hmac(SHA256, &k_region, service.as_bytes());
-	hmac(SHA256, &k_service, "aws4_request".as_bytes())
+    let k_date = hmac(SHA256, format!("AWS4{}", secret).as_bytes(), date.strftime("%Y%m%d").unwrap().to_string().as_bytes());
+    let k_region = hmac(SHA256, &k_date, region.as_bytes());
+    let k_service = hmac(SHA256, &k_region, service.as_bytes());
+    hmac(SHA256, &k_service, "aws4_request".as_bytes())
 }
 
 /// Mark string as AWS4-HMAC-SHA256 hashed
 pub fn string_to_sign(date: Tm, hashed_canonical_request: &str, scope: &str) -> String {
-	format!("AWS4-HMAC-SHA256\n{}\n{}\n{}",
-		date.strftime("%Y%m%dT%H%M%SZ").unwrap(),
-		scope,
-		hashed_canonical_request)
+    format!("AWS4-HMAC-SHA256\n{}\n{}\n{}",
+        date.strftime("%Y%m%dT%H%M%SZ").unwrap(),
+        scope,
+        hashed_canonical_request)
 }
 
 fn signed_headers(headers: &BTreeMap<String, Vec<Vec<u8>>>) -> String {
-	let mut signed = String::new();
+    let mut signed = String::new();
 
-	for (key,_) in headers.iter() {
-		if signed.len() > 0 {
-			signed.push(';')
-		}
+    for (key,_) in headers.iter() {
+        if signed.len() > 0 {
+            signed.push(';')
+        }
 
-		if skipped_headers(key) {
-			continue;
-		}
-		signed.push_str(&key.to_ascii_lowercase());
-	}
+        if skipped_headers(key) {
+            continue;
+        }
+        signed.push_str(&key.to_ascii_lowercase());
+    }
     signed
 }
 
 fn canonical_headers(headers: &BTreeMap<String, Vec<Vec<u8>>>) -> String {
-	let mut canonical = String::new();
+    let mut canonical = String::new();
 
-	for item in headers.iter() {
-		if skipped_headers(item.0) {
-			continue;
-		}
-		canonical.push_str(format!("{}:{}\n", item.0.to_ascii_lowercase(), canonical_values(item.1)).as_ref());
-	}
-	canonical
+    for item in headers.iter() {
+        if skipped_headers(item.0) {
+            continue;
+        }
+        canonical.push_str(format!("{}:{}\n", item.0.to_ascii_lowercase(), canonical_values(item.1)).as_ref());
+    }
+    canonical
 }
 
 fn canonical_values(values: &Vec<Vec<u8>>) -> String {
-	let mut st = String::new();
+    let mut st = String::new();
     for v in values {
         let s = str::from_utf8(v).unwrap();
         if st.len() > 0 {
@@ -308,35 +308,35 @@ fn skipped_headers(header: &str) -> bool {
 }
 
 fn canonical_uri(path: &str) -> String {
-	match path {
-		"" => "/".to_string(),
-		_ => path.to_string()
-	}
+    match path {
+        "" => "/".to_string(),
+        _ => path.to_string()
+    }
 }
 
 fn build_canonical_query_string(params: &Params) -> String {
-	if params.len() == 0 {
-		return String::new();
+    if params.len() == 0 {
+        return String::new();
     }
 
-	let mut output = String::new();
-	for item in params.iter() {
-		if output.len() > 0 {
-			output.push_str("&");
-		}
-		byte_serialize(item.0, &mut output);
-		output.push_str("=");
-		byte_serialize(item.1, &mut output);
-	}
+    let mut output = String::new();
+    for item in params.iter() {
+        if output.len() > 0 {
+            output.push_str("&");
+        }
+        byte_serialize(item.0, &mut output);
+        output.push_str("=");
+        byte_serialize(item.1, &mut output);
+    }
 
-	output
+    output
 }
 
 #[inline]
 fn byte_serialize(input: &str, output: &mut String) {
-	for &byte in input.as_bytes().iter() {
-		percent_encode_to(&[byte], FORM_URLENCODED_ENCODE_SET, output)
-	}
+    for &byte in input.as_bytes().iter() {
+        percent_encode_to(&[byte], FORM_URLENCODED_ENCODE_SET, output)
+    }
 }
 
 // TODO: consolidate these functions
@@ -346,115 +346,114 @@ fn to_hexdigest_from_string(val: &str) -> String {
 }
 
 fn to_hexdigest_from_bytes(val: &[u8]) -> String {
-	let h = hash(SHA256, val);
+    let h = hash(SHA256, val);
     h.to_hex().to_string()
 }
 
 fn build_hostname(service: &str, region: &Region) -> String {
-	//iam has only 1 endpoint, other services have region-based endpoints
-	match service {
-		"iam" => format!("{}.amazonaws.com", service),
-		"s3" => {
-				match *region {
-					Region::UsEast1 => return "s3.amazonaws.com".to_string(),
-					_ => return format!("s3-{}.amazonaws.com", region_in_aws_format(region)),
-				}
-			}
-		_ => format!("{}.{}.amazonaws.com", service, region_in_aws_format(region))
-	}
+    //iam has only 1 endpoint, other services have region-based endpoints
+    match service {
+        "iam" => format!("{}.amazonaws.com", service),
+        "s3" => {
+                match *region {
+                    Region::UsEast1 => return "s3.amazonaws.com".to_string(),
+                    _ => return format!("s3-{}.amazonaws.com", region_in_aws_format(region)),
+                }
+            }
+        _ => format!("{}.{}.amazonaws.com", service, region_in_aws_format(region))
+    }
 }
 
 /// extract_s3_redirect_location takes a Hyper Response and attempts to pull out the temporary endpoint.
 fn extract_s3_redirect_location(response: Response) -> Result<String, AWSError> {
-	// Double checking this feels like belts and suspenders since we're checking the status code
-	// before calling this.  Remove this check?
+    // Double checking this feels like belts and suspenders since we're checking the status code
+    // before calling this.  Remove this check?
 
-	// Verify it's a 307 temporary redirect
-	if response.status != HTTP_TEMPORARY_REDIRECT {
-		return Err(AWSError::new("Trying to find temporary location when status is not 307 temp redirect."))
-	}
+    // Verify it's a 307 temporary redirect
+    if response.status != HTTP_TEMPORARY_REDIRECT {
+        return Err(AWSError::new("Trying to find temporary location when status is not 307 temp redirect."))
+    }
 
-	let mut reader = EventReader::new(response);
-	let mut stack = XmlResponseFromAws::new(reader.events().peekable());
-	stack.next(); // xml start tag
+    let mut reader = EventReader::new(response);
+    let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+    stack.next(); // xml start tag
 
-	// extract and return temporary endpoint location
-	extract_s3_temporary_endpoint_from_xml(&mut stack)
+    // extract and return temporary endpoint location
+    extract_s3_temporary_endpoint_from_xml(&mut stack)
 }
 
 fn field_in_s3_redirect(name: &str) -> bool {
-	if name == "Code" || name == "Message" || name == "Bucket" || name == "RequestId" || name == "HostId" {
-		return true;
-	}
-	false
+    if name == "Code" || name == "Message" || name == "Bucket" || name == "RequestId" || name == "HostId" {
+        return true;
+    }
+    false
 }
 
 /// extract_s3_temporary_endpoint_from_xml takes in XML and tries to find the value of the Endpoint node.
 fn extract_s3_temporary_endpoint_from_xml<'a, T: Peek + Next>(stack: &mut T) -> Result<String, AWSError> {
-	try!(start_element(&"Error".to_string(), stack));
+    try!(start_element(&"Error".to_string(), stack));
 
-	// now find Endpoint contents
-	// This may infinite loop if there's no endpoint in the response: how can we prevent that?
-	loop {
-		let current_name = try!(peek_at_name(stack));
-		if current_name == "Endpoint" {
-			let obj = try!(string_field("Endpoint", stack));
-			return Ok(obj);
-		}
-		if field_in_s3_redirect(&current_name){
-			// <foo>bar</foo>:
-			stack.next(); // skip the start tag <foo>
-			stack.next(); // skip contents bar
-			stack.next(); // skip close tag </foo>
-			continue;
-		}
-		break;
-	}
-	Err(AWSError::new("Couldn't find redirect location for S3 bucket"))
+    // now find Endpoint contents
+    // This may infinite loop if there's no endpoint in the response: how can we prevent that?
+    loop {
+        let current_name = try!(peek_at_name(stack));
+        if current_name == "Endpoint" {
+            let obj = try!(string_field("Endpoint", stack));
+            return Ok(obj);
+        }
+        if field_in_s3_redirect(&current_name){
+            // <foo>bar</foo>:
+            stack.next(); // skip the start tag <foo>
+            stack.next(); // skip contents bar
+            stack.next(); // skip close tag </foo>
+            continue;
+        }
+        break;
+    }
+    Err(AWSError::new("Couldn't find redirect location for S3 bucket"))
 }
 
 
 #[cfg(test)]
 mod tests {
     use super::SignedRequest;
-	use super::extract_s3_temporary_endpoint_from_xml;
-	use xmlutil::*;
-	use regions::*;
-	use std::io::BufReader;
-	use std::fs::File;
-	use xml::reader::*;
+    use super::extract_s3_temporary_endpoint_from_xml;
+    use xmlutil::*;
+    use regions::*;
+    use std::io::BufReader;
+    use std::fs::File;
+    use xml::reader::*;
 
-	#[test]
-	fn get_hostname_none_present() {
-		let region = Region::UsEast1;
-		let request = SignedRequest::new("POST", "sqs", &region, "/");
-		assert_eq!("sqs.us-east-1.amazonaws.com", request.hostname());
-	}
+    #[test]
+    fn get_hostname_none_present() {
+        let region = Region::UsEast1;
+        let request = SignedRequest::new("POST", "sqs", &region, "/");
+        assert_eq!("sqs.us-east-1.amazonaws.com", request.hostname());
+    }
 
-	#[test]
-	fn get_hostname_happy_path() {
-		let region = Region::UsEast1;
-		let mut request = SignedRequest::new("POST", "sqs", &region, "/");
-		request.set_hostname(Some("test-hostname".to_string()));
-		assert_eq!("test-hostname", request.hostname());
-	}
+    #[test]
+    fn get_hostname_happy_path() {
+        let region = Region::UsEast1;
+        let mut request = SignedRequest::new("POST", "sqs", &region, "/");
+        request.set_hostname(Some("test-hostname".to_string()));
+        assert_eq!("test-hostname", request.hostname());
+    }
 
-	#[test]
-	fn get_redirect_location_from_s3() {
-		let file = File::open("tests/sample-data/s3_temp_redirect.xml").unwrap();
-	    let file = BufReader::new(file);
-	    let mut my_parser  = EventReader::new(file);
-	    let my_stack = my_parser.events().peekable();
-	    let mut reader = XmlResponseFromFile::new(my_stack);
-		reader.next(); // xml start node
-		let result = extract_s3_temporary_endpoint_from_xml(&mut reader);
+    #[test]
+    fn get_redirect_location_from_s3() {
+        let file = File::open("tests/sample-data/s3_temp_redirect.xml").unwrap();
+        let file = BufReader::new(file);
+        let mut my_parser  = EventReader::new(file);
+        let my_stack = my_parser.events().peekable();
+        let mut reader = XmlResponseFromFile::new(my_stack);
+        reader.next(); // xml start node
+        let result = extract_s3_temporary_endpoint_from_xml(&mut reader);
 
-		match result {
-			Err(_) => panic!("Couldn't parse s3_temp_redirect.xml"),
-			Ok(location) => {
-				assert_eq!(location, "rusoto1441045966.s3-us-west-1.amazonaws.com");
-			}
-		}
-	}
-
+        match result {
+            Err(_) => panic!("Couldn't parse s3_temp_redirect.xml"),
+            Ok(location) => {
+                assert_eq!(location, "rusoto1441045966.s3-us-west-1.amazonaws.com");
+            }
+        }
+    }
 }

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use xml::EventReader;
 
-use credentials::AWSCredentialsProvider;
+use credentials::ProvideAWSCredentials;
 use error::AWSError;
 use params::{Params, SQSParams};
 use regions::Region;

--- a/tests/dynamodb.rs
+++ b/tests/dynamodb.rs
@@ -8,7 +8,7 @@ use std::thread;
 
 use time::get_time;
 
-use rusoto::credentials::DefaultAWSCredentialsProviderChain;
+use rusoto::credentials::ChainProvider;
 use rusoto::dynamodb::{
     AttributeDefinition,
     AttributeValue,
@@ -27,7 +27,7 @@ use rusoto::regions::Region;
 
 #[test]
 fn main() {
-    let creds = DefaultAWSCredentialsProviderChain::new();
+    let creds = ChainProvider::new().unwrap();
     let region = Region::UsWest2;
 
     let mut dynamodb = DynamoDBHelper::new(creds, &region);

--- a/tests/ecs.rs
+++ b/tests/ecs.rs
@@ -3,12 +3,12 @@
 extern crate rusoto;
 
 use rusoto::ecs::{ECSClient, ECSError, ListClustersRequest};
-use rusoto::credentials::DefaultAWSCredentialsProviderChain;
+use rusoto::credentials::ChainProvider;
 use rusoto::regions::Region;
 
 #[test]
 fn main() {
-    let credentials = DefaultAWSCredentialsProviderChain::new();
+    let credentials = ChainProvider::new().unwrap();
     let region = Region::UsEast1;
     let mut ecs = ECSClient::new(
         credentials,

--- a/tests/kms.rs
+++ b/tests/kms.rs
@@ -3,13 +3,13 @@
 #[macro_use]
 extern crate rusoto;
 
-use rusoto::credentials::DefaultAWSCredentialsProviderChain;
+use rusoto::credentials::ChainProvider;
 use rusoto::regions::Region;
 use rusoto::kms::{KMSHelper, KMSError};
 
 #[test]
 fn main() {
-    let creds = DefaultAWSCredentialsProviderChain::new();
+    let creds = ChainProvider::new().unwrap();
     let region = Region::UsWest2;
 
     let mut kms = KMSHelper::new(creds, &region);

--- a/tests/s3.rs
+++ b/tests/s3.rs
@@ -13,7 +13,7 @@ use std::fs::File;
 
 use time::get_time;
 
-use rusoto::credentials::DefaultAWSCredentialsProviderChain;
+use rusoto::credentials::ChainProvider;
 use rusoto::error::AWSError;
 use rusoto::s3::{
     CannedAcl,
@@ -30,7 +30,7 @@ fn all_s3_tests() {
     let _ = env_logger::init();
     info!("s3 integration tests starting up.");
     let region = Region::UsWest2;
-    let mut s3 = S3Helper::new(DefaultAWSCredentialsProviderChain::new(), &region);
+    let mut s3 = S3Helper::new(ChainProvider::new().unwrap(), &region);
 
     match s3_list_buckets_tests(&mut s3) {
         Ok(_) => { info!("Everything worked for S3 list buckets."); },


### PR DESCRIPTION
Overhaul of the credentials API! This is why I was asking about our breaking changes policy a while back. ;}

There are a few things I did here:

* Removed the "get_" prefix from getters, as in #182.
* Renamed `AWSCredentialsProvider` to `ProvideAWSCredentials`, since traits should be transitive verbs, (e.g. Display, Clone). ["prefer transitive verbs, nouns, and then adjectives"](https://aturon.github.io/style/naming.html)
* Renamed the various credential providers to be less verbose: `EnvironmentProvider`, `ProfileProvider`, `IAMProvider`, `ChainProvider`.
* Turned str/String values into Path/PathBuf where the former was in fact a file system path. Types FTW!
* Use canonical names for the two AWS credentials for methods on `AWSCredentials`: `aws_access_key_id` and `aws_secret_access_key`.
* Revised the API of `ProfileProvider` so it has two constructors, and a getter and setter for each property that would ever make sense to mutate.
  * The first constructor (`new`) tries to use the credentials file at the default location using the "default" profile. If the `HOME` environment variable isn't set and it can't determine the path to the file, it returns an error.
  * The second constructor (`with_configuration`) lets the user specify the path to the credentials file and the name of the profile to use.
  * The confusing `with_profile` method, which sounds like it would temporarily change the profile used for a block of code, but actually mutates the value, is removed in favor of a more standard setter: `set_profile`.
* Revised documentation to be consistent across all credentials types and added docs where they were missing.
* Revised the API of `ChainProvider` so that it has two constructors and no mutating methods.
  * The first constructor (`new`) creates a chain using the default `ProfileProvider` constructor. This is the most common case.
  * The second constructor (`with_profile_provider`) lets the user pass in a previously constructed `ProfileProvider`, allowing them to customize it to their liking with that type's own API. This is the only one of the three providers that has customizable values, so this constructor satisfies any customization needed for the chain provider.