### PR TITLE
Don't recompile constantly when used as a crates.io dependency

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -72,5 +72,10 @@ fn main() {
         generate(service, out_path);
     }
 
-    println!("cargo:rerun-if-changed=codegen");
+    let codegen_dir = Path::new("codegen");
+
+    // avoid unnecessary recompiles when used as a crates.io dependency
+    if codegen_dir.exists() {
+        println!("cargo:rerun-if-changed=codegen");
+    }
 }


### PR DESCRIPTION
Prevents the build script from outputting the `rerun-if-changed=codegen` directive if the codegen directory doesn't exist in the first place (i.e., if it's being used as a crates.io dependency)

Fixes #285