### PR TITLE
Implement Elastic Transcoder Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ build = "build.rs"
 default = ["with-syntex"]
 with-syntex = ["rusoto_codegen/with-syntex"]
 nightly = ["serde_macros", "rusoto_codegen/nightly"]
-all = ["dynamodb", "ecs", "kms", "s3", "sqs"]
+all = ["dynamodb", "ecs", "ets", "kms", "s3", "sqs"]
 dynamodb = []
 ecs = []
+ets = []
 kms = []
 s3 = []
 sqs = []
@@ -46,3 +47,4 @@ serde_macros = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 env_logger = "^0.3.2"
+rand = "^0.3.14"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Service | Cargo feature
 All supported services | all
 [DynamoDB](https://aws.amazon.com/dynamodb/) | dynamodb
 [ECS](https://aws.amazon.com/ecs/) | ecs
+[Elastic Transcoder](https://aws.amazon.com/elastictranscoder/) | ets
 [KMS](https://aws.amazon.com/kms/) | kms
 [S3](https://aws.amazon.com/s3/) | s3
 [SQS](https://aws.amazon.com/sqs/) | sqs

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() {
         Service::new("dynamodb", "2012-08-10"),
         Service::new("kms", "2014-11-01"),
         Service::new("ecs", "2014-11-13"),
+        Service::new("elastictranscoder", "2012-09-25"),
         Service::new("sqs", "2012-11-05"),
     ];
 

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -22,6 +22,7 @@ syntex = { version = "0.30.0", optional = true }
 
 [dependencies]
 Inflector = "0.2.0"
+lazy_static = "0.1.16"
 regex = "0.1.55"
 serde = "0.7.0"
 serde_codegen = { version = "0.7.1", optional = true }

--- a/codegen/src/botocore.in.rs
+++ b/codegen/src/botocore.in.rs
@@ -95,6 +95,8 @@ pub struct HttpRequest {
     pub method: String,
     #[serde(rename="requestUri")]
     pub request_uri: String,
+    #[serde(rename="responseCode")]
+    pub response_code: Option<i32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -122,7 +124,7 @@ pub struct Error {
 
 #[derive(Debug, Deserialize)]
 pub struct HttpError {
-    pub code: String,
+    pub code: Option<String>,
     #[serde(rename="httpStatusCode")]
     pub http_status_code: i32,
     #[serde(rename="senderFault")]
@@ -276,7 +278,7 @@ pub struct Metadata {
     pub json_version: Option<String>,
     pub protocol: String,
     #[serde(rename="serviceAbbreviation")]
-    pub service_abbreviation: String,
+    pub service_abbreviation: Option<String>,
     #[serde(rename="serviceFullName")]
     pub service_full_name: String,
     #[serde(rename="signatureVersion")]

--- a/codegen/src/generator/query.rs
+++ b/codegen/src/generator/query.rs
@@ -61,7 +61,7 @@ impl GenerateProtocol for QueryGenerator {
 
         use credential::ProvideAwsCredentials;
         use error::AwsError;
-        use param::{Params, SQSParams};
+        use param::{Params, ServiceParams};
         use region::Region;
         use signature::SignedRequest;
         use xmlutil::{Next, Peek, XmlParseError, XmlResponseFromAws};

--- a/codegen/src/generator/rest_json.rs
+++ b/codegen/src/generator/rest_json.rs
@@ -1,0 +1,228 @@
+use inflector::Inflector;
+use regex::{Captures, Regex};
+
+use botocore::{Member, Operation, Service, Shape};
+use super::GenerateProtocol;
+
+pub struct RestJsonGenerator;
+
+impl GenerateProtocol for RestJsonGenerator {
+    fn generate_methods(&self, service: &Service) -> String {
+        service.operations.values().map(|operation| {
+            let input_type = operation.input_shape();
+            let output_type = operation.output_shape_or("()");
+
+            // Retrieve the `Shape` for the input for this operation.
+            let input_shape = service.shapes.get(input_type).unwrap();
+
+            // Construct a list of format strings which will be used to format
+            // the request URI, mapping the input struct to the URI arguments.
+            let member_uri_strings = generate_shape_member_uri_strings(input_shape);
+
+            // A boolean controlling whether or not the payload should be loaded
+            // into the request.
+            // According to the AWS SDK documentation, requests should only have
+            // a request body for operations with ANY non-URI or non-query
+            // parameters.
+            let load_payload = input_shape.members
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|(_, member)| member.location.is_none());
+
+            // Construct a list of strings which will be used to load request
+            // parameters from the input struct into a `Params` vec, which will
+            // then be added to the request.
+            let member_param_strings = generate_shape_member_param_strings(input_shape);
+
+            format!("
+                {documentation}
+                pub fn {method_name}(&mut self, input: &{input_type}) -> AwsResult<{output_type}> {{
+                    {encode_input}
+
+                    {request_uri_formatter}
+
+                    let mut request = SignedRequest::new(\"{http_method}\", \"{endpoint_prefix}\", self.region, &request_uri);
+                    request.set_content_type(\"application/x-amz-json-1.1\".to_owned());
+                    {load_payload}
+                    {load_params}
+
+                    let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
+                    let status = result.status.to_u16();
+                    let mut body = String::new();
+                    result.read_to_string(&mut body).unwrap();
+
+                    // `serde-json` serializes field-less structs as \"null\", but AWS returns
+                    // \"{{}}\" for a field-less response, so we must check for this result
+                    // and convert it if necessary.
+                    if body == \"{{}}\" {{
+                        body = \"null\".to_owned();
+                    }}
+
+                    debug!(\"Response body: {{}}\", body);
+                    debug!(\"Response status: {{}}\", status);
+
+                    match status {{
+                        {status_code} => {{
+                            {ok_response}
+                        }}
+                        _ => Err(parse_json_protocol_error(&body)),
+                    }}
+                }}
+                ",
+                documentation = generate_documentation(operation).unwrap_or("".to_owned()),
+                endpoint_prefix = service.metadata.endpoint_prefix,
+                http_method = operation.http.method,
+                input_type = input_type,
+                method_name = operation.name.to_snake_case(),
+                status_code = operation.http.response_code.unwrap_or(200),
+                ok_response = generate_ok_response(operation, output_type),
+                output_type = output_type,
+                request_uri_formatter = generate_uri_formatter(
+                    &generate_snake_case_uri(&operation.http.request_uri),
+                    &member_uri_strings
+                ),
+                load_payload = generate_payload_loading_string(load_payload),
+                load_params = generate_params_loading_string(&member_param_strings),
+                encode_input = generate_encoding_string(load_payload),
+            )
+        }).collect::<Vec<String>>().join("\n")
+    }
+
+    fn generate_prelude(&self) -> String {
+        "use std::io::Read;
+
+        use serde_json;
+
+        use credential::ProvideAwsCredentials;
+        use error::{AwsResult, parse_json_protocol_error};
+        use param::{Params, ServiceParams};
+        use region::Region;
+        use signature::SignedRequest;
+        ".to_owned()
+    }
+
+    fn generate_struct_attributes(&self) -> String {
+        "#[derive(Debug, Default, Deserialize, Serialize)]".to_owned()
+    }
+}
+
+fn generate_encoding_string(load_payload: bool) -> String {
+    match load_payload {
+        false => "".to_owned(),
+        true => {
+            format!(
+                "let encoded = serde_json::to_string(input).unwrap();"
+            )
+        },
+    }
+ }
+
+fn generate_payload_loading_string(load_payload: bool) -> String {
+    match load_payload {
+        false => "".to_owned(),
+        true => {
+            format!(
+                "request.set_payload(Some(encoded.as_bytes()));"
+            )
+        },
+    }
+}
+
+fn generate_snake_case_uri(request_uri: &str) -> String {
+    lazy_static! {
+        static ref URI_ARGS_REGEX: Regex = Regex::new(r"\{([\w\d]+)\}").unwrap();
+    }
+
+    URI_ARGS_REGEX.replace_all(request_uri, |caps: &Captures| {
+        format!("{{{}}}", caps.at(1).map(Inflector::to_snake_case).unwrap())
+    })
+}
+
+fn generate_params_loading_string(param_strings: &Vec<String>) -> String {
+    match param_strings.len() {
+        0 => "".to_owned(),
+        _ => {
+            format!(
+                "let mut params = Params::new();
+                {param_strings}
+                request.set_params(params);",
+                param_strings = param_strings.join("\n")
+            )
+        },
+    }
+}
+
+fn generate_shape_member_param_strings(shape: &Shape) -> Vec<String> {
+    shape.members.as_ref().unwrap().iter()
+        .filter_map(|(member_name, member)| generate_param_load_string(&member_name, member))
+        .collect::<Vec<String>>()
+}
+
+fn generate_param_load_string(member_name: &str, member: &Member) -> Option<String> {
+    match member.location {
+        Some(ref x) if x == "querystring" => {
+            Some(format!(
+                "match input.{field_name} {{
+                    Some(ref x) => params.put(\"{member_name}\", x),
+                    None => {{}},
+                }}",
+                member_name = member_name,
+                field_name = member_name.to_snake_case(),
+            ))
+        },
+        Some(_) => None,
+        None => None,
+    }
+}
+
+fn generate_uri_formatter(request_uri: &str, uri_strings: &Vec<String>) -> String {
+    match uri_strings.len() {
+        0 => {
+            format!(
+                "let request_uri = \"{request_uri}\";",
+                request_uri = request_uri,
+            )
+        },
+        _ => {
+            format!(
+                "let request_uri = format!(\"{request_uri}\", {uri_strings});",
+                request_uri = request_uri,
+                uri_strings = uri_strings.join(", "))
+        },
+    }
+}
+
+fn generate_shape_member_uri_strings(shape: &Shape) -> Vec<String> {
+    shape.members.as_ref().unwrap().iter()
+        .filter_map(|(member_name, member)| generate_member_format_string(&member_name.to_snake_case(), member))
+        .collect::<Vec<String>>()
+}
+
+fn generate_member_format_string(member_name: &str, member: &Member) -> Option<String> {
+    match member.location {
+        Some(ref x) if x == "uri" => {
+            Some(format!(
+                "{member_name} = input.{field_name}",
+                field_name = member_name,
+                member_name = member_name,
+            ))
+        },
+        Some(_) => None,
+        None => None,
+    }
+}
+
+fn generate_documentation(operation: &Operation) -> Option<String> {
+    operation.documentation.as_ref().map(|docs| {
+        format!("#[doc=\"{}\"]", docs.replace("\"", "\\\""))
+    })
+}
+
+fn generate_ok_response(operation: &Operation, output_type: &str) -> String {
+    if operation.output.is_some() {
+        format!("Ok(serde_json::from_str::<{}>(&body).unwrap())", output_type)
+    } else {
+        "Ok(())".to_owned()
+    }
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,7 +1,10 @@
+#![cfg_attr(feature = "nightly", feature(const_fn, core_intrinsics))]
 #![cfg_attr(feature = "serde_macros", feature(custom_derive, plugin))]
 #![cfg_attr(feature = "serde_macros", plugin(serde_macros))]
 
 extern crate inflector;
+#[macro_use] extern crate lazy_static;
+extern crate regex;
 extern crate serde;
 extern crate serde_json;
 

--- a/src/ets.rs
+++ b/src/ets.rs
@@ -1,0 +1,3 @@
+//! Amazon Elastic Transcoder
+
+include!(concat!(env!("OUT_DIR"), "/elastictranscoder.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ mod serialization;
 pub mod dynamodb;
 #[cfg(feature = "ecs")]
 pub mod ecs;
+#[cfg(feature = "ets")]
+pub mod ets;
 #[cfg(feature = "kms")]
 pub mod kms;
 #[cfg(feature = "s3")]

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,19 +1,19 @@
-//! Parameters for talking to SQS.
+//! Parameters for talking to query-based AWS services.
 //!
-//! Key-value pairs for SQS requests.
+//! Key-value pairs for AWS query requests.
 //!
-//! Supports optional parameters for calling SQS.
+//! Supports optional parameters for calling SQS and ETS.
 
 use std::collections::BTreeMap;
 pub type Params = BTreeMap<String, String>;
 
-/// Key:value pair for an SQS parameter.
-pub trait SQSParams {
-	fn put(&mut self, key: &str, val: &str);
+/// Key:value pair for an service parameter.
+pub trait ServiceParams {
+    fn put(&mut self, key: &str, val: &str);
 }
 
-impl SQSParams for Params {
-	fn put(&mut self, key: &str, val: &str) {
-		self.insert(key.into(), val.into());
-	}
+impl ServiceParams for Params {
+    fn put(&mut self, key: &str, val: &str) {
+        self.insert(key.into(), val.into());
+    }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -17,7 +17,7 @@ use xml::*;
 
 use credential::ProvideAwsCredentials;
 use error::AwsError;
-use param::{Params, SQSParams};
+use param::{Params, ServiceParams};
 use region::Region;
 use signature::SignedRequest;
 use xmlutil::*;

--- a/tests/ets.rs
+++ b/tests/ets.rs
@@ -1,0 +1,359 @@
+#![cfg(all(feature = "ets", feature = "s3"))]
+
+extern crate env_logger;
+#[macro_use] extern crate log;
+extern crate rand;
+extern crate rusoto;
+
+use std::clone::Clone;
+use std::ops::{Deref, DerefMut};
+
+use rand::Rng;
+use rusoto::{ChainProvider, ProvideAwsCredentials, Region};
+use rusoto::ets::EtsClient;
+use rusoto::s3::{BucketName, S3Helper};
+
+const AWS_ETS_WEB_PRESET_ID: &'static str = "1351620000001-100070";
+const AWS_ETS_WEB_PRESET_NAME: &'static str = "System preset: Web";
+const AWS_REGION: Region = Region::UsEast1;
+const AWS_SERVICE_RANDOM_SUFFIX_LENGTH: usize = 20;
+
+struct TestEtsClient<P>
+    where P: ProvideAwsCredentials
+{
+    credentials_provider: P,
+    region: Region,
+
+    client: EtsClient<P>,
+
+    s3_helper: Option<S3Helper<P>>,
+    input_bucket: Option<BucketName>,
+    output_bucket: Option<BucketName>,
+}
+
+impl<P> TestEtsClient<P>
+    where P: ProvideAwsCredentials + Clone
+{
+    /// Creates a new `EtsClient` for a test.
+    fn new(credentials_provider: P, region: Region) -> Self {
+        TestEtsClient {
+            credentials_provider: credentials_provider.clone(),
+            region: region,
+            client: EtsClient::new(credentials_provider, region),
+            s3_helper: None,
+            input_bucket: None,
+            output_bucket: None,
+        }
+    }
+
+    fn create_s3_helper(&mut self) {
+        self.s3_helper = Some(S3Helper::new(
+            self.credentials_provider.clone(),
+            self.region
+        ));
+    }
+
+    fn create_bucket(&mut self) -> BucketName {
+        let bucket_name = generate_unique_name("ets-bucket-1");
+        let result = self.s3_helper
+            .as_mut()
+            .unwrap()
+            .create_bucket_in_region(&bucket_name, AWS_REGION, None);
+        let mut location = result
+            .unwrap()
+            .location;
+        // A `Location` is identical to a `BucketName` except that it has a
+        // forward slash prepended to it, so we need to remove it.
+        location.remove(0);
+        info!("Created S3 bucket: {}", location);
+        location
+    }
+}
+
+impl<P> Deref for TestEtsClient<P>
+    where P: ProvideAwsCredentials
+{
+    type Target = EtsClient<P>;
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+impl<P> DerefMut for TestEtsClient<P>
+    where P: ProvideAwsCredentials
+{
+    fn deref_mut<'a>(&'a mut self) -> &'a mut EtsClient<P> {
+        &mut self.client
+    }
+}
+
+impl<P> Drop for TestEtsClient<P>
+    where P: ProvideAwsCredentials
+{
+    fn drop(&mut self) {
+        self.s3_helper.take().map(|mut s3_helper| {
+            self.input_bucket.take().map(|bucket| {
+                match s3_helper.delete_bucket(&bucket, self.region) {
+                    Ok(_) => { info!("Deleted S3 bucket: {}", bucket) },
+                    Err(e) => { error!("Failed to delete S3 bucket: {}", e) }
+                };
+            });
+            self.output_bucket.take().map(|bucket| {
+                match s3_helper.delete_bucket(&bucket, self.region) {
+                    Ok(_) => { info!("Deleted S3 bucket: {}", bucket) },
+                    Err(e) => { error!("Failed to delete S3 bucket: {}", e) }
+                };
+            });
+        });
+    }
+}
+
+// TODO: once Rust has proper support for testing frameworks, this code will
+// need to be refactored so that it is only called once, instead of per test
+// case.
+fn initialize() {
+    let _ = env_logger::init();
+}
+
+fn create_ets_client() -> TestEtsClient<ChainProvider> {
+    TestEtsClient::new(
+        ChainProvider::new().unwrap(),
+        AWS_REGION
+    )
+}
+
+/// Generates a random name for an AWS service by appending a random sequence of
+/// ASCII characters to the specified prefix.
+fn generate_unique_name(prefix: &str) -> String {
+    format!(
+        "{}-{}",
+        prefix,
+        rand::thread_rng()
+            .gen_ascii_chars()
+            .take(AWS_SERVICE_RANDOM_SUFFIX_LENGTH)
+            .collect::<String>()
+    )
+}
+
+#[test]
+#[should_panic(expected = "arn cannot be null")]
+fn create_pipeline_without_arn() {
+    use rusoto::ets::CreatePipelineRequest;
+
+    initialize();
+
+    let mut ets = create_ets_client();
+    ets.create_s3_helper();
+    ets.input_bucket = Some(ets.create_bucket());
+    ets.output_bucket = Some(ets.create_bucket());
+
+    let request = CreatePipelineRequest {
+        input_bucket: ets.input_bucket.as_ref().cloned().unwrap(),
+        output_bucket: ets.output_bucket.as_ref().cloned(),
+        ..CreatePipelineRequest::default()
+    };
+    let response = ets.create_pipeline(&request);
+
+    response.unwrap();
+}
+
+#[test]
+fn create_preset() {
+    use rusoto::ets::{
+        AudioCodecOptions,
+        AudioParameters,
+        CreatePresetRequest,
+        DeletePresetRequest,
+    };
+
+    initialize();
+
+    let mut ets = create_ets_client();
+
+    let name = generate_unique_name("ets-preset-1");
+    let request = CreatePresetRequest {
+        audio: Some(AudioParameters {
+            channels: Some("2".to_owned()),
+            codec: Some("flac".to_owned()),
+            codec_options: Some(AudioCodecOptions {
+                bit_depth: Some("24".to_owned()),
+                ..AudioCodecOptions::default()
+            }),
+            sample_rate: Some("96000".to_owned()),
+            ..AudioParameters::default()
+        }),
+        container: "flac".to_owned(),
+        description: Some("This is an example FLAC preset".to_owned()),
+        name: name.clone(),
+        ..CreatePresetRequest::default()
+    };
+    let response = ets.create_preset(&request);
+
+    assert!(response.is_ok());
+
+    let response = response.unwrap();
+
+    assert!(response.preset.is_some());
+
+    let preset = response.preset.unwrap();
+
+    assert_eq!(preset.container, Some("flac".to_owned()));
+    assert_eq!(preset.description, Some("This is an example FLAC preset".to_owned()));
+    assert_eq!(preset.name, Some(name));
+    assert!(preset.id.is_some());
+
+    let id = preset.id.unwrap();
+
+    info!("Created preset with id: {:?}", &id);
+
+    // Cleanup
+
+    let request = DeletePresetRequest {
+        id: id,
+    };
+    ets.delete_preset(&request).ok();
+}
+
+#[test]
+fn delete_preset() {
+    use rusoto::ets::{
+        AudioCodecOptions,
+        AudioParameters,
+        CreatePresetRequest,
+        DeletePresetRequest,
+    };
+
+    initialize();
+
+    let mut ets = create_ets_client();
+
+    let name = generate_unique_name("ets-preset-1");
+    let request = CreatePresetRequest {
+        audio: Some(AudioParameters {
+            channels: Some("2".to_owned()),
+            codec: Some("flac".to_owned()),
+            codec_options: Some(AudioCodecOptions {
+                bit_depth: Some("24".to_owned()),
+                ..AudioCodecOptions::default()
+            }),
+            sample_rate: Some("96000".to_owned()),
+            ..AudioParameters::default()
+        }),
+        container: "flac".to_owned(),
+        description: Some("This is an example FLAC preset".to_owned()),
+        name: name.clone(),
+        ..CreatePresetRequest::default()
+    };
+    let response = ets.create_preset(&request).unwrap();
+    let preset = response.preset.unwrap();
+    let id = preset.id.unwrap();
+
+    let request = DeletePresetRequest {
+        id: id.clone(),
+    };
+    let response = ets.delete_preset(&request);
+
+    assert!(response.is_ok());
+    info!("Deleted preset with id: {:?}", &id);
+}
+
+#[test]
+fn list_jobs_by_status() {
+    use rusoto::ets::ListJobsByStatusRequest;
+
+    initialize();
+
+    let mut ets = create_ets_client();
+
+    let status = "Submitted".to_owned();
+    let request = ListJobsByStatusRequest {
+        status: status.clone(),
+        ..ListJobsByStatusRequest::default()
+    };
+    let response = ets.list_jobs_by_status(&request);
+
+    assert!(response.is_ok());
+
+    let response = response.unwrap();
+
+    info!("Got list of jobs with status \"{}\": {:?}", &status, response.jobs);
+}
+
+#[test]
+fn list_pipelines() {
+    use rusoto::ets::ListPipelinesRequest;
+
+    initialize();
+
+    let mut ets = create_ets_client();
+
+    let request = ListPipelinesRequest::default();
+    let response = ets.list_pipelines(&request);
+
+    assert!(response.is_ok());
+
+    let response = response.unwrap();
+
+    info!("Got list of pipelines: {:?}", response.pipelines);
+}
+
+#[test]
+fn list_presets() {
+    use rusoto::ets::ListPresetsRequest;
+
+    initialize();
+
+    let mut ets = create_ets_client();
+
+    let request = ListPresetsRequest::default();
+    let response = ets.list_presets(&request);
+
+    assert!(response.is_ok());
+
+    let response = response.unwrap();
+
+    assert!(response.presets.is_some());
+
+    let presets = response.presets.unwrap();
+    info!("Got list of presets.");
+    for preset in presets.iter() {
+        info!("Preset: {:?}", preset.name);
+    }
+
+    let web_preset = presets.iter()
+        .filter(|x| x.id == Some(AWS_ETS_WEB_PRESET_ID.to_owned()))
+        .next();
+
+    assert!(web_preset.is_some());
+
+    let web_preset = web_preset.unwrap();
+
+    assert_eq!(web_preset.id, Some(AWS_ETS_WEB_PRESET_ID.to_owned()));
+    assert_eq!(web_preset.name, Some(AWS_ETS_WEB_PRESET_NAME.to_owned()));
+}
+
+#[test]
+fn read_preset() {
+    use rusoto::ets::ReadPresetRequest;
+
+    initialize();
+
+    let mut ets = create_ets_client();
+
+    let request = ReadPresetRequest {
+        id: AWS_ETS_WEB_PRESET_ID.to_owned(),
+    };
+    let response = ets.read_preset(&request);
+
+    assert!(response.is_ok());
+
+    let response = response.unwrap();
+
+    assert!(response.preset.is_some());
+
+    let preset = response.preset.unwrap();
+    info!("Got preset: {:?}", preset.name);
+
+    assert_eq!(preset.id, Some(AWS_ETS_WEB_PRESET_ID.to_owned()));
+    assert_eq!(preset.name, Some(AWS_ETS_WEB_PRESET_NAME.to_owned()));
+}


### PR DESCRIPTION
I'm interested in implementing Elastic Transcoder support (as I need it for a personal project), so I've begun a PR for it.

I'll post updates and questions here as I work on it.

# Current Status

* [x] Add `ets` feature to `Cargo.toml`
* [x] Generate `elastictranscoder` `Service` in `build.rs`
* [x] Implement `rest-json` generator
    * [x] Add `rest-json` generator
    * [x] Add `request_uri` format code generator function
    * [x] Add `querystring` format code generator function
    * [x] Manually verify it works for all `Ets` operations
        * [x] `cancel_job`
        * [x] `create_job`
        * [x] `create_pipeline`
        * [x] `create_preset`
        * [x] `delete_pipeline`
        * [x] `delete_preset`
        * [x] `list_jobs_by_pipeline`
        * [x] `list_jobs_by_status`
        * [x] `list_pipelines`
        * [x] `list_presets`
        * [x] `read_job`
        * [x] `read_pipeline`
        * [x] `read_preset`
        * [x] `test_role`
        * [x] `update_pipeline`
        * [x] `update_pipeline_notifications`
        * [x] `update_pipeline_status`
* [x] Add tests
    * `EtsClient`
        * generated functions
            * [ ] ~~`cancel_job`~~ (requires `IAM`)
            * [ ] ~~`create_job`~~ (requires `IAM`)
            * [ ] ~~`create_pipeline`~~ (requires `IAM`)
            * [x] `create_preset`
            * [ ] ~~`delete_pipeline`~~ (requires `IAM`)
            * [x] `delete_preset`
            * [ ] ~~`list_jobs_by_pipeline`~~ (requires `IAM`)
            * [x] `list_jobs_by_status` (could be improved)
                * once `create_job` is possible this should be modified to create a job then check for it in the list
            * [x] `list_pipelines` (could be improved)
                * once `create_pipeline` is possible this should be modified to create a pipeline then check for it in the list
            * [x] `list_presets`
            * [ ] ~~`read_job`~~ (requires `IAM`)
            * [ ] ~~`read_pipeline`~~ (requires `IAM`)
            * [x] `read_preset`
            * [ ] ~~`test_role`~~ (requires `IAM`)
            * [ ] ~~`update_pipeline`~~ (requires `IAM`)
            * [ ] ~~`update_pipeline_notifications`~~ (requires `IAM`)
            * [ ] ~~`update_pipeline_status`~~ (requires `IAM`)
        * extra tests
            * [x] `create_pipeline_without_arn`
* [ ] ~~Add documentation~~
* [x] Update `README.md`
    * [x] Add `ETS` to supported services list
* [ ] ~~Bump version~~
* [x] Squash commits
* [x] Rebase on master
* [ ] Update documentation on gh-pages

# Notes

* `HttpError`
    * `code` is now `Option<String>` because `HttpError`s for `Ecs` don't specify it
* `Metadata`
    * `service_abbreviation` is now `Option<String>` because `Ecs` doesn't specify it
* `generator`
    * `generate_protocol` now has a match statement to retrieve the `service_abbreviation` since it's now an `Option<String>`
* `HttpRequest`
    * `response_code` is a new field to accommodate the `responseCode` to expect, which is provided for certain `Ets` operations.

# Future PRs

* Improve error handling by expanding `AWSError` to support AWS error codes
* Add support for request retrying upon a "request throttled" response
* Add `IAM` support
* Add remaining `ETS` test cases (requires `IAM` support)

# Resources

* AWS
    * [Create Job - Amazon Elastic Transcoder][create-job]
    * [Read Job - Amazon Elastic Transcoder][read-job]
    * [Making HTTP Requests to Elastic Transcoder][making-http-requests]
    * [AWS CLI Reference - Elastic Transcoder][aws-ets-reference]
* botocore
    * [botocore - 2012-09-25/service-2.json][botocore-ets]
    * [botocore - serialize.py][botocore-serialize]

[aws-ets-reference]: http://docs.aws.amazon.com/cli/latest/reference/elastictranscoder/index.html
[botocore-ets]: https://github.com/boto/botocore/blob/develop/botocore/data/elastictranscoder/2012-09-25/service-2.json
[botocore-serialize]: https://github.com/boto/botocore/blob/master/botocore/serialize.py
[create-job]: http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-job.html
[making-http-requests]: http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/making-http-requests.html
[read-job]: http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/get-job.html