### PR TITLE
Only do the cargo test step in TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,7 @@ script:
       else
         export CARGO_ARGS="--features $RUSOTO_FEATURES -vv"
       fi
-  - echo "Compiling all of Rusoto" && travis_wait 30 travis-cargo build -- $CARGO_ARGS
-  - echo "Running Rusoto tests" && travis_wait travis-cargo test -- --lib $CARGO_ARGS
+  - echo "Running Rusoto tests" && travis_wait 40 travis-cargo test -- --lib $CARGO_ARGS
   - echo "Running Rusoto benchmarks" && travis_wait travis-cargo bench -- $CARGO_ARGS
   - echo "Running rusoto_credential tests" && (cd credential && travis_wait travis-cargo test)
   - |


### PR DESCRIPTION
Running `cargo test` does very similar things to`cargo build`.  Let's only run tests instead of recompiling the whole crate for tests.