### PR TITLE
Parse JSON error types properly

### DIFF
--- a/codegen/src/generator/error_types.rs
+++ b/codegen/src/generator/error_types.rs
@@ -206,10 +206,13 @@ impl GenerateErrorTypes for JsonErrorTypes {
                     pub fn from_body(body: &str) -> {type_name} {{
                         match from_str::<SerdeJsonValue>(body) {{
                             Ok(json) => {{
-                                let error_type = json.get(\"__type\").and_then(|e| e.as_str()).unwrap_or(\"Unknown\");
+                                let raw_error_type = json.get(\"__type\").and_then(|e| e.as_str()).unwrap_or(\"Unknown\");
                                 let error_message = json.get(\"message\").and_then(|m| m.as_str()).unwrap_or(body);
 
-                                match error_type {{
+                                let pieces: Vec<&str> = raw_error_type.split(\"#\").collect();
+                                let error_type = pieces.last().expect(\"Expected error type\");
+
+                                match *error_type {{
                                     {type_matchers}
                                 }}
                             }},

--- a/tests/dynamodb.rs
+++ b/tests/dynamodb.rs
@@ -2,9 +2,26 @@
 
 extern crate rusoto;
 
-use rusoto::dynamodb::{DynamoDbClient, ListTablesInput};
+use rusoto::dynamodb::{DynamoDbClient, ListTablesInput, ListTablesError};
 use rusoto::{DefaultCredentialsProvider, Region};
 use rusoto::default_tls_client;
+
+#[test]
+fn should_parse_error_type() {
+    let credentials = DefaultCredentialsProvider::new().unwrap();
+    let client = DynamoDbClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
+
+    // limit of -1 should generate a validation error
+    let request = ListTablesInput { limit: Some(-1), ..Default::default() };
+
+    let response = client.list_tables(&request);
+    match response {
+        Err(ListTablesError::Validation(msg)) => {
+            assert!(msg.contains("Member must have value greater than or equal to 1"))
+        }
+        _ => panic!("Should have been a Validation error"),
+    };
+}
 
 #[test]
 fn should_list_tables() {
@@ -14,4 +31,3 @@ fn should_list_tables() {
 
     client.list_tables(&request).unwrap();
 }
-


### PR DESCRIPTION
A deeper inspection of the error parsing code in botocore reveals that they split JSON error types on `"#"` and ignore everything before it.  Apparently valid error types include `SomeError` and `com.foo.bar.baz#SomeOtherError`

Added code to the JSON exception parser to do this for us, as well as a regression test in the DynamoDB tests.

Fixes #571 