### PR TITLE
Parse URI parameters that have values

### DIFF
--- a/codegen/src/generator/rest_xml.rs
+++ b/codegen/src/generator/rest_xml.rs
@@ -17,7 +17,17 @@ impl GenerateProtocol for RestXmlGenerator {
             let (request_uri, maybe_params) = parse_query_string(&operation.http.request_uri);
 
             let add_uri_parameters = match maybe_params {
-                Some(key) => format!("params.put_key(\"{}\");", key),
+                Some(key) => {
+                    if key.contains("=") {
+                        let parts: Vec<_> = key.split("=").collect();
+                        assert_eq!(parts.len(), 2, "service uri parameter has multiple '=' chars");
+                        format!("params.put(\"{}\", \"{}\");",
+                                parts[0],
+                                parts[1])
+                    } else {
+                        format!("params.put_key(\"{}\");", key)
+                    }
+                },
                 _ => "".to_owned(),
             };
 


### PR DESCRIPTION
Most service request URIs look like:

* `/{Bucket}?accelerate`

The `ListObjectsV2` URI looks like:

* `/{Bucket}?list-type=2`

The difference here is the addition of the parameter value.

We can update the protocol generator to use the `params.put(key,value)` function instead of the `params.put_key(key)` when the parameter values exists.

⚠️ I have not added any testing. I can look into this if required.