### PR TITLE
Make OS X CI builds mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,4 +101,3 @@ matrix:
   fast_finish: true
   allow_failures:
     - rust: nightly
-    - os: osx


### PR DESCRIPTION
Removes line allowing Travis CI OS X builds to fail. Without this line, OS X builds passing is now a requirement for new PRs to be merged.