### PR TITLE
Make appveyor use beta channel.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,10 @@ os: Visual Studio 2015
 
 environment:
   global:
-    # This will be used as part of the zipfile name
     PROJECT_NAME: rusoto
   matrix:
     - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: stable
+      CHANNEL: beta
 cache:
   - 'C:\Users\appveyor\.cargo'
 # Install Rust and Cargo


### PR DESCRIPTION
Testing on a Windows laptop shows `beta` channel has significantly better compilation performance.  Let's see how it works on Appveyor!