### PR TITLE
Fixes SQS codegen for input serialization for requests to AWS.

### DIFF
--- a/codegen/src/generator/query.rs
+++ b/codegen/src/generator/query.rs
@@ -359,7 +359,7 @@ fn generate_struct_field_serializers(shape: &Shape) -> String {
                 ",
                 field_name = member_name.to_snake_case(),
                 member_shape_name = member.shape,
-                tag_name = member.tag_name(),
+                tag_name = member_name,
             )
         } else {
             format!(


### PR DESCRIPTION
Fixes #208 .

`DEBUG:hyper::http::h1: request line: Post "/?Action=CreateQueue&QueueName=test_q_1459746067" Http11`

`Verified queue url "https://sqs.us-west-2.amazonaws.com/052774933971/test_q_1459746067" for queue name test_q_1459746067`

👍 