### PR TITLE
Fix Syntex-related Features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ exclude = [".gitignore", ".travis.yml", "docgen.sh"]
 build = "build.rs"
 
 [features]
-default = ["rusoto_codegen/serde_codegen"]
-nightly = ["serde_macros"]
+default = ["with-syntex"]
+with-syntex = ["rusoto_codegen/with-syntex"]
+nightly = ["serde_macros", "rusoto_codegen/nightly"]
 all = ["dynamodb", "ecs", "kms", "s3", "sqs"]
 dynamodb = []
 ecs = []
@@ -27,6 +28,7 @@ sqs = []
 
 [build-dependencies.rusoto_codegen]
 path = "codegen"
+default-features = false
 
 [dependencies]
 serde = "0.7.0"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/rusoto/rusoto"
 build = "build.rs"
 
 [features]
-default = ["serde_codegen", "syntex"]
+default = ["with-syntex"]
+with-syntex = ["serde_codegen", "syntex"]
 nightly = ["serde_macros"]
 
 [build-dependencies]


### PR DESCRIPTION
# Problem

Currently, attempting to build `rusoto` on rustc nightly with the `nightly` feature results in a compilation failure as `rusoto_codegen` will attempt to use `serde_codegen` rather than `serde_macros`.

Enabling the `rusoto_codegen` `nightly` feature as follows does not help:

```sh
cargo build --no-default-features --features "all nightly rusoto_codegen/nightly"
```

This does not help because `rusoto_codegen` will still have its default features active.

# PR

This PR disables default features for `rusoto_codegen` in `rusoto`'s `Cargo.toml`.
Additionally I took the liberty of refactoring the syntex-related features into a `with-syntex` feature which is called by the `default` feature, in both projects.
This decouples syntex-related functionality from the `default` feature, which makes its purpose clearer.

With this PR applied, it is possible to compile rusoto on nightly as follows:

```sh
cargo build --no-default-features --features "all nightly"
```

And on stable as follows:

```sh
cargo build --features all
```