### PR TITLE
Break up credential crate into several modules

### DIFF
--- a/credential/src/environment.rs
+++ b/credential/src/environment.rs
@@ -1,0 +1,41 @@
+use std::env;
+
+use {AwsCredentials, CredentialsError, ProvideAwsCredentials, in_ten_minutes};
+
+/// Provides AWS credentials from environment variables.
+pub struct EnvironmentProvider;
+
+impl ProvideAwsCredentials for EnvironmentProvider {
+    fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        credentials_from_environment()
+    }
+}
+
+fn credentials_from_environment() -> Result<AwsCredentials, CredentialsError> {
+    let env_key = match env::var("AWS_ACCESS_KEY_ID") {
+        Ok(val) => val,
+        Err(_) => return Err(CredentialsError::new("No AWS_ACCESS_KEY_ID in environment"))
+    };
+    let env_secret = match env::var("AWS_SECRET_ACCESS_KEY") {
+        Ok(val) => val,
+        Err(_) => return Err(CredentialsError::new("No AWS_SECRET_ACCESS_KEY in environment"))
+    };
+
+    if env_key.is_empty() || env_secret.is_empty() {
+        return Err(CredentialsError::new("Couldn't find either AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY or both in environment."));
+    }
+
+    // Present when using temporary credentials, e.g. on Lambda with IAM roles
+    let token = match env::var("AWS_SESSION_TOKEN") {
+        Ok(val) => {
+            if val.is_empty() {
+                None
+            } else {
+                Some(val)
+            }
+        }
+        Err(_) => None,
+    };
+
+    Ok(AwsCredentials::new(env_key, env_secret, token, in_ten_minutes()))
+}

--- a/credential/src/iam.rs
+++ b/credential/src/iam.rs
@@ -1,0 +1,79 @@
+use std::io::Read;
+use std::time::Duration as StdDuration;
+
+use hyper::Client;
+use hyper::header::Connection;
+use serde_json::{Value, from_str};
+
+use {AwsCredentials, CredentialsError, ProvideAwsCredentials};
+
+/// Provides AWS credentials from a resource's IAM role.
+pub struct IamProvider;
+
+impl ProvideAwsCredentials for IamProvider {
+    fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+
+        // TODO: backoff and retry on failure.
+        let mut address : String = "http://169.254.169.254/latest/meta-data/iam/security-credentials".to_string();
+        let mut client = Client::new();
+        client.set_read_timeout(Some(StdDuration::from_secs(15)));
+        let mut response;
+        match client.get(&address)
+            .header(Connection::close()).send() {
+                Err(_) => return Err(CredentialsError::new("Couldn't connect to metadata service")), // add Why?
+                Ok(received_response) => response = received_response
+            };
+
+        let mut body = String::new();
+        if let Err(_) = response.read_to_string(&mut body) {
+            return Err(CredentialsError::new("Didn't get a parsable response body from metadata service"));
+        }
+
+        address.push_str("/");
+        address.push_str(&body);
+        body = String::new();
+        match client.get(&address)
+            .header(Connection::close()).send() {
+                Err(_) => return Err(CredentialsError::new("Didn't get a parseable response body from instance role details")),
+                Ok(received_response) => response = received_response
+            };
+
+        if let Err(_) = response.read_to_string(&mut body) {
+            return Err(CredentialsError::new("Had issues with reading iam role response: {}"));
+        }
+
+        let json_object: Value;
+        match from_str(&body) {
+            Err(_) => return Err(CredentialsError::new("Couldn't parse metadata response body.")),
+            Ok(val) => json_object = val
+        };
+
+        let access_key;
+        match json_object.find("AccessKeyId") {
+            None => return Err(CredentialsError::new("Couldn't find AccessKeyId in response.")),
+            Some(val) => access_key = val.as_str().expect("AccessKeyId value was not a string").to_owned().replace("\"", "")
+        };
+
+        let secret_key;
+        match json_object.find("SecretAccessKey") {
+            None => return Err(CredentialsError::new("Couldn't find SecretAccessKey in response.")),
+            Some(val) => secret_key = val.as_str().expect("SecretAccessKey value was not a string").to_owned().replace("\"", "")
+        };
+
+        let expiration;
+        match json_object.find("Expiration") {
+            None => return Err(CredentialsError::new("Couldn't find Expiration in response.")),
+            Some(val) => expiration = val.as_str().expect("Expiration value was not a string").to_owned().replace("\"", "")
+        };
+
+        let expiration_time = try!(expiration.parse());
+
+        let token_from_response;
+        match json_object.find("Token") {
+            None => return Err(CredentialsError::new("Couldn't find Token in response.")),
+            Some(val) => token_from_response = val.as_str().expect("Token value was not a string").to_owned().replace("\"", "")
+        };
+
+        Ok(AwsCredentials::new(access_key, secret_key, Some(token_from_response), expiration_time))
+    }
+}

