### PR TITLE
Support s3 get bucket location

### DIFF
--- a/codegen/src/generator/xml_payload_parser.rs
+++ b/codegen/src/generator/xml_payload_parser.rs
@@ -114,6 +114,31 @@ fn xml_body_parser(output_shape: &str, result_wrapper: &Option<String>, mutable_
 
 
 fn generate_deserializer_body(name: &str, shape: &Shape, service: &Service) -> String {
+    match (&service.metadata.endpoint_prefix[..], name) {
+        ("s3", "GetBucketLocationOutput") => {
+            // override custom deserializer
+            let struct_field_deserializers = shape.members
+                .as_ref()
+                .unwrap()
+                .iter()
+                .filter_map(|(member_name, member)| {
+                    Some(format!("obj.{field_name} = {parse_expression};",
+                                 field_name = generate_field_name(member_name),
+                                 parse_expression = generate_struct_field_parse_expression(shape,
+                                                                                           member_name,
+                                                                                           member,
+                                                                                           &member_name.to_string())))
+                })
+                .collect::<Vec<String>>()
+                .join("\n");
+            return format!("let mut obj = {name}::default();
+                            {struct_field_deserializers}
+                            Ok(obj)",
+                           name = name,
+                           struct_field_deserializers = struct_field_deserializers);
+        },
+        _ => {},
+    }
     match shape.shape_type {
         ShapeType::List => generate_list_deserializer(shape),
         ShapeType::Map => generate_map_deserializer(shape),

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -9,7 +9,7 @@ mod test {
     use std::io::{Read, BufReader};
     use std::fs::File;
     use s3::{S3Client, HeadObjectRequest, GetObjectRequest, ListMultipartUploadsRequest};
-    use s3::{CreateMultipartUploadOutputDeserializer, CompleteMultipartUploadOutputDeserializer};
+    use s3::{CreateMultipartUploadOutputDeserializer, CompleteMultipartUploadOutputDeserializer, GetBucketLocationOutputDeserializer};
     use s3::{ListMultipartUploadsOutputDeserializer, ListPartsRequest, Initiator, Owner};
     use xmlutil::{XmlResponse, Next};
     use xml::EventReader;
@@ -313,6 +313,26 @@ mod test {
 
         let client = S3Client::new(mock, MockCredentialsProvider, Region::UsEast1);
         let _ = client.get_object(&request).unwrap();
+    }
+
+    #[test]
+    fn should_parse_location_constraint() {
+        let file = File::open("codegen/botocore/tests/unit/response_parsing/xml/responses/s3-get-bucket-location.xml").unwrap();
+        let mut file = BufReader::new(file);
+        let mut raw = String::new();
+        file.read_to_string(&mut raw).unwrap();
+        let my_parser  = EventReader::from_str(&raw);
+        let my_stack = my_parser.into_iter().peekable();
+        let mut reader = XmlResponse::new(my_stack);
+        reader.next(); // xml start node
+        let result = GetBucketLocationOutputDeserializer::deserialize("LocationConstraint", &mut reader);
+
+        match result {
+            Err(_) => panic!("Couldn't parse get_bucket_location"),
+            Ok(result) => {
+                assert_eq!(sstr("EU"), result.location_constraint);
+            }
+        }
     }
 
     /// returns Some(String)


### PR DESCRIPTION
GetBucketLocation wasn't parsing response properly.
This is the case where `botocore` also had custom parsing in `handlers.py`.