### PR TITLE
supports cn-north-1 region

### DIFF
--- a/src/region.rs
+++ b/src/region.rs
@@ -20,6 +20,7 @@ pub enum Region {
     UsEast1,
     UsWest1,
     UsWest2,
+    CnNorth1,
 }
 
 /// An error produced when attempting to convert a `str` into a `Region` fails.
@@ -40,6 +41,7 @@ impl Display for Region {
             Region::UsEast1 => "us-east-1",
             Region::UsWest1 => "us-west-1",
             Region::UsWest2 => "us-west-2",
+            Region::CnNorth1 => "cn-north-1",
         };
 
         write!(f, "{}", region_str)
@@ -60,6 +62,7 @@ impl FromStr for Region {
             "us-east-1" => Ok(Region::UsEast1),
             "us-west-1" => Ok(Region::UsWest1),
             "us-west-2" => Ok(Region::UsWest2),
+            "cn-north-1" => Ok(Region::CnNorth1),
             s => Err(ParseRegionError::new(s))
         }
     }
@@ -106,6 +109,7 @@ mod tests {
         assert_eq!("us-east-1".parse(), Ok(Region::UsEast1));
         assert_eq!("us-west-1".parse(), Ok(Region::UsWest1));
         assert_eq!("us-west-2".parse(), Ok(Region::UsWest2));
+        assert_eq!("cn-north-1".parse(), Ok(Region::CnNorth1));
     }
 
     #[test]
@@ -119,5 +123,6 @@ mod tests {
         assert_eq!(Region::UsEast1.to_string(), "us-east-1".to_owned());
         assert_eq!(Region::UsWest1.to_string(), "us-west-1".to_owned());
         assert_eq!(Region::UsWest2.to_string(), "us-west-2".to_owned());
+        assert_eq!(Region::CnNorth1.to_string(), "cn-north-1".to_owned());
     }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -11182,7 +11182,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
 
         request.set_payload(input.body);
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         if let Some(ref md5) = input.content_md5 {
@@ -11243,7 +11243,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
             request.add_header("Content-MD5", &md5);
         }
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
         request.set_payload(input.body);
 
@@ -11497,7 +11497,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         // let mut request = SignedRequest::new("DELETE", "s3", self.region, &uri);
         // let mut params = Params::new();
         //
-        // let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        // let hostname = self.hostname(Some(&input.bucket));
         // request.set_hostname(Some(hostname));
         //
         // params.put("Action", "DeleteObjects");
@@ -11707,7 +11707,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let region = Region::UsEast1;
         let mut create_config : Vec<u8>;
         let mut request = SignedRequest::new("PUT", "s3", region, "");
-        let hostname = format!("{}.s3.amazonaws.com", input.bucket);
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         if needs_create_bucket_config(self.region) {
@@ -11746,7 +11746,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("uploadId", &input.upload_id.to_string());
         request.set_params(params);
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         request.set_payload(input.multipart_upload);
@@ -11800,7 +11800,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("uploads", "");
         request.set_params(params);
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
@@ -11822,7 +11822,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
     pub fn delete_bucket(&mut self, input: &DeleteBucketRequest, region: Region) -> Result<(), AwsError> {
         let mut request = SignedRequest::new("DELETE", "s3", region, "");
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
@@ -11933,7 +11933,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let mut request = SignedRequest::new("GET", "s3", self.region, &uri);
         let mut params = Params::new();
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         params.put("Action", "GetObject");
@@ -12007,7 +12007,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("uploads", "");
         request.set_params(params);
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
@@ -12096,7 +12096,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("uploadId", &input.upload_id.to_string());
         request.set_params(params);
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
@@ -12221,7 +12221,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("uploadId", &input.upload_id.to_string());
         request.set_params(params);
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
@@ -12291,7 +12291,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let mut request = SignedRequest::new("DELETE", "s3", self.region, &uri);
         let mut params = Params::new();
 
-        let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
+        let hostname = self.hostname(Some(&input.bucket));
         request.set_hostname(Some(hostname));
 
         params.put("Action", "DeleteObject");
@@ -12345,6 +12345,19 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
                 Ok(try!(GetBucketReplicationOutputParser::parse_xml("GetBucketReplicationOutput", &mut stack)))
             }
             _ => { Err(AwsError::new("error")) }
+        }
+    }
+
+    fn hostname(&self, bucket: Option<&BucketName>) -> String {
+        let host = match self.region {
+                    Region::UsEast1 => "s3.amazonaws.com".to_string(),
+                    Region::CnNorth1 => format!("s3.{}.amazonaws.com.cn", self.region),
+                    _ => format!("s3-{}.amazonaws.com", self.region),
+                };
+
+        match bucket {
+            Some(b) => format!("{}.s3.amazonaws.com", b),
+            None => host,
         }
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -351,14 +351,25 @@ fn to_hexdigest_from_bytes(val: &[u8]) -> String {
 fn build_hostname(service: &str, region: Region) -> String {
     //iam has only 1 endpoint, other services have region-based endpoints
     match service {
-        "iam" => format!("{}.amazonaws.com", service),
+        "iam" => {
+                match region {
+                    Region::CnNorth1 => format!("{}.{}.amazonaws.com.cn", service, region),
+                    _ => format!("{}.amazonaws.com", service),
+                }
+            }
         "s3" => {
                 match region {
                     Region::UsEast1 => "s3.amazonaws.com".to_string(),
+                    Region::CnNorth1 => format!("s3.{}.amazonaws.com.cn", region),
                     _ => format!("s3-{}.amazonaws.com", region),
                 }
             }
-        _ => format!("{}.{}.amazonaws.com", service, region)
+        _ => {
+                match region {
+                    Region::CnNorth1 => format!("{}.{}.amazonaws.com.cn", service, region),
+                    _ => format!("{}.{}.amazonaws.com", service, region),
+                }
+            }
     }
 }
 


### PR DESCRIPTION
This change is trying to support China "cn-north-1" region.  I have tested my change to access s3 within both CnNorth1 and UsEast1 regions.
A better way is codegen based on "botocore/botocore/data/endpoints.json" but it's need big change.