### PR TITLE
Add `clippy` Linting Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ecs = []
 ets = []
 kms = []
 nightly = ["serde_macros", "rusoto_codegen/nightly"]
+nightly-testing = ["clippy", "nightly"]
 s3 = []
 sqs = []
 with-syntex = ["rusoto_codegen/with-syntex"]
@@ -39,6 +40,10 @@ serde_json = "0.7.0"
 time = "0.1.35"
 url = "0.5.9"
 xml-rs = "0.1.26"
+
+[dependencies.clippy]
+optional = true
+version = "0.0.63"
 
 [dependencies.serde_macros]
 optional = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Rusoto
 
 [![Build Status](https://travis-ci.org/rusoto/rusoto.svg?branch=master)](https://travis-ci.org/rusoto/rusoto)
+[![Clippy Linting
+Result](https://clippy.bashy.io/github/rusoto/rusoto/master/badge.svg)](https://clippy.bashy.io/github/rusoto/rusoto/master/log)
 
 AWS SDK for Rust. [Documentation](https://rusoto.github.io/rusoto/rusoto/index.html).
 

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -22,6 +22,10 @@ regex = "0.1.65"
 serde = "0.7.0"
 serde_json = "0.7.0"
 
+[dependencies.clippy]
+optional = true
+version = "0.0.63"
+
 [dependencies.serde_codegen]
 optional = true
 version = "0.7.2"
@@ -37,4 +41,5 @@ version = "0.31.0"
 [features]
 default = ["with-syntex"]
 nightly = ["serde_macros"]
+nightly-testing = ["clippy", "nightly"]
 with-syntex = ["serde_codegen", "syntex"]

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "nightly", feature(const_fn, core_intrinsics))]
 #![cfg_attr(feature = "serde_macros", feature(custom_derive, plugin))]
 #![cfg_attr(feature = "serde_macros", plugin(serde_macros))]
+#![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 
 extern crate inflector;
 #[macro_use] extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![crate_type = "lib"]
 #![cfg_attr(feature = "nightly", feature(custom_derive, plugin))]
 #![cfg_attr(feature = "nightly", plugin(serde_macros))]
+#![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 #![allow(dead_code)]
 
 //! Rusoto is an [AWS](https://aws.amazon.com/) SDK for Rust.


### PR DESCRIPTION
# Rationale

[`rust-clippy`](https://github.com/Manishearth/rust-clippy) by Manishearth is a very useful tool for automated linting of Rust projects.
It detects and warns the developer about many different classes of error and un-idiomatic code, automatically.

This is a very useful tool for maintaining an idiomatic rust codebase and I find that it highlights any areas in the codebase which might need some improvement.

The `nightly-testing` feature is off by default, and is only intended to be using during development (i.e. not in regular rusoto usage).

# Changes

Add `clippy` as an optional dependency to `Cargo.toml` for `rusoto-codegen`.
Add `clippy` as an optional dependency to `Cargo.toml` for `rusoto`.

Add a `nightly-testing` feature to enable `clippy` linting.