### PR TITLE
Replace All Tabs with Spaces in Source Files

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,11 +38,11 @@ pub fn parse_json_protocol_error(body: &str) -> AwsError {
 
 impl AwsError {
     /// Create a new error with the given message.
-	pub fn new<S>(message: S) -> AwsError where S: Into<String> {
-		AwsError {
+    pub fn new<S>(message: S) -> AwsError where S: Into<String> {
+        AwsError {
             message: message.into(),
         }
-	}
+    }
 }
 
 impl Error for AwsError {

--- a/src/xmlutil.rs
+++ b/src/xmlutil.rs
@@ -17,9 +17,9 @@ use xml::reader::events::*;
 pub struct XmlParseError(pub String);
 
 impl XmlParseError {
-	pub fn new(msg: &str) -> XmlParseError {
-		XmlParseError(msg.to_string())
-	}
+    pub fn new(msg: &str) -> XmlParseError {
+        XmlParseError(msg.to_string())
+    }
 }
 
 /// syntactic sugar for the XML event stack we pass around
@@ -32,32 +32,32 @@ pub trait Peek {
 
 /// Move to the next part of the XML stack
 pub trait Next {
-	fn next(&mut self) -> Option<XmlEvent>;
+    fn next(&mut self) -> Option<XmlEvent>;
 }
 
 /// Wraps the Hyper Response type
 pub struct XmlResponseFromAws<'b> {
-	xml_stack: Peekable<Events<'b, Response>> // refactor to use XmlStack type?
+    xml_stack: Peekable<Events<'b, Response>> // refactor to use XmlStack type?
 }
 
 impl <'b>XmlResponseFromAws<'b> {
-	pub fn new(stack: Peekable<Events<'b, Response>>) -> XmlResponseFromAws {
-		XmlResponseFromAws {
-			xml_stack: stack,
-		}
-	}
+    pub fn new(stack: Peekable<Events<'b, Response>>) -> XmlResponseFromAws {
+        XmlResponseFromAws {
+            xml_stack: stack,
+        }
+    }
 }
 
 impl <'b>Peek for XmlResponseFromAws<'b> {
-	fn peek(&mut self) -> Option<&XmlEvent> {
-		self.xml_stack.peek()
-	}
+    fn peek(&mut self) -> Option<&XmlEvent> {
+        self.xml_stack.peek()
+    }
 }
 
 impl <'b> Next for XmlResponseFromAws<'b> {
-	fn next(&mut self) -> Option<XmlEvent> {
-		self.xml_stack.next()
-	}
+    fn next(&mut self) -> Option<XmlEvent> {
+        self.xml_stack.next()
+    }
 }
 
 impl From<ParseIntError> for XmlParseError{
@@ -66,188 +66,188 @@ impl From<ParseIntError> for XmlParseError{
 
 /// Testing helper, reads from file
 pub struct XmlResponseFromFile<'a> {
-	xml_stack: Peekable<Events<'a, BufReader<File>>>,
+    xml_stack: Peekable<Events<'a, BufReader<File>>>,
 }
 
 impl <'a>XmlResponseFromFile<'a> {
-	pub fn new(my_stack: Peekable<Events<'a, BufReader<File>>>) -> XmlResponseFromFile {
-		XmlResponseFromFile { xml_stack: my_stack }
-	}
+    pub fn new(my_stack: Peekable<Events<'a, BufReader<File>>>) -> XmlResponseFromFile {
+        XmlResponseFromFile { xml_stack: my_stack }
+    }
 }
 
 // Need peek and next implemented.
 impl <'b> Peek for XmlResponseFromFile <'b> {
-	fn peek(&mut self) -> Option<&XmlEvent> {
-		self.xml_stack.peek()
-	}
+    fn peek(&mut self) -> Option<&XmlEvent> {
+        self.xml_stack.peek()
+    }
 }
 
 impl <'b> Next for XmlResponseFromFile <'b> {
-	fn next(&mut self) -> Option<XmlEvent> {
-		self.xml_stack.next()
-	}
+    fn next(&mut self) -> Option<XmlEvent> {
+        self.xml_stack.next()
+    }
 }
 // /testing helper
 
 /// parse Some(String) if the next tag has the right name, otherwise None
 pub fn optional_string_field<T: Peek + Next>(field_name: &str, stack: &mut T) -> Result<Option<String>, XmlParseError> {
-	if try!(peek_at_name(stack)) == field_name {
-		let val = try!(string_field(field_name, stack));
-		Ok(Some(val))
-	} else {
-		Ok(None)
-	}
+    if try!(peek_at_name(stack)) == field_name {
+        let val = try!(string_field(field_name, stack));
+        Ok(Some(val))
+    } else {
+        Ok(None)
+    }
 }
 
 /// return a string field with the right name or throw a parse error
 pub fn string_field<T: Peek + Next>(name: &str, stack: &mut T) -> Result<String, XmlParseError> {
-	try!(start_element(name, stack));
-	let value = try!(characters(stack));
-	try!(end_element(name, stack));
-	Ok(value)
+    try!(start_element(name, stack));
+    let value = try!(characters(stack));
+    try!(end_element(name, stack));
+    Ok(value)
 }
 
 /// return some XML Characters
 pub fn characters<T: Peek + Next>(stack: &mut T) -> Result<String, XmlParseError> {
-	if let Some(XmlEvent::Characters(data)) = stack.next() {
-		Ok(data.to_string())
-	} else {
-		Err(XmlParseError::new("Expected characters"))
-	}
+    if let Some(XmlEvent::Characters(data)) = stack.next() {
+        Ok(data.to_string())
+    } else {
+        Err(XmlParseError::new("Expected characters"))
+    }
 }
 
 /// get the name of the current element in the stack.  throw a parse error if it's not a `StartElement`
 pub fn peek_at_name<T: Peek + Next>(stack: &mut T) -> Result<String, XmlParseError> {
-	let current = stack.peek();
-	if let Some(&XmlEvent::StartElement{ref name, ..}) = current {
-		Ok(name.local_name.to_string())
-	} else {
-		Ok("".to_string())
-	}
+    let current = stack.peek();
+    if let Some(&XmlEvent::StartElement{ref name, ..}) = current {
+        Ok(name.local_name.to_string())
+    } else {
+        Ok("".to_string())
+    }
 }
 
 /// consume a `StartElement` with a specific name or throw an `XmlParseError`
 pub fn start_element<T: Peek + Next>(element_name: &str, stack: &mut T)  -> Result<HashMap<String, String>, XmlParseError> {
-	let next = stack.next();
-	if let Some(XmlEvent::StartElement { name, attributes, .. }) = next {
-		if name.local_name == element_name {
-			let mut attr_map = HashMap::new();
-			for attr in attributes {
-				attr_map.insert(attr.name.local_name, attr.value);
-			}
-			Ok(attr_map)
-		} else {
-			Err(XmlParseError::new(&format!("Expected {} got {}", element_name, name.local_name)))
-		}
-	} else {
-		Err(XmlParseError::new(&format!("Expected StartElement {}", element_name)))
-	}
+    let next = stack.next();
+    if let Some(XmlEvent::StartElement { name, attributes, .. }) = next {
+        if name.local_name == element_name {
+            let mut attr_map = HashMap::new();
+            for attr in attributes {
+                attr_map.insert(attr.name.local_name, attr.value);
+            }
+            Ok(attr_map)
+        } else {
+            Err(XmlParseError::new(&format!("Expected {} got {}", element_name, name.local_name)))
+        }
+    } else {
+        Err(XmlParseError::new(&format!("Expected StartElement {}", element_name)))
+    }
 }
 
 /// consume an `EndElement` with a specific name or throw an `XmlParseError`
 pub fn end_element<T: Peek + Next>(element_name: &str, stack: &mut T)  -> Result<(), XmlParseError> {
-	let next = stack.next();
-	if let Some(XmlEvent::EndElement { name, .. }) = next {
-		if name.local_name == element_name {
-			Ok(())
-		} else {
-			Err(XmlParseError::new(&format!("Expected {} got {}", element_name, name.local_name)))
-		}
-	}else {
-		Err(XmlParseError::new(&format!("Expected EndElement {} got {:?}", element_name, next)))
-	}
+    let next = stack.next();
+    if let Some(XmlEvent::EndElement { name, .. }) = next {
+        if name.local_name == element_name {
+            Ok(())
+        } else {
+            Err(XmlParseError::new(&format!("Expected {} got {}", element_name, name.local_name)))
+        }
+    }else {
+        Err(XmlParseError::new(&format!("Expected EndElement {} got {:?}", element_name, next)))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-	use xml::reader::*;
-	use std::io::BufReader;
-	use std::fs::File;
+    use xml::reader::*;
+    use std::io::BufReader;
+    use std::fs::File;
 
-	#[test]
-	fn peek_at_name_happy_path() {
-	    let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
-	    let file = BufReader::new(file);
-	    let mut my_parser  = EventReader::new(file);
-	    let my_stack = my_parser.events().peekable();
-	    let mut reader = XmlResponseFromFile::new(my_stack);
+    #[test]
+    fn peek_at_name_happy_path() {
+        let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
+        let file = BufReader::new(file);
+        let mut my_parser  = EventReader::new(file);
+        let my_stack = my_parser.events().peekable();
+        let mut reader = XmlResponseFromFile::new(my_stack);
 
-	    loop {
-	        reader.next();
-	        match peek_at_name(&mut reader) {
-	            Ok(data) => {
-	                // println!("Got {}", data);
-	                if data == "QueueUrl" {
-	                    return;
-	                }
-	            }
-	            Err(_) => panic!("Couldn't peek at name")
-	        }
-	    }
-	}
+        loop {
+            reader.next();
+            match peek_at_name(&mut reader) {
+                Ok(data) => {
+                    // println!("Got {}", data);
+                    if data == "QueueUrl" {
+                        return;
+                    }
+                }
+                Err(_) => panic!("Couldn't peek at name")
+            }
+        }
+    }
 
-	#[test]
-	fn start_element_happy_path() {
-	    let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
-	    let file = BufReader::new(file);
-	    let mut my_parser  = EventReader::new(file);
-	    let my_stack = my_parser.events().peekable();
-	    let mut reader = XmlResponseFromFile::new(my_stack);
+    #[test]
+    fn start_element_happy_path() {
+        let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
+        let file = BufReader::new(file);
+        let mut my_parser  = EventReader::new(file);
+        let my_stack = my_parser.events().peekable();
+        let mut reader = XmlResponseFromFile::new(my_stack);
 
-	    // skip two leading fields since we ignore them (xml declaration, return type declaration)
-	    reader.next();
-	    reader.next();
+        // skip two leading fields since we ignore them (xml declaration, return type declaration)
+        reader.next();
+        reader.next();
 
-	    match start_element("ListQueuesResult", &mut reader) {
-	        Ok(_) => (),
-	        Err(_) => panic!("Couldn't find start element")
-	    }
-	}
+        match start_element("ListQueuesResult", &mut reader) {
+            Ok(_) => (),
+            Err(_) => panic!("Couldn't find start element")
+        }
+    }
 
-	#[test]
-	fn string_field_happy_path() {
-	    let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
-	    let file = BufReader::new(file);
-	    let mut my_parser  = EventReader::new(file);
-	    let my_stack = my_parser.events().peekable();
-	    let mut reader = XmlResponseFromFile::new(my_stack);
+    #[test]
+    fn string_field_happy_path() {
+        let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
+        let file = BufReader::new(file);
+        let mut my_parser  = EventReader::new(file);
+        let my_stack = my_parser.events().peekable();
+        let mut reader = XmlResponseFromFile::new(my_stack);
 
-	    // skip two leading fields since we ignore them (xml declaration, return type declaration)
-	    reader.next();
-	    reader.next();
+        // skip two leading fields since we ignore them (xml declaration, return type declaration)
+        reader.next();
+        reader.next();
 
-	    reader.next(); // reader now at ListQueuesResult
+        reader.next(); // reader now at ListQueuesResult
 
-	    // now we're set up to use string:
-	    let my_chars = string_field("QueueUrl", &mut reader).unwrap();
-		assert_eq!(my_chars, "https://sqs.us-east-1.amazonaws.com/347452556413/testqueue")
-	}
+        // now we're set up to use string:
+        let my_chars = string_field("QueueUrl", &mut reader).unwrap();
+        assert_eq!(my_chars, "https://sqs.us-east-1.amazonaws.com/347452556413/testqueue")
+    }
 
-	#[test]
-	fn end_element_happy_path() {
-	    let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
-	    let file = BufReader::new(file);
-	    let mut my_parser  = EventReader::new(file);
-	    let my_stack = my_parser.events().peekable();
-	    let mut reader = XmlResponseFromFile::new(my_stack);
+    #[test]
+    fn end_element_happy_path() {
+        let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
+        let file = BufReader::new(file);
+        let mut my_parser  = EventReader::new(file);
+        let my_stack = my_parser.events().peekable();
+        let mut reader = XmlResponseFromFile::new(my_stack);
 
-	    // skip two leading fields since we ignore them (xml declaration, return type declaration)
-	    reader.next();
-	    reader.next();
+        // skip two leading fields since we ignore them (xml declaration, return type declaration)
+        reader.next();
+        reader.next();
 
 
-	    // TODO: this is fragile and not good: do some looping to find end element?
-	    // But need to do it without being dependent on peek_at_name.
-	    reader.next();
-	    reader.next();
-	    reader.next();
-	    reader.next();
+        // TODO: this is fragile and not good: do some looping to find end element?
+        // But need to do it without being dependent on peek_at_name.
+        reader.next();
+        reader.next();
+        reader.next();
+        reader.next();
 
-	    match end_element("ListQueuesResult", &mut reader) {
-	        Ok(_) => (),
-	        Err(_) => panic!("Couldn't find end element")
-	    }
-	}
+        match end_element("ListQueuesResult", &mut reader) {
+            Ok(_) => (),
+            Err(_) => panic!("Couldn't find end element")
+        }
+    }
 
 }


### PR DESCRIPTION
This replaces all instances of tabbed spacing in the source files with 4 regular
spaces.

Performed by running: `find . -name '*.rs' ! -type d -exec bash -c 'expand -t 4 "$0" > /tmp/e && mv /tmp/e "$0"' {} \;` on the code, as per [this](http://stackoverflow.com/questions/11094383/how-can-i-convert-tabs-to-spaces-in-every-file-of-a-directory) SO answer.

This PR is intended to help with #188, at least until an agreeable `rustfmt.toml` is implemented.