### PR TITLE
Adding a user agent header. Closes #379

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.16.0"
 
 [build-dependencies]
+rustc_version = "0.1.7"
 
 [build-dependencies.rusoto_codegen]
 default-features = false

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,24 @@
+extern crate rustc_version;
 extern crate rusoto_codegen;
 
 use std::env;
 use std::path::Path;
+use std::io::Write;
+use std::fs::File;
 
 use rusoto_codegen::{Service, generate};
+
+/// Parses and generates variables used to construct a User-Agent.
+///
+/// This is used to create a User-Agent header string resembling
+/// `rusoto/x.y.z rust/x.y.z <os>`.
+fn generate_user_agent_vars(output_path: &Path) {
+    let rust_version = rustc_version::version();
+    let mut f = File::create(&output_path.join("user_agent_vars.rs"))
+            .expect("Could not create user agent file");
+    f.write_all(format!("static RUST_VERSION: &'static str = \"{}\";", rust_version).as_bytes())
+            .expect("Unable to write user agent");
+}
 
 /*
 gamelift/2015-10-01/service-2.json:    "protocol":"json"
@@ -72,6 +87,8 @@ fn main() {
     for service in services {
         generate(service, out_path);
     }
+
+    generate_user_agent_vars(out_path);
 
     let codegen_dir = Path::new("codegen");
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,6 +2,9 @@
 //!
 //! Wraps the Hyper library to send PUT, POST, DELETE and GET requests.
 
+extern crate lazy_static;
+
+use std::env;
 use std::io::Read;
 use std::io::Error as IoError;
 use std::error::Error;
@@ -11,11 +14,22 @@ use std::collections::HashMap;
 use hyper::Client;
 use hyper::Error as HyperError;
 use hyper::header::Headers;
+use hyper::header::UserAgent;
 use hyper::method::Method;
 
 use log::LogLevel::Debug;
 
 use signature::SignedRequest;
+
+// Pulls in the statically generated rustc version.
+include!(concat!(env!("OUT_DIR"), "/user_agent_vars.rs"));
+
+// Use a lazy static to cache the default User-Agent header
+// because it never changes once it's been computed.
+lazy_static! {
+    static ref DEFAULT_USER_AGENT: Vec<Vec<u8>> = vec![format!("rusoto/{} rust/{} {}",
+            env!("CARGO_PKG_VERSION"), RUST_VERSION, env::consts::OS).as_bytes().to_vec()];
+}
 
 #[derive(Clone, Default)]
 pub struct HttpResponse {
@@ -74,6 +88,11 @@ impl DispatchSignedRequest for Client {
             hyper_headers.set_raw(h.0.to_owned(), h.1.to_owned());
         }
 
+        // Add a default user-agent header if one is not already present.
+        if !hyper_headers.has::<UserAgent>() {
+            hyper_headers.set_raw("user-agent".to_owned(), DEFAULT_USER_AGENT.clone());
+        }
+
         let mut final_uri = format!("https://{}{}", request.hostname(), request.path());
         if !request.canonical_query_string().is_empty() {
             final_uri = final_uri + &format!("?{}", request.canonical_query_string());
@@ -117,6 +136,6 @@ impl DispatchSignedRequest for Client {
             body: body,
             headers: headers
         })
-        
+
     }
 }


### PR DESCRIPTION
This change adds a `User-Agent` header to Rusoto so that AWS can better track the usage and growth of Rust and Rusto.

The header being added has the following format: `rusoto/<version> rust/<version> <os>`.

* I added a build-time dependency on `rustc_version` in order to parse out the version of rustc used when compiling: https://crates.io/crates/rustc_version.
* I used `env!("CARGO_PKG_VERSION")` to determine the version of Rusoto in use. This macro is expanded at compile time so it's fine to not codegen this.
* Determining the OS is done by accessing `std::env::conts::OS`: https://doc.rust-lang.org/std/env/consts/constant.OS.html. This provides strings like "linux", "macos", etc. However, there isn't a good way that I can find to determine the OS version. I've only included the OS in the PR, but if there's an easy way to get the version or a crate that does this for us, I could update the PR to include it.
* Determining the version of hyper being used by Rusoto would, from what I can tell, require codegen that launches a process to run `cargo metadata`, parse the JSON, and extract out the hyper version there. I wasn't sure if this was an acceptable approach or necessary, so I left that out of the PR for now.
* Constructing the user-agent is done once in a `lazy_static`. Given that I have to clone it anyway to place it in the `hyper::header::Headers`, it might be better to not use a `lazy_static` at all.

Finally, I don't see a great way to test this. Suggestions here would be welcome.