### PR TITLE
Use rayon instead of explicit threading for codegen.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ version = "0.22.0"
 
 [build-dependencies]
 rustc_version = "0.1.7"
+rayon = "0.6.0"
 
 [build-dependencies.rusoto_codegen]
 default-features = false

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -48,7 +48,7 @@ impl Service {
     }
 }
 
-pub fn generate(service: Service, output_path: &Path) {
+pub fn generate(service: Service, output_path: &Path) -> i32 {
     let botocore_destination_path = output_path.join(format!("{}_botocore.rs", service.name));
     let serde_destination_path = output_path.join(format!("{}.rs", service.name));
     let botocore_service_data_path = Path::new(BOTOCORE_DIR)
@@ -58,6 +58,8 @@ pub fn generate(service: Service, output_path: &Path) {
                       botocore_destination_path.as_path());
     serde_generate(botocore_destination_path.as_path(),
                    serde_destination_path.as_path());
+
+    return 1;
 }
 
 fn botocore_generate(input_path: &Path, output_path: &Path) {


### PR DESCRIPTION
Testing a theory for our builds, especially Appveyor: spinning out 42 threads for the services we currently generate is causing our CI instances to thrash between threads.  Rayon does smarter threading and does it for us.

If this makes compilation/test runs faster on CI builds we should ensure codegen exits properly if it can't complete.  Example: https://github.com/rusoto/rusoto/pull/520 ensures codegen errors out if the service definitions aren't in the expected place.

References: https://github.com/rusoto/rusoto/issues/495 and https://github.com/rusoto/rusoto/pull/520 .