### PR TITLE
Fixes up api docs vs gitbook links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ See [LICENSE][license] for details.
 
 [api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
-[rusoto-help]: https://rusoto.github.io/help.html "Getting help with Rusoto"
-[rusoto-overview]: https://rusoto.github.io/ "Rusoto overview"
-[supported-aws-services]: https://rusoto.github.io/supported-aws-services.html "List of AWS services supported by Rusoto"
+[rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"
+[rusoto-overview]: https://www.rusoto.org/ "Rusoto overview"
+[supported-aws-services]: https://www.rusoto.org/supported-aws-services.html "List of AWS services supported by Rusoto"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,8 +45,12 @@ To release the main `rusoto` crate, version 0.4.0:
 
 Add a list of user-facing changes to a new release for the tagged version on GitHub: https://github.com/rusoto/rusoto/releases
 
-### Documentation
+#### API docs
 
-Docs are on Github Pages at [https://rusoto.github.io/rusoto](https://rusoto.github.io/rusoto).
+API docs are on Github Pages at [https://rusoto.github.io/rusoto](https://rusoto.github.io/rusoto).
 
 TravisCI builds and publishes the `gh-pages` branch automatically when changes are merged into master.
+
+#### Gitbook docs
+
+See [the Rusoto gitbook project](https://github.com/rusoto/rusoto.github.io).


### PR DESCRIPTION
Fixes https://github.com/rusoto/rusoto/issues/441 .