### PR TITLE
make `TlsError` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use rusoto_credential::{
     DefaultCredentialsProvider,
     DefaultCredentialsProviderSync,
 };
-pub use request::{DispatchSignedRequest, HttpResponse, HttpDispatchError};
+pub use request::{DispatchSignedRequest, HttpResponse, HttpDispatchError, TlsError};
 pub use signature::SignedRequest;
 pub use request::default_tls_client;
 


### PR DESCRIPTION
I think `TlsError` should be public, so that it's easier to wrap error of `default_tls_client` function.
