### PR TITLE
Reuse hyper client

### DIFF
--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -23,11 +23,10 @@ impl GenerateProtocol for JsonGenerator {
                     request.set_content_type(\"application/x-amz-json-{json_version}\".to_owned());
                     request.add_header(\"x-amz-target\", \"{target_prefix}.{name}\");
                     request.set_payload(payload);
-                    let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-                    let status = result.status.to_u16();
-                    let mut body = String::new();
-                    result.read_to_string(&mut body).unwrap();
-                    match status {{
+                    request.sign(&try!(self.credentials_provider.credentials()));
+                    let response = try!(self.dispatcher.dispatch(&request));
+
+                    match response.status {{
                         200 => {{
                             {ok_response}
                         }}
@@ -54,12 +53,9 @@ impl GenerateProtocol for JsonGenerator {
 
     fn generate_prelude(&self, service: &Service) -> String {
         format!(
-            "use std::io::Read;
-
-            use serde_json;
+            "use serde_json;
 
             use credential::ProvideAwsCredentials;
-            use region;
             use signature::SignedRequest;
 
             {error_imports}",
@@ -164,6 +160,11 @@ pub fn generate_error_type(operation: &Operation, error_documentation: &HashMap<
                 {type_name}::Unknown(err.message)
             }}
         }}
+        impl From<HttpDispatchError> for {type_name} {{
+            fn from(err: HttpDispatchError) -> {type_name} {{
+                {type_name}::HttpDispatch(err)
+            }}
+        }}
         impl fmt::Display for {type_name} {{
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{
                 write!(f, \"{{}}\", self.description())
@@ -205,6 +206,7 @@ fn generate_error_enum_types(operation: &Operation, error_documentation: &HashMa
         enum_types.push("/// A validation error occurred.  Details from AWS are provided.\nValidation(String)".to_string());
     }
 
+    enum_types.push("/// An error occurred dispatching the HTTP request\nHttpDispatch(HttpDispatchError)".to_string());
     enum_types.push("/// An unknown error occurred.  The raw HTTP response is provided.\nUnknown(String)".to_string());
     Some(enum_types.join(","))
 }
@@ -261,6 +263,7 @@ fn generate_error_description_matchers(operation: &Operation) -> Option<String> 
         type_matchers.push(format!("{error_type}::Validation(ref cause) => cause", error_type = error_type));
     }
 
+    type_matchers.push(format!("{error_type}::HttpDispatch(ref dispatch_error) => dispatch_error.description()", error_type = error_type));
     type_matchers.push(format!("{error_type}::Unknown(ref cause) => cause", error_type = error_type));
     Some(type_matchers.join(","))
 }
@@ -276,6 +279,7 @@ fn generate_result_type<'a>(service: &Service, operation: &Operation, output_typ
 fn generate_error_imports(service: &Service) -> &'static str {
     if service.typed_errors() {
         "use error::AwsError;
+        use request::HttpDispatchError;
         use std::error::Error;
         use std::fmt;
         use serde_json::Value as SerdeJsonValue;
@@ -293,7 +297,7 @@ fn generate_documentation(operation: &Operation) -> Option<String> {
 
 fn generate_ok_response(operation: &Operation, output_type: &str) -> String {
     if operation.output.is_some() {
-        format!("Ok(serde_json::from_str::<{}>(&body).unwrap())", output_type)
+        format!("Ok(serde_json::from_str::<{}>(&response.body).unwrap())", output_type)
     } else {
         "Ok(())".to_owned()
     }
@@ -301,8 +305,8 @@ fn generate_ok_response(operation: &Operation, output_type: &str) -> String {
 
 fn generate_err_response(service: &Service, operation: &Operation) -> String {
     if service.typed_errors() {
-        format!("Err({}::from_body(&body))", operation.error_type_name())
+        format!("Err({}::from_body(&response.body))", operation.error_type_name())
     } else {
-        String::from("Err(parse_json_protocol_error(&body))") 
+        String::from("Err(parse_json_protocol_error(&response.body))") 
     }
 }

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -47,7 +47,8 @@ fn generate<P>(service: &Service, protocol_generator: P) -> String where P: Gene
         use hyper::Client;
         use hyper::client::RedirectPolicy;
         use request::DispatchSignedRequest;
-        use region::Region;
+        use region;
+
         {prelude}
 
         {types}
@@ -67,12 +68,12 @@ where P: GenerateProtocol {
         "/// A client for the {service_name} API.
         pub struct {type_name}<P, D> where P: ProvideAwsCredentials, D: DispatchSignedRequest {{
             credentials_provider: P,
-            region: Region,
+            region: region::Region,
             dispatcher: D,
         }}
 
         impl<P> {type_name}<P, Client> where P: ProvideAwsCredentials {{
-            pub fn new(credentials_provider: P, region: Region) -> Self {{
+            pub fn new(credentials_provider: P, region: region::Region) -> Self {{
                 let mut client = Client::new();                
                 client.set_redirect_policy(RedirectPolicy::FollowNone);
                {type_name}::with_request_dispatcher(client, credentials_provider, region)
@@ -80,7 +81,7 @@ where P: GenerateProtocol {
         }}
 
         impl<P, D> {type_name}<P, D> where P: ProvideAwsCredentials, D: DispatchSignedRequest {{
-            pub fn with_request_dispatcher(request_dispatcher: D, credentials_provider: P, region: Region) -> Self {{
+            pub fn with_request_dispatcher(request_dispatcher: D, credentials_provider: P, region: region::Region) -> Self {{
                   {type_name} {{
                     credentials_provider: credentials_provider,
                     region: region,

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -43,7 +43,12 @@ pub fn generate_source(service: &Service) -> String {
 
 fn generate<P>(service: &Service, protocol_generator: P) -> String where P: GenerateProtocol {
     format!(
-        "{prelude}
+        "
+        use hyper::Client;
+        use hyper::client::RedirectPolicy;
+        use request::DispatchSignedRequest;
+        use region::Region;
+        {prelude}
 
         {types}
         {error_types}
@@ -60,19 +65,28 @@ fn generate_client<P>(service: &Service, protocol_generator: &P) -> String
 where P: GenerateProtocol {
     format!(
         "/// A client for the {service_name} API.
-        pub struct {type_name}<P> where P: ProvideAwsCredentials {{
+        pub struct {type_name}<P, D> where P: ProvideAwsCredentials, D: DispatchSignedRequest {{
             credentials_provider: P,
-            region: region::Region,
+            region: Region,
+            dispatcher: D,
         }}
 
-        impl<P> {type_name}<P> where P: ProvideAwsCredentials {{
-            pub fn new(credentials_provider: P, region: region::Region) -> Self {{
-                {type_name} {{
+        impl<P> {type_name}<P, Client> where P: ProvideAwsCredentials {{
+            pub fn new(credentials_provider: P, region: Region) -> Self {{
+                let mut client = Client::new();                
+                client.set_redirect_policy(RedirectPolicy::FollowNone);
+               {type_name}::with_request_dispatcher(client, credentials_provider, region)
+            }}
+        }}
+
+        impl<P, D> {type_name}<P, D> where P: ProvideAwsCredentials, D: DispatchSignedRequest {{
+            pub fn with_request_dispatcher(request_dispatcher: D, credentials_provider: P, region: Region) -> Self {{
+                  {type_name} {{
                     credentials_provider: credentials_provider,
                     region: region,
+                    dispatcher: request_dispatcher
                 }}
             }}
-
             {methods}
         }}
         ",

--- a/src/request.rs
+++ b/src/request.rs
@@ -3,58 +3,119 @@
 //! Wraps the Hyper library to send PUT, POST, DELETE and GET requests.
 
 use std::io::Read;
+use std::io::Error as IoError;
+use std::error::Error;
+use std::fmt;
+use std::collections::HashMap;
 
 use hyper::Client;
-use hyper::client::Response;
-use hyper::client::RedirectPolicy;
+use hyper::Error as HyperError;
 use hyper::header::Headers;
 use hyper::method::Method;
-use signature::SignedRequest;
+
 use log::LogLevel::Debug;
 
-/// Takes a fully formed and signed request and executes it.
-pub fn send_request(signed_request: &SignedRequest) -> Response {
-    let hyper_method = match signed_request.method().as_ref() {
-        "POST" => Method::Post,
-        "PUT" => Method::Put,
-        "DELETE" => Method::Delete,
-        "GET" | _ => Method::Get, // TODO: make the catch-all case unreachable
-    };
+use signature::SignedRequest;
 
-    // translate the headers map to a format Hyper likes
-    let mut hyper_headers = Headers::new();
-    for h in signed_request.headers().iter() {
-        hyper_headers.set_raw(h.0.to_owned(), h.1.to_owned());
+pub struct HttpResponse {
+    pub status: u16,
+    pub body: String,
+    pub headers: HashMap<String, String>
+}
+
+#[derive(Debug, PartialEq)]
+pub struct HttpDispatchError {
+    message: String
+}
+
+impl Error for HttpDispatchError {
+    fn description(&self) -> &str {
+        &self.message
     }
+}
 
-    let mut final_uri = format!("https://{}{}", signed_request.hostname(), signed_request.path());
-    if !signed_request.canonical_query_string().is_empty() {
-        final_uri = final_uri + &format!("?{}", signed_request.canonical_query_string());
+impl fmt::Display for HttpDispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.message)
     }
+}
 
-    if log_enabled!(Debug) {
-        let payload = signed_request.payload().map(|mut payload_bytes| {
-            let mut payload_string = String::new();
+impl From<HyperError> for HttpDispatchError {
+    fn from(err: HyperError) -> HttpDispatchError {
+        HttpDispatchError { message: err.description().to_string() }
+    }
+}
 
-            payload_bytes.read_to_string(&mut payload_string).expect(
-                "Failed to read payload to string"
-            );
+impl From<IoError> for HttpDispatchError {
+    fn from(err: IoError) -> HttpDispatchError {
+        HttpDispatchError { message: err.description().to_string() }
+    }
+}
 
-            payload_string
-        });
+pub trait DispatchSignedRequest {
+    fn dispatch(&self, request: &SignedRequest) -> Result<HttpResponse, HttpDispatchError>;
+}
 
-        debug!("Full request: \n method: {}\n final_uri: {}\n payload: {:?}\nHeaders:\n",
-            hyper_method, final_uri, payload);
-        for h in hyper_headers.iter() {
-            debug!("{}:{}", h.name(), h.value_string());
+impl DispatchSignedRequest for Client {
+    fn dispatch(&self, request: &SignedRequest) -> Result<HttpResponse, HttpDispatchError> {
+        let hyper_method = match request.method().as_ref() {
+            "POST" => Method::Post,
+            "PUT" => Method::Put,
+            "DELETE" => Method::Delete,
+            "GET" => Method::Get,
+            v @ _ => return Err(HttpDispatchError { message: format!("Unsupported HTTP verb {}", v) })
+
+        };
+
+        // translate the headers map to a format Hyper likes
+        let mut hyper_headers = Headers::new();
+        for h in request.headers().iter() {
+            hyper_headers.set_raw(h.0.to_owned(), h.1.to_owned());
         }
-    }
 
-    let mut client = Client::new();
-    client.set_redirect_policy(RedirectPolicy::FollowNone);
+        let mut final_uri = format!("https://{}{}", request.hostname(), request.path());
+        if !request.canonical_query_string().is_empty() {
+            final_uri = final_uri + &format!("?{}", request.canonical_query_string());
+        }
 
-    match signed_request.payload() {
-        None => client.request(hyper_method, &final_uri).headers(hyper_headers).body("").send().unwrap(),
-        Some(payload_contents) => client.request(hyper_method, &final_uri).headers(hyper_headers).body(payload_contents).send().unwrap(),
+        if log_enabled!(Debug) {
+            let payload = request.payload().map(|mut payload_bytes| {
+                let mut payload_string = String::new();
+
+                payload_bytes.read_to_string(&mut payload_string).expect("Failed to read payload to string");
+
+                payload_string
+            });
+
+            debug!("Full request: \n method: {}\n final_uri: {}\n payload: {:?}\nHeaders:\n", hyper_method, final_uri, payload);
+            for h in hyper_headers.iter() {
+                debug!("{}:{}", h.name(), h.value_string());
+            }
+        }
+
+        let mut hyper_response = match request.payload() {
+            None => try!(self.request(hyper_method, &final_uri).headers(hyper_headers).body("").send()),
+            Some(payload_contents) => try!(self.request(hyper_method, &final_uri).headers(hyper_headers).body(payload_contents).send()),
+        };
+
+        let mut body = String::new();
+        try!(hyper_response.read_to_string(&mut body));
+
+        if log_enabled!(Debug) {
+            debug!("Response body:\n{}", body);
+        }
+
+        let mut headers: HashMap<String, String> = HashMap::new();
+
+        for header in hyper_response.headers.iter() {
+            headers.insert(header.name().to_string(), header.value_string());
+        }
+
+        Ok(HttpResponse {
+            status: hyper_response.status.to_u16(),
+            body: body,
+            headers: headers
+        })
+        
     }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -11223,9 +11223,6 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
             }
             _ => {
                 println!("Error: Status code was {}", status);
-                let mut body = String::new();
-                try!(result.read_to_string(&mut body));
-                println!("Error response body: {}", body);
                 Err(AwsError::new("error: didn't get a 200."))
             }
         }
@@ -11292,9 +11289,6 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
             }
             _ => {
                 println!("Error: Status code was {}", status);
-                let mut body = String::new();
-                try!(result.read_to_string(&mut body));
-                println!("Error response body: {}", body);
                 Err(AwsError::new("error uploading object to S3"))
             }
         }
@@ -11794,8 +11788,6 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(try!(CompleteMultipartUploadOutputParser::parse_xml("CompleteMultipartUploadResult", &mut stack)))
             }
             _ => {
-                let mut body = String::new();
-                try!(result.read_to_string(&mut body));
                 Err(AwsError::new("error in complete_multipart_upload"))
             }
         }
@@ -11863,9 +11855,6 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(())
             }
             _ => {
-                let mut body = String::new();
-                try!(result.read_to_string(&mut body));
-                println!("response body: {}", body);
                 Err(AwsError::new(format!("delete bucket error, status was {}", status)))
             }
         }
@@ -11922,7 +11911,6 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
         let version_id = try!(S3Client::<P,D>::get_value_for_header("x-amz-version-id".to_string(), response));
         let e_tag = try!(S3Client::<P,D>::get_value_for_header("ETag".to_string(), response));
         let sse_customer_key_md5 = try!(S3Client::<P,D>::get_value_for_header("x-amz-server-side-encryption-customer-key-MD5".to_string(), response));
-        try!(response.read_to_end(&mut body));
         // make the object to return
         let s3_object = GetObjectOutput {
             delete_marker: delete_marker,
@@ -11980,9 +11968,6 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
             }
             _ => {
                 println!("Error: Status code was {}", status);
-                let mut body = String::new();
-                try!(result.read_to_string(&mut body));
-                println!("Error response body: {}", body);
                 Err(AwsError::new("error in get_object"))
             }
         }
@@ -12265,9 +12250,6 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(try!(ListPartsOutputParser::parse_xml("ListPartsResult", &mut stack)))
             }
             _ => {
-                let mut body = String::new();
-                try!(result.read_to_string(&mut body));
-                println!("Error response body: {}", body);
                 Err(AwsError::new("error in list_parts"))
             }
         }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -11223,6 +11223,7 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
             }
             _ => {
                 println!("Error: Status code was {}", status);
+                println!("Error response body: {}", result.body);
                 Err(AwsError::new("error: didn't get a 200."))
             }
         }
@@ -11288,9 +11289,8 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(put_result)
             }
             _ => {
-                let mut body = result.body;
-                println!("Error response body: {}", body);
                 println!("Error: Status code was {}", status);
+                println!("Error response body: {}", result.body);
                 Err(AwsError::new("error uploading object to S3"))
             }
         }
@@ -11790,8 +11790,7 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(try!(CompleteMultipartUploadOutputParser::parse_xml("CompleteMultipartUploadResult", &mut stack)))
             }
             _ => {
-                let mut body = result.body;
-                println!("Error response body: {}", body);
+                println!("Error response body: {}", result.body);
                 Err(AwsError::new("error in complete_multipart_upload"))
             }
         }
@@ -11859,8 +11858,7 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(())
             }
             _ => {
-                let mut body = result.body;
-                println!("Error response body: {}", body);
+                println!("Error response body: {}", result.body);
                 Err(AwsError::new(format!("delete bucket error, status was {}", status)))
             }
         }
@@ -11973,9 +11971,8 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(s3_object)
             }
             _ => {
-                let mut body = result.body;
-                println!("Error response body: {}", body);
                 println!("Error: Status code was {}", status);
+                println!("Error response body: {}", result.body);
                 Err(AwsError::new("error in get_object"))
             }
         }
@@ -12258,8 +12255,7 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(try!(ListPartsOutputParser::parse_xml("ListPartsResult", &mut stack)))
             }
             _ => {
-                let mut body = result.body;
-                println!("Error response body: {}", body);
+                println!("Error response body: {}", result.body);
                 Err(AwsError::new("error in list_parts"))
             }
         }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -11288,6 +11288,8 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(put_result)
             }
             _ => {
+                let mut body = result.body;
+                println!("Error response body: {}", body);
                 println!("Error: Status code was {}", status);
                 Err(AwsError::new("error uploading object to S3"))
             }
@@ -11788,6 +11790,8 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(try!(CompleteMultipartUploadOutputParser::parse_xml("CompleteMultipartUploadResult", &mut stack)))
             }
             _ => {
+                let mut body = result.body;
+                println!("Error response body: {}", body);
                 Err(AwsError::new("error in complete_multipart_upload"))
             }
         }
@@ -11855,6 +11859,8 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(())
             }
             _ => {
+                let mut body = result.body;
+                println!("Error response body: {}", body);
                 Err(AwsError::new(format!("delete bucket error, status was {}", status)))
             }
         }
@@ -11967,6 +11973,8 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(s3_object)
             }
             _ => {
+                let mut body = result.body;
+                println!("Error response body: {}", body);
                 println!("Error: Status code was {}", status);
                 Err(AwsError::new("error in get_object"))
             }
@@ -12250,6 +12258,8 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
                 Ok(try!(ListPartsOutputParser::parse_xml("ListPartsResult", &mut stack)))
             }
             _ => {
+                let mut body = result.body;
+                println!("Error response body: {}", body);
                 Err(AwsError::new("error in list_parts"))
             }
         }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -10,18 +10,20 @@ use std::io::Read;
 use std::str::FromStr;
 use std::str;
 
-use hyper::client::Response;
+use hyper::client::{Client, RedirectPolicy};
 use openssl::crypto::hash::Type::MD5;
 use openssl::crypto::hash::hash;
 use rustc_serialize::base64::{ToBase64, STANDARD};
 use xml::*;
 
-use credential::ProvideAwsCredentials;
+use credential::{ProvideAwsCredentials, AwsCredentials};
 use error::AwsError;
 use param::{Params, ServiceParams};
 use region::Region;
 use signature::SignedRequest;
 use xmlutil::*;
+use request::{DispatchSignedRequest, HttpResponse};
+use region;
 
 #[derive(Debug, Default)]
 pub struct LifecycleExpiration {
@@ -11017,14 +11019,28 @@ impl MaxPartsWriter {
         params.put(name, &obj.to_string());
     }
 }
-pub struct S3Client<P> where P: ProvideAwsCredentials {
-    credentials_provider: P,
-    region: Region,
+
+pub struct S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedRequest {
+            credentials_provider: P,
+            region: region::Region,
+            dispatcher: D,
+        }
+
+impl<P> S3Client<P, Client> where P: ProvideAwsCredentials {
+    pub fn new(credentials_provider: P, region: region::Region) -> Self {
+        let mut client = Client::new();                
+        client.set_redirect_policy(RedirectPolicy::FollowNone);
+        S3Client::with_request_dispatcher(client, credentials_provider, region)
+    }
 }
 
-impl<P> S3Client<P> where P: ProvideAwsCredentials {
-    pub fn new(credentials_provider: P, region: Region) -> S3Client<P> {
-        S3Client { credentials_provider: credentials_provider, region: region }
+impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedRequest {
+    pub fn with_request_dispatcher(request_dispatcher: D, credentials_provider: P, region: region::Region) -> Self {
+        S3Client {
+            credentials_provider: credentials_provider,
+            region: region,
+            dispatcher: request_dispatcher
+        }
     }
 
     /// Returns metadata about all of the versions of objects in a bucket.
@@ -11034,10 +11050,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "ListObjectVersions");
         ListObjectVersionsRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11055,10 +11071,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketPolicy");
         PutBucketPolicyRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11077,10 +11093,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "ListObjects");
         ListObjectsRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11097,10 +11113,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketWebsite");
         PutBucketWebsiteRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11117,10 +11133,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketNotification");
         PutBucketNotificationRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11139,10 +11155,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketLogging");
         PutBucketLoggingRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11160,10 +11176,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketReplication");
         PutBucketReplicationRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11195,23 +11211,19 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("uploadId", upload_id);
         request.set_params(params);
 
-        let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
 
         match status {
             200 => {
-                for header in result.headers.iter() {
-                    if header.name() == "ETag" {
-                        return Ok(header.value_string());
-                    }
+                match result.headers.get("ETag") {
+                    Some(ref value) => Ok(value.to_string()),
+                    None => Err(AwsError::new("Couldn't find etag in response headers."))
                 }
-                Err(AwsError::new("Couldn't find etag in response headers."))
             }
             _ => {
                 println!("Error: Status code was {}", status);
-                let mut body = String::new();
-                result.read_to_string(&mut body).unwrap();
-                println!("Error response body: {}", body);
+                println!("Error response body: {}", result.body);
                 Err(AwsError::new("error: didn't get a 200."))
             }
         }
@@ -11263,8 +11275,8 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         request.set_hostname(Some(hostname));
         request.set_payload(input.body);
 
-        let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
 
         match status {
             200 => {
@@ -11274,9 +11286,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
             }
             _ => {
                 println!("Error: Status code was {}", status);
-                let mut body = String::new();
-                result.read_to_string(&mut body).unwrap();
-                println!("Error response body: {}", body);
+                println!("Error response body: {}", result.body);
 
                 Err(AwsError::new("error uploading object to S3"))
             }
@@ -11289,10 +11299,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "DeleteBucketCors");
         DeleteBucketCorsRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11310,10 +11320,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketVersioning");
         PutBucketVersioningRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11330,10 +11340,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketCors");
         GetBucketCorsRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11351,10 +11361,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketLifecycle");
         PutBucketLifecycleRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11371,10 +11381,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketAcl");
         GetBucketAclRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11392,10 +11402,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketLogging");
         GetBucketLoggingRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11413,10 +11423,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "HeadBucket");
         HeadBucketRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11432,10 +11442,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let mut params = Params::new();
         params.put("Action", "PutBucketAcl");
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11452,10 +11462,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "DeleteBucketWebsite");
         DeleteBucketWebsiteRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11472,10 +11482,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "DeleteBucketPolicy");
         DeleteBucketPolicyRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11492,10 +11502,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketNotificationConfiguration");
         GetBucketNotificationConfigurationRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11519,8 +11529,8 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         // params.put("Action", "DeleteObjects");
         // DeleteObjectsRequestWriter::write_params(&mut params, "", input);
         // request.set_params(params);
-        // let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        // let status = result.status.to_u16();
+        // let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        // let status = result.status;
         // match status {
         //  200 => {
         //      Ok(try!(DeleteObjectsOutputParser::parse_xml("DeleteObjectsOutput", &mut stack)))
@@ -11535,10 +11545,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "DeleteBucketReplication");
         DeleteBucketReplicationRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11555,10 +11565,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "CopyObject");
         CopyObjectRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11575,10 +11585,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let mut params = Params::new();
         params.put("Action", "ListBuckets");
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
 
         stack.next(); // xml start tag
 
@@ -11602,10 +11612,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketRequestPayment");
         PutBucketRequestPaymentRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11622,10 +11632,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketNotificationConfiguration");
         PutBucketNotificationConfigurationRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11644,10 +11654,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "HeadObject");
         HeadObjectRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11664,10 +11674,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "DeleteBucketTagging");
         DeleteBucketTaggingRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11684,10 +11694,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetObjectTorrent");
         GetObjectTorrentRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11704,10 +11714,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketLifecycle");
         GetBucketLifecycleRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11736,17 +11746,15 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
             Some(ref canned_acl) => request.add_header("x-amz-acl", &canned_acl_in_aws_format(canned_acl)),
         }
 
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
 
         match status {
             200 => {
-                for header in result.headers.iter() {
-                    if header.name() == "Location" {
-                        return Ok(CreateBucketOutput{location: header.value_string()});
-                    }
+                match result.headers.get("Location") {
+                    Some(ref value) => Ok(CreateBucketOutput{ location: value.to_string() }),
+                    None => Err(AwsError::new("Something went wrong when creating a bucket."))
                 }
-                Err(AwsError::new("Something went wrong when creating a bucket."))
             }
             _ => {
                 Err(AwsError::new("error in create_bucket"))
@@ -11767,20 +11775,18 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
 
         request.set_payload(input.multipart_upload);
 
-        let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
 
         match status {
             200 => {
-                let mut reader = EventReader::new(result);
-                let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+                let mut reader = EventReader::from_str(&result.body);
+                let mut stack = XmlResponse::new(reader.events().peekable());
                 stack.next(); // xml start tag
 
                 Ok(try!(CompleteMultipartUploadOutputParser::parse_xml("CompleteMultipartUploadResult", &mut stack)))
             }
             _ => {
-                let mut body = String::new();
-                result.read_to_string(&mut body).unwrap();
                 Err(AwsError::new("error in complete_multipart_upload"))
             }
         }
@@ -11792,10 +11798,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketWebsite");
         GetBucketWebsiteRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -11819,11 +11825,11 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
         request.set_hostname(Some(hostname));
 
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
 
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         match status {
             200 => {
@@ -11841,75 +11847,71 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
         request.set_hostname(Some(hostname));
 
-        let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
         match status {
             204 => {
                 Ok(())
             }
             _ => {
-                let mut body = String::new();
-                result.read_to_string(&mut body).unwrap();
-                println!("resposne body: {}", body);
+                println!("resposne body: {}", result.body);
                 Err(AwsError::new(format!("delete bucket error, status was {}", status)))
             }
         }
     }
 
-    pub fn get_value_for_header(header_name: String, response: &Response) -> Result<String, AwsError> {
-        for header in response.headers.iter() {
-            if header.name() == header_name {
-                return Ok(header.value_string());
-            }
+    pub fn get_value_for_header(header_name: String, response: &HttpResponse) -> Result<String, AwsError> {
+
+        match response.headers.get(&header_name) {
+            Some(ref value) => Ok(value.to_string()),
+            _ => Ok(String::new())
         }
-        Ok(String::new())
         // Err(AwsError::new(format!("Couldn't find field {} in headers", header_name)))
     }
 
     /// Use the Hyper resposne to populate the GetObjectOutput
     // This would be a great candidate for some codegen magicks.
-    pub fn get_object_from_response(response: &mut Response) -> Result<GetObjectOutput, AwsError> {
+    pub fn get_object_from_response(response: &mut HttpResponse) -> Result<GetObjectOutput, AwsError> {
         // get all the goodies for GetObjectOutput
-        let delete_marker_string = try!(S3Client::<P>::get_value_for_header("x-amz-delete-marker".to_string(), &response));
+        let delete_marker_string = try!(S3Client::<P,D>::get_value_for_header("x-amz-delete-marker".to_string(), &response));
         let delete_marker : bool;
         if delete_marker_string.is_empty() {
             delete_marker = false;
         } else {
             delete_marker = bool::from_str(&delete_marker_string).unwrap();
         }
-        let accept_ranges = try!(S3Client::<P>::get_value_for_header("accept-ranges".to_string(), response));
-        let last_modified = try!(S3Client::<P>::get_value_for_header("Last-Modified".to_string(), response));
-        let content_range = try!(S3Client::<P>::get_value_for_header("Content-Range".to_string(), response));
-        let request_charged = try!(S3Client::<P>::get_value_for_header("x-amz-request-charged".to_string(), response));
-        let content_encoding = try!(S3Client::<P>::get_value_for_header("Content-Encoding".to_string(), response));
-        let replication_status = try!(S3Client::<P>::get_value_for_header("x-amz-replication-status".to_string(), response));
-        let storage_class = try!(S3Client::<P>::get_value_for_header("x-amz-storage-class".to_string(), response));
-        let server_side_encryption = try!(S3Client::<P>::get_value_for_header("x-amz-server-side-encryption".to_string(), response));
-        let ssekms_key_id = try!(S3Client::<P>::get_value_for_header("x-amz-server-side-encryption-aws-kms-key-id".to_string(), response));
-        let content_disposition = try!(S3Client::<P>::get_value_for_header("Content-Disposition".to_string(), response));
-        let metadata = try!(S3Client::<P>::get_value_for_header("x-amz-meta-".to_string(), response));
-        let website_redirect_location = try!(S3Client::<P>::get_value_for_header("x-amz-website-redirect-location".to_string(), response));
-        let expires = try!(S3Client::<P>::get_value_for_header("Expires".to_string(), response));
-        let cache_control = try!(S3Client::<P>::get_value_for_header("Cache-Control".to_string(), response));
-        let content_length_string = try!(S3Client::<P>::get_value_for_header("Content-Length".to_string(), response));
+        let accept_ranges = try!(S3Client::<P,D>::get_value_for_header("accept-ranges".to_string(), response));
+        let last_modified = try!(S3Client::<P,D>::get_value_for_header("Last-Modified".to_string(), response));
+        let content_range = try!(S3Client::<P,D>::get_value_for_header("Content-Range".to_string(), response));
+        let request_charged = try!(S3Client::<P,D>::get_value_for_header("x-amz-request-charged".to_string(), response));
+        let content_encoding = try!(S3Client::<P,D>::get_value_for_header("Content-Encoding".to_string(), response));
+        let replication_status = try!(S3Client::<P,D>::get_value_for_header("x-amz-replication-status".to_string(), response));
+        let storage_class = try!(S3Client::<P,D>::get_value_for_header("x-amz-storage-class".to_string(), response));
+        let server_side_encryption = try!(S3Client::<P,D>::get_value_for_header("x-amz-server-side-encryption".to_string(), response));
+        let ssekms_key_id = try!(S3Client::<P,D>::get_value_for_header("x-amz-server-side-encryption-aws-kms-key-id".to_string(), response));
+        let content_disposition = try!(S3Client::<P,D>::get_value_for_header("Content-Disposition".to_string(), response));
+        let metadata = try!(S3Client::<P,D>::get_value_for_header("x-amz-meta-".to_string(), response));
+        let website_redirect_location = try!(S3Client::<P,D>::get_value_for_header("x-amz-website-redirect-location".to_string(), response));
+        let expires = try!(S3Client::<P,D>::get_value_for_header("Expires".to_string(), response));
+        let cache_control = try!(S3Client::<P,D>::get_value_for_header("Cache-Control".to_string(), response));
+        let content_length_string = try!(S3Client::<P,D>::get_value_for_header("Content-Length".to_string(), response));
         let content_length = content_length_string.parse::<i32>().unwrap();
-        let expiration = try!(S3Client::<P>::get_value_for_header("x-amz-expiration".to_string(), response));
-        let missing_meta_string = try!(S3Client::<P>::get_value_for_header("x-amz-missing-meta".to_string(), response));
+        let expiration = try!(S3Client::<P,D>::get_value_for_header("x-amz-expiration".to_string(), response));
+        let missing_meta_string = try!(S3Client::<P,D>::get_value_for_header("x-amz-missing-meta".to_string(), response));
         let missing_meta : i32;
         if missing_meta_string.is_empty() {
             missing_meta = 0;
         } else {
             missing_meta = missing_meta_string.parse::<i32>().unwrap();
         }
-        let restore = try!(S3Client::<P>::get_value_for_header("x-amz-restore".to_string(), response));
-        let sse_customer_algorithm = try!(S3Client::<P>::get_value_for_header("x-amz-server-side-encryption-customer-algorithm".to_string(), response));
-        let content_type = try!(S3Client::<P>::get_value_for_header("Content-Type".to_string(), response));
-        let content_language = try!(S3Client::<P>::get_value_for_header("Content-Language".to_string(), response));
-        let version_id = try!(S3Client::<P>::get_value_for_header("x-amz-version-id".to_string(), response));
-        let e_tag = try!(S3Client::<P>::get_value_for_header("ETag".to_string(), response));
-        let sse_customer_key_md5 = try!(S3Client::<P>::get_value_for_header("x-amz-server-side-encryption-customer-key-MD5".to_string(), response));
-        let mut body : Vec<u8> = Vec::new();
-        response.read_to_end(&mut body).unwrap();
+        let restore = try!(S3Client::<P,D>::get_value_for_header("x-amz-restore".to_string(), response));
+        let sse_customer_algorithm = try!(S3Client::<P,D>::get_value_for_header("x-amz-server-side-encryption-customer-algorithm".to_string(), response));
+        let content_type = try!(S3Client::<P,D>::get_value_for_header("Content-Type".to_string(), response));
+        let content_language = try!(S3Client::<P,D>::get_value_for_header("Content-Language".to_string(), response));
+        let version_id = try!(S3Client::<P,D>::get_value_for_header("x-amz-version-id".to_string(), response));
+        let e_tag = try!(S3Client::<P,D>::get_value_for_header("ETag".to_string(), response));
+        let sse_customer_key_md5 = try!(S3Client::<P,D>::get_value_for_header("x-amz-server-side-encryption-customer-key-MD5".to_string(), response));
+
         // make the object to return
         let s3_object = GetObjectOutput {
             delete_marker: delete_marker,
@@ -11924,7 +11926,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
             ssekms_key_id: ssekms_key_id,
             content_disposition: content_disposition,
             metadata: HashMap::new(),
-            body: body,
+            body: response.body.clone().into_bytes(),
             website_redirect_location: website_redirect_location,
             expires: expires,
             cache_control: cache_control,
@@ -11956,20 +11958,18 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         GetObjectRequestWriter::write_params(&mut params, "", input);
 
         request.set_params(params);
-        let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
 
         match status {
             200 => {
-                let s3_object = try!(S3Client::<P>::get_object_from_response(&mut result));
+                let s3_object = try!(S3Client::<P,D>::get_object_from_response(&mut result));
 
                 Ok(s3_object)
             }
             _ => {
                 println!("Error: Status code was {}", status);
-                let mut body = String::new();
-                result.read_to_string(&mut body).unwrap();
-                println!("Error response body: {}", body);
+                println!("Error response body: {}", result.body);
                 Err(AwsError::new("error in get_object"))
             }
         }
@@ -11982,10 +11982,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketPolicy");
         GetBucketPolicyRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12002,10 +12002,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketVersioning");
         GetBucketVersioningRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12026,10 +12026,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
         request.set_hostname(Some(hostname));
 
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
 
         match status {
@@ -12048,10 +12048,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketRequestPayment");
         GetBucketRequestPaymentRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12068,10 +12068,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketTagging");
         PutBucketTaggingRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12088,10 +12088,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketTagging");
         GetBucketTaggingRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12115,10 +12115,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
         request.set_hostname(Some(hostname));
 
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
 
         match status {
@@ -12136,10 +12136,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutObjectAcl");
         PutObjectAclRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12156,10 +12156,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketLocation");
         GetBucketLocationRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12176,10 +12176,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "PutBucketCors");
         PutBucketCorsRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12196,10 +12196,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "DeleteBucketLifecycle");
         DeleteBucketLifecycleRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12216,10 +12216,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketNotification");
         GetBucketNotificationConfigurationRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12240,21 +12240,19 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";
         request.set_hostname(Some(hostname));
 
-        let mut result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
 
         match status {
             200 => {
-                let mut reader = EventReader::new(result);
-                let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+                let mut reader = EventReader::from_str(&result.body);
+                let mut stack = XmlResponse::new(reader.events().peekable());
                 stack.next(); // xml start tag
 
                 Ok(try!(ListPartsOutputParser::parse_xml("ListPartsResult", &mut stack)))
             }
             _ => {
-                let mut body = String::new();
-                result.read_to_string(&mut body).unwrap();
-                println!("Error response body: {}", body);
+                println!("Error response body: {}", result.body);
 
                 Err(AwsError::new("error in list_parts"))
             }
@@ -12267,10 +12265,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetObjectAcl");
         GetObjectAclRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12289,7 +12287,7 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
     //      object_id, part_number, upload_id));
     //
     //  let result = request.sign_and_execute(&self.credentials_provider.credentials());
-    //  let status = result.status.to_u16();
+    //  let status = result.status;
     //
     //  match status {
     //      200 => {
@@ -12313,8 +12311,8 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "DeleteObject");
         DeleteObjectRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
 
         match status {
             204 => {
@@ -12331,10 +12329,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "RestoreObject");
         RestoreObjectRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12350,10 +12348,10 @@ impl<P> S3Client<P> where P: ProvideAwsCredentials {
         params.put("Action", "GetBucketReplication");
         GetBucketReplicationRequestWriter::write_params(&mut params, "", input);
         request.set_params(params);
-        let result = request.sign_and_execute(try!(self.credentials_provider.credentials()));
-        let status = result.status.to_u16();
-        let mut reader = EventReader::new(result);
-        let mut stack = XmlResponseFromAws::new(reader.events().peekable());
+        let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
+        let status = result.status;
+        let mut reader = EventReader::from_str(&result.body);
+        let mut stack = XmlResponse::new(reader.events().peekable());
         stack.next(); // xml start tag
         stack.next();
         match status {
@@ -12372,7 +12370,7 @@ const S3_MINIMUM_PART_SIZE: usize = 5242880;
 
 /// Wraps the generated S3 client with a higher level interface
 pub struct S3Helper<P> where P: ProvideAwsCredentials {
-    client: S3Client<P>,
+    client: S3Client<P, Client>,
 }
 
 /// Canned ACL for S3
@@ -12723,9 +12721,71 @@ pub fn canned_acl_in_aws_format(canned_acl: &CannedAcl) -> String {
     }
 }
 
+/// `extract_s3_redirect_location` takes a Hyper `Response` and attempts to pull out the temporary endpoint.
+fn extract_s3_redirect_location(response: HttpResponse) -> Result<String, AwsError> {
+
+    let mut reader = EventReader::from_str(&response.body);
+    let mut stack = XmlResponse::new(reader.events().peekable());
+    stack.next(); // xml start tag
+
+    // extract and return temporary endpoint location
+    extract_s3_temporary_endpoint_from_xml(&mut stack)
+}
+
+fn field_in_s3_redirect(name: &str) -> bool {
+    if name == "Code" || name == "Message" || name == "Bucket" || name == "RequestId" || name == "HostId" {
+        return true;
+    }
+    false
+}
+
+
+/// `extract_s3_temporary_endpoint_from_xml` takes in XML and tries to find the value of the Endpoint node.
+fn extract_s3_temporary_endpoint_from_xml<T: Peek + Next>(stack: &mut T) -> Result<String, AwsError> {
+    try!(start_element(&"Error".to_string(), stack));
+
+    // now find Endpoint contents
+    // This may infinite loop if there's no endpoint in the response: how can we prevent that?
+    loop {
+        let current_name = try!(peek_at_name(stack));
+        if current_name == "Endpoint" {
+            let obj = try!(string_field("Endpoint", stack));
+            return Ok(obj);
+        }
+        if field_in_s3_redirect(&current_name){
+            // <foo>bar</foo>:
+            stack.next(); // skip the start tag <foo>
+            stack.next(); // skip contents bar
+            stack.next(); // skip close tag </foo>
+            continue;
+        }
+        break;
+    }
+    Err(AwsError::new("Couldn't find redirect location for S3 bucket"))
+}
+
+fn sign_and_execute<D>(dispatcher: &D, request: &mut SignedRequest, creds: AwsCredentials) -> HttpResponse where D: DispatchSignedRequest{
+    request.sign(&creds);
+    let response = dispatcher.dispatch(request).expect("Error dispatching request");
+    debug!("Sent request to AWS");
+
+    if response.status == 307 {
+        debug!("Got a redirect response, resending request.");
+        // extract location from response, modify request and re-sign and resend.
+        let new_hostname = extract_s3_redirect_location(response).unwrap();
+        request.set_hostname(Some(new_hostname.to_string()));
+
+        // This does a lot of appending and not clearing/creation, so we'll have to do that ourselves:
+        request.sign(&creds);
+        return dispatcher.dispatch(request).unwrap();
+    }
+
+    response
+}
+
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
+    use std::io::{Read, BufReader};
     use std::fs::File;
     use std::str;
 
@@ -12738,15 +12798,18 @@ mod tests {
     use super::ListBucketsOutputParser;
     use super::ListMultipartUploadsOutputParser;
     use super::ListPartsOutputParser;
+    use super::extract_s3_temporary_endpoint_from_xml;
     use xmlutil::*;
 
     #[test]
     fn list_buckets_happy_path() {
         let file = File::open("tests/sample-data/s3_get_buckets.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = BufReader::new(file);
+        let mut raw = String::new();
+        file.read_to_string(&mut raw).unwrap();
+        let mut my_parser  = EventReader::from_str(&raw);
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
         reader.next(); // xml start node
         let result = ListBucketsOutputParser::parse_xml("ListAllMyBucketsResult", &mut reader);
 
@@ -12759,10 +12822,12 @@ mod tests {
     #[test]
     fn initiate_multipart_upload_happy_path() {
         let file = File::open("tests/sample-data/s3_initiate_multipart_upload.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = BufReader::new(file);
+        let mut raw = String::new();
+        file.read_to_string(&mut raw).unwrap();
+        let mut my_parser  = EventReader::from_str(&raw);
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
         reader.next(); // xml start node
         let result = CreateMultipartUploadOutputParser::parse_xml("InitiateMultipartUploadResult", &mut reader);
 
@@ -12785,10 +12850,12 @@ mod tests {
     #[test]
     fn complete_multipart_upload_happy_path() {
         let file = File::open("tests/sample-data/s3_complete_multipart_upload.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = BufReader::new(file);
+        let mut raw = String::new();
+        file.read_to_string(&mut raw).unwrap();
+        let mut my_parser  = EventReader::from_str(&raw);
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
         reader.next(); // xml start node
         let result = CompleteMultipartUploadOutputParser::parse_xml("CompleteMultipartUploadResult", &mut reader);
 
@@ -12817,10 +12884,12 @@ mod tests {
     #[test]
     fn list_multipart_upload_happy_path() {
         let file = File::open("tests/sample-data/s3_list_multipart_uploads.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = BufReader::new(file);
+        let mut raw = String::new();
+        file.read_to_string(&mut raw).unwrap();
+        let mut my_parser  = EventReader::from_str(&raw);
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
         reader.next(); // xml start node
         let result = ListMultipartUploadsOutputParser::parse_xml("ListMultipartUploadsResult", &mut reader);
 
@@ -12854,10 +12923,12 @@ mod tests {
     #[test]
     fn list_multipart_upload_parts_happy_path() {
         let file = File::open("tests/sample-data/s3_multipart_uploads_with_parts.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = BufReader::new(file);
+        let mut raw = String::new();
+        file.read_to_string(&mut raw).unwrap();
+        let mut my_parser  = EventReader::from_str(&raw);        
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
         reader.next(); // xml start node
         let result = ListPartsOutputParser::parse_xml("ListPartsResult", &mut reader);
 
@@ -12895,10 +12966,12 @@ mod tests {
     #[test]
     fn list_multipart_upload_no_uploads() {
         let file = File::open("tests/sample-data/s3_list_multipart_uploads_no_multipart_uploads.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = BufReader::new(file);
+        let mut raw = String::new();
+        file.read_to_string(&mut raw).unwrap();
+        let mut my_parser  = EventReader::from_str(&raw);        
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
         reader.next(); // xml start node
         let result = ListMultipartUploadsOutputParser::parse_xml("ListMultipartUploadsResult", &mut reader);
 
@@ -12940,4 +13013,26 @@ mod tests {
             panic!("us-east-1 should not have bucket constraint.");
         }
     }
+
+
+    #[test]
+    fn get_redirect_location_from_s3() {
+        let file = File::open("tests/sample-data/s3_temp_redirect.xml").unwrap();
+        let mut file = BufReader::new(file);
+        let mut body = String::new();
+        file.read_to_string(&mut body).unwrap();
+        let mut my_parser  = EventReader::from_str(&body);
+        let my_stack = my_parser.events().peekable();
+        let mut reader = XmlResponse::new(my_stack);
+        reader.next(); // xml start node
+        let result = extract_s3_temporary_endpoint_from_xml(&mut reader);
+
+        match result {
+            Err(_) => panic!("Couldn't parse s3_temp_redirect.xml"),
+            Ok(location) => {
+                assert_eq!(location, "rusoto1441045966.s3-us-west-1.amazonaws.com");
+            }
+        }
+    }
+
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -27,7 +27,6 @@ use credential::AwsCredentials;
 use error::AwsError;
 use param::Params;
 use region::Region;
-use request::send_request;
 
 const HTTP_TEMPORARY_REDIRECT: StatusCode = StatusCode::TemporaryRedirect;
 
@@ -148,12 +147,12 @@ impl <'a> SignedRequest <'a> {
     /// Calculate the signature from the credentials provided and the request data
     /// Add the calculated signature to the request headers and execute it
     /// Return the hyper HTTP response
-    pub fn sign_and_execute(&mut self, creds: AwsCredentials) -> Response {
-        self.sign(&creds);
-        self.execute(creds)
-    }
+    //pub fn sign_and_execute(&mut self, creds: AwsCredentials) -> Response {
+    //    self.sign(&creds);
+    //    self.execute(creds)
+    //}
 
-    fn sign(&mut self, creds: &AwsCredentials) {
+    pub fn sign(&mut self, creds: &AwsCredentials) {
         debug!("Creating request to send to AWS.");
         let hostname = match self.hostname {
             Some(ref h) => h.to_string(),
@@ -235,6 +234,7 @@ impl <'a> SignedRequest <'a> {
         self.add_header("authorization", &auth_header);
     }
 
+/*
     fn execute(&mut self, creds: AwsCredentials) -> Response {
         let response = send_request(self);
         debug!("Sent request to AWS");
@@ -252,6 +252,7 @@ impl <'a> SignedRequest <'a> {
 
         response
     }
+    */
 }
 
 fn signature(string_to_sign: &str, signing_key: Vec<u8>) -> String {

--- a/src/xmlutil.rs
+++ b/src/xmlutil.rs
@@ -5,11 +5,8 @@
 
 use std::iter::Peekable;
 use std::num::ParseIntError;
-use hyper::client::response::*;
 use std::collections::HashMap;
 use xml::reader::*;
-use std::io::BufReader;
-use std::fs::File;
 use xml::reader::events::*;
 
 /// generic Error for XML parsing
@@ -23,7 +20,7 @@ impl XmlParseError {
 }
 
 /// syntactic sugar for the XML event stack we pass around
-pub type XmlStack<'a> = Peekable<Events<'a, Response>>;
+pub type XmlStack<'a> = Peekable<Events<'a, &'a[u8]>>;
 
 /// Peek at next items in the XML stack
 pub trait Peek {
@@ -36,27 +33,42 @@ pub trait Next {
 }
 
 /// Wraps the Hyper Response type
-pub struct XmlResponseFromAws<'b> {
-    xml_stack: Peekable<Events<'b, Response>> // refactor to use XmlStack type?
+pub struct XmlResponse<'b> {
+    xml_stack: Peekable<Events<'b, &'b [u8]>> // refactor to use XmlStack type?
 }
 
-impl <'b>XmlResponseFromAws<'b> {
-    pub fn new(stack: Peekable<Events<'b, Response>>) -> XmlResponseFromAws {
-        XmlResponseFromAws {
+impl <'b>XmlResponse<'b> {
+    pub fn new(stack: Peekable<Events<'b, &'b [u8]>>) -> XmlResponse {
+        XmlResponse {
             xml_stack: stack,
         }
     }
 }
 
-impl <'b>Peek for XmlResponseFromAws<'b> {
+impl <'b>Peek for XmlResponse<'b> {
     fn peek(&mut self) -> Option<&XmlEvent> {
+        loop {
+            match self.xml_stack.peek() {
+                Some(&XmlEvent::Whitespace(_)) => {  },
+                _ => break
+            }
+            self.xml_stack.next();
+        }
         self.xml_stack.peek()
     }
 }
 
-impl <'b> Next for XmlResponseFromAws<'b> {
+impl <'b> Next for XmlResponse<'b> {
     fn next(&mut self) -> Option<XmlEvent> {
-        self.xml_stack.next()
+        let mut maybe_event;
+        loop {
+            maybe_event = self.xml_stack.next();
+            match maybe_event {
+                Some(XmlEvent::Whitespace(_)) => {},
+                _ => break
+            }
+        }
+        maybe_event
     }
 }
 
@@ -64,30 +76,6 @@ impl From<ParseIntError> for XmlParseError{
     fn from(_e:ParseIntError) -> XmlParseError { XmlParseError::new("ParseIntError") }
 }
 
-/// Testing helper, reads from file
-pub struct XmlResponseFromFile<'a> {
-    xml_stack: Peekable<Events<'a, BufReader<File>>>,
-}
-
-impl <'a>XmlResponseFromFile<'a> {
-    pub fn new(my_stack: Peekable<Events<'a, BufReader<File>>>) -> XmlResponseFromFile {
-        XmlResponseFromFile { xml_stack: my_stack }
-    }
-}
-
-// Need peek and next implemented.
-impl <'b> Peek for XmlResponseFromFile <'b> {
-    fn peek(&mut self) -> Option<&XmlEvent> {
-        self.xml_stack.peek()
-    }
-}
-
-impl <'b> Next for XmlResponseFromFile <'b> {
-    fn next(&mut self) -> Option<XmlEvent> {
-        self.xml_stack.next()
-    }
-}
-// /testing helper
 
 /// parse Some(String) if the next tag has the right name, otherwise None
 pub fn optional_string_field<T: Peek + Next>(field_name: &str, stack: &mut T) -> Result<Option<String>, XmlParseError> {
@@ -109,18 +97,11 @@ pub fn string_field<T: Peek + Next>(name: &str, stack: &mut T) -> Result<String,
 
 /// return some XML Characters
 pub fn characters<T: Peek + Next>(stack: &mut T) -> Result<String, XmlParseError> {
-
-    // AWS can send an empty tag (like <reason/>) when content is empty
-    if let Some(&XmlEvent::EndElement { .. }) = stack.peek() {
-        return Ok(String::new());
-    }
-
     if let Some(XmlEvent::Characters(data)) = stack.next() {
         Ok(data.to_string())
-    } else {
-        Err(XmlParseError::new("Expected characters"))
+    } else { 
+         Err(XmlParseError::new("Expected characters"))
     }
-
 }
 
 /// get the name of the current element in the stack.  throw a parse error if it's not a `StartElement`
@@ -133,24 +114,22 @@ pub fn peek_at_name<T: Peek + Next>(stack: &mut T) -> Result<String, XmlParseErr
     }
 }
 
-/// consume a `StartElement` with a specific name or throw an `XmlParseError`. Skip Whitespace events
+/// consume a `StartElement` with a specific name or throw an `XmlParseError`
 pub fn start_element<T: Peek + Next>(element_name: &str, stack: &mut T)  -> Result<HashMap<String, String>, XmlParseError> {
-    loop {
-        match stack.next() {
-            Some(XmlEvent::Whitespace(_)) => continue,
-            Some(XmlEvent::StartElement { name, attributes, .. }) => {
-                if name.local_name == element_name {
-                    let mut attr_map = HashMap::new();
-                    for attr in attributes {
-                        attr_map.insert(attr.name.local_name, attr.value);
-                    }
-                    return Ok(attr_map);
-                } else {
-                    return Err(XmlParseError::new(&format!("Expected {} got {}", element_name, name.local_name)));
-                }
-            },
-            other => return Err(XmlParseError::new(&format!("Expected StartElement {}, got {:?}", element_name, other))),
+    let next = stack.next();
+
+    if let Some(XmlEvent::StartElement { name, attributes, .. }) = next {
+        if name.local_name == element_name {
+            let mut attr_map = HashMap::new();
+            for attr in attributes {
+                attr_map.insert(attr.name.local_name, attr.value);
+            }
+            Ok(attr_map)
+        } else {
+            Err(XmlParseError::new(&format!("START Expected {} got {}", element_name, name.local_name)))
         }
+    } else {
+        Err(XmlParseError::new(&format!("Expected StartElement {}", element_name)))
     }
 }
 
@@ -161,55 +140,33 @@ pub fn end_element<T: Peek + Next>(element_name: &str, stack: &mut T)  -> Result
         if name.local_name == element_name {
             Ok(())
         } else {
-            Err(XmlParseError::new(&format!("Expected {} got {}", element_name, name.local_name)))
+            Err(XmlParseError::new(&format!("END Expected {} got {}", element_name, name.local_name)))
         }
     }else {
         Err(XmlParseError::new(&format!("Expected EndElement {} got {:?}", element_name, next)))
     }
 }
 
-/// skip a tag and all its children
-pub fn skip_tree<T: Peek + Next>(stack: &mut T) {
-
-    let mut deep: usize = 0;
-
-    loop {
-        match stack.next() {
-            None => break,
-            Some(XmlEvent::StartElement { .. }) => deep += 1,
-            Some(XmlEvent::EndElement { ..}) => {
-                if deep > 1 {
-                    deep -= 1;
-                } else {
-                    break;
-                }
-            },
-            _ => (),
-        }
-    }
-
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use xml::reader::*;
-    use std::io::BufReader;
+    use std::io::Read;
     use std::fs::File;
 
     #[test]
     fn peek_at_name_happy_path() {
-        let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
+        let mut body = String::new();
+        let _size = file.read_to_string(&mut body);
+        let mut my_parser  = EventReader::new(body.as_bytes());
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
 
         loop {
             reader.next();
             match peek_at_name(&mut reader) {
                 Ok(data) => {
-                    // println!("Got {}", data);
                     if data == "QueueUrl" {
                         return;
                     }
@@ -221,11 +178,12 @@ mod tests {
 
     #[test]
     fn start_element_happy_path() {
-        let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
+        let mut body = String::new();
+        let _size = file.read_to_string(&mut body);
+        let mut my_parser  = EventReader::new(body.as_bytes());
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
 
         // skip two leading fields since we ignore them (xml declaration, return type declaration)
         reader.next();
@@ -239,11 +197,12 @@ mod tests {
 
     #[test]
     fn string_field_happy_path() {
-        let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
+        let mut body = String::new();
+        let _size = file.read_to_string(&mut body);
+        let mut my_parser  = EventReader::new(body.as_bytes());
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
 
         // skip two leading fields since we ignore them (xml declaration, return type declaration)
         reader.next();
@@ -258,11 +217,12 @@ mod tests {
 
     #[test]
     fn end_element_happy_path() {
-        let file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
+        let mut file = File::open("tests/sample-data/list_queues_with_queue.xml").unwrap();
+        let mut body = String::new();
+        let _size = file.read_to_string(&mut body);
+        let mut my_parser  = EventReader::new(body.as_bytes());
         let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
+        let mut reader = XmlResponse::new(my_stack);
 
         // skip two leading fields since we ignore them (xml declaration, return type declaration)
         reader.next();
@@ -280,25 +240,6 @@ mod tests {
             Ok(_) => (),
             Err(_) => panic!("Couldn't find end element")
         }
-    }
-
-    #[test]
-    fn skip_tree_with_subtree() {
-        let file = File::open("tests/sample-data/skip_tree.xml").unwrap();
-        let file = BufReader::new(file);
-        let mut my_parser  = EventReader::new(file);
-        let my_stack = my_parser.events().peekable();
-        let mut reader = XmlResponseFromFile::new(my_stack);
-
-        // skip two leading fields since we ignore them (xml declaration, return type declaration)
-        reader.next();
-        reader.next();
-
-        // skip tag a
-        skip_tree(&mut reader);
-
-        // expect tag f
-        start_element("f", &mut reader).expect("Missing tag f");
     }
 
 }

--- a/src/xmlutil.rs
+++ b/src/xmlutil.rs
@@ -147,6 +147,27 @@ pub fn end_element<T: Peek + Next>(element_name: &str, stack: &mut T)  -> Result
     }
 }
 
+/// skip a tag and all its children
+pub fn skip_tree<T: Peek + Next>(stack: &mut T) {
+
+    let mut deep: usize = 0;
+
+    loop {
+        match stack.next() {
+            None => break,
+            Some(XmlEvent::StartElement { .. }) => deep += 1,
+            Some(XmlEvent::EndElement { ..}) => {
+                if deep > 1 {
+                    deep -= 1;
+                } else {
+                    break;
+                }
+            },
+            _ => (),
+        }
+    }
+
+}
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Updates codegen to produce services that reuse an HTTP client instead of making a new one for every request.  Fixes #173 at long last.

Also hides the HTTP dispatch implementation behind a `DispatchSignedRequest` trait, viz:
```
pub trait DispatchSignedRequest {
    fn dispatch(&self, request: &SignedRequest) 
        -> Result<HttpResponse, HttpDispatchError>;
}
```
The trait is currently implemented for `hyper::Client`.

The `FooService::new(creds, region)` method for all the generated services defaults to the Hyper implementation, so things continue to function as usual.  Since that signature remains the same, it shouldn't significantly trouble existing code that uses it.  A new `FooService::with_request_dispatcher(dispatcher, creds, region)` constructor is also provided.

This will also make more rigorous unit testing possible since we can now mock the whole HTTP request + response by swapping Hyper out for a local implementation.