### PR TITLE
All codegen'd structs derives for Debug, Clone

### DIFF
--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -64,14 +64,14 @@ impl GenerateProtocol for JsonGenerator {
                                   serialized: bool,
                                   deserialized: bool)
                                   -> String {
-        let mut derived = vec!["Default"];
+        let mut derived = vec!["Default", "Debug", "Clone"];
 
         if serialized {
             derived.push("Serialize");
         }
 
         if deserialized {
-            derived.push("Deserialize, Debug, Clone")
+            derived.push("Deserialize")
         }
 
         format!("#[derive({})]", derived.join(","))

--- a/codegen/src/generator/json.rs
+++ b/codegen/src/generator/json.rs
@@ -60,7 +60,6 @@ impl GenerateProtocol for JsonGenerator {
     }
 
     fn generate_struct_attributes(&self,
-                                  _struct_name: &str,
                                   serialized: bool,
                                   deserialized: bool)
                                   -> String {

--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -39,7 +39,6 @@ pub trait GenerateProtocol {
 
     /// Add any attributes that should decorate the struct for the given type (typically `Debug`, `Clone`, etc.)
     fn generate_struct_attributes(&self,
-                                  struct_name: &str,
                                   serialized: bool,
                                   deserialized: bool)
                                   -> String;
@@ -293,12 +292,12 @@ fn generate_struct<P>(service: &Service,
             "{attributes}
             pub struct {name};
             ",
-            attributes = protocol_generator.generate_struct_attributes(name, serialized, deserialized),
+            attributes = protocol_generator.generate_struct_attributes(serialized, deserialized),
             name = name,
         )
     } else {
         let struct_attributes =
-            protocol_generator.generate_struct_attributes(name, serialized, deserialized);
+            protocol_generator.generate_struct_attributes(serialized, deserialized);
         // Serde attributes are only needed if deriving the Serialize or Deserialize trait
         let need_serde_attrs = struct_attributes.contains("erialize");
         format!(

--- a/codegen/src/generator/query.rs
+++ b/codegen/src/generator/query.rs
@@ -71,7 +71,6 @@ impl GenerateProtocol for QueryGenerator {
     }
 
     fn generate_struct_attributes(&self,
-                                  _struct_name: &str,
                                   _serialized: bool,
                                   deserialized: bool)
                                   -> String {

--- a/codegen/src/generator/rest_json.rs
+++ b/codegen/src/generator/rest_json.rs
@@ -108,14 +108,14 @@ impl GenerateProtocol for RestJsonGenerator {
                                   serialized: bool,
                                   deserialized: bool)
                                   -> String {
-        let mut derived = vec!["Default"];
+        let mut derived = vec!["Default", "Debug", "Clone"];
 
         if serialized {
             derived.push("Serialize");
         }
 
         if deserialized {
-            derived.push("Deserialize, Debug, Clone")
+            derived.push("Deserialize")
         }
 
         format!("#[derive({})]", derived.join(","))

--- a/codegen/src/generator/rest_json.rs
+++ b/codegen/src/generator/rest_json.rs
@@ -104,7 +104,6 @@ impl GenerateProtocol for RestJsonGenerator {
     }
 
     fn generate_struct_attributes(&self,
-                                  _struct_name: &str,
                                   serialized: bool,
                                   deserialized: bool)
                                   -> String {

--- a/codegen/src/generator/rest_xml.rs
+++ b/codegen/src/generator/rest_xml.rs
@@ -104,7 +104,6 @@ impl GenerateProtocol for RestXmlGenerator {
     }
 
     fn generate_struct_attributes(&self,
-                                  _struct_name: &str,
                                   _serialized: bool,
                                   _deserialized: bool)
                                   -> String {

--- a/codegen/src/generator/rest_xml.rs
+++ b/codegen/src/generator/rest_xml.rs
@@ -104,17 +104,11 @@ impl GenerateProtocol for RestXmlGenerator {
     }
 
     fn generate_struct_attributes(&self,
-                                  struct_name: &str,
+                                  _struct_name: &str,
                                   _serialized: bool,
-                                  deserialized: bool)
+                                  _deserialized: bool)
                                   -> String {
-        let mut derived = vec!["Default"];
-
-        // a few exceptions to get the generated S3 tests to compile
-        if deserialized || struct_name == "GetBucketPolicyOutput" ||
-           struct_name == "GetObjectOutput" {
-            derived.push("Debug")
-        }
+        let derived = vec!["Default", "Clone", "Debug"];
 
         format!("#[derive({})]", derived.join(","))
     }

--- a/codegen/src/generator/xml_payload_parser.rs
+++ b/codegen/src/generator/xml_payload_parser.rs
@@ -3,13 +3,8 @@ use inflector::Inflector;
 use botocore::{Member, Operation, Service, Shape, ShapeType};
 use super::{generate_field_name, mutate_type_name};
 
-pub fn generate_struct_attributes(deserialized: bool) -> String {
-    let mut derived = vec!["Default"];
-
-    if deserialized {
-        derived.push("Debug, Clone")
-    }
-
+pub fn generate_struct_attributes(_deserialized: bool) -> String {
+    let derived = vec!["Default", "Debug", "Clone"];
     format!("#[derive({})]", derived.join(","))
 }
 


### PR DESCRIPTION
This PR makes all API structs derive `Clone` and `Debug`, see #585 for discussion.

This does increase system resource consumption somewhat. On my MacBook Pro, 9d442b0e (master HEAD as of March 25) takes 460 seconds to build, `rustc` maxes at 9215 Mb and results in a rlib that is 156 MB. Building this PR takes 491 seconds, with `rustc` maxing at 9651 Mb and resulting in an rlib that is 161 Mb.

I did not change the signature of the `generate_struct_attributes` method, but it now contains the `struct_name` parameter that no implementation makes use of. Please tell me if there is a good reason for them looking like they do or if they should be trimmed.