### PR TITLE
There should be no trailing slash in DELETE object

### DIFF
--- a/src/s3.rs
+++ b/src/s3.rs
@@ -10583,7 +10583,7 @@ impl<P, D> S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
         if !is_dns_compatible(&input.bucket) {
             path = format!("{}{}/", path, &input.bucket);
         }
-        path = format!("{}{}/", path, &input.key);
+        path = format!("{}{}", path, &input.key);
         let mut request = SignedRequest::new("DELETE", "s3", self.region, &path);
         let mut params = Params::new();
 


### PR DESCRIPTION
Otherwise, the object name isn't OK.

For instance, you can have an object named test and another named test/. They are distinct.

A little test case : 

- Add an object named "bleh" to an s3 bucket, and run the following script : 
```
extern crate rusoto;

use rusoto::s3::{S3Client, DeleteObjectRequest, DefaultCredentialsProvider};

#[test]
fn it_works() {
    let s3 = S3Client::new(DefaultCredentialsProvider::new().unwrap(), rusoto::Region::UsWest2);
    s3.delete_object(&DeleteObjectRequest {
        bucket: "rusototester".to_string(),
        key: "bleh",
        ..Default::default()
    })
}
```

If you list the objects, you'll notice bleh is still there. That's because the request tried to delete the (non-existing) file "bleh/"