### PR TITLE
Add mock request dispatcher and example unit test using it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ extern crate xml;
 pub use credential::{
     AwsCredentials,
     ChainProvider,
+    CredentialsError,
     EnvironmentProvider,
     IamProvider,
     ProfileProvider,
@@ -68,6 +69,7 @@ pub use credential::{
 };
 pub use region::{ParseRegionError, Region};
 pub use request::{DispatchSignedRequest, HttpResponse, HttpDispatchError};
+pub use signature::SignedRequest;
 
 mod credential;
 mod param;
@@ -78,6 +80,8 @@ mod xmlutil;
 mod serialization;
 #[macro_use] mod signature;
 
+#[cfg(test)]
+mod mock;
 
 #[cfg(feature = "acm")]
 pub mod acm;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,0 +1,55 @@
+//! Mock request dispatcher and credentials for unit testing services
+use super::{DispatchSignedRequest, HttpResponse, HttpDispatchError, SignedRequest};
+use super::{ProvideAwsCredentials, CredentialsError, AwsCredentials};
+use chrono::{Duration, UTC};
+
+const ONE_DAY: i64 = 86400;
+
+pub struct MockCredentialsProvider;
+
+impl ProvideAwsCredentials for MockCredentialsProvider {
+    fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+		Ok(AwsCredentials::new("mock_key", "mock_secret", None, UTC::now() + Duration::seconds(ONE_DAY)))
+    }
+}
+
+pub struct MockRequestDispatcher {
+	mock_response: HttpResponse,
+	request_checker: Option<Box<Fn(&SignedRequest)>>
+}
+
+impl MockRequestDispatcher {
+	pub fn with_status(status: u16) -> MockRequestDispatcher {
+		let mut response = HttpResponse::default();
+		response.status = status;
+		MockRequestDispatcher { 
+			mock_response: response,
+			request_checker: None
+		}
+	}
+
+	pub fn with_body(mut self, body: &str) -> MockRequestDispatcher {
+		self.mock_response.body = body.to_owned();
+		self
+	}
+
+	pub fn with_request_checker<F>(mut self, checker: F) -> MockRequestDispatcher where F: Fn(&SignedRequest) + 'static {
+		self.request_checker = Some(Box::new(checker));
+		self
+	}
+
+	pub fn with_header(mut self, key: String, value: String) -> MockRequestDispatcher {
+		self.mock_response.headers.insert(key, value);
+		self
+	}
+
+}
+
+impl DispatchSignedRequest for MockRequestDispatcher {
+	fn dispatch(&self, request: &SignedRequest) -> Result<HttpResponse, HttpDispatchError> {
+		if self.request_checker.is_some() {
+			self.request_checker.as_ref().unwrap()(request);
+		}
+		Ok(self.mock_response.clone())
+	}
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -17,6 +17,7 @@ use log::LogLevel::Debug;
 
 use signature::SignedRequest;
 
+#[derive(Clone, Default)]
 pub struct HttpResponse {
     pub status: u16,
     pub body: String,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -28,17 +28,17 @@ const HTTP_TEMPORARY_REDIRECT: StatusCode = StatusCode::TemporaryRedirect;
 /// the Amazon Signature Version 4 signing process
 #[derive(Debug)]
 pub struct SignedRequest<'a> {
-    method: String,
-    service: String,
-    region: Region,
-    path: String,
-    headers: BTreeMap<String, Vec<Vec<u8>>>,
-    params: Params,
-    hostname: Option<String>,
-    payload: Option<&'a [u8]>,
-    content_type: Option<String>,
-    canonical_query_string: String,
-    canonical_uri: String,
+    pub method: String,
+    pub service: String,
+    pub region: Region,
+    pub path: String,
+    pub headers: BTreeMap<String, Vec<Vec<u8>>>,
+    pub params: Params,
+    pub hostname: Option<String>,
+    pub payload: Option<&'a [u8]>,
+    pub content_type: Option<String>,
+    pub canonical_query_string: String,
+    pub canonical_uri: String,
 }
 
 impl <'a> SignedRequest <'a> {

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -3,3 +3,44 @@
 #![cfg_attr(feature = "nightly-testing", allow(while_let_loop))]
 
 include!(concat!(env!("OUT_DIR"), "/sqs.rs"));
+
+#[cfg(test)]
+mod test {
+	use sqs::{SqsClient, CreateQueueRequest};
+    use super::super::{Region, SignedRequest};
+    use super::super::mock::*;
+
+    extern crate env_logger;
+
+    #[test]
+    // sample response from the SQS documentation
+    fn should_parse_example_create_queue_response() {
+        let mock = MockRequestDispatcher::with_status(200)
+            .with_body(r#"
+				<?xml version="1.0" encoding="UTF-8"?>
+				<CreateQueueResponse>
+					<CreateQueueResult>
+						<QueueUrl>http://queue.amazonaws.com/123456789012/testQueue</QueueUrl>
+					</CreateQueueResult>
+					<ResponseMetadata>
+						<RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId>
+					</ResponseMetadata>
+				</CreateQueueResponse>
+            "#)
+            .with_request_checker(|request: &SignedRequest| {
+                assert_eq!(request.method, "POST");
+                assert_eq!(request.path, "/");
+                assert_eq!(request.params.get("Action"), Some(&"CreateQueue".to_string()));
+                assert_eq!(request.params.get("QueueName"), Some(&"testQueue".to_string()));
+                assert_eq!(request.payload, None);
+            });
+
+        let client = SqsClient::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+
+        let mut request = CreateQueueRequest::default();
+        request.queue_name = "testQueue".to_string();
+
+        let result = client.create_queue(&request).unwrap();
+        assert_eq!(result.queue_url, Some("http://queue.amazonaws.com/123456789012/testQueue".to_string()));
+    }
+}


### PR DESCRIPTION
Pulled this out of some un-merged stuff since there's a need for it.

Adds a `MockRequestDispatcher` that allows the whole HTTP request/response to be easily mocked for unit tests.  There's an example unit test in `sqs.rs` that demonstrates its use.

Essentially, you create a mock dispatcher that always returns a specified body, status code, and headers.  That mock is used by the `WhateverClient` that our codegen outputs instead of the default, and then when a method is called, it gets the mocked response back.