### PR TITLE
Add cloudformation support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,9 @@ env_logger = "0.3.3"
 rand = "^0.3.14"
 
 [features]
-all = ["acm", "cloudhsm", "cloudtrail", "codecommit", "codedeploy", "codepipeline", "cognito-identity", "config", "datapipeline", "devicefarm", "directconnect", "ds", "dynamodb", "dynamodbstreams", "ec2", "ecr", "ecs", "elastictranscoder", "emr", "events", "firehose", "iam", "inspector", "iot", "kinesis", "kms", "logs", "machinelearning", "marketplacecommerceanalytics", "opsworks", "route53domains", "s3", "sqs", "ssm", "storagegateway", "swf", "waf", "workspaces"]
+all = ["acm", "cloudformation", "cloudhsm", "cloudtrail", "codecommit", "codedeploy", "codepipeline", "cognito-identity", "config", "datapipeline", "devicefarm", "directconnect", "ds", "dynamodb", "dynamodbstreams", "ec2", "ecr", "ecs", "elastictranscoder", "emr", "events", "firehose", "iam", "inspector", "iot", "kinesis", "kms", "logs", "machinelearning", "marketplacecommerceanalytics", "opsworks", "route53domains", "s3", "sqs", "ssm", "storagegateway", "swf", "waf", "workspaces"]
 acm = []
+cloudformation = []
 cloudhsm = []
 cloudtrail = []
 codecommit = []

--- a/build.rs
+++ b/build.rs
@@ -47,6 +47,7 @@ fn main() {
 
     let services = services! {
         ["acm", "2015-12-08"],
+        ["cloudformation", "2010-05-15"],
         ["cloudhsm", "2014-05-30"],
         ["cloudtrail", "2013-11-01"],
         ["codecommit", "2015-04-13"],

--- a/codegen/src/generator/query.rs
+++ b/codegen/src/generator/query.rs
@@ -3,6 +3,7 @@ use inflector::Inflector;
 
 use botocore::{Member, Operation, Service, Shape, ShapeType};
 use super::GenerateProtocol;
+use super::generate_field_name;
 use super::tests::{Response, find_responses};
 use util::case_insensitive_btreemap_get;
 
@@ -378,7 +379,7 @@ fn generate_struct_field_deserializers(shape: &Shape, service: &Service) -> Stri
                 {leave_wrapper_expression};
                 continue;
             }}",
-            field_name = member_name.to_snake_case(),
+            field_name = generate_field_name(member_name),
             parse_expression = parse_expression,
             wrapper_location_name = wrapper_location_name.or_else(|| parse_expression_location_name).unwrap_or(&location_name),
             enter_wrapper_expression = enter_wrapper_expression,
@@ -489,7 +490,7 @@ fn generate_struct_field_serializers(shape: &Shape) -> String {
     &obj.{field_name},
 );
                 ",
-                field_name = member_name.to_snake_case(),
+                field_name = generate_field_name(member_name),
                 member_shape_name = member.shape,
                 tag_name = member_name,
             )
@@ -503,7 +504,7 @@ fn generate_struct_field_serializers(shape: &Shape) -> String {
     );
 }}
                 ",
-                field_name = member_name.to_snake_case(),
+                field_name = generate_field_name(member_name),
                 member_shape_name = member.shape,
                 tag_name = member.tag_name(),
             )

--- a/src/cloudformation.rs
+++ b/src/cloudformation.rs
@@ -1,0 +1,3 @@
+//! AWS CloudFormation
+
+include!(concat!(env!("OUT_DIR"), "/cloudformation.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ mod mock;
 
 #[cfg(feature = "acm")]
 pub mod acm;
+#[allow(unused_imports)]
+#[cfg(feature = "cloudformation")]
+pub mod cloudformation;
 #[cfg(feature = "cloudhsm")]
 pub mod cloudhsm;
 #[cfg(feature = "cloudtrail")]


### PR DESCRIPTION
This was surprisingly easy to do: nice work rusoto developers.  Only had
to make a single change:

- Make sure the struct field serializers/deserializers call
  `generate_field_name`, which seems to be called when generating the
  actual struct fields.