### PR TITLE
Fixed the signed request doesn't match error when the path contains spaces

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -27,7 +27,7 @@ pub fn send_request(signed_request: &SignedRequest) -> Response {
         hyper_headers.set_raw(h.0.to_owned(), h.1.to_owned());
     }
 
-    let mut final_uri = format!("https://{}{}", signed_request.hostname(), signed_request.canonical_uri());
+    let mut final_uri = format!("https://{}{}", signed_request.hostname(), signed_request.path());
     if !signed_request.canonical_query_string().is_empty() {
         final_uri = final_uri + &format!("?{}", signed_request.canonical_query_string());
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -19,7 +19,7 @@ use openssl::crypto::hmac::hmac;
 use rustc_serialize::hex::ToHex;
 use time::Tm;
 use time::now_utc;
-use url::percent_encoding::{percent_encode_to, FORM_URLENCODED_ENCODE_SET};
+use url::percent_encoding::{percent_encode_to, DEFAULT_ENCODE_SET, FORM_URLENCODED_ENCODE_SET};
 use xmlutil::*;
 use xml::reader::*;
 
@@ -80,6 +80,10 @@ impl <'a> SignedRequest <'a> {
 
     pub fn method(&self) -> &str {
         &self.method
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
     }
 
     pub fn canonical_uri(&self) -> &str {
@@ -308,7 +312,7 @@ fn skipped_headers(header: &str) -> bool {
 fn canonical_uri(path: &str) -> String {
     match path {
         "" => "/".to_string(),
-        _ => path.to_string()
+        _ => encode_uri(path)
     }
 }
 
@@ -328,6 +332,15 @@ fn build_canonical_query_string(params: &Params) -> String {
     }
 
     output
+}
+
+#[inline]
+fn encode_uri(uri: &str) -> String {
+    let mut encoded_uri = String::new();
+    for &byte in uri.as_bytes().iter() {
+        percent_encode_to(&[byte], DEFAULT_ENCODE_SET, &mut encoded_uri);
+    }
+    encoded_uri
 }
 
 #[inline]

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -144,8 +144,8 @@ impl <'a> SignedRequest <'a> {
     /// Calculate the signature from the credentials provided and the request data
     /// Add the calculated signature to the request headers and execute it
     /// Return the hyper HTTP response
-    pub fn sign_and_execute(&mut self, creds: &AwsCredentials) -> Response {
-        self.sign(creds);
+    pub fn sign_and_execute(&mut self, creds: AwsCredentials) -> Response {
+        self.sign(&creds);
         self.execute(creds)
     }
 
@@ -231,7 +231,7 @@ impl <'a> SignedRequest <'a> {
         self.add_header("authorization", &auth_header);
     }
 
-    fn execute(&mut self, creds: &AwsCredentials) -> Response {
+    fn execute(&mut self, creds: AwsCredentials) -> Response {
         let response = send_request(self);
         debug!("Sent request to AWS");
 
@@ -242,7 +242,8 @@ impl <'a> SignedRequest <'a> {
             self.set_hostname(Some(new_hostname.to_string()));
 
             // This does a lot of appending and not clearing/creation, so we'll have to do that ourselves:
-            return self.sign_and_execute(creds);
+            self.sign(&creds);
+            return self.execute(creds);
         }
 
         response


### PR DESCRIPTION
I'm getting an signed request doesn't match error from aws when trying to upload a file with spaces in its name. It turns out that the canonical URI is not encoded, when encoding is required by aws:
http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html