### PR TITLE
Reqwest and hyper-native-tls together.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ version = ">= 0.5.0"
 
 [dependencies]
 chrono = "0.2.21"
-hyper = "0.9.14"
+hyper = "0.10.0"
+hyper-native-tls = "0.2.1"
 lazy_static = "0.2.1"
 log = "0.3.6"
 md5 = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ use std::default::Default;
 
 use rusoto::{DefaultCredentialsProvider, Region};
 use rusoto::dynamodb::{DynamoDbClient, ListTablesInput};
+use rusoto::default_tls_client;
 
 fn main() {
   let provider = DefaultCredentialsProvider::new().unwrap();
-  let client = DynamoDbClient::new(provider, Region::UsEast1);
+  let client = DynamoDbClient::new(default_tls_client().unwrap(), provider, Region::UsEast1);
   let list_tables_input: ListTablesInput = Default::default();
 
   match client.list_tables(&list_tables_input) {

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "0.2.1"
 regex = "0.1.65"
 serde = "0.8.0"
 serde_json = "0.8.0"
-hyper = "0.9.14"
+hyper = "0.10.0"
 
 [dependencies.clippy]
 optional = true

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -55,7 +55,6 @@ fn generate<P, E>(service: &Service, protocol_generator: P, error_type_generator
     service_code.push_str(
         "#[allow(warnings)]
         use hyper::Client;
-        use hyper::client::RedirectPolicy;
         use hyper::status::StatusCode;
         use request::DispatchSignedRequest;
         use region;
@@ -84,16 +83,8 @@ fn generate_client<P>(service: &Service, protocol_generator: &P) -> String
             dispatcher: D,
         }}
 
-        impl<P> {type_name}<P, Client> where P: ProvideAwsCredentials {{
-            pub fn new(credentials_provider: P, region: region::Region) -> Self {{
-                let mut client = Client::new();
-                client.set_redirect_policy(RedirectPolicy::FollowNone);
-               {type_name}::with_request_dispatcher(client, credentials_provider, region)
-            }}
-        }}
-
         impl<P, D> {type_name}<P, D> where P: ProvideAwsCredentials, D: DispatchSignedRequest {{
-            pub fn with_request_dispatcher(request_dispatcher: D, credentials_provider: P, region: region::Region) -> Self {{
+            pub fn new(request_dispatcher: D, credentials_provider: P, region: region::Region) -> Self {{
                   {type_name} {{
                     credentials_provider: credentials_provider,
                     region: region,

--- a/codegen/src/generator/tests.rs
+++ b/codegen/src/generator/tests.rs
@@ -82,7 +82,7 @@ fn generate_response_parse_test(service: &Service, response: Response) -> Option
             let mock_response =  MockResponseReader::read_response(r#\"{response_dir_name}\"#, \"{response_file_name}\");
             let mock = MockRequestDispatcher::with_status(200)
                 .with_body(&mock_response);
-            let client = {client_type}::with_request_dispatcher(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+            let client = {client_type}::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
             {request_constructor}
             let result = client.{action}({request_params});
             assert!(result.is_ok(), \"parse error: {{:?}}\", result);

--- a/credential/Cargo.toml
+++ b/credential/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.3.0"
 
 [dependencies]
 chrono = "0.2.25"
-hyper = "0.9.14"
+reqwest = "0.3.0"
 regex = "0.1.80"
 serde_json = "0.8.3"
 

--- a/credential/src/container.rs
+++ b/credential/src/container.rs
@@ -1,9 +1,7 @@
 use std::env;
 use std::io::Read;
-use std::time::Duration as StdDuration;
 
-use hyper::Client;
-use hyper::header::Connection;
+use reqwest;
 use serde_json::{self, Value};
 
 use {
@@ -29,10 +27,7 @@ impl ProvideAwsCredentials for ContainerProvider {
 
         let address: String = format!("http://{}{}", AWS_CREDENTIALS_PROVIDER_IP, aws_container_credentials_relative_uri);
 
-        let mut client = Client::new();
-        client.set_read_timeout(Some(StdDuration::from_secs(15)));
-        let mut response = match client.get(&address)
-            .header(Connection::close()).send()
+        let mut response = match reqwest::get(&address)
         {
             Ok(response) => response,
             Err(_) => return Err(CredentialsError::new("Couldn't connect to credentials provider")), // add why?

--- a/credential/src/lib.rs
+++ b/credential/src/lib.rs
@@ -5,7 +5,7 @@
 //! Types for loading and managing AWS access credentials for API requests.
 
 extern crate chrono;
-extern crate hyper;
+extern crate reqwest;
 extern crate regex;
 extern crate serde_json;
 

--- a/src/cloudformation.rs
+++ b/src/cloudformation.rs
@@ -62,7 +62,7 @@ mod test {
         let filters = vec!["CREATE_IN_PROGRESS".to_owned(), "DELETE_COMPLETE".to_owned()];
         let request = ListStacksInput { stack_status_filter: Some(filters), ..Default::default() };
 
-        let client = CloudFormationClient::with_request_dispatcher(mock,
+        let client = CloudFormationClient::new(mock,
                                                                    MockCredentialsProvider,
                                                                    Region::UsEast1);
         let _result = client.list_stacks(&request).unwrap();

--- a/src/cloudwatch.rs
+++ b/src/cloudwatch.rs
@@ -42,7 +42,7 @@ mod test {
 	        metric_data: metric_data,
 	    };
 
-        let client = CloudWatchClient::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+        let client = CloudWatchClient::new(mock, MockCredentialsProvider, Region::UsEast1);
 		let response = client.put_metric_data(&request).unwrap();
 		println!("{:#?}", response);
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 
 extern crate chrono;
 extern crate hyper;
+extern crate hyper_native_tls;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate md5;
@@ -77,6 +78,7 @@ pub use rusoto_credential::{
 };
 pub use request::{DispatchSignedRequest, HttpResponse, HttpDispatchError};
 pub use signature::SignedRequest;
+pub use request::default_tls_client;
 
 mod param;
 mod region;

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -149,7 +149,7 @@ mod test {
         req.bucket = "rusoto1440826511".to_owned();
         req.key = "testfile.zip".to_owned();
 
-        let client = S3Client::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+        let client = S3Client::new(mock, MockCredentialsProvider, Region::UsEast1);
         let result = client.list_parts(&req).unwrap();
         assert_eq!(result.bucket, sstr("rusoto1440826511"));
         assert_eq!(result.upload_id, sstr("PeePB_uORK5f2AURP_SWcQ4NO1P1oqnGNNNFK3nhFfzMeksdvG7x7nFfH1qk7a3HSossNYB7t8QhcN1Fg6ax7AXbwvAKIZ9DilB4tUcpM7qyUEgkszN4iDmMvSaImGFK"));
@@ -203,7 +203,7 @@ mod test {
         let mut req = ListMultipartUploadsRequest::default();
         req.bucket = "test-bucket".to_owned();
        
-        let client = S3Client::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+        let client = S3Client::new(mock, MockCredentialsProvider, Region::UsEast1);
         let result = client.list_multipart_uploads(&req).unwrap();
 
         assert_eq!(result.bucket, sstr("rusoto1440826568"));
@@ -241,7 +241,7 @@ mod test {
                 assert_eq!(request.payload, None);
             });
 
-        let client = S3Client::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+        let client = S3Client::new(mock, MockCredentialsProvider, Region::UsEast1);
         let result = client.list_buckets().unwrap();
 
         let owner = result.owner.unwrap();
@@ -265,7 +265,7 @@ mod test {
             .with_header("x-amz-expiration".to_string(), "foo".to_string())
             .with_header("x-amz-restore".to_string(), "bar".to_string());
 
-        let client = S3Client::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+        let client = S3Client::new(mock, MockCredentialsProvider, Region::UsEast1);
         let request = HeadObjectRequest::default();
         let result = client.head_object(&request).unwrap();
 
@@ -309,7 +309,7 @@ mod test {
                 assert_eq!(request.payload, None);
             });
 
-        let client = S3Client::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+        let client = S3Client::new(mock, MockCredentialsProvider, Region::UsEast1);
         let _ = client.get_object(&request).unwrap();
     }
 

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -117,7 +117,7 @@ mod test {
             ..Default::default()
         };
 
-        let client = SqsClient::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+        let client = SqsClient::new(mock, MockCredentialsProvider, Region::UsEast1);
         let _result = client.receive_message(&request).unwrap();
     }
 }

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -64,7 +64,7 @@ mod test {
         };
 
         let client =
-            SqsClient::with_request_dispatcher(mock, MockCredentialsProvider, Region::UsEast1);
+            SqsClient::new(mock, MockCredentialsProvider, Region::UsEast1);
         let _result = client.send_message(&request).unwrap();
     }
 

--- a/tests/acm.rs
+++ b/tests/acm.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::acm::{AcmClient, ListCertificatesRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_certificates() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = AcmClient::new(credentials, Region::UsEast1);
+    let client = AcmClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListCertificatesRequest::default();
 
     client.list_certificates(&request).unwrap();

--- a/tests/cloudformation.rs
+++ b/tests/cloudformation.rs
@@ -4,10 +4,11 @@ extern crate rusoto;
 
 use rusoto::cloudformation::{CloudFormationClient, ListStacksInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_stacks() {
-    let client = CloudFormationClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
+    let client = CloudFormationClient::new(default_tls_client().unwrap(), DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
     let request = ListStacksInput::default();
 
     let result = client.list_stacks(&request).unwrap();
@@ -16,7 +17,7 @@ fn should_list_stacks() {
 
 #[test]
 fn should_list_stacks_with_status_filter() {
-    let client = CloudFormationClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
+    let client = CloudFormationClient::new(default_tls_client().unwrap(), DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
 
     let filters = vec!["CREATE_COMPLETE".to_owned()];
     let request = ListStacksInput {

--- a/tests/cloudhsm.rs
+++ b/tests/cloudhsm.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::cloudhsm::{CloudHsmClient, ListHapgsRequest, ListHsmsRequest, ListLunaClientsRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_hapgs() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudHsmClient::new(credentials, Region::UsEast1);
+    let client = CloudHsmClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListHapgsRequest::default();
 
     client.list_hapgs(&request).unwrap();
@@ -17,7 +18,7 @@ fn should_list_hapgs() {
 #[test]
 fn should_list_hsms() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudHsmClient::new(credentials, Region::UsEast1);
+    let client = CloudHsmClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListHsmsRequest::default();
 
     client.list_hsms(&request).unwrap();
@@ -25,7 +26,7 @@ fn should_list_hsms() {
 #[test]
 fn should_list_luna_clients() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudHsmClient::new(credentials, Region::UsEast1);
+    let client = CloudHsmClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListLunaClientsRequest::default();
 
     client.list_luna_clients(&request).unwrap();

--- a/tests/cloudtrail.rs
+++ b/tests/cloudtrail.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::cloudtrail::{CloudTrailClient, DescribeTrailsRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_trails() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudTrailClient::new(credentials, Region::UsEast1);
+    let client = CloudTrailClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeTrailsRequest::default();
 
     client.describe_trails(&request).unwrap();

--- a/tests/cloudwatch.rs
+++ b/tests/cloudwatch.rs
@@ -4,10 +4,11 @@ extern crate rusoto;
 
 use rusoto::cloudwatch::{CloudWatchClient, PutMetricDataInput, Dimension, MetricDatum};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_put_metric_data() {
-    let client = CloudWatchClient::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
+    let client = CloudWatchClient::new(default_tls_client().unwrap(), DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
 
 	let metric_data = vec![
 		MetricDatum {

--- a/tests/codecommit.rs
+++ b/tests/codecommit.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::codecommit::{CodeCommitClient, ListRepositoriesInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_repositories() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CodeCommitClient::new(credentials, Region::UsEast1);
+    let client = CodeCommitClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListRepositoriesInput::default();
 
     client.list_repositories(&request).unwrap();

--- a/tests/codedeploy.rs
+++ b/tests/codedeploy.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::codedeploy::{CodeDeployClient, ListApplicationsInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_applications() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CodeDeployClient::new(credentials, Region::UsEast1);
+    let client = CodeDeployClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListApplicationsInput::default();
 
     client.list_applications(&request).unwrap();

--- a/tests/codepipeline.rs
+++ b/tests/codepipeline.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::codepipeline::{CodePipelineClient, ListPipelinesInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_pipelines() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CodePipelineClient::new(credentials, Region::UsEast1);
+    let client = CodePipelineClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListPipelinesInput::default();
 
     client.list_pipelines(&request).unwrap();

--- a/tests/cognitoidentity.rs
+++ b/tests/cognitoidentity.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::cognitoidentity::{CognitoIdentityClient, ListIdentitiesInput, ListIdentitiesError, ListIdentityPoolsInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_identity_pools() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CognitoIdentityClient::new(credentials, Region::UsEast1);
+    let client = CognitoIdentityClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     let mut request = ListIdentityPoolsInput::default();
     request.max_results = 10;
@@ -19,7 +20,7 @@ fn should_list_identity_pools() {
 #[test]
 fn should_handle_validation_errors_gracefully() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CognitoIdentityClient::new(credentials, Region::UsEast1);
+    let client = CognitoIdentityClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     let mut request = ListIdentitiesInput::default();
     request.max_results = 10;

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::config::{ConfigServiceClient, DescribeConfigRulesRequest, DescribeDeliveryChannelsRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_config_rules() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = ConfigServiceClient::new(credentials, Region::UsEast1);
+    let client = ConfigServiceClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     let request = DescribeConfigRulesRequest::default();
 
@@ -24,7 +25,7 @@ fn should_describe_config_rules() {
 #[test]
 fn should_describe_delivery_channels() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = ConfigServiceClient::new(credentials, Region::UsEast1);
+    let client = ConfigServiceClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     let request = DescribeDeliveryChannelsRequest::default();
 

--- a/tests/datapipeline.rs
+++ b/tests/datapipeline.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::datapipeline::{DataPipelineClient, ListPipelinesInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_pipelines() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DataPipelineClient::new(credentials, Region::UsEast1);
+    let client = DataPipelineClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListPipelinesInput::default();
 
     client.list_pipelines(&request).unwrap();

--- a/tests/devicefarm.rs
+++ b/tests/devicefarm.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::devicefarm::{DeviceFarmClient, ListDevicesRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 pub fn should_list_devices() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DeviceFarmClient::new(credentials, Region::UsWest2);
+    let client = DeviceFarmClient::new(default_tls_client().unwrap(), credentials, Region::UsWest2);
     let request = ListDevicesRequest::default();
 
     client.list_devices(&request).unwrap();

--- a/tests/directconnect.rs
+++ b/tests/directconnect.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::directconnect::{DirectConnectClient, DescribeConnectionsRequest, DescribeConnectionsError};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_connections() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectConnectClient::new(credentials, Region::UsEast1);
+    let client = DirectConnectClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeConnectionsRequest::default();
 
     client.describe_connections(&request).unwrap();
@@ -17,7 +18,7 @@ fn should_describe_connections() {
 #[test]
 fn should_fail_gracefully() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectConnectClient::new(credentials, Region::UsEast1);
+    let client = DirectConnectClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     let request = DescribeConnectionsRequest {
         connection_id: Some("invalid".to_string())
@@ -32,7 +33,7 @@ fn should_fail_gracefully() {
 #[test]
 fn should_describe_locations() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectConnectClient::new(credentials, Region::UsEast1);
+    let client = DirectConnectClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     client.describe_locations().unwrap();
 }
@@ -40,7 +41,7 @@ fn should_describe_locations() {
 #[test]
 fn should_describe_virtual_gateways() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectConnectClient::new(credentials, Region::UsEast1);
+    let client = DirectConnectClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     client.describe_virtual_gateways().unwrap();
 }

--- a/tests/ds.rs
+++ b/tests/ds.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::ds::{DirectoryServiceClient, DescribeTrustsRequest, DescribeDirectoriesRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_trusts() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectoryServiceClient::new(credentials, Region::UsEast1);
+    let client = DirectoryServiceClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeTrustsRequest::default();
 
     client.describe_trusts(&request).unwrap();
@@ -17,7 +18,7 @@ fn should_describe_trusts() {
 #[test]
 fn should_describe_directories() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DirectoryServiceClient::new(credentials, Region::UsEast1);
+    let client = DirectoryServiceClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeDirectoriesRequest::default();
 
     client.describe_directories(&request).unwrap();

--- a/tests/dynamodb.rs
+++ b/tests/dynamodb.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::dynamodb::{DynamoDbClient, ListTablesInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_tables() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DynamoDbClient::new(credentials, Region::UsEast1);
+    let client = DynamoDbClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListTablesInput::default();
 
     client.list_tables(&request).unwrap();

--- a/tests/dynamodbstreams.rs
+++ b/tests/dynamodbstreams.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::dynamodbstreams::{DynamoDbStreamsClient, ListStreamsInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_streams() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = DynamoDbStreamsClient::new(credentials, Region::UsEast1);
+    let client = DynamoDbStreamsClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListStreamsInput::default();
 
     client.list_streams(&request).unwrap();

--- a/tests/ec2.rs
+++ b/tests/ec2.rs
@@ -5,12 +5,13 @@ extern crate rusoto;
 use rusoto::ec2::{Ec2Client, CreateSnapshotRequest, DescribeInstancesRequest};
 use rusoto::ec2::{CreateTagsRequest, Tag};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 use std::error::Error;
 
 #[test]
 fn main() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let ec2 = Ec2Client::new(credentials, Region::UsEast1);
+    let ec2 = Ec2Client::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     let mut req = DescribeInstancesRequest::default();
     req.instance_ids = Some(vec!["i-00000000".into(), "i-00000001".into()]);
@@ -30,7 +31,7 @@ fn main() {
 #[should_panic(expected="<Message>Request would have succeeded, but DryRun flag is set.</Message>")]
 fn dry_run() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let ec2 = Ec2Client::new(credentials, Region::UsEast1);
+    let ec2 = Ec2Client::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let req = CreateSnapshotRequest {
         volume_id: "v-00000001".into(),
         description: None,
@@ -44,7 +45,7 @@ fn dry_run() {
 #[should_panic(expected="<Code>InvalidID</Code>")]
 fn query_serialization_name() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let ec2 = Ec2Client::new(credentials, Region::UsEast1);
+    let ec2 = Ec2Client::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let req = CreateTagsRequest {
         dry_run: None,
         resources: vec!["v-00000001".into()],

--- a/tests/ecr.rs
+++ b/tests/ecr.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::ecr::{EcrClient, DescribeRepositoriesRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_repositories() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = EcrClient::new(credentials, Region::UsEast1);
+    let client = EcrClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeRepositoriesRequest::default();
 
     client.describe_repositories(&request).unwrap();

--- a/tests/ecs.rs
+++ b/tests/ecs.rs
@@ -4,12 +4,13 @@ extern crate rusoto;
 
 use rusoto::ecs::{EcsClient, ListClustersRequest, ListClustersError};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn main() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
 
-    let ecs = EcsClient::new(credentials, Region::UsEast1);
+    let ecs = EcsClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     // http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListClusters.html
     match ecs.list_clusters(&ListClustersRequest::default()) {

--- a/tests/elastictranscoder.rs
+++ b/tests/elastictranscoder.rs
@@ -14,6 +14,7 @@ use rand::Rng;
 use rusoto::{ChainProvider, ProvideAwsCredentials, Region};
 use rusoto::elastictranscoder::EtsClient;
 use rusoto::s3::{BucketName, S3Client, CreateBucketRequest, DeleteBucketRequest};
+use rusoto::default_tls_client;
 
 const AWS_ETS_WEB_PRESET_ID: &'static str = "1351620000001-100070";
 const AWS_ETS_WEB_PRESET_NAME: &'static str = "System preset: Web";
@@ -41,7 +42,7 @@ impl<P> TestEtsClient<P>
         TestEtsClient {
             credentials_provider: credentials_provider.clone(),
             region: region,
-            client: EtsClient::new(credentials_provider, region),
+            client: EtsClient::new(default_tls_client().unwrap(), credentials_provider, region),
             s3_client: None,
             input_bucket: None,
             output_bucket: None,
@@ -49,7 +50,7 @@ impl<P> TestEtsClient<P>
     }
 
     fn create_s3_client(&mut self) {
-        self.s3_client = Some(S3Client::new(
+        self.s3_client = Some(S3Client::new(default_tls_client().unwrap(),
             self.credentials_provider.clone(),
             self.region
         ));

--- a/tests/emr.rs
+++ b/tests/emr.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::emr::{EmrClient, ListClustersInput, DescribeJobFlowsInput, DescribeJobFlowsError};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_clusters() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = EmrClient::new(credentials, Region::UsEast1);
+    let client = EmrClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListClustersInput::default();
 
     client.list_clusters(&request).unwrap();
@@ -17,7 +18,7 @@ fn should_list_clusters() {
 #[test]
 fn should_handle_deprecation_gracefully() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = EmrClient::new(credentials, Region::UsEast1);
+    let client = EmrClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeJobFlowsInput::default();
 
     match client.describe_job_flows(&request) {

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::events::{CloudWatchEventsClient, ListRulesRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_rules() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudWatchEventsClient::new(credentials, Region::UsEast1);
+    let client = CloudWatchEventsClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListRulesRequest::default();
 
     client.list_rules(&request).unwrap();

--- a/tests/firehose.rs
+++ b/tests/firehose.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::firehose::{KinesisFirehoseClient, ListDeliveryStreamsInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_delivery_streams() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = KinesisFirehoseClient::new(credentials, Region::UsEast1);
+    let client = KinesisFirehoseClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListDeliveryStreamsInput::default();
 
     client.list_delivery_streams(&request).unwrap();

--- a/tests/iam.rs
+++ b/tests/iam.rs
@@ -5,12 +5,13 @@ extern crate rusoto;
 use rusoto::iam::IamClient;
 use rusoto::iam::{GetUserRequest, ListUsersRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn get_user() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
 
-    let iam = IamClient::new(credentials, Region::UsEast1);
+    let iam = IamClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     // http://docs.aws.amazon.com/IAM/latest/APIReference/Welcome.html
     let request = GetUserRequest {
@@ -23,7 +24,7 @@ fn get_user() {
 fn list_users() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
 
-    let iam = IamClient::new(credentials, Region::UsEast1);
+    let iam = IamClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     // http://docs.aws.amazon.com/IAM/latest/APIReference/Welcome.html
     let request = ListUsersRequest {

--- a/tests/inspector.rs
+++ b/tests/inspector.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::inspector::{InspectorClient, ListAssessmentRunsRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_assessment_runs() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = InspectorClient::new(credentials, Region::UsEast1);
+    let client = InspectorClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListAssessmentRunsRequest::default();
 
     client.list_assessment_runs(&request).unwrap();

--- a/tests/iot.rs
+++ b/tests/iot.rs
@@ -6,12 +6,13 @@ extern crate env_logger;
 extern crate log;
 use rusoto::iot::{IotClient, ListThingsRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_things() {
     let _ = env_logger::init();
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = IotClient::new(credentials, Region::UsEast1);
+    let client = IotClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListThingsRequest::default();
 
     client.list_things(&request).unwrap();

--- a/tests/kinesis.rs
+++ b/tests/kinesis.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::kinesis::{KinesisClient, ListStreamsInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_streams() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = KinesisClient::new(credentials, Region::UsEast1);
+    let client = KinesisClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListStreamsInput::default();
 
     client.list_streams(&request).unwrap();

--- a/tests/kms.rs
+++ b/tests/kms.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::kms::{KmsClient, ListKeysRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_keys() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = KmsClient::new(credentials, Region::UsEast1);
+    let client = KmsClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListKeysRequest::default();
 
     client.list_keys(&request).unwrap();

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::logs::{CloudWatchLogsClient, DescribeLogGroupsRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_log_groups() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = CloudWatchLogsClient::new(credentials, Region::UsEast1);
+    let client = CloudWatchLogsClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeLogGroupsRequest::default();
 
     client.describe_log_groups(&request).unwrap();

--- a/tests/machinelearning.rs
+++ b/tests/machinelearning.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::machinelearning::{MachineLearningClient, DescribeDataSourcesInput, DescribeBatchPredictionsInput, DescribeEvaluationsInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_batch_predictions() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = MachineLearningClient::new(credentials, Region::UsEast1);
+    let client = MachineLearningClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeBatchPredictionsInput::default();
 
     client.describe_batch_predictions(&request).unwrap();
@@ -16,7 +17,7 @@ fn should_describe_batch_predictions() {
 #[test]
 fn should_describe_data_sources() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = MachineLearningClient::new(credentials, Region::UsEast1);
+    let client = MachineLearningClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeDataSourcesInput::default();
 
     client.describe_data_sources(&request).unwrap();
@@ -24,7 +25,7 @@ fn should_describe_data_sources() {
 #[test]
 fn should_describe_evaluations() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = MachineLearningClient::new(credentials, Region::UsEast1);
+    let client = MachineLearningClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     let request = DescribeEvaluationsInput::default();
 

--- a/tests/opsworks.rs
+++ b/tests/opsworks.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::opsworks::{OpsWorksClient, DescribeStacksRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_stacks() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = OpsWorksClient::new(credentials, Region::UsEast1);
+    let client = OpsWorksClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeStacksRequest::default();
 
     client.describe_stacks(&request).unwrap();
@@ -17,7 +18,7 @@ fn should_describe_stacks() {
 #[test]
 fn should_describe_my_user_profile() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = OpsWorksClient::new(credentials, Region::UsEast1);
+    let client = OpsWorksClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     client.describe_my_user_profile().unwrap();
 }

--- a/tests/route53domains.rs
+++ b/tests/route53domains.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::route53domains::{Route53DomainsClient, ListOperationsRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_operations() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = Route53DomainsClient::new(credentials, Region::UsEast1);
+    let client = Route53DomainsClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListOperationsRequest::default();
 
     client.list_operations(&request).unwrap();

--- a/tests/s3.rs
+++ b/tests/s3.rs
@@ -16,6 +16,7 @@ use rusoto::s3::{S3Client, HeadObjectRequest, CopyObjectRequest, GetObjectReques
                  CORSRule, CreateBucketRequest, DeleteBucketRequest, CreateMultipartUploadRequest,
                  UploadPartRequest, CompleteMultipartUploadRequest, CompletedMultipartUpload,
                  CompletedPart, CompletedPartList};
+use rusoto::default_tls_client;
 
 type TestClient = S3Client<DefaultCredentialsProvider, Client>;
 
@@ -26,7 +27,8 @@ type TestClient = S3Client<DefaultCredentialsProvider, Client>;
 fn test_all_the_things() {
     let _ = env_logger::init();
 
-    let client = S3Client::new(DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
+    let client = S3Client::new(default_tls_client().unwrap(),
+        DefaultCredentialsProvider::new().unwrap(), Region::UsEast1);
 
     // a random number should probably be appended here too
     let test_bucket = format!("rusoto_test_bucket_{}", get_time().sec);

--- a/tests/sqs.rs
+++ b/tests/sqs.rs
@@ -5,12 +5,12 @@ extern crate rusoto;
 use rusoto::sqs::SqsClient;
 use rusoto::sqs::ListQueuesRequest;
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn list_queues() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-
-    let sqs = SqsClient::new(credentials, Region::EuWest1);
+    let sqs = SqsClient::new(default_tls_client().unwrap(), credentials, Region::EuWest1);
 
     // http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/Welcome.html
     let request = ListQueuesRequest {

--- a/tests/ssm.rs
+++ b/tests/ssm.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::ssm::{SsmClient, ListDocumentsRequest, ListCommandsRequest, ListCommandInvocationsRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_documents() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = SsmClient::new(credentials, Region::UsEast1);
+    let client = SsmClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListDocumentsRequest::default();
 
     client.list_documents(&request).unwrap();
@@ -17,7 +18,7 @@ fn should_list_documents() {
 #[test]
 fn should_list_commands() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = SsmClient::new(credentials, Region::UsEast1);
+    let client = SsmClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListCommandsRequest::default();
 
     client.list_commands(&request).unwrap();
@@ -26,7 +27,7 @@ fn should_list_commands() {
 #[test]
 fn should_list_command_invocations() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = SsmClient::new(credentials, Region::UsEast1);
+    let client = SsmClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListCommandInvocationsRequest::default();
 
     client.list_command_invocations(&request).unwrap();

--- a/tests/storagegateway.rs
+++ b/tests/storagegateway.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::storagegateway::{StorageGatewayClient, ListGatewaysInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_gateways() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = StorageGatewayClient::new(credentials, Region::UsEast1);
+    let client = StorageGatewayClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = ListGatewaysInput::default();
 
     client.list_gateways(&request).unwrap();

--- a/tests/swf.rs
+++ b/tests/swf.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::swf::{SwfClient, ListDomainsInput};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_list_domains() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = SwfClient::new(credentials, Region::UsEast1);
+    let client = SwfClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
 
     let mut request = ListDomainsInput::default();
     request.maximum_page_size = Some(10);

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -4,11 +4,12 @@ extern crate rusoto;
 
 use rusoto::workspaces::{WorkspacesClient, DescribeWorkspacesRequest};
 use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::default_tls_client;
 
 #[test]
 fn should_describe_workspaces() {
     let credentials = DefaultCredentialsProvider::new().unwrap();
-    let client = WorkspacesClient::new(credentials, Region::UsEast1);
+    let client = WorkspacesClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeWorkspacesRequest::default();
 
     client.describe_workspaces(&request).unwrap();


### PR DESCRIPTION
One possible fix for https://github.com/rusoto/rusoto/issues/486 .

I like this option because it makes our credentials sourcing code for instance metadata and ECS containers clearer.  I've also forced our service `Client` types to be supplied a request dispatcher.  This is eased by a new helper function that makes a hyper-native-tls Client that can be dropped in, as the integration test and code samples show.  This change will encourage users of an AWS service client to re-use the request dispatcher across services.  This is different from our now-removed default client constructor which made a new `hyper` client per AWS service client construction.  I suppose we should verify it's thread-safe to do this.

Potential future pitfalls are if `reqwest` and `hyper-native-tls` have a library-related conflict in the future.  I think we can keep them all in lockstep though, avoiding any problems.