### PR TITLE
Update crate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,48 +1,47 @@
 [package]
-name = "rusoto"
-version = "0.12.1"
-authors = [
-  "Anthony DiMarco <ocramida@gmail.com>",
-  "Jimmy Cuadra <jimmy@jimmycuadra.com>",
-  "Matthew Mayer <matthewkmayer@gmail.com>",
-]
-license = "MIT"
-readme = "README.md"
-keywords = ["AWS", "Amazon"]
+authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>"]
+build = "build.rs"
 description = "AWS SDK for Rust"
-repository = "https://github.com/rusoto/rusoto"
 documentation = "http://rusoto.github.io/rusoto/rusoto/index.html"
 exclude = [".gitignore", ".travis.yml", "docgen.sh"]
-build = "build.rs"
+keywords = ["AWS", "Amazon"]
+license = "MIT"
+name = "rusoto"
+readme = "README.md"
+repository = "https://github.com/rusoto/rusoto"
+version = "0.12.1"
+
+[build-dependencies.rusoto_codegen]
+default-features = false
+path = "codegen"
+
+[dependencies]
+chrono = "0.2.21"
+hyper = "0.8.1"
+log = "0.3.6"
+openssl = "0.7.9"
+regex = "0.1.65"
+rustc-serialize = "0.3.19"
+serde = "0.7.0"
+serde_json = "0.7.0"
+time = "0.1.35"
+url = "0.5.9"
+xml-rs = "0.1.26"
+
+[dependencies.serde_macros]
+optional = true
+version = "0.7.2"
+
+[dev-dependencies]
+env_logger = "0.3.3"
 
 [features]
-default = ["with-syntex"]
-with-syntex = ["rusoto_codegen/with-syntex"]
-nightly = ["serde_macros", "rusoto_codegen/nightly"]
 all = ["dynamodb", "ecs", "kms", "s3", "sqs"]
+default = ["with-syntex"]
 dynamodb = []
 ecs = []
 kms = []
+nightly = ["serde_macros", "rusoto_codegen/nightly"]
 s3 = []
 sqs = []
-
-[build-dependencies.rusoto_codegen]
-path = "codegen"
-default-features = false
-
-[dependencies]
-serde = "0.7.0"
-serde_json = "0.7.0"
-xml-rs = "^0.1.26"
-time = "^0.1.34"
-openssl = "^0.7.7"
-hyper = "^0.7.2"
-url = "^0.2.37"
-rustc-serialize = "^0.3.18"
-regex = "^0.1.51"
-chrono = "^0.2.19"
-log = "^0.3.3"
-serde_macros = { version = "0.7.0", optional = true }
-
-[dev-dependencies]
-env_logger = "^0.3.2"
+with-syntex = ["rusoto_codegen/with-syntex"]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,30 +1,39 @@
 [package]
-name = "rusoto_codegen"
-version = "0.1.0"
-authors = [
-  "Anthony DiMarco <ocramida@gmail.com>",
-  "Jimmy Cuadra <jimmy@jimmycuadra.com>",
-  "Matthew Mayer <matthewkmayer@gmail.com>",
-]
+authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>"]
+build = "build.rs"
 description = "Code generation library for Rusoto."
 license = "MIT"
+name = "rusoto_codegen"
 repository = "https://github.com/rusoto/rusoto"
-build = "build.rs"
+version = "0.1.0"
 
-[features]
-default = ["with-syntex"]
-with-syntex = ["serde_codegen", "syntex"]
-nightly = ["serde_macros"]
+[build-dependencies.serde_codegen]
+optional = true
+version = "0.7.2"
 
-[build-dependencies]
-serde_codegen = { version = "0.7.0", optional = true }
-syntex = { version = "0.30.0", optional = true }
+[build-dependencies.syntex]
+optional = true
+version = "0.31.0"
 
 [dependencies]
 Inflector = "0.2.0"
-regex = "0.1.55"
+regex = "0.1.65"
 serde = "0.7.0"
-serde_codegen = { version = "0.7.1", optional = true }
 serde_json = "0.7.0"
-serde_macros = { version = "0.7.0", optional = true }
-syntex = { version = "0.31.0", optional = true }
+
+[dependencies.serde_codegen]
+optional = true
+version = "0.7.2"
+
+[dependencies.serde_macros]
+optional = true
+version = "0.7.2"
+
+[dependencies.syntex]
+optional = true
+version = "0.31.0"
+
+[features]
+default = ["with-syntex"]
+nightly = ["serde_macros"]
+with-syntex = ["serde_codegen", "syntex"]


### PR DESCRIPTION
* Updated all dependencies to the latest versions, expect xml-rs, which we're very behind on and will require some code updates to be compatible with the newest version. Hyper is now 0.8.x, which means downstream crates that use Rusoto currently have to build two versions of hyper if they're using 0.8.x.
* Updated the format of the Cargo.toml files via `cargo add`. Now we can use that to update dependencies. (`cargo install cargo-edit`, https://github.com/killercup/cargo-edit)