### PR TITLE
Make credentials provider Sync

### DIFF
--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -71,7 +71,7 @@ impl AWSCredentials {
 }
 
 /// A type that produces `AWSCredentials`.
-pub trait ProvideAWSCredentials {
+pub trait ProvideAWSCredentials: Sync {
     /// Produce a new `AWSCredentials`.
 	fn credentials(&mut self) -> Result<&AWSCredentials, AWSError>;
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -71,7 +71,7 @@ impl AWSCredentials {
 }
 
 /// A type that produces `AWSCredentials`.
-pub trait ProvideAWSCredentials: Sync {
+pub trait ProvideAWSCredentials: Send + Sync {
     /// Produce a new `AWSCredentials`.
 	fn credentials(&mut self) -> Result<&AWSCredentials, AWSError>;
 }


### PR DESCRIPTION
This makes the client objects shareable between threads.

Unfortunately, no tests since the tests don't seem to compile.

Fixes #203