### PR TITLE
Fix mismatched types in s3 test

### DIFF
--- a/tests/s3.rs
+++ b/tests/s3.rs
@@ -92,7 +92,7 @@ fn test_multipart_upload(client: &TestClient, bucket: &str, filename: &str) {
     let upload_id = response.upload_id.unwrap();
 
     // create 2 upload parts
-    let create_upload_part = |body: Vec<u8>, part_number: i32| -> UploadPartRequest {
+    let create_upload_part = |body: Vec<u8>, part_number: i64| -> UploadPartRequest {
         UploadPartRequest {
             body: Some(body),
             bucket: bucket.to_owned(),


### PR DESCRIPTION
I was seeing this:

```rust
$ cargo test --features s3

error[E0308]: mismatched types
   --> tests/s3.rs:101:26
    |
101 |             part_number: part_number,
    |                          ^^^^^^^^^^^ expected i64, found i32
```