### PR TITLE
Disable `unused_attributes` Warning Selectively

### DIFF
--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -173,6 +173,7 @@ fn generate_struct_fields(service: &Service, shape: &Shape) -> String {
             lines.push(format!("#[doc=\"{}\"]", docs.replace("\"", "\\\"")));
         }
 
+        lines.push("#[allow(unused_attributes)]".to_owned());
         lines.push(format!("#[serde(rename=\"{}\")]", member_name));
 
         if let Some(shape_type) = service.shape_type_for_member(member) {


### PR DESCRIPTION
# Problem

Currently, generated files will lose their `#[derive(Deserialize)]` line, which causes rust to incorrectly determine that lines with `#[serde(rename="...")]` are unused, throwing the warning.

A more in-depth explanation of the issue can be found [here](http://stackoverflow.com/questions/33925368/how-can-i-disable-the-unused-attribute-warning-when-using-serde-library).

# PR

Until this issue is corrected upstream, this commit disables the `unused_attributes` warning exclusively on the offending lines.

# Notes

This occurs when compiling on nightly with `serde_macros` enabled.
For example:

```sh
cargo build --no-default-features --features "all nightly"
```