### PR TITLE
Update readme with package's latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For example, to include only S3 and SQS:
 
 ``` toml
 [dependencies]
-rusoto = {version = "0.20", features = ["s3", "sqs"]}
+rusoto = {version = "0.22", features = ["s3", "sqs"]}
 ```
 
 You can use the Cargo feature "all" to build Rusoto with support for every available service. Warning: building with "all" can require upwards of 5 GB of memory. Most people do not need all 40+ services so use individual features to enable the services you use.


### PR DESCRIPTION
Using the version 0.20 throws the following error during ring v0.4.3 compilation:
```
error[E0277]: the trait bound `&&std::vec::Vec<std::string::String>: std::iter::Iterator` is not satisfied
   --> /home/vagrant/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.4.3/build.rs:206:14
    |
206 |             .args(&args)
    |              ^^^^ the trait `std::iter::Iterator` is not implemented for `&&std::vec::Vec<std::string::String>`
    |
    = note: `&&std::vec::Vec<std::string::String>` is not an iterator; maybe try calling `.iter()` or a similar method
    = note: required because of the requirements on the impl of `std::iter::IntoIterator` for `&&std::vec::Vec<std::string::String>`
```