### PR TITLE
Capitalization cleanup.

### DIFF
--- a/codegen/src/generator/ec2.rs
+++ b/codegen/src/generator/ec2.rs
@@ -506,7 +506,7 @@ if prefix != \"\" {{
 
 fn generate_struct_field_serializers(shape: &Shape) -> String {
     shape.members.as_ref().unwrap().iter().map(|(member_name, member)| {
-        let tag_name = capitalize_first(member.location_name.as_ref().unwrap_or(member_name).to_owned());
+        let tag_name = capitalize_first(member.location_name.as_ref().unwrap_or(member_name).as_ref());
         if shape.required(member_name) {
             format!(
                 "{member_shape_name}Serializer::serialize(

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -1,7 +1,6 @@
 use inflector::Inflector;
 
 use botocore::{Service, Shape, ShapeType, Operation};
-use std::ascii::AsciiExt;
 use self::ec2::Ec2Generator;
 use self::json::JsonGenerator;
 use self::query::QueryGenerator;
@@ -271,11 +270,19 @@ impl Operation {
     }
 }
 
-fn capitalize_first(word: String) -> String {
-    assert!(word.is_ascii());
+/// Takes a string and returns it with the first letter capitalized.
+/// If the input string is empty an empty string is returned.
+fn capitalize_first<S>(word: S) -> String where S: Into<String> {
+    let s = word.into();
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
 
-    let mut result = word.into_bytes();
-    result[0] = result[0].to_ascii_uppercase();
-
-    String::from_utf8(result).unwrap()
+#[test]
+fn capitalize_first_test() {
+    assert_eq!(capitalize_first("a &str test"), "A &str test".to_owned());
+    assert_eq!(capitalize_first("a String test".to_owned()), "A String test".to_owned());
 }

--- a/codegen/src/generator/tests.rs
+++ b/codegen/src/generator/tests.rs
@@ -1,12 +1,6 @@
 use std::fs;
 
-fn capitalise(s: &str) -> String {
-    let mut c = s.chars();
-    match c.next() {
-        None => String::new(),
-        Some(f) => f.to_uppercase().chain(c).collect(),
-    }
-}
+use super::capitalize_first;
 
 #[derive(Debug, Clone	)]
 pub struct Response {
@@ -27,9 +21,9 @@ impl Response {
         if let Some(file_name) = maybe_file_name_and_extension.get(0) {
             let file_name_parts: Vec<&str> = file_name.split("-").collect();
 
-            service_name = file_name_parts.get(0).map(|s| capitalise(s));
+            service_name = file_name_parts.get(0).map(|s| capitalize_first(*s));
 
-            action = Some(file_name_parts.into_iter().skip(1).map(|w| capitalise(w)).collect());
+            action = Some(file_name_parts.into_iter().skip(1).map(|w| capitalize_first(w)).collect());
         }
 
         service_name


### PR DESCRIPTION
Remove capitalise in codegen/src/generator/tests.rs and use instead the capitalize_first function in codegen/src/generated/mod.rs.

Modify capitalize_first to handle any unicode scalar values instead of just ascii values and do it slightly more efficiently than the former capitalise function.