### PR TITLE
query.rs: AWS lists are 1 based, not 0 based.

### DIFF
--- a/codegen/src/generator/query.rs
+++ b/codegen/src/generator/query.rs
@@ -335,7 +335,8 @@ fn generate_serializer_signature(name: &str, shape: &Shape) -> String {
 fn generate_list_serializer(shape: &Shape) -> String {
     format!(
         "for (index, element) in obj.iter().enumerate() {{
-    let key = format!(\"{{}}.{{}}\", name, index);
+    // Lists are one-based, see example here: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html
+    let key = format!(\"{{}}.{{}}\", name, index+1);
     {name}Serializer::serialize(params, &key, element);
 }}
         ",


### PR DESCRIPTION
Fixes #324 

I verified this was universal by looking at the botocore code, specifically [this line](https://github.com/boto/botocore/blob/6bd797f140a8e33d8f9e6fcc49f429e09d985b33/botocore/serialize.py#L218).