### PR TITLE
0.4.0 is the lastest reqwest

### DIFF
--- a/credential/Cargo.toml
+++ b/credential/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.5.0"
 
 [dependencies]
 chrono = "0.2.25"
-reqwest = "0.3.0"
+reqwest = "0.4.0"
 regex = "0.2.1"
 serde_json = "0.9.4"
 retry = "0.4.0"


### PR DESCRIPTION
Bumping this to 0.4.0 doesn't break building rusoto on 1.15.1 of the compiler.