### PR TITLE
Remove `clippy` Badge from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Rusoto
 
 [![Build Status](https://travis-ci.org/rusoto/rusoto.svg?branch=master)](https://travis-ci.org/rusoto/rusoto)
-[![Clippy Linting
-Result](https://clippy.bashy.io/github/rusoto/rusoto/master/badge.svg)](https://clippy.bashy.io/github/rusoto/rusoto/master/log)
 
 AWS SDK for Rust. [Documentation](https://rusoto.github.io/rusoto/rusoto/index.html).
 


### PR DESCRIPTION
Remove `clippy` badge from `README.md`. The badge is being removed because it is currently broken for projects like Rusoto which have submodule dependencies, but also because the `clippy` badge does not provide sufficient value to justify a place in the `README.md`.