### PR TITLE
Update Syntex ependency to 0.31.0

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -27,4 +27,4 @@ serde = "0.7.0"
 serde_codegen = { version = "0.7.1", optional = true }
 serde_json = "0.7.0"
 serde_macros = { version = "0.7.0", optional = true }
-syntex = { version = "0.30.0", optional = true }
+syntex = { version = "0.31.0", optional = true }


### PR DESCRIPTION
Syntex updated their crate to 0.31.0.
This PR updates the `Cargo.toml` for `rusoto-codegen` to use this new version, which fixes compilation.