### PR TITLE
Bump serde_codegen dependency to 0.8.14

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.0"
 
 [dependencies.serde_codegen]
 optional = true
-version = "0.8.0"
+version = "0.8.14"
 
 [dependencies.serde_macros]
 optional = true


### PR DESCRIPTION
Just a bump of the dependency version.  Fixes #413 and gets our whole crate working again.