### PR TITLE
Adds top level descriptions for error type enums.

### DIFF
--- a/codegen/src/generator/error_types.rs
+++ b/codegen/src/generator/error_types.rs
@@ -23,8 +23,8 @@ pub trait GenerateErrorTypes {
     }
 
     fn generate_error_type(&self, operation: &Operation, error_documentation: &HashMap<&String, &String>) -> String {
-
         format!("
+            /// Errors returned by {operation}
             #[derive(Debug, PartialEq)]
             pub enum {type_name} {{
                 {error_types}
@@ -55,6 +55,7 @@ pub trait GenerateErrorTypes {
              }}
          }}
          ",
+         operation = operation.name,
          type_name = operation.error_type_name(),
          error_from_body_impl = self.generate_error_from_body_impl(operation),
          error_from_type_impl = self.generate_error_from_type_impl(operation),


### PR DESCRIPTION
Fixes https://github.com/rusoto/rusoto/issues/334 .

Previously docs looked like this:

<img width="787" alt="screen shot 2016-08-08 at 9 40 31 pm" src="https://cloud.githubusercontent.com/assets/4998189/17504797/e0947998-5db0-11e6-91d7-5f400cb29022.png">

With this PR:

<img width="638" alt="screen shot 2016-12-30 at 7 08 05 pm" src="https://cloud.githubusercontent.com/assets/4998189/21575530/6bd465da-cec3-11e6-9ae8-20aeb3d2fa61.png">
