### PR TITLE
raw_body must be used in parsing blob type

### DIFF
--- a/codegen/src/generator/xml_payload_parser.rs
+++ b/codegen/src/generator/xml_payload_parser.rs
@@ -57,7 +57,7 @@ fn payload_body_parser(payload_type: ShapeType,
                        payload_member: &str)
                        -> String {
     let response_body = match payload_type {
-        ShapeType::Blob => "Some(response.body.as_bytes().to_vec())",
+        ShapeType::Blob => "Some(response.raw_body.to_vec())",
         _ => "Some(response.body.to_owned())",
     };
 


### PR DESCRIPTION
From rusoto v0.23.0, I've noticed that `rusoto::s3::GetObjectOutput#output` always returns `Some("")` even when other fields like `e_tag` is correct.
When payload shape is blob (e.g., s3:GetObject), `response.raw_body` must be used instead of `response.body`.