### PR TITLE
Do not emit unused serde attributes

### DIFF
--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -69,27 +69,6 @@ impl GenerateProtocol for JsonGenerator {
     fn timestamp_type(&self) -> &'static str {
         "f64"
     }
-
-    fn generate_additional_annotations(&self, service: &Service, shape_name: &str, type_name: &str) -> Vec<String> {
-        // serde can no longer handle recursively defined types without help
-        // annotate them to avoid compiler overflows
-        match service.service_type_name() {
-            "DynamoDb" | "DynamoDbStreams" => {
-                if type_name == "ListAttributeValue" || type_name == "MapAttributeValue" {
-                    return vec!["#[serde(bound=\"\")]".to_owned()];
-                }
-            },
-            "Emr" => {
-                if shape_name == "Configuration" && type_name == "ConfigurationList" {
-                    return vec!["#[serde(bound=\"\")]".to_owned()];
-                }
-            },
-            _ => {}
-        }
-
-        Vec::<String>::with_capacity(0)
-    }
-
 }
 
 fn can_skip_serializer(struct_name: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "rusoto"]
 #![crate_type = "lib"]
-#![cfg_attr(feature = "unstable", feature(custom_attribute, proc_macro))]
+#![cfg_attr(feature = "unstable", feature(proc_macro))]
 #![cfg_attr(feature = "nightly-testing", feature(plugin))]
 #![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 #![cfg_attr(feature = "nightly-testing", allow(cyclomatic_complexity, used_underscore_binding, ptr_arg, suspicious_else_formatting))]


### PR DESCRIPTION
This is why #476 was required. Codegen was generating structs with `#[serde(...)]` attributes but no `#[derive(Serialize, Deserialize)]`. Also the bounds thing was fixed back in serde 0.8.0.