### PR TITLE
create a shared hyper client for each AWS service instance

### DIFF
--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -18,7 +18,7 @@ impl GenerateProtocol for JsonGenerator {
                     request.set_content_type(\"application/x-amz-json-{json_version}\".to_owned());
                     request.add_header(\"x-amz-target\", \"{target_prefix}.{name}\");
                     request.set_payload(Some(encoded.as_bytes()));
-                    let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
+                    let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()), &self.client);
                     let status = result.status.to_u16();
                     let mut body = String::new();
                     result.read_to_string(&mut body).unwrap();

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -34,7 +34,9 @@ pub fn generate_source(service: &Service) -> String {
 
 fn generate<P>(service: &Service, protocol_generator: P) -> String where P: GenerateProtocol {
     format!(
-        "{prelude}
+        "
+        use hyper::client::{{Client, RedirectPolicy}};
+        {prelude}
 
         {types}
 
@@ -52,13 +54,17 @@ where P: GenerateProtocol {
         pub struct {type_name}<P> where P: ProvideAwsCredentials {{
             credentials_provider: P,
             region: Region,
+            client: Client
         }}
 
         impl<P> {type_name}<P> where P: ProvideAwsCredentials {{
             pub fn new(credentials_provider: P, region: Region) -> Self {{
+                let mut client = Client::new();
+                client.set_redirect_policy(RedirectPolicy::FollowNone);
                 {type_name} {{
                     credentials_provider: credentials_provider,
                     region: region,
+                    client: client
                 }}
             }}
 

--- a/codegen/src/generator/query.rs
+++ b/codegen/src/generator/query.rs
@@ -24,7 +24,7 @@ impl GenerateProtocol for QueryGenerator {
 
     request.set_params(params);
 
-    let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
+    let result = request.sign_and_execute(try!(self.credentials_provider.credentials()), &self.client);
     let status = result.status.to_u16();
     let mut reader = EventReader::new(result);
     let mut stack = XmlResponseFromAws::new(reader.events().peekable());

--- a/codegen/src/generator/rest_json.rs
+++ b/codegen/src/generator/rest_json.rs
@@ -47,7 +47,7 @@ impl GenerateProtocol for RestJsonGenerator {
                     {load_payload}
                     {load_params}
 
-                    let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
+                    let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()), &self.client);
                     let status = result.status.to_u16();
                     let mut body = String::new();
                     result.read_to_string(&mut body).unwrap();

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,14 +6,13 @@ use std::io::Read;
 
 use hyper::Client;
 use hyper::client::Response;
-use hyper::client::RedirectPolicy;
 use hyper::header::Headers;
 use hyper::method::Method;
 use signature::SignedRequest;
 use log::LogLevel::Debug;
 
 /// Takes a fully formed and signed request and executes it.
-pub fn send_request(signed_request: &SignedRequest) -> Response {
+pub fn send_request(signed_request: &SignedRequest, client: &Client) -> Response {
     let hyper_method = match signed_request.method().as_ref() {
         "POST" => Method::Post,
         "PUT" => Method::Put,
@@ -49,9 +48,6 @@ pub fn send_request(signed_request: &SignedRequest) -> Response {
             debug!("{}:{}", h.name(), h.value_string());
         }
     }
-
-    let mut client = Client::new();
-    client.set_redirect_policy(RedirectPolicy::FollowNone);
 
     match signed_request.payload() {
         None => client.request(hyper_method, &final_uri).headers(hyper_headers).body("").send().unwrap(),

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::str;
 
-use hyper::client::Response;
+use hyper::client::{Client, Response};
 use hyper::status::StatusCode;
 use openssl::crypto::hash::Type::SHA256;
 use openssl::crypto::hash::hash;
@@ -140,7 +140,7 @@ impl <'a> SignedRequest <'a> {
     /// Calculate the signature from the credentials provided and the request data
     /// Add the calculated signature to the request headers and execute it
     /// Return the hyper HTTP response
-    pub fn sign_and_execute(&mut self, creds: &AwsCredentials) -> Response {
+    pub fn sign_and_execute(&mut self, creds: &AwsCredentials, client: &Client) -> Response {
         debug!("Creating request to send to AWS.");
         let hostname = match self.hostname {
             Some(ref h) => h.to_string(),
@@ -221,7 +221,7 @@ impl <'a> SignedRequest <'a> {
         self.remove_header("authorization");
         self.add_header("authorization", &auth_header);
 
-        let response = send_request(&self);
+        let response = send_request(&self, client);
         debug!("Sent request to AWS");
 
         if response.status == HTTP_TEMPORARY_REDIRECT {
@@ -231,7 +231,7 @@ impl <'a> SignedRequest <'a> {
             self.set_hostname(Some(new_hostname.to_string()));
 
             // This does a lot of appending and not clearing/creation, so we'll have to do that ourselves:
-            return self.sign_and_execute(creds);
+            return self.sign_and_execute(creds, client);
         }
 
         response


### PR DESCRIPTION
The hyper client implements connection pooling for us behind the scenes, so creating a new `hyper::client::Client` for every single HTTP request is inefficient.

A client-per-service seems reasonable, and makes it easy to maintain existing `FooClient::new()` signatures by having `new()` create the hyper client instead of taking some kind of globally shared client as an argument.

Fixes #173 