### PR TITLE
Use exponential backoff retry for cred sourcing

### DIFF
--- a/credential/Cargo.toml
+++ b/credential/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.2.25"
 reqwest = "0.3.0"
 regex = "0.2.1"
 serde_json = "0.9.4"
+retry = "0.4.0"
 
 [dependencies.clippy]
 optional = true

--- a/credential/src/container.rs
+++ b/credential/src/container.rs
@@ -23,7 +23,7 @@ impl ProvideAwsCredentials for ContainerProvider {
         let address: String = format!("http://{}{}", AWS_CREDENTIALS_PROVIDER_IP, aws_container_credentials_relative_uri);
 
         let mut response =
-            match retry::retry_exponentially(5, 0_f64, || { reqwest::get(&address) },
+            match retry::retry_exponentially(5, 7f64, || { reqwest::get(&address) },
             |response_attempt| {
                 match response_attempt.as_ref() {
                     Ok(response_returned) => response_returned.status().is_success(),

--- a/credential/src/instance_metadata.rs
+++ b/credential/src/instance_metadata.rs
@@ -14,7 +14,7 @@ impl ProvideAwsCredentials for InstanceMetadataProvider {
     fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
         let mut address : String = "http://169.254.169.254/latest/meta-data/iam/security-credentials".to_string();
         let mut response =
-            match retry::retry_exponentially(5, 0_f64, || { reqwest::get(&address) },
+            match retry::retry_exponentially(5, 7f64, || { reqwest::get(&address) },
             |response_attempt| {
                 match response_attempt.as_ref() {
                     Ok(response_returned) => response_returned.status().is_success(),

--- a/credential/src/lib.rs
+++ b/credential/src/lib.rs
@@ -8,6 +8,7 @@ extern crate chrono;
 extern crate reqwest;
 extern crate regex;
 extern crate serde_json;
+extern crate retry;
 
 pub use environment::EnvironmentProvider;
 pub use container::ContainerProvider;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 format_strings = false
 fn_brace_style = "PreferSameLine"
 item_brace_style = "PreferSameLine"
+max_width = 140 # allow longer lines to run through rustfmt


### PR DESCRIPTION
Fixes https://github.com/rusoto/rusoto/issues/437 when complete.

`rustfmt` did interesting things to the file.