### PR TITLE
Fix main build by annotating recursively defined types for serde

### DIFF
--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -98,11 +98,9 @@ impl GenerateProtocol for JsonGenerator {
     }
 
     fn generate_additional_annotations(&self, service: &Service, shape_name: &str, type_name: &str) -> Vec<String> {
-        let service_name = service.service_type_name();
-
         // serde can no longer handle recursively defined types without help
         // annotate them to avoid compiler overflows
-        match service_name {
+        match service.service_type_name() {
             "DynamoDb" | "DynamoDbStreams" => {
                 if type_name == "ListAttributeValue" || type_name == "MapAttributeValue" {
                     return vec![format!("#[serde(bound=\"\")]")];

--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -2,7 +2,7 @@ use inflector::Inflector;
 
 use std::collections::HashMap;
 
-use botocore::{Operation, Service, Shape};
+use botocore::{Operation, Service};
 use super::GenerateProtocol;
 
 pub struct JsonGenerator;
@@ -97,9 +97,15 @@ impl GenerateProtocol for JsonGenerator {
         "f64"
     }
 
-    fn generate_additional_annotations(&self, _service: &Service, _shape: &Shape, type_name: &str) -> Vec<String> {
-        if type_name == "ListAttributeValue" || type_name == "MapAttributeValue" {
-            vec![format!("#[serde(bound=\"\")]")]
+    fn generate_additional_annotations(&self, service: &Service, shape_name: &str, type_name: &str) -> Vec<String> {
+        let service_name = service.service_type_name();
+
+        if (service_name == "DynamoDb" || service_name == "DynamoDbStreams") &&
+           (type_name == "ListAttributeValue" || type_name == "MapAttributeValue") {
+                vec![format!("#[serde(bound=\"\")]")]
+        } else if service.service_type_name() == "Emr" &&
+            shape_name == "Configuration" && type_name == "ConfigurationList" {
+                vec![format!("#[serde(bound=\"\")]")]
         } else {
             Vec::<String>::with_capacity(0)
         }

--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -2,7 +2,7 @@ use inflector::Inflector;
 
 use std::collections::HashMap;
 
-use botocore::{Operation, Service};
+use botocore::{Operation, Service, Shape};
 use super::GenerateProtocol;
 
 pub struct JsonGenerator;
@@ -95,6 +95,14 @@ impl GenerateProtocol for JsonGenerator {
 
     fn timestamp_type(&self) -> &'static str {
         "f64"
+    }
+
+    fn generate_additional_annotations(&self, _service: &Service, _shape: &Shape, type_name: &str) -> Vec<String> {
+        if type_name == "ListAttributeValue" || type_name == "MapAttributeValue" {
+            vec![format!("#[serde(bound=\"\")]")]
+        } else {
+            Vec::<String>::with_capacity(0)
+        }
     }
 
 }

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -28,7 +28,7 @@ pub trait GenerateProtocol {
         None
     }
 
-    fn generate_additional_annotations(&self, _service: &Service, _shape: &Shape, _type_name: &str) -> Vec<String> {
+    fn generate_additional_annotations(&self, _service: &Service, _shape_name: &str, _type_name: &str) -> Vec<String> {
         Vec::<String>::with_capacity(0)
     }
 
@@ -179,7 +179,7 @@ fn generate_struct<P>(
             ",
             attributes = protocol_generator.generate_struct_attributes(),
             name = name,
-            struct_fields = generate_struct_fields(service, shape, protocol_generator),
+            struct_fields = generate_struct_fields(service, shape, name, protocol_generator),
         )
     }
 
@@ -194,7 +194,7 @@ pub fn generate_field_name(member_name: &str) -> String {
     }
 }
 
-fn generate_struct_fields<P>(service: &Service, shape: &Shape, protocol_generator: &P) -> String where P: GenerateProtocol {
+fn generate_struct_fields<P>(service: &Service, shape: &Shape, shape_name: &str, protocol_generator: &P) -> String where P: GenerateProtocol {
     shape.members.as_ref().unwrap().iter().map(|(member_name, member)| {
         let mut lines: Vec<String> = Vec::new();
         let name = generate_field_name(member_name);
@@ -208,7 +208,7 @@ fn generate_struct_fields<P>(service: &Service, shape: &Shape, protocol_generato
         lines.push("#[allow(unused_attributes)]".to_owned());
         lines.push(format!("#[serde(rename=\"{}\")]", member_name));
 
-        lines.append(&mut protocol_generator.generate_additional_annotations(service, shape, &type_name));
+        lines.append(&mut protocol_generator.generate_additional_annotations(service, shape_name, &type_name));
 
         if let Some(shape_type) = service.shape_type_for_member(member) {
             if shape_type == "blob" {

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -28,6 +28,10 @@ pub trait GenerateProtocol {
         None
     }
 
+    fn generate_additional_annotations(&self, _service: &Service, _shape: &Shape, _type_name: &str) -> Vec<String> {
+        Vec::<String>::with_capacity(0)
+    }
+
     fn timestamp_type(&self) -> &'static str;
 }
 
@@ -120,7 +124,7 @@ where P: GenerateProtocol {
         let type_name = &capitalize_first(name.to_string());
 
         if type_name == "String" {
-            return protocol_generator.generate_support_types(type_name, shape, &service);
+            return protocol_generator.generate_support_types(&type_name, shape, &service);
         }
 
         if shape.exception() && service.typed_errors() {
@@ -175,7 +179,7 @@ fn generate_struct<P>(
             ",
             attributes = protocol_generator.generate_struct_attributes(),
             name = name,
-            struct_fields = generate_struct_fields(service, shape),
+            struct_fields = generate_struct_fields(service, shape, protocol_generator),
         )
     }
 
@@ -190,17 +194,21 @@ pub fn generate_field_name(member_name: &str) -> String {
     }
 }
 
-fn generate_struct_fields(service: &Service, shape: &Shape) -> String {
+fn generate_struct_fields<P>(service: &Service, shape: &Shape, protocol_generator: &P) -> String where P: GenerateProtocol {
     shape.members.as_ref().unwrap().iter().map(|(member_name, member)| {
-        let mut lines = Vec::with_capacity(4);
+        let mut lines: Vec<String> = Vec::new();
         let name = generate_field_name(member_name);
 
         if let Some(ref docs) = member.documentation {
             lines.push(format!("#[doc=\"{}\"]", docs.replace("\\","\\\\").replace("\"", "\\\"")));
         }
 
+        let type_name = capitalize_first(member.shape.to_string());
+
         lines.push("#[allow(unused_attributes)]".to_owned());
         lines.push(format!("#[serde(rename=\"{}\")]", member_name));
+
+        lines.append(&mut protocol_generator.generate_additional_annotations(service, shape, &type_name));
 
         if let Some(shape_type) = service.shape_type_for_member(member) {
             if shape_type == "blob" {
@@ -216,7 +224,6 @@ fn generate_struct_fields(service: &Service, shape: &Shape) -> String {
             }
         }
 
-        let type_name = capitalize_first(member.shape.to_string());
 
         if shape.required(member_name) {
             lines.push(format!("pub {}: {},",  name, type_name));


### PR DESCRIPTION
Adds a hook to `GenerateProtocol` that allows implementing types to add arbitrary annotations to each `struct` field.  A default implementation is provided that adds nothing.

Uses that hook to add `#[serde(bound="")]` annotations to the recursively defined types that were causing the latest round of Serde explosions.

Fixes #302 - The build with all features and tests now passes.