### PR TITLE
Use path-style endpoint for DNS-incompatible buckets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ version = ">= 0.2.5"
 [dependencies]
 chrono = "0.2.21"
 hyper = "0.9.10"
+lazy_static = "0.1.16"
 log = "0.3.6"
 md5 = "0.2"
 regex = "0.1.65"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 
 extern crate chrono;
 extern crate hyper;
+#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate md5;
 extern crate regex;

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -17,6 +17,7 @@ use hyper::client::{Client, RedirectPolicy};
 use md5;
 use rustc_serialize::base64::{ToBase64, STANDARD};
 use xml::*;
+use regex::Regex;
 
 use credential::{ProvideAwsCredentials, AwsCredentials, CredentialsError};
 use param::{Params, ServiceParams};
@@ -11147,9 +11148,16 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     /// request parameters as selection criteria to return a subset of the objects in
     /// a bucket.
     pub fn list_objects(&self, input: &ListObjectsRequest) -> Result<ListObjectsOutput, S3Error> {
-        let uri = format!("/{}", &input.bucket);
-        let mut request = SignedRequest::new("GET", "s3", self.region, &uri);
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = path + &input.bucket + "/";
+        }
+        let mut request = SignedRequest::new("GET", "s3", self.region, &path);
 
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
         let mut params = Params::new();
 
         ListObjectsRequestWriter::write_params(&mut params, "", input);
