### PR TITLE
Annotates Dynamodb example to not compile.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! The following code shows a simple example of using Rusoto's DynamoDB API to
 //! list the names of all tables in a database.
 //!
-//! ```
+//! ```rust,ignore
 //! use std::default::Default;
 //!
 //! use rusoto::{DefaultCredentialsProvider, Region};
@@ -159,4 +159,3 @@ pub mod gamelift;
 #[cfg(feature = "support")]
 pub mod support;
 */
-


### PR DESCRIPTION
Fixes #360 .

An alternative would be putting the code behind a feature flag but I couldn't get that to work.

Another alternative is to put the rustdoc into the dynamodb docs and link to it from the top-level documentation.