### PR TITLE
adds with_default_region() service client constructor

### DIFF
--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -87,13 +87,17 @@ fn generate_client<P>(service: &Service, protocol_generator: &P) -> String
             pub fn new(credentials_provider: P, region: region::Region) -> Self {{
                 let mut client = Client::new();
                 client.set_redirect_policy(RedirectPolicy::FollowNone);
-               {type_name}::with_request_dispatcher(client, credentials_provider, region)
+                {type_name}::with_request_dispatcher(client, credentials_provider, region)
+            }}
+
+            pub fn with_default_region(credentials_provider: P) -> Self {{
+                Self::new(credentials_provider, region::default_region())
             }}
         }}
 
         impl<P, D> {type_name}<P, D> where P: ProvideAwsCredentials, D: DispatchSignedRequest {{
             pub fn with_request_dispatcher(request_dispatcher: D, credentials_provider: P, region: region::Region) -> Self {{
-                  {type_name} {{
+                {type_name} {{
                     credentials_provider: credentials_provider,
                     region: region,
                     dispatcher: request_dispatcher

--- a/src/region.rs
+++ b/src/region.rs
@@ -4,6 +4,7 @@
 //!
 //! For example: `UsEast1` to "us-east-1"
 
+use std;
 use std::error::Error;
 use std::str::FromStr;
 use std::fmt::{Display, Error as FmtError, Formatter};
@@ -63,7 +64,8 @@ impl FromStr for Region {
     type Err = ParseRegionError;
 
     fn from_str(s: &str) -> Result<Region, ParseRegionError> {
-        match s {
+        let v : &str = &s.to_lowercase();
+        match v {
             "ap-northeast-1" => Ok(Region::ApNortheast1),
             "ap-northeast-2" => Ok(Region::ApNortheast2),
             "ap-south-1" => Ok(Region::ApSouth1),
@@ -101,6 +103,19 @@ impl Error for ParseRegionError {
 impl Display for ParseRegionError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
         write!(f, "{}", self.message)
+    }
+}
+
+pub fn default_region() -> Region {
+    match std::env::var("AWS_DEFAULT_REGION") {
+        Ok(v) => {
+            let slice : &str = &v;
+            match Region::from_str(slice) {
+                Ok(region) => region,
+                Err(_) => Region::UsEast1,
+            }
+        },
+        Err(_) => Region::UsEast1,
     }
 }
 


### PR DESCRIPTION
This is an initial implementation of https://github.com/rusoto/rusoto/issues/497.

When creating a client, the method will look up AWS_DEFAULT_REGION and use the region specified in the environment variable.  If the value is malformed or not set, us-east-1 will be used.

- Rust AFAIK does not allow function overloading with different number of arguments.  So, I had to resort to a different name for this constructor
- Instead of default_region() returning a Result, I decided to fall back on `us-east-1` which is an identical behavior to the official AWS SDKs.