### PR TITLE
Pull AWS_SESSION_TOKEN from environment for credentials.

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -119,7 +119,19 @@ fn credentials_from_environment() -> Result<AwsCredentials, AwsError> {
         return Err(AwsError::new("Couldn't find either AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY or both in environment."));
     }
 
-    Ok(AwsCredentials::new(env_key, env_secret, None, in_ten_minutes()))
+    // Present when using temporary credentials, e.g. on Lambda with IAM roles
+    let token = match var("AWS_SESSION_TOKEN") {
+        Ok(val) => {
+            if val.is_empty() {
+                None
+            } else {
+                Some(val)
+            }
+        }
+        Err(_) => None,
+    };
+
+    Ok(AwsCredentials::new(env_key, env_secret, token, in_ten_minutes()))
 }
 
 /// Provides AWS credentials from a profile in a credentials file.


### PR DESCRIPTION
Ran into this when running rusoto in a Lambda which has an IAM role allowing it to access S3. Fails before this change, succeeds after. 

This is also what botocore does: https://github.com/boto/botocore/blob/develop/botocore/credentials.py#L489