### PR TITLE
Change default ShapeType::Integer from i32 to i64

### DIFF
--- a/codegen/src/generator/mod.rs
+++ b/codegen/src/generator/mod.rs
@@ -185,7 +185,7 @@ fn generate_primitive_type(name: &str, shape_type: ShapeType, for_timestamps: &s
         ShapeType::Boolean => "bool",
         ShapeType::Double => "f64",
         ShapeType::Float => "f32",
-        ShapeType::Integer => "i32",
+        ShapeType::Integer => "i64",
         ShapeType::Long => "i64",
         ShapeType::String => "String",
         ShapeType::Timestamp => for_timestamps,

--- a/codegen/src/generator/rest_response_parser.rs
+++ b/codegen/src/generator/rest_response_parser.rs
@@ -112,7 +112,7 @@ fn parse_single_header(service: &Service,
 fn generate_header_primitive_parser(shape: &Shape) -> String {
     let statement = match shape.shape_type {
         ShapeType::String | ShapeType::Timestamp => "value",
-        ShapeType::Integer => "i32::from_str(&value).unwrap()",
+        ShapeType::Integer => "i64::from_str(&value).unwrap()",
         ShapeType::Long => "i64::from_str(&value).unwrap()",
         ShapeType::Double => "f64::from_str(&value).unwrap()",
         ShapeType::Float => "f32::from_str(&value).unwrap()",

--- a/codegen/src/generator/xml_payload_parser.rs
+++ b/codegen/src/generator/xml_payload_parser.rs
@@ -266,7 +266,7 @@ fn generate_map_deserializer(shape: &Shape) -> String {
 fn generate_primitive_deserializer(shape: &Shape) -> String {
     let statement = match shape.shape_type {
         ShapeType::String | ShapeType::Timestamp => "try!(characters(stack))",
-        ShapeType::Integer => "i32::from_str(try!(characters(stack)).as_ref()).unwrap()",
+        ShapeType::Integer => "i64::from_str(try!(characters(stack)).as_ref()).unwrap()",
         ShapeType::Long => "i64::from_str(try!(characters(stack)).as_ref()).unwrap()",
         ShapeType::Double => "f64::from_str(try!(characters(stack)).as_ref()).unwrap()",
         ShapeType::Float => "f32::from_str(try!(characters(stack)).as_ref()).unwrap()",

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -191,7 +191,7 @@ mod credential {
                 &GetSessionTokenRequest {
                     serial_number: self.mfa_serial.clone(),
                     token_code: self.mfa_code.clone(),
-                    duration_seconds: Some(self.session_duration.num_seconds() as i32),
+                    duration_seconds: Some(self.session_duration.num_seconds() as i64),
                     ..Default::default()
                 }) {
                 Ok(resp) => {
@@ -276,7 +276,7 @@ mod credential {
             match self.sts_client.assume_role(&AssumeRoleRequest {
                 role_arn: self.role_arn.clone(),
                 role_session_name: self.session_name.clone(),
-                duration_seconds: Some(self.session_duration.num_seconds() as i32),
+                duration_seconds: Some(self.session_duration.num_seconds() as i64),
                 external_id: self.external_id.clone(),
                 policy: self.scope_down_policy.clone(),
                 serial_number: self.mfa_serial.clone(),
@@ -350,7 +350,7 @@ mod credential {
                 provider_id: self.wif_provider.clone(),
                 role_arn: self.role_arn.clone(),
                 role_session_name: self.session_name.clone(),
-                duration_seconds: Some(self.session_duration.num_seconds() as i32),
+                duration_seconds: Some(self.session_duration.num_seconds() as i64),
                 policy: self.scope_down_policy.clone(),
                 ..Default::default()
             }) {


### PR DESCRIPTION
I remapped ShapeType::Integer to i64 to allow S3 to hold up files greater than 2GB, as discussed in the issue #568