@@ -11252,13 +11260,19 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     /// Uploads a part in a multipart upload.
     /// **Note:** After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.
     pub fn upload_part(&self, input: &UploadPartRequest) -> Result<String, S3Error> {
-        let object_id = &input.key;
-        let mut request = SignedRequest::new("PUT", "s3", self.region, &format!("/{}", object_id));
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        path = format!("{}{}", path, &input.key);
+        let mut request = SignedRequest::new("PUT", "s3", self.region, &path);
 
         request.set_payload(input.body);
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         if let Some(ref md5) = input.content_md5 {
             request.add_header("Content-MD5", md5);
@@ -11291,7 +11305,10 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     /// Adds an object to a bucket.
     pub fn put_object(&self, input: &PutObjectRequest) -> Result<PutObjectOutput, S3Error> {
         let mut uri = String::from("/");
-        uri = uri +  &input.key.to_string();
+        if !is_dns_compatible(&input.bucket) {
+            uri = uri + &input.bucket + "/";
+        }
+        uri = uri + &input.key;
         let mut request = SignedRequest::new("PUT", "s3", self.region, &uri);
 
         if let Some(ref class) = input.storage_class {
@@ -11335,8 +11352,10 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
             None => request.set_content_type("binary/octet-stream".to_string())
         };
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
         request.set_payload(input.body);
 
         let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
@@ -11795,9 +11814,15 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     pub fn create_bucket(&self, input: &CreateBucketRequest) -> Result<CreateBucketOutput, S3Error> {
         let region = Region::UsEast1;
         let mut create_config : Vec<u8>;
-        let mut request = SignedRequest::new("PUT", "s3", region, "");
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = path + &input.bucket;
+        }
+        let mut request = SignedRequest::new("PUT", "s3", region, &path);
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         if needs_create_bucket_config(self.region) {
             create_config = create_bucket_config_xml(self.region);
@@ -11826,15 +11851,22 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     }
     /// Completes a multipart upload by assembling previously uploaded parts.
     pub fn complete_multipart_upload(&self, input: &CompleteMultipartUploadRequest) -> Result<CompleteMultipartUploadOutput, S3Error> {
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        path = format!("{}{}", path, &input.key);
         let mut request = SignedRequest::new("POST", "s3", self.region,
-            &format!("/{}", input.key));
+            &path);
 
         let mut params = Params::new();
         params.put("uploadId", &input.upload_id.to_string());
         request.set_params(params);
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         request.set_payload(input.multipart_upload);
 
@@ -11879,15 +11911,21 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     /// **Note:** After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.
     pub fn create_multipart_upload(&self, input: &CreateMultipartUploadRequest) -> Result<CreateMultipartUploadOutput, S3Error> {
 
-        let object_name = &input.key;
-        let mut request = SignedRequest::new("POST", "s3", self.region, &format!("/{}", object_name));
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        path = format!("{}{}", path, &input.key);
+        let mut request = SignedRequest::new("POST", "s3", self.region, &path);
 
         let mut params = Params::new();
         params.put("uploads", "");
         request.set_params(params);
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
         let status = result.status;
@@ -11906,10 +11944,16 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     /// Markers) in the bucket must be deleted before the bucket itself can be
     /// deleted.
     pub fn delete_bucket(&self, input: &DeleteBucketRequest, region: Region) -> Result<(), S3Error> {
-        let mut request = SignedRequest::new("DELETE", "s3", region, "");
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        let mut request = SignedRequest::new("DELETE", "s3", region, &path);
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
         let status = result.status;
@@ -12009,13 +12053,18 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
 
     /// Retrieves objects from Amazon S3.
     pub fn get_object(&self, input: &GetObjectRequest) -> Result<GetObjectOutput, S3Error> {
-        let mut uri = String::from("/");
-        uri = uri +  &input.key.to_string();
-        let mut request = SignedRequest::new("GET", "s3", self.region, &uri);
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        path = format!("{}{}", path, &input.key);
+        let mut request = SignedRequest::new("GET", "s3", self.region, &path);
         let mut params = Params::new();
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         params.put("Action", "GetObject");
         GetObjectRequestWriter::write_params(&mut params, "", input);
@@ -12080,14 +12129,20 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     }
     /// This operation lists in-progress multipart uploads.
     pub fn list_multipart_uploads(&self, input: &ListMultipartUploadsRequest) -> Result<ListMultipartUploadsOutput, S3Error> {
-        let mut request = SignedRequest::new("GET", "s3", self.region, "/");
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        let mut request = SignedRequest::new("GET", "s3", self.region, &path);
 
         let mut params = Params::new();
         params.put("uploads", "");
         request.set_params(params);
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
         let status = result.status;
@@ -12169,14 +12224,21 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     /// part storage, you should call the List Parts operation and ensure the parts
     /// list is empty.
     pub fn abort_multipart_upload(&self, input: &AbortMultipartUploadRequest) -> Result<AbortMultipartUploadOutput, S3Error> {
-        let mut request = SignedRequest::new("DELETE", "s3", self.region, &format!("/{}", input.key));
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        path = format!("{}{}", path, &input.key);
+        let mut request = SignedRequest::new("DELETE", "s3", self.region, &path);
 
         let mut params = Params::new();
         params.put("uploadId", &input.upload_id.to_string());
         request.set_params(params);
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         let result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
         let status = result.status;
@@ -12294,14 +12356,21 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     }
     /// Lists the parts that have been uploaded for a specific multipart upload.
     pub fn list_parts(&self, input: &ListPartsRequest) -> Result<ListPartsOutput, S3Error> {
-        let mut request = SignedRequest::new("GET", "s3", self.region, &format!("/{}", input.key));
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        path = format!("{}{}", path, &input.key);
+        let mut request = SignedRequest::new("GET", "s3", self.region, &path);
 
         let mut params = Params::new();
         params.put("uploadId", &input.upload_id.to_string());
         request.set_params(params);
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         let mut result = sign_and_execute(&self.dispatcher, &mut request, try!(self.credentials_provider.credentials()));
         let status = result.status;
@@ -12362,13 +12431,18 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     /// marker, which becomes the latest version of the object. If there isn't a null
     /// version, Amazon S3 does not remove any objects.
     pub fn delete_object(&self, input: &DeleteObjectRequest) -> Result<DeleteObjectOutput, S3Error> {
-        let mut uri = String::from("/");
-        uri = uri +  &input.key.to_string();
-        let mut request = SignedRequest::new("DELETE", "s3", self.region, &uri);
+        let mut path = String::from("/");
+        if !is_dns_compatible(&input.bucket) {
+            path = format!("{}{}/", path, &input.bucket);
+        }
+        path = path +  &input.key;
+        let mut request = SignedRequest::new("DELETE", "s3", self.region, &path);
         let mut params = Params::new();
 
-        let hostname = self.hostname(Some(&input.bucket));
-        request.set_hostname(Some(hostname));
+        if is_dns_compatible(&input.bucket) {
+            let hostname = self.hostname(Some(&input.bucket));
+            request.set_hostname(Some(hostname));
+        }
 
         params.put("Action", "DeleteObject");
         DeleteObjectRequestWriter::write_params(&mut params, "", input);
@@ -12858,6 +12932,19 @@ fn sign_and_execute<D>(dispatcher: &D, request: &mut SignedRequest, creds: AwsCr
     response
 }
 
+fn is_valid_subdomain(bucket: &BucketName) -> bool {
+    lazy_static! {
+        static ref SUBDOMAIN_RE: Regex = Regex::new(r"^[a-z0-9][a-z0-9.-]+[a-z0-9]$").unwrap();
+        static ref IPV4_RE: Regex = Regex::new(r"(\d+\.){3}\d+").unwrap();
+        static ref INVALID_RE: Regex = Regex::new(r"[.-]{2}").unwrap();
+    }
+    bucket.len() < 64 && SUBDOMAIN_RE.is_match(&bucket) && !IPV4_RE.is_match(&bucket) && !INVALID_RE.is_match(&bucket)
+}
+
+fn is_dns_compatible(bucket: &BucketName) -> bool {
+    is_valid_subdomain(&bucket) && !bucket.contains(".")
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{Read, BufReader};
@@ -13110,4 +13197,29 @@ mod tests {
         }
     }
 
+    #[test]
+    fn valid_subdomain() {
+        assert!(super::is_valid_subdomain(&"foo-bar".to_string()));
+        assert!(super::is_valid_subdomain(&"foo.bar".to_string()));
+    }
+
+    #[test]
+    fn invalid_subdomain() {
+        assert!(!super::is_valid_subdomain(&"foo--bar".to_string()));
+    }
+
+    #[test]
+    fn dns_compatible_bucket() {
+        assert!(super::is_dns_compatible(&"foo-bar".to_string()));
+    }
+
+    #[test]
+    fn bucket_with_invalid_subdomain_is_dns_incompatible() {
+        assert!(!super::is_dns_compatible(&"foo--bar".to_string()));
+    }
+
+    #[test]
+    fn bucket_with_dot_is_dns_incompatible() {
+        assert!(!super::is_dns_compatible(&"foo.bar".to_string()));
+    }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -11150,7 +11150,7 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     pub fn list_objects(&self, input: &ListObjectsRequest) -> Result<ListObjectsOutput, S3Error> {
         let mut path = String::from("/");
         if !is_dns_compatible(&input.bucket) {
-            path = path + &input.bucket + "/";
+            path = format!("{}{}/", path, &input.bucket);
         }
         let mut request = SignedRequest::new("GET", "s3", self.region, &path);
 
@@ -11306,9 +11306,9 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
     pub fn put_object(&self, input: &PutObjectRequest) -> Result<PutObjectOutput, S3Error> {
         let mut uri = String::from("/");
         if !is_dns_compatible(&input.bucket) {
-            uri = uri + &input.bucket + "/";
+            uri = format!("{}{}/", uri, &input.bucket);
         }
-        uri = uri + &input.key;
+        uri = format!("{}{}", uri, &input.key);
         let mut request = SignedRequest::new("PUT", "s3", self.region, &uri);
 
         if let Some(ref class) = input.storage_class {
@@ -11816,7 +11816,7 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
         let mut create_config : Vec<u8>;
         let mut path = String::from("/");
         if !is_dns_compatible(&input.bucket) {
-            path = path + &input.bucket;
+            path = format!("{}{}/", path, &input.bucket);
         }
         let mut request = SignedRequest::new("PUT", "s3", region, &path);
         if is_dns_compatible(&input.bucket) {
@@ -12435,7 +12435,7 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
         if !is_dns_compatible(&input.bucket) {
             path = format!("{}{}/", path, &input.bucket);
         }
-        path = path +  &input.key;
+        path = format!("{}{}/", path, &input.key);
         let mut request = SignedRequest::new("DELETE", "s3", self.region, &path);
         let mut params = Params::new();
 


### PR DESCRIPTION
Small amount of work added on top of @eagletmt 's work from https://github.com/rusoto/rusoto/pull/344 .  I ran the new code through our S3 tests with a bucket called `a.bucketname` in us-east-1 and it all worked as expected.

Fixes https://github.com/rusoto/rusoto/issues/330 .