### PR TITLE
Add Nikita to authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [package]
-authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>"]
+authors = [
+    "Anthony DiMarco <ocramida@gmail.com>",
+    "Jimmy Cuadra <jimmy@jimmycuadra.com>",
+    "Matthew Mayer <matthewkmayer@gmail.com>",
+    "Nikita Pekin <contact@nikitapek.in>"
+]
 build = "build.rs"
 description = "AWS SDK for Rust"
 documentation = "http://rusoto.github.io/rusoto/rusoto/index.html"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,5 +1,10 @@
 [package]
-authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>"]
+authors = [
+    "Anthony DiMarco <ocramida@gmail.com>",
+    "Jimmy Cuadra <jimmy@jimmycuadra.com>",
+    "Matthew Mayer <matthewkmayer@gmail.com>",
+    "Nikita Pekin <contact@nikitapek.in>"
+]
 build = "build.rs"
 description = "Code generation library for Rusoto."
 license = "MIT"

--- a/credential/Cargo.toml
+++ b/credential/Cargo.toml
@@ -1,5 +1,10 @@
 [package]
-authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>"]
+authors = [
+    "Anthony DiMarco <ocramida@gmail.com>",
+    "Jimmy Cuadra <jimmy@jimmycuadra.com>",
+    "Matthew Mayer <matthewkmayer@gmail.com>",
+    "Nikita Pekin <contact@nikitapek.in>"
+]
 license = "MIT"
 description = "AWS credential tooling"
 name = "rusoto_credential"


### PR DESCRIPTION
Add Nikita to the authors list in the `Cargo.toml` files for the crates. Per Anthony's [suggestion](https://github.com/rusoto/rusoto/pull/433#discussion_r88791907). I'm not sure if you meant for just `credential` or for the other crates as well. I can modify the PR to only add my name to `credential` if that's what you meant.