### PR TITLE
Updates contributing doc with required version of Rust.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ### Setting up build environment (only needed once)
 
-Install Rust **1.8.0** or later - http://www.rust-lang.org/
+Install Rust **1.9.0** or later - http://www.rust-lang.org/
 
 Check out code from github.
 


### PR DESCRIPTION
This file got out of date.  Perhaps we should change it to refer to the README for the required version instead of specifying it here.