### PR TITLE
chain credentials providers together with or_else()

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -459,8 +459,8 @@ impl ProvideAwsCredentials for ChainProvider {
                 None => Err(AwsError::new(""))
             }
         })
-		.or(IamProvider.credentials())
-		.or(Err(AwsError::new("Couldn't find AWS credentials in environment, credentials file, or IAM role.")))
+		.or_else(|_| IamProvider.credentials())
+		.or_else(|_| Err(AwsError::new("Couldn't find AWS credentials in environment, credentials file, or IAM role.")))
     }
 }
 


### PR DESCRIPTION
Stops the `ChainProvider` for waiting for all credentials providers to return.

Fixes #292 