### PR TITLE
Run codegen only when necessary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,4 +20,6 @@ fn main() {
     for service in services {
         generate(service, out_path);
     }
+
+    println!("cargo:rerun-if-changed=codegen");
 }


### PR DESCRIPTION
This 1-line PR causes the rusoto build script to output `cargo:rerun-if-changed=codegen`, which tells cargo that the build script only needs to be rerun if something in the codegen directory changed, which is the only time that codegen actually needs to be rerun.  The generated code is entirely a function of the contents of that directory.

As things stood, the build script ran every single time any `cargo build` or `cargo test` was run, which dirtied the entire build and caused the whole crate to be recompiled every single time, even if literally nothing had changed.

The code that's generated by the build script (and lives under something like `target/debug/build/rusoto-002a4bb2634057d2/out/`) is still recompiled if something relevant in `src/` is modified, like you'd expect.  So, for example, if codegen has been run for dynamodb, and you modify `src/dynamodb.rs` (or anything else in its dependency tree like `src/credential.rs`), the generated code will be recompiled as a result of that change, but it won't be regenerated first because it doesn't need to be.

The practical upshot of this change is that it's now possible to make minor changes to tests and a few other things without waiting 30 seconds for the entire crate to regenerate and recompile each time.  

It also makes it possible to test out manual changes to the generated code to see if they'd have the desired effect.  e.g., you could make a manual tweak to `target/debug/build/rusoto-002a4bb2634057d2/out/dynamodb.rs` and run `cargo test --features dynamodb` to test the change before making it in the codegen itself, which saves rather a lot of time.