### PR TITLE
Remove Syntex Build Dependency

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -11,10 +11,6 @@ version = "0.2.2"
 optional = true
 version = "0.7.6"
 
-[build-dependencies.syntex]
-optional = true
-version = "0.32.0"
-
 [dependencies]
 Inflector = "0.2.0"
 lazy_static = "0.1.16"

--- a/codegen/build.rs
+++ b/codegen/build.rs
@@ -1,6 +1,5 @@
 #[cfg(not(feature = "serde_macros"))]
 mod inner {
-    extern crate syntex;
     extern crate serde_codegen;
 
     use std::env;


### PR DESCRIPTION
Remove the syntex build dependency declaration from the codegen `Cargo.toml` as well
as the codegen `build.rs`. The functionality utilizing syntex in the build
script was removed earlier, but the actual dependency was not (erroneously).