### PR TITLE
Update serde to use serde_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,13 @@ version = "0.0"
 path = "credential"
 version = "0.1.0"
 
-[dependencies.serde_macros]
+[dependencies.serde_codegen]
 optional = true
 version = "0.8.0"
+
+[dependencies.serde_derive]
+optional = true
+version = "0.8.19"
 
 [dev-dependencies]
 env_logger = "0.3.3"
@@ -66,9 +70,9 @@ codepipeline = []
 cognito-identity = []
 config = []
 datapipeline = []
+default = ["rusoto_codegen/serde_codegen", "serde_codegen"]
 devicefarm = []
 directconnect = []
-default = ["with-syntex"]
 ds = []
 dynamodb = []
 dynamodbstreams = []
@@ -95,7 +99,6 @@ sqs = []
 ssm = []
 storagegateway = []
 swf = []
-unstable = ["serde_macros", "rusoto_codegen/unstable"]
+unstable = ["rusoto_codegen/unstable", "serde_derive"]
 waf = []
-with-syntex = ["rusoto_codegen/with-syntex"]
 workspaces = []

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -31,16 +31,11 @@ version = "0.0"
 optional = true
 version = "0.8.14"
 
-[dependencies.serde_macros]
+[dependencies.serde_derive]
 optional = true
-version = "0.8.0"
-
-[dependencies.syntex]
-optional = true
-version = "0.45.1"
+version = "0.8.19"
 
 [features]
-default = ["with-syntex"]
+default = ["serde_codegen"]
 nightly-testing = ["clippy", "unstable"]
-unstable = ["serde_macros"]
-with-syntex = ["serde_codegen", "syntex"]
+unstable = ["serde_derive"]

--- a/codegen/build.rs
+++ b/codegen/build.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "serde_macros"))]
+#[cfg(not(feature = "serde_derive"))]
 mod inner {
     extern crate serde_codegen;
 
@@ -14,7 +14,8 @@ mod inner {
         serde_codegen::expand(&src, &dst).unwrap();
     }
 }
-#[cfg(feature = "serde_macros")]
+
+#[cfg(feature = "serde_derive")]
 mod inner {
     pub fn main() {}
 }

--- a/codegen/src/botocore.rs
+++ b/codegen/src/botocore.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde_macros")]
+#[cfg(feature = "serde_derive")]
 include!("botocore.in.rs");
-#[cfg(not(feature = "serde_macros"))]
+#[cfg(not(feature = "serde_derive"))]
 include!(concat!(env!("OUT_DIR"), "/botocore.rs"));

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "unstable", feature(const_fn, drop_types_in_const))]
-#![cfg_attr(feature = "serde_macros", feature(custom_derive, plugin))]
-#![cfg_attr(feature = "serde_macros", plugin(serde_macros))]
+#![cfg_attr(feature = "serde_derive", feature(proc_macro))]
+#![cfg_attr(feature = "nightly-testing", feature(plugin))]
 #![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 #![cfg_attr(not(feature = "unstable"), deny(warnings))]
 
@@ -11,10 +11,11 @@ extern crate regex;
 extern crate serde;
 extern crate serde_json;
 
-#[cfg(not(feature = "serde_macros"))]
+#[cfg(feature = "serde_derive")]
+#[macro_use]
+extern crate serde_derive;
+#[cfg(not(feature = "serde_derive"))]
 extern crate serde_codegen;
-#[cfg(not(feature = "serde_macros"))]
-extern crate syntex;
 
 use std::fs::File;
 use std::io::{Read, Write};
@@ -89,12 +90,12 @@ fn botocore_generate(input_path: &Path, output_path: &Path) {
     ));
 }
 
-#[cfg(not(feature = "serde_macros"))]
+#[cfg(not(feature = "serde_derive"))]
 fn serde_generate(source: &Path, destination: &Path) {
     ::serde_codegen::expand(&source, &destination).unwrap();
 }
 
-#[cfg(feature = "serde_macros")]
+#[cfg(feature = "serde_derive")]
 fn serde_generate(source: &Path, destination: &Path) {
     ::std::fs::copy(source, destination).expect(&format!(
         "Failed to copy {:?} to {:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "rusoto"]
 #![crate_type = "lib"]
-#![cfg_attr(feature = "unstable", feature(custom_derive, plugin))]
-#![cfg_attr(feature = "unstable", plugin(serde_macros))]
+#![cfg_attr(feature = "unstable", feature(proc_macro))]
+#![cfg_attr(feature = "nightly-testing", feature(plugin))]
 #![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 #![cfg_attr(feature = "nightly-testing", allow(cyclomatic_complexity, used_underscore_binding, ptr_arg, suspicious_else_formatting))]
 #![allow(dead_code)]
@@ -57,6 +57,10 @@ extern crate serde_json;
 extern crate time;
 extern crate url;
 extern crate xml;
+
+#[cfg(feature = "serde_derive")]
+#[macro_use]
+extern crate serde_derive;
 
 pub use region::{ParseRegionError, Region};
 pub use rusoto_credential::{


### PR DESCRIPTION
Update all references to `serde_macros` to instead use `serde_derive`, the new
implementation which utilizes the `proc_macro` feature to provide codegen.
Remove the no longer needed direct `syntex` dependency.
Remove the `with-syntex` feature flag from `rusoto` in favour of directly
setting the `rusoto_codegen/serde_codegen` flag in the `default` feature.
Remove the `with-syntex` feature in favour of directly setting the
`serde_codegen` feature in `rusoto_codegen`.
Re-organize features to correctly map to their intended function (e.g.
`serde_macros`) feature no longer provides the feature `plugin` because that is
only needed for `clippy` (i.e. when the `nightly-testing` feature is active).