### PR TITLE
Feat response parse tests

### DIFF
--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -13,6 +13,7 @@ mod ec2;
 mod json;
 mod query;
 mod rest_json;
+mod tests;
 
 pub trait GenerateProtocol {
     fn generate_methods(&self, service: &Service) -> String;
@@ -28,6 +29,10 @@ pub trait GenerateProtocol {
 
     fn generate_additional_annotations(&self, _service: &Service, _shape_name: &str, _type_name: &str) -> Vec<String> {
         Vec::<String>::with_capacity(0)
+    }
+
+    fn generate_tests(&self, _service: &Service) -> Option<String> {
+        None
     }
 
     fn timestamp_type(&self) -> &'static str;
@@ -61,11 +66,14 @@ fn generate<P, E>(service: &Service, protocol_generator: P, error_type_generator
         {types}
         {error_types}
 
-        {client}",
+        {client}
+        
+        {tests}",
         client = generate_client(service, &protocol_generator),
         prelude = &protocol_generator.generate_prelude(service),
         types = generate_types(service, &protocol_generator),
         error_types = error_type_generator.generate_error_types(service).unwrap_or("".to_string()),
+        tests = &protocol_generator.generate_tests(service).unwrap_or("".to_string()),
     )
 }
 

--- a/codegen/src/generator/tests.rs
+++ b/codegen/src/generator/tests.rs
@@ -1,0 +1,60 @@
+use std::fs;
+
+fn capitalise(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().chain(c).collect(),
+    }
+}
+
+#[derive(Debug, Clone	)]
+pub struct Response {
+    pub service: String,
+    pub action: String,
+    pub file_name: String,
+    pub extension: String,
+}
+
+impl Response {
+    pub fn from_response_file_name(f: &str) -> Option<Response> {
+        let maybe_file_name_and_extension: Vec<&str> = f.split(".").collect();
+
+        let mut service_name = None;
+        let mut action = None;
+        let extension = maybe_file_name_and_extension.get(1);
+
+        if let Some(file_name) = maybe_file_name_and_extension.get(0) {
+            let file_name_parts: Vec<&str> = file_name.split("-").collect();
+
+            service_name = file_name_parts.get(0).map(|s| capitalise(s));
+
+            action = Some(file_name_parts.into_iter().skip(1).map(|w| capitalise(w)).collect());
+        }
+
+        service_name
+            .and_then(|s| action
+                .and_then(|a| extension
+                    .and_then(|e|
+                        Some(Response { 
+                            service: s, 
+                            action: a, 
+                            file_name: f.to_owned(),
+                            extension: e.to_string(),
+                        })
+                    )
+                )
+            )
+    }
+}
+
+pub fn find_responses() -> Vec<Response> {
+    let dir = fs::read_dir("./codegen/botocore/tests/unit/response_parsing/xml/responses")
+        .expect("read_dir");
+
+    dir
+        .map(|d| d.expect("direntry").file_name().into_string().expect("osstr"))
+        .flat_map(|f| Response::from_response_file_name(&f))
+        .filter(|r| r.extension == "xml")
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ extern crate xml;
 pub use credential::{
     AwsCredentials,
     ChainProvider,
+    CredentialsError,
     EnvironmentProvider,
     IamProvider,
     ProfileProvider,
@@ -68,6 +69,7 @@ pub use credential::{
 };
 pub use region::{ParseRegionError, Region};
 pub use request::{DispatchSignedRequest, HttpResponse, HttpDispatchError};
+pub use signature::SignedRequest;
 
 mod credential;
 mod param;
@@ -78,6 +80,8 @@ mod xmlutil;
 mod serialization;
 #[macro_use] mod signature;
 
+#[cfg(test)]
+mod mock;
 
 #[cfg(feature = "acm")]
 pub mod acm;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,4 +1,8 @@
 //! Mock request dispatcher and credentials for unit testing services
+
+use std::fs::File;
+use std::io::Read;
+
 use super::{DispatchSignedRequest, HttpResponse, HttpDispatchError, SignedRequest};
 use super::{ProvideAwsCredentials, CredentialsError, AwsCredentials};
 use chrono::{Duration, UTC};
@@ -52,4 +56,28 @@ impl DispatchSignedRequest for MockRequestDispatcher {
 		}
 		Ok(self.mock_response.clone())
 	}
+}
+
+pub trait ReadMockResponse {
+	fn read_response(file_name: &str) -> String;
+}
+
+pub struct MockResponseReader;
+
+impl ReadMockResponse for MockResponseReader {
+	fn read_response(response_name: &str) -> String {
+		let file_name = format!("./codegen/botocore/tests/unit/response_parsing/xml/responses/{}", response_name);
+
+		let mut input_file = File::open(&file_name)
+			.expect("couldn't find file");
+
+	    let mut mock_response = String::new();
+
+	    input_file.read_to_string(&mut mock_response).expect(&format!(
+	        "Failed to read {:?}",
+	        file_name,
+	    ));
+
+        mock_response
+	} 
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,0 +1,55 @@
+//! Mock request dispatcher and credentials for unit testing services
+use super::{DispatchSignedRequest, HttpResponse, HttpDispatchError, SignedRequest};
+use super::{ProvideAwsCredentials, CredentialsError, AwsCredentials};
+use chrono::{Duration, UTC};
+
+const ONE_DAY: i64 = 86400;
+
+pub struct MockCredentialsProvider;
+
+impl ProvideAwsCredentials for MockCredentialsProvider {
+    fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+		Ok(AwsCredentials::new("mock_key", "mock_secret", None, UTC::now() + Duration::seconds(ONE_DAY)))
+    }
+}
+
+pub struct MockRequestDispatcher {
+	mock_response: HttpResponse,
+	request_checker: Option<Box<Fn(&SignedRequest)>>
+}
+
+impl MockRequestDispatcher {
+	pub fn with_status(status: u16) -> MockRequestDispatcher {
+		let mut response = HttpResponse::default();
+		response.status = status;
+		MockRequestDispatcher { 
+			mock_response: response,
+			request_checker: None
+		}
+	}
+
+	pub fn with_body(mut self, body: &str) -> MockRequestDispatcher {
+		self.mock_response.body = body.to_owned();
+		self
+	}
+
+	pub fn with_request_checker<F>(mut self, checker: F) -> MockRequestDispatcher where F: Fn(&SignedRequest) + 'static {
+		self.request_checker = Some(Box::new(checker));
+		self
+	}
+
+	pub fn with_header(mut self, key: String, value: String) -> MockRequestDispatcher {
+		self.mock_response.headers.insert(key, value);
+		self
+	}
+
+}
+
+impl DispatchSignedRequest for MockRequestDispatcher {
+	fn dispatch(&self, request: &SignedRequest) -> Result<HttpResponse, HttpDispatchError> {
+		if self.request_checker.is_some() {
+			self.request_checker.as_ref().unwrap()(request);
+		}
+		Ok(self.mock_response.clone())
+	}
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -17,6 +17,7 @@ use log::LogLevel::Debug;
 
 use signature::SignedRequest;
 
+#[derive(Clone, Default)]
 pub struct HttpResponse {
     pub status: u16,
     pub body: String,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -28,17 +28,17 @@ const HTTP_TEMPORARY_REDIRECT: StatusCode = StatusCode::TemporaryRedirect;
 /// the Amazon Signature Version 4 signing process
 #[derive(Debug)]
 pub struct SignedRequest<'a> {
-    method: String,
-    service: String,
-    region: Region,
-    path: String,
-    headers: BTreeMap<String, Vec<Vec<u8>>>,
-    params: Params,
-    hostname: Option<String>,
-    payload: Option<&'a [u8]>,
-    content_type: Option<String>,
-    canonical_query_string: String,
-    canonical_uri: String,
+    pub method: String,
+    pub service: String,
+    pub region: Region,
+    pub path: String,
+    pub headers: BTreeMap<String, Vec<Vec<u8>>>,
+    pub params: Params,
+    pub hostname: Option<String>,
+    pub payload: Option<&'a [u8]>,
+    pub content_type: Option<String>,
+    pub canonical_query_string: String,
+    pub canonical_uri: String,
 }
 
 impl <'a> SignedRequest <'a> {

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -6,9 +6,6 @@ include!(concat!(env!("OUT_DIR"), "/sqs.rs"));
 
 #[cfg(test)]
 mod test {
-	use std::fs::File;
-	use std::io::Read;
-
 	use sqs::{SqsClient, CreateQueueRequest};
     use super::super::{Region, SignedRequest};
     use super::super::mock::*;
@@ -18,17 +15,8 @@ mod test {
     #[test]
     // sample response from the SQS documentation
     fn should_parse_example_create_queue_response() {
-		let sample_creation_response_location = "./codegen/botocore/tests/unit/response_parsing/xml/responses/sqs-create-queue.xml";
-		let mut input_file = File::open(sample_creation_response_location)
-			.expect("couldn't find file");
-
-	    let mut mock_response = String::new();
-
-	    input_file.read_to_string(&mut mock_response).expect(&format!(
-	        "Failed to read {:?}",
-	        sample_creation_response_location,
-	    ));
-
+        let mock_response =  MockResponseReader::read_response("sqs-create-queue.xml");
+		
         let mock = MockRequestDispatcher::with_status(200)
             .with_body(&mock_response)
             .with_request_checker(|request: &SignedRequest| {

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -3,3 +3,44 @@
 #![cfg_attr(feature = "nightly-testing", allow(while_let_loop))]
 
 include!(concat!(env!("OUT_DIR"), "/sqs.rs"));
+
+#[cfg(test)]
+mod test {
+	use sqs::{SqsClient, CreateQueueRequest};
+    use super::super::{Region, SignedRequest};
+    use super::super::mock::*;
+
+    extern crate env_logger;
+
+    #[test]
+    // sample response from the SQS documentation
+    fn should_parse_example_create_queue_response() {
+        let mock = MockRequestDispatcher::with_status(200)
+            .with_body(r#"
+				<?xml version="1.0" encoding="UTF-8"?>
+				<CreateQueueResponse>
+					<CreateQueueResult>
+						<QueueUrl>http://queue.amazonaws.com/123456789012/testQueue</QueueUrl>
+					</CreateQueueResult>
+					<ResponseMetadata>
+						<RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId>
+					</ResponseMetadata>
+				</CreateQueueResponse>
+            "#)
+            .with_request_checker(|request: &SignedRequest| {
+                assert_eq!(request.method, "POST");
+                assert_eq!(request.path, "/");
+                assert_eq!(request.params.get("Action"), Some(&"CreateQueue".to_string()));
+                assert_eq!(request.params.get("QueueName"), Some(&"testQueue".to_string()));
+                assert_eq!(request.payload, None);
+            });
+
+        let client = SqsClient::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+
+        let mut request = CreateQueueRequest::default();
+        request.queue_name = "testQueue".to_string();
+
+        let result = client.create_queue(&request).unwrap();
+        assert_eq!(result.queue_url, Some("http://queue.amazonaws.com/123456789012/testQueue".to_string()));
+    }
+}

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -6,6 +6,9 @@ include!(concat!(env!("OUT_DIR"), "/sqs.rs"));
 
 #[cfg(test)]
 mod test {
+	use std::fs::File;
+	use std::io::Read;
+
 	use sqs::{SqsClient, CreateQueueRequest};
     use super::super::{Region, SignedRequest};
     use super::super::mock::*;
@@ -15,18 +18,19 @@ mod test {
     #[test]
     // sample response from the SQS documentation
     fn should_parse_example_create_queue_response() {
+		let sample_creation_response_location = "./codegen/botocore/tests/unit/response_parsing/xml/responses/sqs-create-queue.xml";
+		let mut input_file = File::open(sample_creation_response_location)
+			.expect("couldn't find file");
+
+	    let mut mock_response = String::new();
+
+	    input_file.read_to_string(&mut mock_response).expect(&format!(
+	        "Failed to read {:?}",
+	        sample_creation_response_location,
+	    ));
+
         let mock = MockRequestDispatcher::with_status(200)
-            .with_body(r#"
-				<?xml version="1.0" encoding="UTF-8"?>
-				<CreateQueueResponse>
-					<CreateQueueResult>
-						<QueueUrl>http://queue.amazonaws.com/123456789012/testQueue</QueueUrl>
-					</CreateQueueResult>
-					<ResponseMetadata>
-						<RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId>
-					</ResponseMetadata>
-				</CreateQueueResponse>
-            "#)
+            .with_body(&mock_response)
             .with_request_checker(|request: &SignedRequest| {
                 assert_eq!(request.method, "POST");
                 assert_eq!(request.path, "/");
@@ -41,6 +45,6 @@ mod test {
         request.queue_name = "testQueue".to_string();
 
         let result = client.create_queue(&request).unwrap();
-        assert_eq!(result.queue_url, Some("http://queue.amazonaws.com/123456789012/testQueue".to_string()));
+        assert_eq!(result.queue_url, Some("http://sqs.us-east-1.amazonaws.com/123456789012/testQueue".to_string()));
     }
 }


### PR DESCRIPTION
I ran with [https://github.com/rusoto/rusoto/pull/368](https://github.com/rusoto/rusoto/pull/368)
and generated the tests automatically from the list of xml response files.

It doesn't verify the request that the client sends, or that the response is parsed faithfully, only that the response doesn't cause an error.

Tests are only generated where there's a response file present and a matching service operation.

On my test run with features=all I had 41 tests and 2 of those failed:
test sqs::protocol_tests::test_parse_sqs_get_queue_attributes ... FAILED
test sqs::protocol_tests::test_parse_sqs_receive_message ... FAILED
