### PR TITLE
fix incorrect struct field name

### DIFF
--- a/codegen/src/generator/ec2.rs
+++ b/codegen/src/generator/ec2.rs
@@ -18,7 +18,7 @@ impl GenerateProtocol for Ec2Generator {
 
                     params.put(\"Action\", \"{operation_name}\");
                     params.put(\"Version\", \"{api_version}\");
-    
+
                     {serialize_input}
 
                     request.set_params(params);
@@ -417,7 +417,7 @@ fn generate_struct_field_serializers(shape: &Shape) -> String {
                 ",
                 field_name = generate_field_name(member_name),
                 member_shape_name = member.shape,
-                tag_name = member.tag_name(),
+                tag_name = member.location_name.clone().unwrap_or(member_name.clone()),
             )
         }
     }).collect::<Vec<String>>().join("\n")


### PR DESCRIPTION
for example the ec2::DescribeSnapshotsRequest with filters render to this:

`https://ec2.ap-southeast-1.amazonaws.com/?Action=DescribeSnapshots&Filter.0.String=volume-id&Filter.0.Value.0=vol-xxx&Version=2015-10-01`

while the correct url should be:

`https://ec2.ap-southeast-1.amazonaws.com/?Action=DescribeSnapshots&Filter.0.Name=volume-id&Filter.0.Value.0=vol-xxx&Version=2015-10-01`