### PR TITLE
Annotate DynamoDb rustdoc example to only run with feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,10 @@
 //! The following code shows a simple example of using Rusoto's DynamoDB API to
 //! list the names of all tables in a database.
 //!
-//! ```
+//! ```rust
+//! # #![feature(stmt_expr_attributes)]
+//! # #[cfg(feature = "dynamodb")]
+//! # {
 //! use std::default::Default;
 //!
 //! use rusoto::{DefaultCredentialsProvider, Region};
@@ -42,6 +45,7 @@
 //!         println!("Error: {:?}", error);
 //!     },
 //! }
+//! # }
 
 extern crate chrono;
 extern crate hyper;


### PR DESCRIPTION
Add dynamodb feature flag to the example in the root rustdoc, to avoid the test
being run without the dynamodb module being available.

Closes #360. Alternative to #361.