### PR TITLE
Adds Rust 1.16.0 as a compatible, tested version of Rust.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ language: rust
 cache: cargo
 # run builds for all the trains (and more)
 rust:
-  # check that it compiles on the latest stable compiler
   - stable
   - beta
   - nightly
+  - 1.16.0
 os:
   - linux
   - osx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ environment:
   matrix:
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: 1.16.0
 cache:
   - 'C:\Users\appveyor\.cargo'
 # Install Rust and Cargo


### PR DESCRIPTION
🎉 new version of Rust came out, we still support at least 1.16.0.