### PR TITLE
Use crate reqwest for http client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 name = "rusoto"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.20.0"
+version = "0.30.0"
 
 [build-dependencies]
 rustc_version = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = ">= 0.4.0"
 
 [dependencies]
 chrono = "0.2.21"
-hyper = { version = "0.9.14" , default-features = false, features = [] }
+hyper = { version = "0.9" , default-features = false, features = [] }
 lazy_static = "0.2.1"
 log = "0.3.6"
 md5 = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = ">= 0.4.0"
 
 [dependencies]
 chrono = "0.2.21"
-hyper = { version = "0.9" , default-features = false, features = [] }
+hyper = { version = "0.9.13" , default-features = false, features = [] }
 lazy_static = "0.2.1"
 log = "0.3.6"
 md5 = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = ">= 0.4.0"
 
 [dependencies]
 chrono = "0.2.21"
-hyper = "0.9.10"
+hyper = { version = "0.9" , default-features = false, features = [] }
 lazy_static = "0.2.1"
 log = "0.3.6"
 md5 = "0.2"
@@ -38,6 +38,7 @@ serde_json = "0.8.0"
 time = "0.1.35"
 url = "1.2.0"
 xml-rs = "0.1.26"
+reqwest = "0.1.0"
 
 [dependencies.clippy]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ extern crate serde_json;
 extern crate time;
 extern crate url;
 extern crate xml;
+extern crate reqwest;
 
 #[cfg(feature = "serde_derive")]
 #[macro_use]

--- a/src/request.rs
+++ b/src/request.rs
@@ -3,7 +3,6 @@
 //! Wraps the Hyper library to send PUT, POST, DELETE and GET requests.
 
 extern crate lazy_static;
-extern crate reqwest;
 
 use std::env;
 use std::io::Read;
@@ -12,7 +11,7 @@ use std::error::Error;
 use std::fmt;
 use std::collections::HashMap;
 
-use self::reqwest::{Client, Error as ReqwestError};
+use reqwest::{Client, Error as ReqwestError};
 use hyper::Error as HyperError;
 use hyper::header::Headers;
 use hyper::header::UserAgent;

--- a/src/request.rs
+++ b/src/request.rs
@@ -3,6 +3,7 @@
 //! Wraps the Hyper library to send PUT, POST, DELETE and GET requests.
 
 extern crate lazy_static;
+extern crate reqwest;
 
 use std::env;
 use std::io::Read;
@@ -11,7 +12,7 @@ use std::error::Error;
 use std::fmt;
 use std::collections::HashMap;
 
-use hyper::Client;
+use self::reqwest::{Client, Error as ReqwestError};
 use hyper::Error as HyperError;
 use hyper::header::Headers;
 use hyper::header::UserAgent;
@@ -57,6 +58,12 @@ impl fmt::Display for HttpDispatchError {
 
 impl From<HyperError> for HttpDispatchError {
     fn from(err: HyperError) -> HttpDispatchError {
+        HttpDispatchError { message: err.description().to_string() }
+    }
+}
+
+impl From<ReqwestError> for HttpDispatchError {
+    fn from(err: ReqwestError) -> HttpDispatchError {
         HttpDispatchError { message: err.description().to_string() }
     }
 }
@@ -128,12 +135,12 @@ impl DispatchSignedRequest for Client {
 
         let mut headers: HashMap<String, String> = HashMap::new();
 
-        for header in hyper_response.headers.iter() {
+        for header in hyper_response.headers().iter() {
             headers.insert(header.name().to_string(), header.value_string());
         }
 
         Ok(HttpResponse {
-            status: hyper_response.status.to_u16(),
+            status: hyper_response.status().to_u16(),
             body: body,
             headers: headers
         })

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -15,7 +15,7 @@ use std::num::ParseIntError;
 use std::str::{FromStr, ParseBoolError};
 use std::str;
 
-use self::reqwest::Client;
+use self::reqwest::{Client, RedirectPolicy};
 use md5;
 use rusoto_credential::{
     ProvideAwsCredentials,
@@ -9163,7 +9163,7 @@ pub struct S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
 impl<P> S3Client<P, Client> where P: ProvideAwsCredentials {
     pub fn new(credentials_provider: P, region: region::Region) -> Self {
         let mut client = Client::new().unwrap();
-        client.redirect(reqwest::RedirectPolicy::none());
+        client.redirect(RedirectPolicy::none());
         S3Client::with_request_dispatcher(client, credentials_provider, region)
     }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -13,7 +13,7 @@ use std::num::ParseIntError;
 use std::str::{FromStr, ParseBoolError};
 use std::str;
 
-use hyper::client::{Client, RedirectPolicy};
+use reqwest::Client;
 use md5;
 use rusoto_credential::{
     ProvideAwsCredentials,
@@ -9160,8 +9160,8 @@ pub struct S3Client<P, D> where P: ProvideAwsCredentials, D: DispatchSignedReque
 
 impl<P> S3Client<P, Client> where P: ProvideAwsCredentials {
     pub fn new(credentials_provider: P, region: region::Region) -> Self {
-        let mut client = Client::new();
-        client.set_redirect_policy(RedirectPolicy::FollowNone);
+        let mut client = Client::new().unwrap();
+        client.redirect(reqwest::RedirectPolicy::none());
         S3Client::with_request_dispatcher(client, credentials_provider, region)
     }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(feature = "nightly-testing", allow(cyclomatic_complexity))]
 #![allow(unused_variables, unused_mut)]
 
+extern crate reqwest;
+
 use std::fmt;
 use std::ascii::AsciiExt;
 use std::collections::HashMap;
@@ -13,7 +15,7 @@ use std::num::ParseIntError;
 use std::str::{FromStr, ParseBoolError};
 use std::str;
 
-use reqwest::Client;
+use self::reqwest::Client;
 use md5;
 use rusoto_credential::{
     ProvideAwsCredentials,


### PR DESCRIPTION
This way Rusoto can eliminate dependency on hyper::client, and it removes dependency on out-of-date openssl 0.7.