### PR TITLE
bump minimum rustc version to 1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ rust:
   - stable
   # and the first stable one (this should be bumped as the minimum Rust version
   # required changes)
-  - 1.11.0
+  - 1.12.0
   - beta
   - nightly
 os:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You may be looking for:
 
 ## Requirements
 
-Rust 1.11.0 or later is required.
+Rust 1.12.0 or later is required.
 
 On OS X and Windows, you may need to install the openssl runtime and headers to get the `rust-openssl` dependency to build. Instructions for that can be found [here](https://github.com/sfackler/rust-openssl#building).
 


### PR DESCRIPTION
Fixes #449 by bumping minimum rustc version to one that will actually compile the upstream dependencies.