### PR TITLE
make types from request module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use credential::{
 };
 pub use error::{AwsError, AwsResult};
 pub use region::{ParseRegionError, Region};
+pub use request::{DispatchSignedRequest, HttpResponse, HttpDispatchError};
 
 mod credential;
 mod error;


### PR DESCRIPTION
Exposes types from the `request` module.  Fixes #322 

Note that this follows the pattern of other types we've made public like `ProvideAwsCredentials` and would be used externally as just `rusoto::DispatchSignedRequest` etc.