--- a/credential/src/profile.rs
+++ b/credential/src/profile.rs
@@ -1,0 +1,291 @@
+use std::ascii::AsciiExt;
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+use {AwsCredentials, CredentialsError, ProvideAwsCredentials, in_ten_minutes};
+
+/// Provides AWS credentials from a profile in a credentials file.
+#[derive(Clone, Debug)]
+pub struct ProfileProvider {
+    credentials: Option<AwsCredentials>,
+    file_path: PathBuf,
+    profile: String,
+}
+
+impl ProfileProvider {
+    /// Create a new `ProfileProvider` for the default credentials file path and profile name.
+    pub fn new() -> Result<ProfileProvider, CredentialsError> {
+        let profile_location = match env::var("AWS_SHARED_CREDENTIALS_FILE") {
+            Ok(path) => PathBuf::from(path),
+            Err(_) => {
+                match ProfileProvider::default_profile_location() {
+                    Ok(path) => path,
+                    Err(err) => return Err(err),
+                }
+            }
+        };
+
+        Ok(ProfileProvider {
+            credentials: None,
+            file_path: profile_location,
+            profile: "default".to_owned(),
+        })
+    }
+
+    /// Default credentials file location:
+    /// `~/.aws/credentials` (Linux/Mac)
+    /// `%USERPROFILE%\.aws\credentials` (Windows)
+    fn default_profile_location() -> Result<PathBuf, CredentialsError> {
+        match env::home_dir() {
+            Some(home_path) => {
+                let mut credentials_path = PathBuf::from(".aws");
+
+                credentials_path.push("credentials");
+
+                Ok(home_path.join(credentials_path))
+            }
+            None => Err(CredentialsError::new("The environment variable HOME must be set.")),
+        }
+    }
+
+    /// Create a new `ProfileProvider` for the credentials file at the given path, using
+    /// the given profile.
+    pub fn with_configuration<F, P>(file_path: F, profile: P) -> ProfileProvider
+    where F: Into<PathBuf>, P: Into<String> {
+        ProfileProvider {
+            credentials: None,
+            file_path: file_path.into(),
+            profile: profile.into(),
+        }
+    }
+
+    /// Get a reference to the credentials file path.
+    pub fn file_path(&self) -> &Path {
+        self.file_path.as_ref()
+    }
+
+    /// Get a reference to the profile name.
+    pub fn profile(&self) -> &str {
+        &self.profile
+    }
+
+    /// Set the credentials file path.
+    pub fn set_file_path<F>(&mut self, file_path: F) where F: Into<PathBuf> {
+        self.file_path = file_path.into();
+    }
+
+    /// Set the profile name.
+    pub fn set_profile<P>(&mut self, profile: P) where P: Into<String> {
+        self.profile = profile.into();
+    }
+}
+
+impl ProvideAwsCredentials for ProfileProvider {
+    fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        parse_credentials_file(self.file_path()).and_then(|mut profiles| {
+            profiles.remove(self.profile()).ok_or_else(|| CredentialsError::new("profile not found"))
+        })
+    }
+}
+
+fn parse_credentials_file(file_path: &Path) -> Result<HashMap<String, AwsCredentials>, CredentialsError> {
+    match fs::metadata(file_path) {
+        Err(_) => return Err(CredentialsError::new("Couldn't stat credentials file.")),
+        Ok(metadata) => {
+            if !metadata.is_file() {
+                return Err(CredentialsError::new("Couldn't open file."));
+            }
+        }
+    };
+
+    let file = try!(File::open(file_path));
+
+    let profile_regex = Regex::new(r"^\[([^\]]+)\]$").unwrap();
+    let mut profiles: HashMap<String, AwsCredentials> = HashMap::new();
+    let mut access_key: Option<String> = None;
+    let mut secret_key: Option<String> = None;
+    let mut token: Option<String> = None;
+    let mut profile_name: Option<String> = None;
+
+    let file_lines = BufReader::new(&file);
+    for line in file_lines.lines() {
+
+        let unwrapped_line : String = line.unwrap();
+
+        // skip comments
+        if unwrapped_line.starts_with('#') {
+            continue;
+        }
+
+        // handle the opening of named profile blocks
+        if profile_regex.is_match(&unwrapped_line) {
+
+            if profile_name.is_some() && access_key.is_some() && secret_key.is_some() {
+                let creds = AwsCredentials::new(access_key.unwrap(), secret_key.unwrap(), token, in_ten_minutes());
+                profiles.insert(profile_name.unwrap(), creds);
+            }
+
+            access_key = None;
+            secret_key = None;
+            token = None;
+
+            let caps = profile_regex.captures(&unwrapped_line).unwrap();
+            profile_name = Some(caps.at(1).unwrap().to_string());
+            continue;
+        }
+
+        // otherwise look for key=value pairs we care about
+        let lower_case_line = unwrapped_line.to_ascii_lowercase().to_string();
+
+        if lower_case_line.contains("aws_access_key_id") &&
+            access_key.is_none()
+        {
+            let v: Vec<&str> = unwrapped_line.split('=').collect();
+            if !v.is_empty() {
+                access_key = Some(v[1].trim_matches(' ').to_string());
+            }
+        } else if lower_case_line.contains("aws_secret_access_key") &&
+            secret_key.is_none()
+        {
+            let v: Vec<&str> = unwrapped_line.split('=').collect();
+            if !v.is_empty() {
+                secret_key = Some(v[1].trim_matches(' ').to_string());
+            }
+        } else if lower_case_line.contains("aws_session_token") &&
+            token.is_none()
+        {
+            let v: Vec<&str> = unwrapped_line.split('=').collect();
+            if !v.is_empty() {
+                token = Some(v[1].trim_matches(' ').to_string());
+            }
+        }
+
+        // we could potentially explode here to indicate that the file is invalid
+
+    }
+
+    if profile_name.is_some() && access_key.is_some() && secret_key.is_some() {
+        let creds = AwsCredentials::new(access_key.unwrap(), secret_key.unwrap(), token, in_ten_minutes());
+        profiles.insert(profile_name.unwrap(), creds);
+    }
+
+    if profiles.is_empty() {
+        return Err(CredentialsError::new("No credentials found."));
+    }
+
+    Ok(profiles)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::path::Path;
+
+    use {CredentialsError, ProvideAwsCredentials};
+    use super::*;
+
+    #[test]
+    fn parse_credentials_file_default_profile() {
+        let result = super::parse_credentials_file(
+            Path::new("tests/sample-data/default_profile_credentials")
+        );
+        assert!(result.is_ok());
+
+        let profiles = result.ok().unwrap();
+        assert_eq!(profiles.len(), 1);
+
+        let default_profile = profiles.get("default").unwrap();
+        assert_eq!(default_profile.aws_access_key_id(), "foo");
+        assert_eq!(default_profile.aws_secret_access_key(), "bar");
+    }
+
+    #[test]
+    fn parse_credentials_file_multiple_profiles() {
+        let result = super::parse_credentials_file(
+            Path::new("tests/sample-data/multiple_profile_credentials")
+        );
+        assert!(result.is_ok());
+
+        let profiles = result.ok().unwrap();
+        assert_eq!(profiles.len(), 2);
+
+        let foo_profile = profiles.get("foo").unwrap();
+        assert_eq!(foo_profile.aws_access_key_id(), "foo_access_key");
+        assert_eq!(foo_profile.aws_secret_access_key(), "foo_secret_key");
+
+        let bar_profile = profiles.get("bar").unwrap();
+        assert_eq!(bar_profile.aws_access_key_id(), "bar_access_key");
+        assert_eq!(bar_profile.aws_secret_access_key(), "bar_secret_key");
+
+    }
+
+    #[test]
+    fn profile_provider_happy_path() {
+        let provider = ProfileProvider::with_configuration(
+            "tests/sample-data/multiple_profile_credentials",
+            "foo",
+        );
+        let result = provider.credentials();
+
+        assert!(result.is_ok());
+
+        let creds = result.ok().unwrap();
+        assert_eq!(creds.aws_access_key_id(), "foo_access_key");
+        assert_eq!(creds.aws_secret_access_key(), "foo_secret_key");
+    }
+
+    #[test]
+    fn profile_provider_via_environment_variable() {
+        let credentials_path = "tests/sample-data/default_profile_credentials";
+        env::set_var("AWS_SHARED_CREDENTIALS_FILE", credentials_path);
+        let result = ProfileProvider::new();
+        assert!(result.is_ok());
+        let provider = result.unwrap();
+        assert_eq!(provider.file_path().to_str().unwrap(), credentials_path);
+        env::remove_var("AWS_SHARED_CREDENTIALS_FILE");
+    }
+
+    #[test]
+    fn profile_provider_bad_profile() {
+        let provider = ProfileProvider::with_configuration(
+            "tests/sample-data/multiple_profile_credentials",
+            "not_a_profile",
+        );
+        let result = provider.credentials();
+
+        assert!(result.is_err());
+        assert_eq!(result.err(), Some(CredentialsError::new("profile not found")));
+    }
+
+    #[test]
+    fn profile_provider_profile_name() {
+       let mut provider = ProfileProvider::new().unwrap();
+       assert_eq!("default", provider.profile());
+       provider.set_profile("foo");
+       assert_eq!("foo", provider.profile());
+    }
+
+    #[test]
+    fn existing_file_no_credentials() {
+        let result = super::parse_credentials_file(Path::new("tests/sample-data/no_credentials"));
+        assert_eq!(result.err(), Some(CredentialsError::new("No credentials found.")))
+    }
+
+    #[test]
+    fn parse_credentials_bad_path() {
+        let result = super::parse_credentials_file(Path::new("/bad/file/path"));
+        assert_eq!(result.err(), Some(CredentialsError::new("Couldn't stat credentials file.")));
+    }
+
+    #[test]
+    fn parse_credentials_directory_path() {
+        let result = super::parse_credentials_file(Path::new("tests/"));
+        assert_eq!(result.err(), Some(CredentialsError::new("Couldn't open file.")));
+    }
+}


### PR DESCRIPTION
This PR builds upon PR #433 (so don't merge until that one is merged), and is intended to close #431. It takes the new `rusoto_credential` crate provided by #433 and splits it into several modules, one for each credentials provider (e.g. `iam`, `profile`).

This PR should be ready to merge right after #433, unless anyone has further ideas on how to split it up.