### PR TITLE
Improves S3 integration test by ensuring obj payload has contents.

### DIFF
--- a/tests/s3.rs
+++ b/tests/s3.rs
@@ -181,6 +181,7 @@ fn test_get_object(client: &TestClient, bucket: &str, filename: &str) {
 
     let result = client.get_object(&get_req).unwrap();
     println!("get object result: {:#?}", result);
+    assert!(result.body.unwrap().len() > 0);
 }
 
 fn test_get_object_range(client: &TestClient, bucket: &str, filename: &str) {


### PR DESCRIPTION
Improves a test to ensure we don't regress like https://github.com/rusoto/rusoto/pull/569 again.