### PR TITLE
Fixed Serde errors

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -20,7 +20,7 @@ Inflector = "0.2.0"
 lazy_static = "0.1.16"
 regex = "0.1.65"
 serde = "0.7.9"
-serde_json = "0.7.9"
+serde_json = "0.7.1"
 
 [dependencies.clippy]
 optional = true

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -19,8 +19,8 @@ version = "0.32.0"
 Inflector = "0.2.0"
 lazy_static = "0.1.16"
 regex = "0.1.65"
-serde = "0.7.6"
-serde_json = "0.7.0"
+serde = "0.7.9"
+serde_json = "0.7.9"
 
 [dependencies.clippy]
 optional = true
@@ -28,11 +28,11 @@ version = "0.0"
 
 [dependencies.serde_codegen]
 optional = true
-version = "0.7.6"
+version = "0.7.9"
 
 [dependencies.serde_macros]
 optional = true
-version = "0.7.5"
+version = "0.7.9"
 
 [dependencies.syntex]
 optional = true

--- a/codegen/build.rs
+++ b/codegen/build.rs
@@ -12,13 +12,9 @@ mod inner {
         let src = Path::new("src/botocore.in.rs");
         let dst = Path::new(&out_dir).join("botocore.rs");
 
-        let mut registry = syntex::Registry::new();
-
-        serde_codegen::register(&mut registry);
-        registry.expand("", &src, &dst).unwrap();
+        serde_codegen::expand(&src, &dst).unwrap();
     }
 }
-
 #[cfg(feature = "serde_macros")]
 mod inner {
     pub fn main() {}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -5,7 +5,8 @@
 #![cfg_attr(not(feature = "nightly"), deny(warnings))]
 
 extern crate inflector;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
 extern crate regex;
 extern crate serde;
 extern crate serde_json;
@@ -33,10 +34,12 @@ pub struct Service {
 }
 
 impl Service {
-    pub fn new<S>(name: S, protocol_date: S) -> Self where S: Into<String> {
+    pub fn new<S>(name: S, protocol_date: S) -> Self
+        where S: Into<String>
+    {
         Service {
             name: name.into(),
-            protocol_date: protocol_date.into()
+            protocol_date: protocol_date.into(),
         }
     }
 }
@@ -44,12 +47,13 @@ impl Service {
 pub fn generate(service: Service, output_path: &Path) {
     let botocore_destination_path = output_path.join(format!("{}_botocore.rs", service.name));
     let serde_destination_path = output_path.join(format!("{}.rs", service.name));
-    let botocore_service_data_path = Path::new(BOTOCORE_DIR).join(
-        format!("{}/{}/service-2.json", service.name, service.protocol_date)
-    );
+    let botocore_service_data_path = Path::new(BOTOCORE_DIR)
+        .join(format!("{}/{}/service-2.json", service.name, service.protocol_date));
 
-    botocore_generate(botocore_service_data_path.as_path(), botocore_destination_path.as_path());
-    serde_generate(botocore_destination_path.as_path(), serde_destination_path.as_path());
+    botocore_generate(botocore_service_data_path.as_path(),
+                      botocore_destination_path.as_path());
+    serde_generate(botocore_destination_path.as_path(),
+                   serde_destination_path.as_path());
 }
 
 fn botocore_generate(input_path: &Path, output_path: &Path) {
@@ -85,10 +89,7 @@ fn botocore_generate(input_path: &Path, output_path: &Path) {
 
 #[cfg(not(feature = "serde_macros"))]
 fn serde_generate(source: &Path, destination: &Path) {
-    let mut registry = ::syntex::Registry::new();
-
-    ::serde_codegen::register(&mut registry);
-    registry.expand("", source, destination).expect("Failed to generate code with Serde");
+    ::serde_codegen::expand(&source, &destination).unwrap();
 }
 
 #[cfg(feature = "serde_macros")]


### PR DESCRIPTION
Error: 
```error: mismatched types:
 expected `&mut syntex::Registry`,
    found `&mut inner::syntex::Registry`
(expected struct `syntex::Registry`,
    found struct `inner::syntex::Registry`)```

Fixed based on https://users.rust-lang.org/t/here-is-how-to-avoid-being-broken-by-syntex-updates/6189?u=dtolnay