### PR TITLE
use url encoded path in s3 request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -94,7 +94,7 @@ impl DispatchSignedRequest for Client {
             hyper_headers.set_raw("user-agent".to_owned(), DEFAULT_USER_AGENT.clone());
         }
 
-        let mut final_uri = format!("https://{}{}", request.hostname(), request.path());
+        let mut final_uri = format!("https://{}{}", request.hostname(), request.canonical_path());
         if !request.canonical_query_string().is_empty() {
             final_uri = final_uri + &format!("?{}", request.canonical_query_string());
         }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -83,6 +83,10 @@ impl <'a> SignedRequest <'a> {
         &self.path
     }
 
+    pub fn canonical_path(&self) -> String {
+        canonical_uri(&self.path)
+    }
+
     pub fn canonical_uri(&self) -> &str {
         &self.canonical_uri
     }
@@ -455,11 +459,11 @@ mod tests {
     }
     #[test]
     fn query_percent_encoded() {
-        let mut request = SignedRequest::new("GET", "s3", Region::UsEast1, "/path with spaces: the sequel");
+        let mut request = SignedRequest::new("GET", "s3", Region::UsEast1, "/path with spaces: the sequel++");
         request.add_param("key:with@funny&characters", "value with/funny%characters/Рускии");
         let canonical_query_string = super::build_canonical_query_string(&request.params);
         assert_eq!("key%3Awith%40funny%26characters=value%20with%2Ffunny%25characters%2F%D0%A0%D1%83%D1%81%D0%BA%D0%B8%D0%B8", canonical_query_string);
         let canonical_uri_string = super::canonical_uri(&request.path);
-        assert_eq!("/path%20with%20spaces%3A%20the%20sequel", canonical_uri_string);
+        assert_eq!("/path%20with%20spaces%3A%20the%20sequel%2B%2B", canonical_uri_string);
     }
 }


### PR DESCRIPTION
use path url encoding on s3 path in http request body

the encoding done in the signature calculation already includes this step, so i think the signature is correct.