### PR TITLE
[WIP] Swap hyper client for reqwest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = ">= 0.5.0"
 
 [dependencies]
 chrono = "0.2.21"
-hyper = "0.9.10"
+reqwest = "0.2.0"
 lazy_static = "0.2.1"
 log = "0.3.6"
 md5 = "0.2"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ use rusoto::dynamodb::{DynamoDbClient, ListTablesInput};
 
 fn main() {
   let provider = DefaultCredentialsProvider::new().unwrap();
-  let client = DynamoDbClient::new(provider, Region::UsEast1);
+  let client = DynamoDbClient::new(provider, Region::UsEast1).unwrap();
   let list_tables_input: ListTablesInput = Default::default();
 
   match client.list_tables(&list_tables_input) {

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "0.2.1"
 regex = "0.1.65"
 serde = "0.8.0"
 serde_json = "0.8.0"
+reqwest = "0.2.0"
 
 [dependencies.clippy]
 optional = true

--- a/codegen/src/generator/ec2.rs
+++ b/codegen/src/generator/ec2.rs
@@ -29,7 +29,7 @@ impl GenerateProtocol for Ec2Generator {
                     let result = try!(self.dispatcher.dispatch(&request));
 
                     match result.status {{
-                        200 => {{
+                        StatusCode::Ok => {{
                             let mut reader = EventReader::from_str(&result.body);
                             let mut stack = XmlResponse::new(reader.events().peekable());
                             stack.next();

--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -26,7 +26,7 @@ impl GenerateProtocol for JsonGenerator {
                     let response = try!(self.dispatcher.dispatch(&request));
 
                     match response.status {{
-                        200 => {{
+                        StatusCode::Ok => {{
                             {ok_response}
                         }}
                         _ => Err({error_type}::from_body(&response.body)),

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -54,9 +54,11 @@ fn generate<P, E>(service: &Service, protocol_generator: P, error_type_generator
     let mut service_code = String::with_capacity(969984);
     service_code.push_str(
         "#[allow(warnings)]
-        use hyper::Client;
-        use hyper::client::RedirectPolicy;
+        use reqwest::Client;
+        use reqwest::RedirectPolicy;
         use request::DispatchSignedRequest;
+        use reqwest::StatusCode;
+        use reqwest::Error as ReqwestError;
         use region;
 
         use std::fmt;
@@ -84,10 +86,10 @@ fn generate_client<P>(service: &Service, protocol_generator: &P) -> String
         }}
 
         impl<P> {type_name}<P, Client> where P: ProvideAwsCredentials {{
-            pub fn new(credentials_provider: P, region: region::Region) -> Self {{
-                let mut client = Client::new();
-                client.set_redirect_policy(RedirectPolicy::FollowNone);
-               {type_name}::with_request_dispatcher(client, credentials_provider, region)
+            pub fn new(credentials_provider: P, region: region::Region) -> Result<Self, ReqwestError> {{
+                let mut client = try!(Client::new());
+                client.redirect(RedirectPolicy::none());
+                return Ok({type_name}::with_request_dispatcher(client, credentials_provider, region));
             }}
         }}
 

--- a/codegen/src/generator/query.rs
+++ b/codegen/src/generator/query.rs
@@ -30,7 +30,7 @@ impl GenerateProtocol for QueryGenerator {
                     {xml_stack_loader}
 
                     match result.status {{
-                        200 => {{
+                        StatusCode::Ok => {{
                             {method_return_value}
                         }}
                         _ => {{

--- a/codegen/src/generator/rest_xml.rs
+++ b/codegen/src/generator/rest_xml.rs
@@ -53,7 +53,7 @@ impl GenerateProtocol for RestXmlGenerator {
                     let response = try!(self.dispatcher.dispatch(&request));
 
                     match response.status {{
-                        200|204 => {{
+                        StatusCode::Ok|StatusCode::NoContent => {{
                             {parse_response}
                         }},
                         _ => Err({error_type}::from_body(&response.body))

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -10,6 +10,7 @@ extern crate lazy_static;
 extern crate regex;
 extern crate serde;
 extern crate serde_json;
+extern crate reqwest;
 
 #[cfg(feature = "serde_derive")]
 #[macro_use]

--- a/credential/Cargo.toml
+++ b/credential/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.3.0"
 
 [dependencies]
 chrono = "0.2.25"
-hyper = "0.9.12"
+reqwest = "0.2.0"
 regex = "0.1.80"
 serde_json = "0.8.3"
 

--- a/credential/src/container.rs
+++ b/credential/src/container.rs
@@ -1,9 +1,7 @@
 use std::env;
 use std::io::Read;
-use std::time::Duration as StdDuration;
 
-use hyper::Client;
-use hyper::header::Connection;
+use reqwest;
 use serde_json::{self, Value};
 
 use {
@@ -29,10 +27,7 @@ impl ProvideAwsCredentials for ContainerProvider {
 
         let address: String = format!("http://{}{}", AWS_CREDENTIALS_PROVIDER_IP, aws_container_credentials_relative_uri);
 
-        let mut client = Client::new();
-        client.set_read_timeout(Some(StdDuration::from_secs(15)));
-        let mut response = match client.get(&address)
-            .header(Connection::close()).send()
+        let mut response = match reqwest::get(&address)
         {
             Ok(response) => response,
             Err(_) => return Err(CredentialsError::new("Couldn't connect to credentials provider")), // add why?

--- a/credential/src/lib.rs
+++ b/credential/src/lib.rs
@@ -5,7 +5,7 @@
 //! Types for loading and managing AWS access credentials for API requests.
 
 extern crate chrono;
-extern crate hyper;
+extern crate reqwest;
 extern crate regex;
 extern crate serde_json;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! }
 
 extern crate chrono;
-extern crate hyper;
+extern crate reqwest;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate md5;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,9 +1,13 @@
 //! Mock request dispatcher and credentials for unit testing services
+
+use std::fs::File;
+use std::io::Read;
+use std::collections::HashMap;
+
 use super::{DispatchSignedRequest, HttpResponse, HttpDispatchError, SignedRequest};
 use super::{ProvideAwsCredentials, CredentialsError, AwsCredentials};
 use chrono::{Duration, UTC};
-use std::fs::File;
-use std::io::Read;
+use reqwest::StatusCode;
 
 const ONE_DAY: i64 = 86400;
 
@@ -22,8 +26,11 @@ pub struct MockRequestDispatcher {
 
 impl MockRequestDispatcher {
 	pub fn with_status(status: u16) -> MockRequestDispatcher {
-		let mut response = HttpResponse::default();
-		response.status = status;
+		let response = HttpResponse {
+			status: StatusCode::from_u16(status),
+			body: "".to_string(),
+			headers: HashMap::new(),
+		} ;
 		MockRequestDispatcher { 
 			mock_response: response,
 			request_checker: None

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,6 @@
 //! AWS API requests.
 //!
-//! Wraps the Hyper library to send PUT, POST, DELETE and GET requests.
+//! Wraps the Reqwest library to send PUT, POST, DELETE and GET requests.
 
 extern crate lazy_static;
 
@@ -10,12 +10,13 @@ use std::io::Error as IoError;
 use std::error::Error;
 use std::fmt;
 use std::collections::HashMap;
+use std::str::FromStr;
 
-use hyper::Client;
-use hyper::Error as HyperError;
-use hyper::header::Headers;
-use hyper::header::UserAgent;
-use hyper::method::Method;
+use reqwest::Client;
+use reqwest::header::{UserAgent, Headers};
+use reqwest::StatusCode;
+use reqwest::Method;
+use reqwest::Error as ReqwestError;
 
 use log::LogLevel::Debug;
 
@@ -27,13 +28,14 @@ include!(concat!(env!("OUT_DIR"), "/user_agent_vars.rs"));
 // Use a lazy static to cache the default User-Agent header
 // because it never changes once it's been computed.
 lazy_static! {
-    static ref DEFAULT_USER_AGENT: Vec<Vec<u8>> = vec![format!("rusoto/{} rust/{} {}",
-            env!("CARGO_PKG_VERSION"), RUST_VERSION, env::consts::OS).as_bytes().to_vec()];
+    static ref DEFAULT_USER_AGENT: String = format!("rusoto/{} rust/{} {}",
+            env!("CARGO_PKG_VERSION"), RUST_VERSION, env::consts::OS);
 }
 
-#[derive(Clone, Default)]
+// This had Default as well:
+#[derive(Clone)]
 pub struct HttpResponse {
-    pub status: u16,
+    pub status: StatusCode,
     pub body: String,
     pub headers: HashMap<String, String>
 }
@@ -55,8 +57,8 @@ impl fmt::Display for HttpDispatchError {
     }
 }
 
-impl From<HyperError> for HttpDispatchError {
-    fn from(err: HyperError) -> HttpDispatchError {
+impl From<ReqwestError> for HttpDispatchError {
+    fn from(err: ReqwestError) -> HttpDispatchError {
         HttpDispatchError { message: err.description().to_string() }
     }
 }
@@ -73,31 +75,32 @@ pub trait DispatchSignedRequest {
 
 impl DispatchSignedRequest for Client {
     fn dispatch(&self, request: &SignedRequest) -> Result<HttpResponse, HttpDispatchError> {
-        let hyper_method = match request.method().as_ref() {
-            "POST" => Method::Post,
-            "PUT" => Method::Put,
-            "DELETE" => Method::Delete,
-            "GET" => Method::Get,
-            "HEAD" => Method::Head,
-            v => return Err(HttpDispatchError { message: format!("Unsupported HTTP verb {}", v) })
-
+        // TODO: be more graceful for using the builder:
+        let http_method = match Method::from_str(request.method().as_ref()) {
+            Ok(method) => method,
+            Err(e) => return Err(HttpDispatchError { message: format!("Unsupported HTTP verb. {}", e) }),
         };
-
-        // translate the headers map to a format Hyper likes
-        let mut hyper_headers = Headers::new();
-        for h in request.headers().iter() {
-            hyper_headers.set_raw(h.0.to_owned(), h.1.to_owned());
-        }
-
-        // Add a default user-agent header if one is not already present.
-        if !hyper_headers.has::<UserAgent>() {
-            hyper_headers.set_raw("user-agent".to_owned(), DEFAULT_USER_AGENT.clone());
-        }
-
         let mut final_uri = format!("https://{}{}", request.hostname(), request.canonical_path());
         if !request.canonical_query_string().is_empty() {
             final_uri = final_uri + &format!("?{}", request.canonical_query_string());
         }
+
+        let mut request_builder = self.request(http_method.clone(), &final_uri);
+
+        request_builder = match request.payload() {
+            None => request_builder,
+            Some(payload_contents) => request_builder.body(payload_contents),
+        };
+
+        // translate the headers map to a format Reqwest/Hyper likes
+        let mut request_headers = Headers::new();
+        for h in request.headers().iter() {
+            request_headers.set_raw(h.0.to_owned(), h.1.to_owned());
+        }
+        request_builder = request_builder.headers(request_headers.clone());
+
+        // TODO: overwrite.  Is that the default?
+        request_builder = request_builder.header(UserAgent(DEFAULT_USER_AGENT.clone()));
 
         if log_enabled!(Debug) {
             let payload = request.payload().map(|mut payload_bytes| {
@@ -108,34 +111,31 @@ impl DispatchSignedRequest for Client {
                     .unwrap_or_else(|_| String::from("<non-UTF-8 data>"))
             });
 
-            debug!("Full request: \n method: {}\n final_uri: {}\n payload: {}\nHeaders:\n", hyper_method, final_uri, payload.unwrap_or("".to_owned()));
-            for h in hyper_headers.iter() {
+            debug!("Full request: \n method: {}\n final_uri: {}\n payload: {:?}\nHeaders:\n", http_method, final_uri, payload);
+            for h in request_headers.iter() {
                 debug!("{}:{}", h.name(), h.value_string());
             }
         }
 
-        let mut hyper_response = match request.payload() {
-            None => try!(self.request(hyper_method, &final_uri).headers(hyper_headers).body("").send()),
-            Some(payload_contents) => try!(self.request(hyper_method, &final_uri).headers(hyper_headers).body(payload_contents).send()),
-        };
+        let mut request_response = try!(request_builder.send());
 
         let mut body = String::new();
-        try!(hyper_response.read_to_string(&mut body));
+        // We should pass back a Read object instead:
+        try!(request_response.read_to_string(&mut body));
 
         if log_enabled!(Debug) {
             debug!("Response body:\n{}", body);
         }
 
-        let mut headers: HashMap<String, String> = HashMap::new();
-
-        for header in hyper_response.headers.iter() {
-            headers.insert(header.name().to_string(), header.value_string());
+        let mut request_headers_as_hashmap: HashMap<String, String> = HashMap::new();
+        for h in request_headers.iter() {
+            request_headers_as_hashmap.insert(h.name().to_string(), h.value_string());
         }
 
         Ok(HttpResponse {
-            status: hyper_response.status.to_u16(),
+            status: request_response.status().clone(),
             body: body,
-            headers: headers
+            headers: request_headers_as_hashmap
         })
 
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::str;
 
-use hyper::status::StatusCode;
+use reqwest::StatusCode;
 use ring::{digest, hmac};
 use rusoto_credential::AwsCredentials;
 use rustc_serialize::hex::ToHex;

--- a/tests/acm.rs
+++ b/tests/acm.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_certificates() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = AcmClient::new(credentials, Region::UsEast1);
+    let client = AcmClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListCertificatesRequest::default();
 
     client.list_certificates(&request).unwrap();

--- a/tests/cloudformation.rs
+++ b/tests/cloudformation.rs
@@ -7,7 +7,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 
 #[test]
 fn should_list_stacks() {
-    let client = CloudFormationClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
+    let client = CloudFormationClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1).unwrap();
     let request = ListStacksInput::default();
 
     let result = client.list_stacks(&request).unwrap();
@@ -16,7 +16,7 @@ fn should_list_stacks() {
 
 #[test]
 fn should_list_stacks_with_status_filter() {
-    let client = CloudFormationClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
+    let client = CloudFormationClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1).unwrap();
 
     let filters = vec!["CREATE_COMPLETE".to_owned()];
     let request = ListStacksInput {

--- a/tests/cloudhsm.rs
+++ b/tests/cloudhsm.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_hapgs() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudHsmClient::new(credentials, Region::UsEast1);
+    let client = CloudHsmClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListHapgsRequest::default();
 
     client.list_hapgs(&request).unwrap();
@@ -17,7 +17,7 @@ fn should_list_hapgs() {
 #[test]
 fn should_list_hsms() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudHsmClient::new(credentials, Region::UsEast1);
+    let client = CloudHsmClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListHsmsRequest::default();
 
     client.list_hsms(&request).unwrap();
@@ -25,7 +25,7 @@ fn should_list_hsms() {
 #[test]
 fn should_list_luna_clients() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudHsmClient::new(credentials, Region::UsEast1);
+    let client = CloudHsmClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListLunaClientsRequest::default();
 
     client.list_luna_clients(&request).unwrap();

--- a/tests/cloudtrail.rs
+++ b/tests/cloudtrail.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_trails() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudTrailClient::new(credentials, Region::UsEast1);
+    let client = CloudTrailClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeTrailsRequest::default();
 
     client.describe_trails(&request).unwrap();

--- a/tests/cloudwatch.rs
+++ b/tests/cloudwatch.rs
@@ -7,7 +7,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 
 #[test]
 fn should_put_metric_data() {
-    let client = CloudWatchClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
+	let client = CloudWatchClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1).unwrap();
 
 	let metric_data = vec![
 		MetricDatum {

--- a/tests/codecommit.rs
+++ b/tests/codecommit.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_repositories() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CodeCommitClient::new(credentials, Region::UsEast1);
+    let client = CodeCommitClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListRepositoriesInput::default();
 
     client.list_repositories(&request).unwrap();

--- a/tests/codedeploy.rs
+++ b/tests/codedeploy.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_applications() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CodeDeployClient::new(credentials, Region::UsEast1);
+    let client = CodeDeployClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListApplicationsInput::default();
 
     client.list_applications(&request).unwrap();

--- a/tests/codepipeline.rs
+++ b/tests/codepipeline.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_pipelines() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CodePipelineClient::new(credentials, Region::UsEast1);
+    let client = CodePipelineClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListPipelinesInput::default();
 
     client.list_pipelines(&request).unwrap();

--- a/tests/cognitoidentity.rs
+++ b/tests/cognitoidentity.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_identity_pools() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CognitoIdentityClient::new(credentials, Region::UsEast1);
+    let client = CognitoIdentityClient::new(credentials, Region::UsEast1).unwrap();
 
     let mut request = ListIdentityPoolsInput::default();
     request.max_results = 10;
@@ -19,7 +19,7 @@ fn should_list_identity_pools() {
 #[test]
 fn should_handle_validation_errors_gracefully() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CognitoIdentityClient::new(credentials, Region::UsEast1);
+    let client = CognitoIdentityClient::new(credentials, Region::UsEast1).unwrap();
 
     let mut request = ListIdentitiesInput::default();
     request.max_results = 10;

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_config_rules() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = ConfigServiceClient::new(credentials, Region::UsEast1);
+    let client = ConfigServiceClient::new(credentials, Region::UsEast1).unwrap();
 
     let request = DescribeConfigRulesRequest::default();
 
@@ -24,7 +24,7 @@ fn should_describe_config_rules() {
 #[test]
 fn should_describe_delivery_channels() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = ConfigServiceClient::new(credentials, Region::UsEast1);
+    let client = ConfigServiceClient::new(credentials, Region::UsEast1).unwrap();
 
     let request = DescribeDeliveryChannelsRequest::default();
 

--- a/tests/datapipeline.rs
+++ b/tests/datapipeline.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_pipelines() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DataPipelineClient::new(credentials, Region::UsEast1);
+    let client = DataPipelineClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListPipelinesInput::default();
 
     client.list_pipelines(&request).unwrap();

--- a/tests/devicefarm.rs
+++ b/tests/devicefarm.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 pub fn should_list_devices() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DeviceFarmClient::new(credentials, Region::UsWest2);
+    let client = DeviceFarmClient::new(credentials, Region::UsWest2).unwrap();
     let request = ListDevicesRequest::default();
 
     client.list_devices(&request).unwrap();

--- a/tests/directconnect.rs
+++ b/tests/directconnect.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_connections() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectConnectClient::new(credentials, Region::UsEast1);
+    let client = DirectConnectClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeConnectionsRequest::default();
 
     client.describe_connections(&request).unwrap();
@@ -17,7 +17,7 @@ fn should_describe_connections() {
 #[test]
 fn should_fail_gracefully() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectConnectClient::new(credentials, Region::UsEast1);
+    let client = DirectConnectClient::new(credentials, Region::UsEast1).unwrap();
 
     let request = DescribeConnectionsRequest {
         connection_id: Some("invalid".to_string())
@@ -32,7 +32,7 @@ fn should_fail_gracefully() {
 #[test]
 fn should_describe_locations() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectConnectClient::new(credentials, Region::UsEast1);
+    let client = DirectConnectClient::new(credentials, Region::UsEast1).unwrap();
 
     client.describe_locations().unwrap();
 }
@@ -40,7 +40,7 @@ fn should_describe_locations() {
 #[test]
 fn should_describe_virtual_gateways() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectConnectClient::new(credentials, Region::UsEast1);
+    let client = DirectConnectClient::new(credentials, Region::UsEast1).unwrap();
 
     client.describe_virtual_gateways().unwrap();
 }

--- a/tests/ds.rs
+++ b/tests/ds.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_trusts() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectoryServiceClient::new(credentials, Region::UsEast1);
+    let client = DirectoryServiceClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeTrustsRequest::default();
 
     client.describe_trusts(&request).unwrap();
@@ -17,7 +17,7 @@ fn should_describe_trusts() {
 #[test]
 fn should_describe_directories() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectoryServiceClient::new(credentials, Region::UsEast1);
+    let client = DirectoryServiceClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeDirectoriesRequest::default();
 
     client.describe_directories(&request).unwrap();

--- a/tests/dynamodb.rs
+++ b/tests/dynamodb.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_tables() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DynamoDbClient::new(credentials, Region::UsEast1);
+    let client = DynamoDbClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListTablesInput::default();
 
     client.list_tables(&request).unwrap();

--- a/tests/dynamodbstreams.rs
+++ b/tests/dynamodbstreams.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_streams() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DynamoDbStreamsClient::new(credentials, Region::UsEast1);
+    let client = DynamoDbStreamsClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListStreamsInput::default();
 
     client.list_streams(&request).unwrap();

--- a/tests/ec2.rs
+++ b/tests/ec2.rs
@@ -10,7 +10,7 @@ use std::error::Error;
 #[test]
 fn main() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let ec2 = Ec2Client::new(credentials, Region::UsEast1);
+    let ec2 = Ec2Client::new(credentials, Region::UsEast1).unwrap();
 
     let mut req = DescribeInstancesRequest::default();
     req.instance_ids = Some(vec!["i-00000000".into(), "i-00000001".into()]);
@@ -30,7 +30,7 @@ fn main() {
 #[should_panic(expected="<Message>Request would have succeeded, but DryRun flag is set.</Message>")]
 fn dry_run() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let ec2 = Ec2Client::new(credentials, Region::UsEast1);
+    let ec2 = Ec2Client::new(credentials, Region::UsEast1).unwrap();
     let req = CreateSnapshotRequest {
         volume_id: "v-00000001".into(),
         description: None,
@@ -44,7 +44,7 @@ fn dry_run() {
 #[should_panic(expected="<Code>InvalidID</Code>")]
 fn query_serialization_name() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let ec2 = Ec2Client::new(credentials, Region::UsEast1);
+    let ec2 = Ec2Client::new(credentials, Region::UsEast1).unwrap();
     let req = CreateTagsRequest {
         dry_run: None,
         resources: vec!["v-00000001".into()],

--- a/tests/ecr.rs
+++ b/tests/ecr.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_repositories() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = EcrClient::new(credentials, Region::UsEast1);
+    let client = EcrClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeRepositoriesRequest::default();
 
     client.describe_repositories(&request).unwrap();

--- a/tests/ecs.rs
+++ b/tests/ecs.rs
@@ -9,7 +9,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 fn main() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
 
-    let ecs = EcsClient::new(credentials, Region::UsEast1);
+    let ecs = EcsClient::new(credentials, Region::UsEast1).unwrap();
 
     // http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListClusters.html
     match ecs.list_clusters(&ListClustersRequest::default()) {

--- a/tests/elastictranscoder.rs
+++ b/tests/elastictranscoder.rs
@@ -9,7 +9,7 @@ extern crate rusoto;
 use std::clone::Clone;
 use std::ops::{Deref, DerefMut};
 
-use hyper::Client;
+use reqwest::Client;
 use rand::Rng;
 use rusoto::{ChainProvider, ProvideAwsCredentials, Region};
 use rusoto::elastictranscoder::EtsClient;

--- a/tests/emr.rs
+++ b/tests/emr.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_clusters() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = EmrClient::new(credentials, Region::UsEast1);
+    let client = EmrClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListClustersInput::default();
 
     client.list_clusters(&request).unwrap();
@@ -17,7 +17,7 @@ fn should_list_clusters() {
 #[test]
 fn should_handle_deprecation_gracefully() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = EmrClient::new(credentials, Region::UsEast1);
+    let client = EmrClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeJobFlowsInput::default();
 
     match client.describe_job_flows(&request) {

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_rules() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudWatchEventsClient::new(credentials, Region::UsEast1);
+    let client = CloudWatchEventsClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListRulesRequest::default();
 
     client.list_rules(&request).unwrap();

--- a/tests/firehose.rs
+++ b/tests/firehose.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_delivery_streams() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = KinesisFirehoseClient::new(credentials, Region::UsEast1);
+    let client = KinesisFirehoseClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListDeliveryStreamsInput::default();
 
     client.list_delivery_streams(&request).unwrap();

--- a/tests/iam.rs
+++ b/tests/iam.rs
@@ -10,7 +10,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 fn get_user() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
 
-    let iam = IamClient::new(credentials, Region::UsEast1);
+    let iam = IamClient::new(credentials, Region::UsEast1).unwrap();
 
     // http://docs.aws.amazon.com/IAM/latest/APIReference/Welcome.html
     let request = GetUserRequest {
@@ -23,7 +23,7 @@ fn get_user() {
 fn list_users() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
 
-    let iam = IamClient::new(credentials, Region::UsEast1);
+    let iam = IamClient::new(credentials, Region::UsEast1).unwrap();
 
     // http://docs.aws.amazon.com/IAM/latest/APIReference/Welcome.html
     let request = ListUsersRequest {

--- a/tests/inspector.rs
+++ b/tests/inspector.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_assessment_runs() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = InspectorClient::new(credentials, Region::UsEast1);
+    let client = InspectorClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListAssessmentRunsRequest::default();
 
     client.list_assessment_runs(&request).unwrap();

--- a/tests/iot.rs
+++ b/tests/iot.rs
@@ -11,7 +11,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 fn should_list_things() {
     let _ = env_logger::init();
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = IotClient::new(credentials, Region::UsEast1);
+    let client = IotClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListThingsRequest::default();
 
     client.list_things(&request).unwrap();

--- a/tests/kinesis.rs
+++ b/tests/kinesis.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_streams() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = KinesisClient::new(credentials, Region::UsEast1);
+    let client = KinesisClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListStreamsInput::default();
 
     client.list_streams(&request).unwrap();

--- a/tests/kms.rs
+++ b/tests/kms.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_keys() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = KmsClient::new(credentials, Region::UsEast1);
+    let client = KmsClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListKeysRequest::default();
 
     client.list_keys(&request).unwrap();

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_log_groups() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudWatchLogsClient::new(credentials, Region::UsEast1);
+    let client = CloudWatchLogsClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeLogGroupsRequest::default();
 
     client.describe_log_groups(&request).unwrap();

--- a/tests/machinelearning.rs
+++ b/tests/machinelearning.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_batch_predictions() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = MachineLearningClient::new(credentials, Region::UsEast1);
+    let client = MachineLearningClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeBatchPredictionsInput::default();
 
     client.describe_batch_predictions(&request).unwrap();
@@ -16,7 +16,7 @@ fn should_describe_batch_predictions() {
 #[test]
 fn should_describe_data_sources() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = MachineLearningClient::new(credentials, Region::UsEast1);
+    let client = MachineLearningClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeDataSourcesInput::default();
 
     client.describe_data_sources(&request).unwrap();
@@ -24,7 +24,7 @@ fn should_describe_data_sources() {
 #[test]
 fn should_describe_evaluations() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = MachineLearningClient::new(credentials, Region::UsEast1);
+    let client = MachineLearningClient::new(credentials, Region::UsEast1).unwrap();
 
     let request = DescribeEvaluationsInput::default();
 

--- a/tests/opsworks.rs
+++ b/tests/opsworks.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_stacks() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = OpsWorksClient::new(credentials, Region::UsEast1);
+    let client = OpsWorksClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeStacksRequest::default();
 
     client.describe_stacks(&request).unwrap();
@@ -17,7 +17,7 @@ fn should_describe_stacks() {
 #[test]
 fn should_describe_my_user_profile() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = OpsWorksClient::new(credentials, Region::UsEast1);
+    let client = OpsWorksClient::new(credentials, Region::UsEast1).unwrap();
 
     client.describe_my_user_profile().unwrap();
 }

--- a/tests/route53domains.rs
+++ b/tests/route53domains.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_operations() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = Route53DomainsClient::new(credentials, Region::UsEast1);
+    let client = Route53DomainsClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListOperationsRequest::default();
 
     client.list_operations(&request).unwrap();

--- a/tests/s3.rs
+++ b/tests/s3.rs
@@ -5,7 +5,7 @@ extern crate hyper;
 extern crate env_logger;
 extern crate log;
 
-use hyper::Client;
+use reqwest::Client;
 use std::fs::File;
 use std::io::Read;
 use time::get_time;

--- a/tests/s3.rs
+++ b/tests/s3.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "s3")]
 extern crate rusoto;
 extern crate time;
-extern crate hyper;
+extern crate reqwest;
 extern crate env_logger;
 extern crate log;
 
@@ -26,7 +26,7 @@ type TestClient = S3Client<DefaultCredentialsProvider, Client>;
 fn test_all_the_things() {
     let _ = env_logger::init();
 
-    let client = S3Client::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
+    let client = S3Client::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1).unwrap();
 
     // a random number should probably be appended here too
     let test_bucket = format!("rusoto_test_bucket_{}", get_time().sec);

--- a/tests/sqs.rs
+++ b/tests/sqs.rs
@@ -10,7 +10,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 fn list_queues() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
 
-    let sqs = SqsClient::new(credentials, Region::EuWest1);
+    let sqs = SqsClient::new(credentials, Region::EuWest1).unwrap();
 
     // http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/Welcome.html
     let request = ListQueuesRequest {

--- a/tests/ssm.rs
+++ b/tests/ssm.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_documents() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = SsmClient::new(credentials, Region::UsEast1);
+    let client = SsmClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListDocumentsRequest::default();
 
     client.list_documents(&request).unwrap();
@@ -17,7 +17,7 @@ fn should_list_documents() {
 #[test]
 fn should_list_commands() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = SsmClient::new(credentials, Region::UsEast1);
+    let client = SsmClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListCommandsRequest::default();
 
     client.list_commands(&request).unwrap();
@@ -26,7 +26,7 @@ fn should_list_commands() {
 #[test]
 fn should_list_command_invocations() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = SsmClient::new(credentials, Region::UsEast1);
+    let client = SsmClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListCommandInvocationsRequest::default();
 
     client.list_command_invocations(&request).unwrap();

--- a/tests/storagegateway.rs
+++ b/tests/storagegateway.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_gateways() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = StorageGatewayClient::new(credentials, Region::UsEast1);
+    let client = StorageGatewayClient::new(credentials, Region::UsEast1).unwrap();
     let request = ListGatewaysInput::default();
 
     client.list_gateways(&request).unwrap();

--- a/tests/swf.rs
+++ b/tests/swf.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_list_domains() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = SwfClient::new(credentials, Region::UsEast1);
+    let client = SwfClient::new(credentials, Region::UsEast1).unwrap();
 
     let mut request = ListDomainsInput::default();
     request.maximum_page_size = Some(10);

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -8,7 +8,7 @@ use rusoto::{DefaultCredentialsProvider, Region};
 #[test]
 fn should_describe_workspaces() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = WorkspacesClient::new(credentials, Region::UsEast1);
+    let client = WorkspacesClient::new(credentials, Region::UsEast1).unwrap();
     let request = DescribeWorkspacesRequest::default();
 
     client.describe_workspaces(&request).unwrap();


### PR DESCRIPTION
## New description
Entirely swaps out `hyper` for `reqwest`.  Fixes https://github.com/rusoto/rusoto/issues/486 .

Benefits:
* insulation from openssl binding issues: `reqwest` uses [rust-native-tls](https://github.com/sfackler/rust-native-tls).
* strongly typed status codes (`reqwest` not required but it's in this PR 😄 ).
* higher level abstractions over HTTP requests.  `reqwest::get("https://www.rust-lang.org")` for example.
* insulation from coming breaking changes to hyper, such as [when it implements async](https://github.com/hyperium/hyper/issues/907#issuecomment-255509020) and updates openssl bindings.

Original PR: https://github.com/rusoto/rusoto/pull/471 .

## Original ticket:
Carved out from https://github.com/rusoto/rusoto/issues/486 .

This doesn't set timeouts, which doesn't appear to be exposed in reqwest yet. (issue here: https://github.com/seanmonstar/reqwest/issues/36 )

Also not tested yet, I should fire up [moe](https://github.com/matthewkmayer/moe) and test locally.