### PR TITLE
Fix `lazy_static` Usage

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(const_fn, core_intrinsics))]
+#![cfg_attr(feature = "nightly", feature(const_fn, core_intrinsics, drop_types_in_const))]
 #![cfg_attr(feature = "serde_macros", feature(custom_derive, plugin))]
 #![cfg_attr(feature = "serde_macros", plugin(serde_macros))]
 #![cfg_attr(feature = "nightly-testing", plugin(clippy))]


### PR DESCRIPTION
# Issue

Due to [RFC 1440][rfc-1440], having types with destructors being used in static items and in const functions requires enabling the `drop_types_in_const` feature on nightly.

Since we use the `lazy_static!` macro to [lazily create a static Regex][codegen-regex], and `lazy_static` uses [`UnsafeCell` internally][lazy_static-unsafe-cell], then as of [rust-lang/rust/pull/33130][rust-pr-33130], this change affects us. In the latest nightly versions, we require the `drop_types_in_const` feature to be enabled in order to compile.

# Solution

This PR enables the `drop_types_in_const` feature on nightly builds.

# Resources

* [rust-lang/rust/issues/30667 - UnsafeCell allows types with destructors to end up in statics.][rust-issue-30667]
* [rust-lang/rust/issues/33156 - permit `Drop` types in statics (tracking issue for RFC #1440)][rust-issue-33156]
* [rust-lang/rust/pull/33130 - Implement constant support in MIR.][rust-pr-33130]
* [rust-lang/rfcs/pull/1140 - RFC - Allow Drop types in statics/const functions][rfc-1440-pr]
* [rust-lang/rfcs - RFC 1440][rfc-1440]

[codegen-regex]: https://github.com/rusoto/rusoto/blob/4878335df0963f0dc4ae807f0bfe5a83cc9f729e/codegen/src/generator/rest_json.rs#L127-L129
[lazy_static-unsafe-cell]: https://github.com/rust-lang-nursery/lazy-static.rs/blob/2005102f0684728567b6e7922ca843f06544c427/src/nightly_lazy.rs#L7
[rfc-1440]: https://github.com/rust-lang/rfcs/blob/82a969b5e0f8d6e75a4d581b06ddb6ddd9c5dee7/text/1440-drop-types-in-const.md
[rfc-1440-pr]: https://github.com/rust-lang/rfcs/pull/1440
[rust-pr-33130]: https://github.com/rust-lang/rust/pull/33130
[rust-issue-30667]: https://github.com/rust-lang/rust/issues/30667
[rust-issue-33156]: https://github.com/rust-lang/rust/issues/33156