### PR TITLE
don't overwrite content-type header after signature calculation

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -36,7 +36,6 @@ pub struct SignedRequest<'a> {
     pub params: Params,
     pub hostname: Option<String>,
     pub payload: Option<&'a [u8]>,
-    pub content_type: Option<String>,
     pub canonical_query_string: String,
     pub canonical_uri: String,
 }
@@ -53,14 +52,12 @@ impl <'a> SignedRequest <'a> {
             params: Params::new(),
             hostname: None,
             payload: None,
-            content_type: None,
             canonical_query_string: String::new(),
             canonical_uri: String::new(),
          }
     }
-
     pub fn set_content_type(&mut self, content_type: String) {
-        self.content_type = Some(content_type);
+        self.add_header("content-type", &content_type);
     }
 
     pub fn set_hostname(&mut self, hostname: Option<String>) {
@@ -165,6 +162,16 @@ impl <'a> SignedRequest <'a> {
         self.remove_header("x-amz-date");
         self.add_header("x-amz-date", &date.strftime("%Y%m%dT%H%M%SZ").unwrap().to_string());
 
+        // if there's no content-type header set, set it to the default value
+        match self.headers.entry("content-type".to_owned()) {
+            Entry::Vacant(entry) => {
+                let mut values = Vec::new();
+                values.push("application/octet-stream".as_bytes().to_vec());
+                entry.insert(values);
+            },
+            _ => {}
+        }
+
         // build the canonical request
         let signed_headers = signed_headers(&self.headers);
         self.canonical_uri = canonical_uri(&self.path);
@@ -185,28 +192,20 @@ impl <'a> SignedRequest <'a> {
                 self.add_header("x-amz-content-sha256", &to_hexdigest(""));
             }
             Some(payload) => {
-                // This is hashing the payload twice, booo:
+                let digest = to_hexdigest(payload);
                 canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
                     &self.method,
                     self.canonical_uri,
                     self.canonical_query_string,
                     canonical_headers,
                     signed_headers,
-                    &to_hexdigest(payload));
+                    &digest);
                 self.remove_header("x-amz-content-sha256");
-                self.add_header("x-amz-content-sha256", &to_hexdigest(payload));
+                self.add_header("x-amz-content-sha256", &digest);
                 self.remove_header("content-length");
                 self.add_header("content-length", &format!("{}", payload.len()));
             }
         }
-
-        self.remove_header("content-type");
-        let ct = match self.content_type {
-            Some(ref h) => h.to_string(),
-            None => String::from("application/octet-stream")
-        };
-
-        self.add_header("content-type", &ct);
 
         // use the hashed canonical request to build the string to sign
         let hashed_canonical_request = to_hexdigest(&canonical_request);

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -163,13 +163,10 @@ impl <'a> SignedRequest <'a> {
         self.add_header("x-amz-date", &date.strftime("%Y%m%dT%H%M%SZ").unwrap().to_string());
 
         // if there's no content-type header set, set it to the default value
-        match self.headers.entry("content-type".to_owned()) {
-            Entry::Vacant(entry) => {
-                let mut values = Vec::new();
-                values.push("application/octet-stream".as_bytes().to_vec());
-                entry.insert(values);
-            },
-            _ => {}
+        if let Entry::Vacant(entry) = self.headers.entry("content-type".to_owned()) {
+            let mut values = Vec::new();
+            values.push("application/octet-stream".as_bytes().to_vec());
+            entry.insert(values);
         }
 
         // build the canonical request


### PR DESCRIPTION
Fixes #446 

I eliminated the `content_type` field from the `Signature` object altogether.  Calling `set_content_type()` now sets the header instead of that field, and the default value for the header is inserted if the header isn't set at all, and that all occurs BEFORE the signature calculation, so it doesn't break if it ends up being set to the default value.

This should preserve existing functionality (S3 was the only place using `content_type`), as well as fix existing bugs.