### PR TITLE
RFC: streaming support

### DIFF
--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -218,7 +218,10 @@ fn test_get_object(client: &TestClient, bucket: &str, filename: &str) {
 
     let result = client.get_object(&get_req).unwrap();
     println!("get object result: {:#?}", result);
-    assert!(result.body.unwrap().len() > 0);
+
+    let mut body: Vec<u8> = Vec::new();
+    assert!(result.body.unwrap().read_to_end(&mut body).is_ok());
+    assert!(body.len() > 0);
 }
 
 fn test_get_object_range(client: &TestClient, bucket: &str, filename: &str) {

--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -220,7 +220,18 @@ fn test_get_object(client: &TestClient, bucket: &str, filename: &str) {
     println!("get object result: {:#?}", result);
 
     let mut body: Vec<u8> = Vec::new();
-    assert!(result.body.unwrap().read_to_end(&mut body).is_ok());
+    let mut buf: [u8; 5] = [0; 5];
+    let mut stream = result.body.unwrap();
+
+    while let Ok(len) = stream.read(&mut buf) {
+        if len == 0 {
+            break;
+        }
+
+        println!("read {} bytes", len);
+        body.extend_from_slice(&buf);
+    }
+
     assert!(body.len() > 0);
 }
 

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -27,26 +27,24 @@ impl ProvideAwsCredentials for MockCredentialsProvider {
 }
 
 pub struct MockRequestDispatcher {
-    mock_response: HttpResponse,
+    status: StatusCode,
+    body: Vec<u8>,
+    headers: HashMap<String, String>,
     request_checker: Option<Box<Fn(&SignedRequest)>>,
 }
 
 impl MockRequestDispatcher {
     pub fn with_status(status: u16) -> MockRequestDispatcher {
-        let response = HttpResponse {
+        MockRequestDispatcher {
             status: StatusCode::from_u16(status),
             body: b"".to_vec(),
             headers: HashMap::new(),
-        };
-
-        MockRequestDispatcher {
-            mock_response: response,
             request_checker: None,
         }
     }
 
     pub fn with_body(mut self, body: &str) -> MockRequestDispatcher {
-        self.mock_response.body = body.as_bytes().to_vec();
+        self.body = body.as_bytes().to_vec();
         self
     }
 
@@ -56,9 +54,8 @@ impl MockRequestDispatcher {
         self
     }
 
-    pub fn with_header<S1, S2>(mut self, key: S1, value: S2) -> MockRequestDispatcher
-        where S1: Into<String>, S2: Into<String> {
-        self.mock_response.headers.insert(key.into(), value.into());
+    pub fn with_header(mut self, key: &str, value: &str) -> MockRequestDispatcher {
+        self.headers.insert(key.into(), value.into());
         self
     }
 }
@@ -68,7 +65,11 @@ impl DispatchSignedRequest for MockRequestDispatcher {
         if self.request_checker.is_some() {
             self.request_checker.as_ref().unwrap()(request);
         }
-        Ok(self.mock_response.clone())
+        Ok(HttpResponse {
+            status: self.status,
+            body: self.body.clone(),
+            headers: self.headers.clone(),
+        })
     }
 }
 

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -5,6 +5,7 @@ extern crate hyper;
 extern crate rusoto_core;
 
 use std::fs::File;
+use std::io::Cursor;
 use std::io::Read;
 use std::collections::HashMap;
 
@@ -67,7 +68,7 @@ impl DispatchSignedRequest for MockRequestDispatcher {
         }
         Ok(HttpResponse {
             status: self.status,
-            body: self.body.clone(),
+            body: Box::new(Cursor::new(self.body.clone())),
             headers: self.headers.clone(),
         })
     }

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -35,7 +35,6 @@ lazy_static! {
 }
 
 
-#[derive(Clone)]
 pub struct HttpResponse {
     pub status: StatusCode,
     pub body: Vec<u8>,

--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -439,6 +441,11 @@ impl From<HttpDispatchError> for AddTagsToCertificateError {
         AddTagsToCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToCertificateError {
+    fn from(err: io::Error) -> AddTagsToCertificateError {
+        AddTagsToCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -528,6 +535,11 @@ impl From<HttpDispatchError> for DeleteCertificateError {
         DeleteCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteCertificateError {
+    fn from(err: io::Error) -> DeleteCertificateError {
+        DeleteCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -609,6 +621,11 @@ impl From<CredentialsError> for DescribeCertificateError {
 impl From<HttpDispatchError> for DescribeCertificateError {
     fn from(err: HttpDispatchError) -> DescribeCertificateError {
         DescribeCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCertificateError {
+    fn from(err: io::Error) -> DescribeCertificateError {
+        DescribeCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCertificateError {
@@ -698,6 +715,11 @@ impl From<HttpDispatchError> for GetCertificateError {
         GetCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetCertificateError {
+    fn from(err: io::Error) -> GetCertificateError {
+        GetCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -779,6 +801,11 @@ impl From<HttpDispatchError> for ImportCertificateError {
         ImportCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportCertificateError {
+    fn from(err: io::Error) -> ImportCertificateError {
+        ImportCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -849,6 +876,11 @@ impl From<CredentialsError> for ListCertificatesError {
 impl From<HttpDispatchError> for ListCertificatesError {
     fn from(err: HttpDispatchError) -> ListCertificatesError {
         ListCertificatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListCertificatesError {
+    fn from(err: io::Error) -> ListCertificatesError {
+        ListCertificatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListCertificatesError {
@@ -927,6 +959,11 @@ impl From<CredentialsError> for ListTagsForCertificateError {
 impl From<HttpDispatchError> for ListTagsForCertificateError {
     fn from(err: HttpDispatchError) -> ListTagsForCertificateError {
         ListTagsForCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForCertificateError {
+    fn from(err: io::Error) -> ListTagsForCertificateError {
+        ListTagsForCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForCertificateError {
@@ -1014,6 +1051,11 @@ impl From<HttpDispatchError> for RemoveTagsFromCertificateError {
         RemoveTagsFromCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTagsFromCertificateError {
+    fn from(err: io::Error) -> RemoveTagsFromCertificateError {
+        RemoveTagsFromCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTagsFromCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1093,6 +1135,11 @@ impl From<CredentialsError> for RequestCertificateError {
 impl From<HttpDispatchError> for RequestCertificateError {
     fn from(err: HttpDispatchError) -> RequestCertificateError {
         RequestCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RequestCertificateError {
+    fn from(err: io::Error) -> RequestCertificateError {
+        RequestCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RequestCertificateError {
@@ -1183,6 +1230,11 @@ impl From<CredentialsError> for ResendValidationEmailError {
 impl From<HttpDispatchError> for ResendValidationEmailError {
     fn from(err: HttpDispatchError) -> ResendValidationEmailError {
         ResendValidationEmailError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResendValidationEmailError {
+    fn from(err: io::Error) -> ResendValidationEmailError {
+        ResendValidationEmailError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResendValidationEmailError {
@@ -1308,13 +1360,14 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AddTagsToCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1333,13 +1386,14 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1358,15 +1412,18 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1385,15 +1442,20 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetCertificateResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1412,15 +1474,18 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ImportCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ImportCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ImportCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1439,15 +1504,20 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListCertificatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListCertificatesResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListCertificatesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCertificatesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1467,15 +1537,18 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTagsForCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1495,11 +1568,16 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RemoveTagsFromCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -1517,15 +1595,18 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RequestCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RequestCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RequestCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RequestCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1544,13 +1625,14 @@ impl<P, D> Acm for AcmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(ResendValidationEmailError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResendValidationEmailError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2995,6 +2997,11 @@ impl From<HttpDispatchError> for CreateApiKeyError {
         CreateApiKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateApiKeyError {
+    fn from(err: io::Error) -> CreateApiKeyError {
+        CreateApiKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3094,6 +3101,11 @@ impl From<HttpDispatchError> for CreateAuthorizerError {
         CreateAuthorizerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateAuthorizerError {
+    fn from(err: io::Error) -> CreateAuthorizerError {
+        CreateAuthorizerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3190,6 +3202,11 @@ impl From<CredentialsError> for CreateBasePathMappingError {
 impl From<HttpDispatchError> for CreateBasePathMappingError {
     fn from(err: HttpDispatchError) -> CreateBasePathMappingError {
         CreateBasePathMappingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateBasePathMappingError {
+    fn from(err: io::Error) -> CreateBasePathMappingError {
+        CreateBasePathMappingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateBasePathMappingError {
@@ -3302,6 +3319,11 @@ impl From<HttpDispatchError> for CreateDeploymentError {
         CreateDeploymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDeploymentError {
+    fn from(err: io::Error) -> CreateDeploymentError {
+        CreateDeploymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3405,6 +3427,11 @@ impl From<CredentialsError> for CreateDocumentationPartError {
 impl From<HttpDispatchError> for CreateDocumentationPartError {
     fn from(err: HttpDispatchError) -> CreateDocumentationPartError {
         CreateDocumentationPartError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDocumentationPartError {
+    fn from(err: io::Error) -> CreateDocumentationPartError {
+        CreateDocumentationPartError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDocumentationPartError {
@@ -3511,6 +3538,11 @@ impl From<HttpDispatchError> for CreateDocumentationVersionError {
         CreateDocumentationVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDocumentationVersionError {
+    fn from(err: io::Error) -> CreateDocumentationVersionError {
+        CreateDocumentationVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDocumentationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3605,6 +3637,11 @@ impl From<CredentialsError> for CreateDomainNameError {
 impl From<HttpDispatchError> for CreateDomainNameError {
     fn from(err: HttpDispatchError) -> CreateDomainNameError {
         CreateDomainNameError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDomainNameError {
+    fn from(err: io::Error) -> CreateDomainNameError {
+        CreateDomainNameError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDomainNameError {
@@ -3705,6 +3742,11 @@ impl From<HttpDispatchError> for CreateModelError {
         CreateModelError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateModelError {
+    fn from(err: io::Error) -> CreateModelError {
+        CreateModelError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3802,6 +3844,11 @@ impl From<CredentialsError> for CreateRequestValidatorError {
 impl From<HttpDispatchError> for CreateRequestValidatorError {
     fn from(err: HttpDispatchError) -> CreateRequestValidatorError {
         CreateRequestValidatorError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateRequestValidatorError {
+    fn from(err: io::Error) -> CreateRequestValidatorError {
+        CreateRequestValidatorError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateRequestValidatorError {
@@ -3909,6 +3956,11 @@ impl From<HttpDispatchError> for CreateResourceError {
         CreateResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateResourceError {
+    fn from(err: io::Error) -> CreateResourceError {
+        CreateResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4001,6 +4053,11 @@ impl From<CredentialsError> for CreateRestApiError {
 impl From<HttpDispatchError> for CreateRestApiError {
     fn from(err: HttpDispatchError) -> CreateRestApiError {
         CreateRestApiError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateRestApiError {
+    fn from(err: io::Error) -> CreateRestApiError {
+        CreateRestApiError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateRestApiError {
@@ -4099,6 +4156,11 @@ impl From<CredentialsError> for CreateStageError {
 impl From<HttpDispatchError> for CreateStageError {
     fn from(err: HttpDispatchError) -> CreateStageError {
         CreateStageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateStageError {
+    fn from(err: io::Error) -> CreateStageError {
+        CreateStageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateStageError {
@@ -4205,6 +4267,11 @@ impl From<HttpDispatchError> for CreateUsagePlanError {
         CreateUsagePlanError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateUsagePlanError {
+    fn from(err: io::Error) -> CreateUsagePlanError {
+        CreateUsagePlanError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateUsagePlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4304,6 +4371,11 @@ impl From<HttpDispatchError> for CreateUsagePlanKeyError {
         CreateUsagePlanKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateUsagePlanKeyError {
+    fn from(err: io::Error) -> CreateUsagePlanKeyError {
+        CreateUsagePlanKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateUsagePlanKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4390,6 +4462,11 @@ impl From<CredentialsError> for DeleteApiKeyError {
 impl From<HttpDispatchError> for DeleteApiKeyError {
     fn from(err: HttpDispatchError) -> DeleteApiKeyError {
         DeleteApiKeyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteApiKeyError {
+    fn from(err: io::Error) -> DeleteApiKeyError {
+        DeleteApiKeyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteApiKeyError {
@@ -4488,6 +4565,11 @@ impl From<HttpDispatchError> for DeleteAuthorizerError {
         DeleteAuthorizerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAuthorizerError {
+    fn from(err: io::Error) -> DeleteAuthorizerError {
+        DeleteAuthorizerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4574,6 +4656,11 @@ impl From<CredentialsError> for DeleteBasePathMappingError {
 impl From<HttpDispatchError> for DeleteBasePathMappingError {
     fn from(err: HttpDispatchError) -> DeleteBasePathMappingError {
         DeleteBasePathMappingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBasePathMappingError {
+    fn from(err: io::Error) -> DeleteBasePathMappingError {
+        DeleteBasePathMappingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBasePathMappingError {
@@ -4669,6 +4756,11 @@ impl From<HttpDispatchError> for DeleteClientCertificateError {
         DeleteClientCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteClientCertificateError {
+    fn from(err: io::Error) -> DeleteClientCertificateError {
+        DeleteClientCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4761,6 +4853,11 @@ impl From<CredentialsError> for DeleteDeploymentError {
 impl From<HttpDispatchError> for DeleteDeploymentError {
     fn from(err: HttpDispatchError) -> DeleteDeploymentError {
         DeleteDeploymentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDeploymentError {
+    fn from(err: io::Error) -> DeleteDeploymentError {
+        DeleteDeploymentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDeploymentError {
@@ -4858,6 +4955,11 @@ impl From<CredentialsError> for DeleteDocumentationPartError {
 impl From<HttpDispatchError> for DeleteDocumentationPartError {
     fn from(err: HttpDispatchError) -> DeleteDocumentationPartError {
         DeleteDocumentationPartError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDocumentationPartError {
+    fn from(err: io::Error) -> DeleteDocumentationPartError {
+        DeleteDocumentationPartError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDocumentationPartError {
@@ -4958,6 +5060,11 @@ impl From<HttpDispatchError> for DeleteDocumentationVersionError {
         DeleteDocumentationVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDocumentationVersionError {
+    fn from(err: io::Error) -> DeleteDocumentationVersionError {
+        DeleteDocumentationVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDocumentationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5046,6 +5153,11 @@ impl From<CredentialsError> for DeleteDomainNameError {
 impl From<HttpDispatchError> for DeleteDomainNameError {
     fn from(err: HttpDispatchError) -> DeleteDomainNameError {
         DeleteDomainNameError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDomainNameError {
+    fn from(err: io::Error) -> DeleteDomainNameError {
+        DeleteDomainNameError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDomainNameError {
@@ -5137,6 +5249,11 @@ impl From<CredentialsError> for DeleteIntegrationError {
 impl From<HttpDispatchError> for DeleteIntegrationError {
     fn from(err: HttpDispatchError) -> DeleteIntegrationError {
         DeleteIntegrationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteIntegrationError {
+    fn from(err: io::Error) -> DeleteIntegrationError {
+        DeleteIntegrationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteIntegrationError {
@@ -5238,6 +5355,11 @@ impl From<HttpDispatchError> for DeleteIntegrationResponseError {
         DeleteIntegrationResponseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteIntegrationResponseError {
+    fn from(err: io::Error) -> DeleteIntegrationResponseError {
+        DeleteIntegrationResponseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5327,6 +5449,11 @@ impl From<CredentialsError> for DeleteMethodError {
 impl From<HttpDispatchError> for DeleteMethodError {
     fn from(err: HttpDispatchError) -> DeleteMethodError {
         DeleteMethodError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteMethodError {
+    fn from(err: io::Error) -> DeleteMethodError {
+        DeleteMethodError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteMethodError {
@@ -5426,6 +5553,11 @@ impl From<HttpDispatchError> for DeleteMethodResponseError {
         DeleteMethodResponseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteMethodResponseError {
+    fn from(err: io::Error) -> DeleteMethodResponseError {
+        DeleteMethodResponseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteMethodResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5520,6 +5652,11 @@ impl From<CredentialsError> for DeleteModelError {
 impl From<HttpDispatchError> for DeleteModelError {
     fn from(err: HttpDispatchError) -> DeleteModelError {
         DeleteModelError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteModelError {
+    fn from(err: io::Error) -> DeleteModelError {
+        DeleteModelError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteModelError {
@@ -5618,6 +5755,11 @@ impl From<CredentialsError> for DeleteRequestValidatorError {
 impl From<HttpDispatchError> for DeleteRequestValidatorError {
     fn from(err: HttpDispatchError) -> DeleteRequestValidatorError {
         DeleteRequestValidatorError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteRequestValidatorError {
+    fn from(err: io::Error) -> DeleteRequestValidatorError {
+        DeleteRequestValidatorError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteRequestValidatorError {
@@ -5720,6 +5862,11 @@ impl From<HttpDispatchError> for DeleteResourceError {
         DeleteResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteResourceError {
+    fn from(err: io::Error) -> DeleteResourceError {
+        DeleteResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5813,6 +5960,11 @@ impl From<HttpDispatchError> for DeleteRestApiError {
         DeleteRestApiError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRestApiError {
+    fn from(err: io::Error) -> DeleteRestApiError {
+        DeleteRestApiError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5901,6 +6053,11 @@ impl From<CredentialsError> for DeleteStageError {
 impl From<HttpDispatchError> for DeleteStageError {
     fn from(err: HttpDispatchError) -> DeleteStageError {
         DeleteStageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteStageError {
+    fn from(err: io::Error) -> DeleteStageError {
+        DeleteStageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteStageError {
@@ -5993,6 +6150,11 @@ impl From<CredentialsError> for DeleteUsagePlanError {
 impl From<HttpDispatchError> for DeleteUsagePlanError {
     fn from(err: HttpDispatchError) -> DeleteUsagePlanError {
         DeleteUsagePlanError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteUsagePlanError {
+    fn from(err: io::Error) -> DeleteUsagePlanError {
+        DeleteUsagePlanError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteUsagePlanError {
@@ -6092,6 +6254,11 @@ impl From<HttpDispatchError> for DeleteUsagePlanKeyError {
         DeleteUsagePlanKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteUsagePlanKeyError {
+    fn from(err: io::Error) -> DeleteUsagePlanKeyError {
+        DeleteUsagePlanKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteUsagePlanKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6183,6 +6350,11 @@ impl From<CredentialsError> for FlushStageAuthorizersCacheError {
 impl From<HttpDispatchError> for FlushStageAuthorizersCacheError {
     fn from(err: HttpDispatchError) -> FlushStageAuthorizersCacheError {
         FlushStageAuthorizersCacheError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for FlushStageAuthorizersCacheError {
+    fn from(err: io::Error) -> FlushStageAuthorizersCacheError {
+        FlushStageAuthorizersCacheError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for FlushStageAuthorizersCacheError {
@@ -6279,6 +6451,11 @@ impl From<HttpDispatchError> for FlushStageCacheError {
         FlushStageCacheError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for FlushStageCacheError {
+    fn from(err: io::Error) -> FlushStageCacheError {
+        FlushStageCacheError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for FlushStageCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6366,6 +6543,11 @@ impl From<HttpDispatchError> for GenerateClientCertificateError {
         GenerateClientCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GenerateClientCertificateError {
+    fn from(err: io::Error) -> GenerateClientCertificateError {
+        GenerateClientCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GenerateClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6450,6 +6632,11 @@ impl From<HttpDispatchError> for GetAccountError {
         GetAccountError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAccountError {
+    fn from(err: io::Error) -> GetAccountError {
+        GetAccountError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6530,6 +6717,11 @@ impl From<CredentialsError> for GetApiKeyError {
 impl From<HttpDispatchError> for GetApiKeyError {
     fn from(err: HttpDispatchError) -> GetApiKeyError {
         GetApiKeyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetApiKeyError {
+    fn from(err: io::Error) -> GetApiKeyError {
+        GetApiKeyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetApiKeyError {
@@ -6616,6 +6808,11 @@ impl From<HttpDispatchError> for GetApiKeysError {
         GetApiKeysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetApiKeysError {
+    fn from(err: io::Error) -> GetApiKeysError {
+        GetApiKeysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetApiKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6700,6 +6897,11 @@ impl From<CredentialsError> for GetAuthorizerError {
 impl From<HttpDispatchError> for GetAuthorizerError {
     fn from(err: HttpDispatchError) -> GetAuthorizerError {
         GetAuthorizerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetAuthorizerError {
+    fn from(err: io::Error) -> GetAuthorizerError {
+        GetAuthorizerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetAuthorizerError {
@@ -6793,6 +6995,11 @@ impl From<HttpDispatchError> for GetAuthorizersError {
         GetAuthorizersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAuthorizersError {
+    fn from(err: io::Error) -> GetAuthorizersError {
+        GetAuthorizersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAuthorizersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6878,6 +7085,11 @@ impl From<CredentialsError> for GetBasePathMappingError {
 impl From<HttpDispatchError> for GetBasePathMappingError {
     fn from(err: HttpDispatchError) -> GetBasePathMappingError {
         GetBasePathMappingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBasePathMappingError {
+    fn from(err: io::Error) -> GetBasePathMappingError {
+        GetBasePathMappingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBasePathMappingError {
@@ -6968,6 +7180,11 @@ impl From<HttpDispatchError> for GetBasePathMappingsError {
         GetBasePathMappingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBasePathMappingsError {
+    fn from(err: io::Error) -> GetBasePathMappingsError {
+        GetBasePathMappingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBasePathMappingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7056,6 +7273,11 @@ impl From<HttpDispatchError> for GetClientCertificateError {
         GetClientCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetClientCertificateError {
+    fn from(err: io::Error) -> GetClientCertificateError {
+        GetClientCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7142,6 +7364,11 @@ impl From<CredentialsError> for GetClientCertificatesError {
 impl From<HttpDispatchError> for GetClientCertificatesError {
     fn from(err: HttpDispatchError) -> GetClientCertificatesError {
         GetClientCertificatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetClientCertificatesError {
+    fn from(err: io::Error) -> GetClientCertificatesError {
+        GetClientCertificatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetClientCertificatesError {
@@ -7237,6 +7464,11 @@ impl From<HttpDispatchError> for GetDeploymentError {
         GetDeploymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDeploymentError {
+    fn from(err: io::Error) -> GetDeploymentError {
+        GetDeploymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7329,6 +7561,11 @@ impl From<HttpDispatchError> for GetDeploymentsError {
         GetDeploymentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDeploymentsError {
+    fn from(err: io::Error) -> GetDeploymentsError {
+        GetDeploymentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7414,6 +7651,11 @@ impl From<CredentialsError> for GetDocumentationPartError {
 impl From<HttpDispatchError> for GetDocumentationPartError {
     fn from(err: HttpDispatchError) -> GetDocumentationPartError {
         GetDocumentationPartError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDocumentationPartError {
+    fn from(err: io::Error) -> GetDocumentationPartError {
+        GetDocumentationPartError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDocumentationPartError {
@@ -7509,6 +7751,11 @@ impl From<HttpDispatchError> for GetDocumentationPartsError {
         GetDocumentationPartsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDocumentationPartsError {
+    fn from(err: io::Error) -> GetDocumentationPartsError {
+        GetDocumentationPartsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDocumentationPartsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7596,6 +7843,11 @@ impl From<CredentialsError> for GetDocumentationVersionError {
 impl From<HttpDispatchError> for GetDocumentationVersionError {
     fn from(err: HttpDispatchError) -> GetDocumentationVersionError {
         GetDocumentationVersionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDocumentationVersionError {
+    fn from(err: io::Error) -> GetDocumentationVersionError {
+        GetDocumentationVersionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDocumentationVersionError {
@@ -7689,6 +7941,11 @@ impl From<CredentialsError> for GetDocumentationVersionsError {
 impl From<HttpDispatchError> for GetDocumentationVersionsError {
     fn from(err: HttpDispatchError) -> GetDocumentationVersionsError {
         GetDocumentationVersionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDocumentationVersionsError {
+    fn from(err: io::Error) -> GetDocumentationVersionsError {
+        GetDocumentationVersionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDocumentationVersionsError {
@@ -7785,6 +8042,11 @@ impl From<HttpDispatchError> for GetDomainNameError {
         GetDomainNameError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDomainNameError {
+    fn from(err: io::Error) -> GetDomainNameError {
+        GetDomainNameError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7870,6 +8132,11 @@ impl From<CredentialsError> for GetDomainNamesError {
 impl From<HttpDispatchError> for GetDomainNamesError {
     fn from(err: HttpDispatchError) -> GetDomainNamesError {
         GetDomainNamesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDomainNamesError {
+    fn from(err: io::Error) -> GetDomainNamesError {
+        GetDomainNamesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDomainNamesError {
@@ -7959,6 +8226,11 @@ impl From<HttpDispatchError> for GetExportError {
         GetExportError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetExportError {
+    fn from(err: io::Error) -> GetExportError {
+        GetExportError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetExportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8044,6 +8316,11 @@ impl From<CredentialsError> for GetIntegrationError {
 impl From<HttpDispatchError> for GetIntegrationError {
     fn from(err: HttpDispatchError) -> GetIntegrationError {
         GetIntegrationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetIntegrationError {
+    fn from(err: io::Error) -> GetIntegrationError {
+        GetIntegrationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetIntegrationError {
@@ -8132,6 +8409,11 @@ impl From<HttpDispatchError> for GetIntegrationResponseError {
         GetIntegrationResponseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetIntegrationResponseError {
+    fn from(err: io::Error) -> GetIntegrationResponseError {
+        GetIntegrationResponseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8214,6 +8496,11 @@ impl From<CredentialsError> for GetMethodError {
 impl From<HttpDispatchError> for GetMethodError {
     fn from(err: HttpDispatchError) -> GetMethodError {
         GetMethodError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetMethodError {
+    fn from(err: io::Error) -> GetMethodError {
+        GetMethodError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetMethodError {
@@ -8302,6 +8589,11 @@ impl From<HttpDispatchError> for GetMethodResponseError {
         GetMethodResponseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetMethodResponseError {
+    fn from(err: io::Error) -> GetMethodResponseError {
+        GetMethodResponseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetMethodResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8384,6 +8676,11 @@ impl From<CredentialsError> for GetModelError {
 impl From<HttpDispatchError> for GetModelError {
     fn from(err: HttpDispatchError) -> GetModelError {
         GetModelError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetModelError {
+    fn from(err: io::Error) -> GetModelError {
+        GetModelError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetModelError {
@@ -8477,6 +8774,11 @@ impl From<HttpDispatchError> for GetModelTemplateError {
         GetModelTemplateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetModelTemplateError {
+    fn from(err: io::Error) -> GetModelTemplateError {
+        GetModelTemplateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetModelTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8565,6 +8867,11 @@ impl From<HttpDispatchError> for GetModelsError {
         GetModelsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetModelsError {
+    fn from(err: io::Error) -> GetModelsError {
+        GetModelsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetModelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8650,6 +8957,11 @@ impl From<CredentialsError> for GetRequestValidatorError {
 impl From<HttpDispatchError> for GetRequestValidatorError {
     fn from(err: HttpDispatchError) -> GetRequestValidatorError {
         GetRequestValidatorError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetRequestValidatorError {
+    fn from(err: io::Error) -> GetRequestValidatorError {
+        GetRequestValidatorError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetRequestValidatorError {
@@ -8745,6 +9057,11 @@ impl From<HttpDispatchError> for GetRequestValidatorsError {
         GetRequestValidatorsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRequestValidatorsError {
+    fn from(err: io::Error) -> GetRequestValidatorsError {
+        GetRequestValidatorsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRequestValidatorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8830,6 +9147,11 @@ impl From<CredentialsError> for GetResourceError {
 impl From<HttpDispatchError> for GetResourceError {
     fn from(err: HttpDispatchError) -> GetResourceError {
         GetResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetResourceError {
+    fn from(err: io::Error) -> GetResourceError {
+        GetResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetResourceError {
@@ -8921,6 +9243,11 @@ impl From<HttpDispatchError> for GetResourcesError {
         GetResourcesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetResourcesError {
+    fn from(err: io::Error) -> GetResourcesError {
+        GetResourcesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9002,6 +9329,11 @@ impl From<CredentialsError> for GetRestApiError {
 impl From<HttpDispatchError> for GetRestApiError {
     fn from(err: HttpDispatchError) -> GetRestApiError {
         GetRestApiError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetRestApiError {
+    fn from(err: io::Error) -> GetRestApiError {
+        GetRestApiError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetRestApiError {
@@ -9090,6 +9422,11 @@ impl From<HttpDispatchError> for GetRestApisError {
         GetRestApisError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRestApisError {
+    fn from(err: io::Error) -> GetRestApisError {
+        GetRestApisError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRestApisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9175,6 +9512,11 @@ impl From<HttpDispatchError> for GetSdkError {
         GetSdkError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSdkError {
+    fn from(err: io::Error) -> GetSdkError {
+        GetSdkError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSdkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9258,6 +9600,11 @@ impl From<HttpDispatchError> for GetSdkTypeError {
         GetSdkTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSdkTypeError {
+    fn from(err: io::Error) -> GetSdkTypeError {
+        GetSdkTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSdkTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9337,6 +9684,11 @@ impl From<CredentialsError> for GetSdkTypesError {
 impl From<HttpDispatchError> for GetSdkTypesError {
     fn from(err: HttpDispatchError) -> GetSdkTypesError {
         GetSdkTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSdkTypesError {
+    fn from(err: io::Error) -> GetSdkTypesError {
+        GetSdkTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSdkTypesError {
@@ -9420,6 +9772,11 @@ impl From<HttpDispatchError> for GetStageError {
         GetStageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetStageError {
+    fn from(err: io::Error) -> GetStageError {
+        GetStageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9500,6 +9857,11 @@ impl From<CredentialsError> for GetStagesError {
 impl From<HttpDispatchError> for GetStagesError {
     fn from(err: HttpDispatchError) -> GetStagesError {
         GetStagesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetStagesError {
+    fn from(err: io::Error) -> GetStagesError {
+        GetStagesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetStagesError {
@@ -9585,6 +9947,11 @@ impl From<CredentialsError> for GetUsageError {
 impl From<HttpDispatchError> for GetUsageError {
     fn from(err: HttpDispatchError) -> GetUsageError {
         GetUsageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetUsageError {
+    fn from(err: io::Error) -> GetUsageError {
+        GetUsageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetUsageError {
@@ -9675,6 +10042,11 @@ impl From<CredentialsError> for GetUsagePlanError {
 impl From<HttpDispatchError> for GetUsagePlanError {
     fn from(err: HttpDispatchError) -> GetUsagePlanError {
         GetUsagePlanError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetUsagePlanError {
+    fn from(err: io::Error) -> GetUsagePlanError {
+        GetUsagePlanError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetUsagePlanError {
@@ -9769,6 +10141,11 @@ impl From<HttpDispatchError> for GetUsagePlanKeyError {
         GetUsagePlanKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetUsagePlanKeyError {
+    fn from(err: io::Error) -> GetUsagePlanKeyError {
+        GetUsagePlanKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetUsagePlanKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9859,6 +10236,11 @@ impl From<CredentialsError> for GetUsagePlanKeysError {
 impl From<HttpDispatchError> for GetUsagePlanKeysError {
     fn from(err: HttpDispatchError) -> GetUsagePlanKeysError {
         GetUsagePlanKeysError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetUsagePlanKeysError {
+    fn from(err: io::Error) -> GetUsagePlanKeysError {
+        GetUsagePlanKeysError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetUsagePlanKeysError {
@@ -9956,6 +10338,11 @@ impl From<CredentialsError> for GetUsagePlansError {
 impl From<HttpDispatchError> for GetUsagePlansError {
     fn from(err: HttpDispatchError) -> GetUsagePlansError {
         GetUsagePlansError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetUsagePlansError {
+    fn from(err: io::Error) -> GetUsagePlansError {
+        GetUsagePlansError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetUsagePlansError {
@@ -10061,6 +10448,11 @@ impl From<HttpDispatchError> for ImportApiKeysError {
         ImportApiKeysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportApiKeysError {
+    fn from(err: io::Error) -> ImportApiKeysError {
+        ImportApiKeysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportApiKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10158,6 +10550,11 @@ impl From<CredentialsError> for ImportDocumentationPartsError {
 impl From<HttpDispatchError> for ImportDocumentationPartsError {
     fn from(err: HttpDispatchError) -> ImportDocumentationPartsError {
         ImportDocumentationPartsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ImportDocumentationPartsError {
+    fn from(err: io::Error) -> ImportDocumentationPartsError {
+        ImportDocumentationPartsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ImportDocumentationPartsError {
@@ -10260,6 +10657,11 @@ impl From<HttpDispatchError> for ImportRestApiError {
         ImportRestApiError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportRestApiError {
+    fn from(err: io::Error) -> ImportRestApiError {
+        ImportRestApiError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10356,6 +10758,11 @@ impl From<CredentialsError> for PutIntegrationError {
 impl From<HttpDispatchError> for PutIntegrationError {
     fn from(err: HttpDispatchError) -> PutIntegrationError {
         PutIntegrationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutIntegrationError {
+    fn from(err: io::Error) -> PutIntegrationError {
+        PutIntegrationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutIntegrationError {
@@ -10461,6 +10868,11 @@ impl From<HttpDispatchError> for PutIntegrationResponseError {
         PutIntegrationResponseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutIntegrationResponseError {
+    fn from(err: io::Error) -> PutIntegrationResponseError {
+        PutIntegrationResponseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10559,6 +10971,11 @@ impl From<CredentialsError> for PutMethodError {
 impl From<HttpDispatchError> for PutMethodError {
     fn from(err: HttpDispatchError) -> PutMethodError {
         PutMethodError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutMethodError {
+    fn from(err: io::Error) -> PutMethodError {
+        PutMethodError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutMethodError {
@@ -10665,6 +11082,11 @@ impl From<HttpDispatchError> for PutMethodResponseError {
         PutMethodResponseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutMethodResponseError {
+    fn from(err: io::Error) -> PutMethodResponseError {
+        PutMethodResponseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutMethodResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10765,6 +11187,11 @@ impl From<HttpDispatchError> for PutRestApiError {
         PutRestApiError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutRestApiError {
+    fn from(err: io::Error) -> PutRestApiError {
+        PutRestApiError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10857,6 +11284,11 @@ impl From<CredentialsError> for TestInvokeAuthorizerError {
 impl From<HttpDispatchError> for TestInvokeAuthorizerError {
     fn from(err: HttpDispatchError) -> TestInvokeAuthorizerError {
         TestInvokeAuthorizerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TestInvokeAuthorizerError {
+    fn from(err: io::Error) -> TestInvokeAuthorizerError {
+        TestInvokeAuthorizerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TestInvokeAuthorizerError {
@@ -10953,6 +11385,11 @@ impl From<HttpDispatchError> for TestInvokeMethodError {
         TestInvokeMethodError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TestInvokeMethodError {
+    fn from(err: io::Error) -> TestInvokeMethodError {
+        TestInvokeMethodError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TestInvokeMethodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11043,6 +11480,11 @@ impl From<CredentialsError> for UpdateAccountError {
 impl From<HttpDispatchError> for UpdateAccountError {
     fn from(err: HttpDispatchError) -> UpdateAccountError {
         UpdateAccountError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAccountError {
+    fn from(err: io::Error) -> UpdateAccountError {
+        UpdateAccountError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAccountError {
@@ -11138,6 +11580,11 @@ impl From<HttpDispatchError> for UpdateApiKeyError {
         UpdateApiKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateApiKeyError {
+    fn from(err: io::Error) -> UpdateApiKeyError {
+        UpdateApiKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11229,6 +11676,11 @@ impl From<CredentialsError> for UpdateAuthorizerError {
 impl From<HttpDispatchError> for UpdateAuthorizerError {
     fn from(err: HttpDispatchError) -> UpdateAuthorizerError {
         UpdateAuthorizerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAuthorizerError {
+    fn from(err: io::Error) -> UpdateAuthorizerError {
+        UpdateAuthorizerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAuthorizerError {
@@ -11328,6 +11780,11 @@ impl From<HttpDispatchError> for UpdateBasePathMappingError {
         UpdateBasePathMappingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateBasePathMappingError {
+    fn from(err: io::Error) -> UpdateBasePathMappingError {
+        UpdateBasePathMappingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateBasePathMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11421,6 +11878,11 @@ impl From<CredentialsError> for UpdateClientCertificateError {
 impl From<HttpDispatchError> for UpdateClientCertificateError {
     fn from(err: HttpDispatchError) -> UpdateClientCertificateError {
         UpdateClientCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateClientCertificateError {
+    fn from(err: io::Error) -> UpdateClientCertificateError {
+        UpdateClientCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateClientCertificateError {
@@ -11520,6 +11982,11 @@ impl From<CredentialsError> for UpdateDeploymentError {
 impl From<HttpDispatchError> for UpdateDeploymentError {
     fn from(err: HttpDispatchError) -> UpdateDeploymentError {
         UpdateDeploymentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateDeploymentError {
+    fn from(err: io::Error) -> UpdateDeploymentError {
+        UpdateDeploymentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateDeploymentError {
@@ -11625,6 +12092,11 @@ impl From<HttpDispatchError> for UpdateDocumentationPartError {
         UpdateDocumentationPartError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDocumentationPartError {
+    fn from(err: io::Error) -> UpdateDocumentationPartError {
+        UpdateDocumentationPartError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDocumentationPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11722,6 +12194,11 @@ impl From<CredentialsError> for UpdateDocumentationVersionError {
 impl From<HttpDispatchError> for UpdateDocumentationVersionError {
     fn from(err: HttpDispatchError) -> UpdateDocumentationVersionError {
         UpdateDocumentationVersionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateDocumentationVersionError {
+    fn from(err: io::Error) -> UpdateDocumentationVersionError {
+        UpdateDocumentationVersionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateDocumentationVersionError {
@@ -11824,6 +12301,11 @@ impl From<HttpDispatchError> for UpdateDomainNameError {
         UpdateDomainNameError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDomainNameError {
+    fn from(err: io::Error) -> UpdateDomainNameError {
+        UpdateDomainNameError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11920,6 +12402,11 @@ impl From<CredentialsError> for UpdateIntegrationError {
 impl From<HttpDispatchError> for UpdateIntegrationError {
     fn from(err: HttpDispatchError) -> UpdateIntegrationError {
         UpdateIntegrationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateIntegrationError {
+    fn from(err: io::Error) -> UpdateIntegrationError {
+        UpdateIntegrationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateIntegrationError {
@@ -12022,6 +12509,11 @@ impl From<HttpDispatchError> for UpdateIntegrationResponseError {
         UpdateIntegrationResponseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateIntegrationResponseError {
+    fn from(err: io::Error) -> UpdateIntegrationResponseError {
+        UpdateIntegrationResponseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12116,6 +12608,11 @@ impl From<CredentialsError> for UpdateMethodError {
 impl From<HttpDispatchError> for UpdateMethodError {
     fn from(err: HttpDispatchError) -> UpdateMethodError {
         UpdateMethodError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateMethodError {
+    fn from(err: io::Error) -> UpdateMethodError {
+        UpdateMethodError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateMethodError {
@@ -12221,6 +12718,11 @@ impl From<HttpDispatchError> for UpdateMethodResponseError {
         UpdateMethodResponseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateMethodResponseError {
+    fn from(err: io::Error) -> UpdateMethodResponseError {
+        UpdateMethodResponseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateMethodResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12318,6 +12820,11 @@ impl From<HttpDispatchError> for UpdateModelError {
         UpdateModelError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateModelError {
+    fn from(err: io::Error) -> UpdateModelError {
+        UpdateModelError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12409,6 +12916,11 @@ impl From<CredentialsError> for UpdateRequestValidatorError {
 impl From<HttpDispatchError> for UpdateRequestValidatorError {
     fn from(err: HttpDispatchError) -> UpdateRequestValidatorError {
         UpdateRequestValidatorError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateRequestValidatorError {
+    fn from(err: io::Error) -> UpdateRequestValidatorError {
+        UpdateRequestValidatorError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateRequestValidatorError {
@@ -12510,6 +13022,11 @@ impl From<HttpDispatchError> for UpdateResourceError {
         UpdateResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateResourceError {
+    fn from(err: io::Error) -> UpdateResourceError {
+        UpdateResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12608,6 +13125,11 @@ impl From<HttpDispatchError> for UpdateRestApiError {
         UpdateRestApiError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateRestApiError {
+    fn from(err: io::Error) -> UpdateRestApiError {
+        UpdateRestApiError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12702,6 +13224,11 @@ impl From<HttpDispatchError> for UpdateStageError {
         UpdateStageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateStageError {
+    fn from(err: io::Error) -> UpdateStageError {
+        UpdateStageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12791,6 +13318,11 @@ impl From<CredentialsError> for UpdateUsageError {
 impl From<HttpDispatchError> for UpdateUsageError {
     fn from(err: HttpDispatchError) -> UpdateUsageError {
         UpdateUsageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateUsageError {
+    fn from(err: io::Error) -> UpdateUsageError {
+        UpdateUsageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateUsageError {
@@ -12888,6 +13420,11 @@ impl From<CredentialsError> for UpdateUsagePlanError {
 impl From<HttpDispatchError> for UpdateUsagePlanError {
     fn from(err: HttpDispatchError) -> UpdateUsagePlanError {
         UpdateUsagePlanError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateUsagePlanError {
+    fn from(err: io::Error) -> UpdateUsagePlanError {
+        UpdateUsagePlanError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateUsagePlanError {
@@ -13524,13 +14061,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13545,7 +14082,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateApiKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateApiKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13568,13 +14107,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13589,8 +14128,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateAuthorizerError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAuthorizerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13613,13 +14153,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13634,8 +14174,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateBasePathMappingError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateBasePathMappingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13658,13 +14199,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13679,8 +14220,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDeploymentError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13703,13 +14245,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13723,7 +14265,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateDocumentationPartError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDocumentationPartError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -13746,13 +14293,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13766,7 +14313,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateDocumentationVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDocumentationVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -13787,13 +14339,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13808,8 +14360,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDomainNameError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDomainNameError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13830,13 +14383,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13850,7 +14403,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateModelError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateModelError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13872,13 +14429,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13893,8 +14450,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateRequestValidatorError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRequestValidatorError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13918,13 +14476,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13939,8 +14497,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13960,13 +14519,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -13981,7 +14540,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateRestApiError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRestApiError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14002,13 +14563,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -14022,7 +14583,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateStageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -14043,13 +14608,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -14064,8 +14629,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateUsagePlanError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUsagePlanError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14088,13 +14654,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -14109,8 +14675,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateUsagePlanKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUsagePlanKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14130,8 +14697,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14141,7 +14707,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteApiKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteApiKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14165,8 +14733,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14176,8 +14743,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteAuthorizerError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAuthorizerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14201,8 +14769,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14212,8 +14779,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteBasePathMappingError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBasePathMappingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14236,8 +14804,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14246,7 +14813,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteClientCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteClientCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -14269,8 +14841,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14280,8 +14851,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteDeploymentError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14305,8 +14877,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14315,7 +14886,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteDocumentationPartError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDocumentationPartError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -14338,8 +14914,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14348,7 +14923,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteDocumentationVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDocumentationVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -14370,8 +14950,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14381,8 +14960,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteDomainNameError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDomainNameError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14407,8 +14987,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -14418,8 +14997,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteIntegrationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIntegrationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14445,8 +15025,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -14455,7 +15034,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteIntegrationResponseError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIntegrationResponseError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -14477,8 +15061,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -14488,7 +15071,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteMethodError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteMethodError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14514,8 +15099,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -14525,8 +15109,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteMethodResponseError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteMethodResponseError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14548,8 +15133,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14558,7 +15142,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteModelError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteModelError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -14581,8 +15169,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14592,8 +15179,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteRequestValidatorError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRequestValidatorError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14615,8 +15203,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14626,8 +15213,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14647,8 +15235,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14658,7 +15245,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteRestApiError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRestApiError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14680,8 +15269,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14690,7 +15278,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteStageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteStageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -14712,8 +15304,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14723,8 +15314,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteUsagePlanError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUsagePlanError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14748,8 +15340,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14759,8 +15350,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteUsagePlanKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUsagePlanKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14784,8 +15376,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14794,7 +15385,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(FlushStageAuthorizersCacheError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(FlushStageAuthorizersCacheError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -14817,8 +15413,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -14828,8 +15423,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(FlushStageCacheError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(FlushStageCacheError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14851,13 +15447,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -14871,7 +15467,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GenerateClientCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GenerateClientCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -14890,13 +15491,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -14910,7 +15511,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetAccountError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAccountError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -14933,13 +15538,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -14953,7 +15558,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetApiKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetApiKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -14988,13 +15597,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15008,7 +15617,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetApiKeysError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetApiKeysError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -15031,13 +15644,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15052,7 +15665,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetAuthorizerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAuthorizerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15082,13 +15697,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15103,8 +15718,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetAuthorizersError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAuthorizersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15128,13 +15744,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15149,8 +15765,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBasePathMappingError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBasePathMappingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15180,13 +15797,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15201,8 +15818,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBasePathMappingsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBasePathMappingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15225,13 +15843,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15246,8 +15864,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetClientCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetClientCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15276,13 +15895,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15297,8 +15916,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetClientCertificatesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetClientCertificatesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15328,13 +15948,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15349,7 +15969,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetDeploymentError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15379,13 +16001,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15400,8 +16022,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetDeploymentsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeploymentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15425,13 +16048,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15446,8 +16069,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetDocumentationPartError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDocumentationPartError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15486,13 +16110,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15507,8 +16131,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetDocumentationPartsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDocumentationPartsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15532,13 +16157,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15552,7 +16177,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetDocumentationVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDocumentationVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -15582,13 +16212,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15602,7 +16232,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetDocumentationVersionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDocumentationVersionsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -15624,13 +16259,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15645,7 +16280,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetDomainNameError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDomainNameError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15674,13 +16311,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15695,8 +16332,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetDomainNamesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDomainNamesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15725,14 +16363,17 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
                 let mut result = ExportResponse::default();
-                result.body = Some(response.body);
+
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+
+                result.body = Some(body);
 
                 if let Some(content_disposition) = response.headers.get("Content-Disposition") {
                     let value = content_disposition.to_owned();
@@ -15745,7 +16386,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetExportError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetExportError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -15769,13 +16414,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15790,8 +16435,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetIntegrationError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIntegrationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15817,13 +16463,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15838,8 +16484,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetIntegrationResponseError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIntegrationResponseError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15862,13 +16509,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15882,7 +16529,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetMethodError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetMethodError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -15907,13 +16558,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15928,8 +16579,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetMethodResponseError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetMethodResponseError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -15955,13 +16607,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -15975,7 +16627,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetModelError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetModelError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -15998,13 +16654,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16019,8 +16675,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetModelTemplateError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetModelTemplateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16048,13 +16705,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16068,7 +16725,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetModelsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetModelsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16091,13 +16752,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16112,8 +16773,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetRequestValidatorError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRequestValidatorError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16143,13 +16805,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16164,8 +16826,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetRequestValidatorsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRequestValidatorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16193,13 +16856,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16213,7 +16876,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16245,13 +16912,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16266,7 +16933,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetResourcesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetResourcesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16286,13 +16955,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16306,7 +16975,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetRestApiError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRestApiError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16332,13 +17005,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16352,7 +17025,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetRestApisError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRestApisError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16380,14 +17057,17 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
                 let mut result = SdkResponse::default();
-                result.body = Some(response.body);
+
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+
+                result.body = Some(body);
 
                 if let Some(content_disposition) = response.headers.get("Content-Disposition") {
                     let value = content_disposition.to_owned();
@@ -16400,7 +17080,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetSdkError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSdkError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16419,13 +17103,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16439,7 +17123,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetSdkTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSdkTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16465,13 +17153,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16485,7 +17173,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetSdkTypesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSdkTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16506,13 +17198,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16526,7 +17218,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetStageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetStageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16550,13 +17246,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16570,7 +17266,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetStagesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetStagesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16602,13 +17302,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16622,7 +17322,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetUsageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUsageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16642,13 +17346,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16663,7 +17367,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetUsagePlanError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUsagePlanError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16687,13 +17393,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16708,8 +17414,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetUsagePlanKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUsagePlanKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16742,13 +17449,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16763,8 +17470,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetUsagePlanKeysError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUsagePlanKeysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16796,13 +17504,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16817,7 +17525,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetUsagePlansError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUsagePlansError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16844,13 +17554,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16865,7 +17575,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ImportApiKeysError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportApiKeysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16896,13 +17608,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16916,7 +17628,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ImportDocumentationPartsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportDocumentationPartsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -16944,13 +17661,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -16965,7 +17682,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ImportRestApiError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportRestApiError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16990,13 +17709,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17011,8 +17730,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutIntegrationError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutIntegrationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17038,13 +17758,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17059,8 +17779,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutIntegrationResponseError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutIntegrationResponseError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17083,13 +17804,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17103,7 +17824,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutMethodError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutMethodError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -17128,13 +17853,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17149,8 +17874,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutMethodResponseError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutMethodResponseError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17182,13 +17908,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17202,7 +17928,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutRestApiError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRestApiError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -17226,13 +17956,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17247,8 +17977,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(TestInvokeAuthorizerError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestInvokeAuthorizerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17273,13 +18004,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17294,8 +18025,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(TestInvokeMethodError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestInvokeMethodError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17315,13 +18047,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17336,7 +18068,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateAccountError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAccountError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17356,13 +18090,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17377,7 +18111,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateApiKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateApiKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17401,13 +18137,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17422,8 +18158,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateAuthorizerError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAuthorizerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17447,13 +18184,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17468,8 +18205,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateBasePathMappingError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateBasePathMappingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17492,13 +18230,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17512,7 +18250,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateClientCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateClientCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -17535,13 +18278,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17556,8 +18299,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateDeploymentError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17581,13 +18325,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17601,7 +18345,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateDocumentationPartError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDocumentationPartError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -17625,13 +18374,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17645,7 +18394,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateDocumentationVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDocumentationVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -17667,13 +18421,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17688,8 +18442,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateDomainNameError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDomainNameError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17714,13 +18469,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17735,8 +18490,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateIntegrationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateIntegrationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17763,13 +18519,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17783,7 +18539,12 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateIntegrationResponseError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateIntegrationResponseError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -17805,13 +18566,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17826,7 +18587,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateMethodError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateMethodError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17852,13 +18615,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17873,8 +18636,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateMethodResponseError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateMethodResponseError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17896,13 +18660,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17916,7 +18680,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateModelError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateModelError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -17939,13 +18707,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -17960,8 +18728,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateRequestValidatorError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRequestValidatorError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17985,13 +18754,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -18006,8 +18775,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18027,13 +18797,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -18048,7 +18818,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateRestApiError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRestApiError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18070,13 +18842,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -18090,7 +18862,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateStageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateStageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -18111,13 +18887,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -18131,7 +18907,11 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateUsageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateUsageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -18153,13 +18933,13 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -18174,8 +18954,9 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateUsagePlanError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateUsagePlanError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -816,6 +818,11 @@ impl From<HttpDispatchError> for AssociateFleetError {
         AssociateFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateFleetError {
+    fn from(err: io::Error) -> AssociateFleetError {
+        AssociateFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -916,6 +923,11 @@ impl From<CredentialsError> for CreateFleetError {
 impl From<HttpDispatchError> for CreateFleetError {
     fn from(err: HttpDispatchError) -> CreateFleetError {
         CreateFleetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateFleetError {
+    fn from(err: io::Error) -> CreateFleetError {
+        CreateFleetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateFleetError {
@@ -1022,6 +1034,11 @@ impl From<HttpDispatchError> for CreateStackError {
         CreateStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateStackError {
+    fn from(err: io::Error) -> CreateStackError {
+        CreateStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1114,6 +1131,11 @@ impl From<HttpDispatchError> for CreateStreamingURLError {
         CreateStreamingURLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateStreamingURLError {
+    fn from(err: io::Error) -> CreateStreamingURLError {
+        CreateStreamingURLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateStreamingURLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1203,6 +1225,11 @@ impl From<HttpDispatchError> for DeleteFleetError {
         DeleteFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteFleetError {
+    fn from(err: io::Error) -> DeleteFleetError {
+        DeleteFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1289,6 +1316,11 @@ impl From<HttpDispatchError> for DeleteStackError {
         DeleteStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteStackError {
+    fn from(err: io::Error) -> DeleteStackError {
+        DeleteStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1365,6 +1397,11 @@ impl From<HttpDispatchError> for DescribeFleetsError {
         DescribeFleetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeFleetsError {
+    fn from(err: io::Error) -> DescribeFleetsError {
+        DescribeFleetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeFleetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1439,6 +1476,11 @@ impl From<HttpDispatchError> for DescribeImagesError {
         DescribeImagesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeImagesError {
+    fn from(err: io::Error) -> DescribeImagesError {
+        DescribeImagesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1509,6 +1551,11 @@ impl From<CredentialsError> for DescribeSessionsError {
 impl From<HttpDispatchError> for DescribeSessionsError {
     fn from(err: HttpDispatchError) -> DescribeSessionsError {
         DescribeSessionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSessionsError {
+    fn from(err: io::Error) -> DescribeSessionsError {
+        DescribeSessionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSessionsError {
@@ -1583,6 +1630,11 @@ impl From<CredentialsError> for DescribeStacksError {
 impl From<HttpDispatchError> for DescribeStacksError {
     fn from(err: HttpDispatchError) -> DescribeStacksError {
         DescribeStacksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeStacksError {
+    fn from(err: io::Error) -> DescribeStacksError {
+        DescribeStacksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeStacksError {
@@ -1669,6 +1721,11 @@ impl From<HttpDispatchError> for DisassociateFleetError {
         DisassociateFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateFleetError {
+    fn from(err: io::Error) -> DisassociateFleetError {
+        DisassociateFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1742,6 +1799,11 @@ impl From<HttpDispatchError> for ExpireSessionError {
         ExpireSessionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ExpireSessionError {
+    fn from(err: io::Error) -> ExpireSessionError {
+        ExpireSessionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ExpireSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1808,6 +1870,11 @@ impl From<CredentialsError> for ListAssociatedFleetsError {
 impl From<HttpDispatchError> for ListAssociatedFleetsError {
     fn from(err: HttpDispatchError) -> ListAssociatedFleetsError {
         ListAssociatedFleetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAssociatedFleetsError {
+    fn from(err: io::Error) -> ListAssociatedFleetsError {
+        ListAssociatedFleetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAssociatedFleetsError {
@@ -1878,6 +1945,11 @@ impl From<CredentialsError> for ListAssociatedStacksError {
 impl From<HttpDispatchError> for ListAssociatedStacksError {
     fn from(err: HttpDispatchError) -> ListAssociatedStacksError {
         ListAssociatedStacksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAssociatedStacksError {
+    fn from(err: io::Error) -> ListAssociatedStacksError {
+        ListAssociatedStacksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAssociatedStacksError {
@@ -1968,6 +2040,11 @@ impl From<HttpDispatchError> for StartFleetError {
         StartFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartFleetError {
+    fn from(err: io::Error) -> StartFleetError {
+        StartFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2046,6 +2123,11 @@ impl From<CredentialsError> for StopFleetError {
 impl From<HttpDispatchError> for StopFleetError {
     fn from(err: HttpDispatchError) -> StopFleetError {
         StopFleetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopFleetError {
+    fn from(err: io::Error) -> StopFleetError {
+        StopFleetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopFleetError {
@@ -2158,6 +2240,11 @@ impl From<HttpDispatchError> for UpdateFleetError {
         UpdateFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateFleetError {
+    fn from(err: io::Error) -> UpdateFleetError {
+        UpdateFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2262,6 +2349,11 @@ impl From<CredentialsError> for UpdateStackError {
 impl From<HttpDispatchError> for UpdateStackError {
     fn from(err: HttpDispatchError) -> UpdateStackError {
         UpdateStackError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateStackError {
+    fn from(err: io::Error) -> UpdateStackError {
+        UpdateStackError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateStackError {
@@ -2430,15 +2522,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AssociateFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AssociateFleetResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AssociateFleetError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2457,13 +2554,21 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateFleetResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2481,13 +2586,21 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateStackResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2505,15 +2618,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateStreamingURLResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateStreamingURLResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateStreamingURLError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStreamingURLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2532,13 +2650,21 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteFleetResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2556,13 +2682,21 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteStackResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2580,15 +2714,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeFleetsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeFleetsResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeFleetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFleetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2607,15 +2746,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeImagesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeImagesResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeImagesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeImagesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2634,15 +2778,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeSessionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeSessionsResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeSessionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSessionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2661,15 +2810,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeStacksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeStacksResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeStacksError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStacksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2688,15 +2842,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisassociateFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisassociateFleetResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DisassociateFleetError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2715,14 +2874,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ExpireSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ExpireSessionResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ExpireSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ExpireSessionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2742,15 +2907,18 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAssociatedFleetsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAssociatedFleetsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListAssociatedFleetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAssociatedFleetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2770,15 +2938,18 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAssociatedStacksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAssociatedStacksResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListAssociatedStacksError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAssociatedStacksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2795,13 +2966,21 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StartFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartFleetResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2817,15 +2996,20 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<StopFleetResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopFleetResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(StopFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2843,13 +3027,21 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateFleetResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2867,13 +3059,21 @@ impl<P, D> AppStream for AppStreamClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateStackResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -7353,6 +7355,11 @@ impl From<HttpDispatchError> for AttachInstancesError {
         AttachInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachInstancesError {
+    fn from(err: io::Error) -> AttachInstancesError {
+        AttachInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7417,6 +7424,11 @@ impl From<CredentialsError> for AttachLoadBalancerTargetGroupsError {
 impl From<HttpDispatchError> for AttachLoadBalancerTargetGroupsError {
     fn from(err: HttpDispatchError) -> AttachLoadBalancerTargetGroupsError {
         AttachLoadBalancerTargetGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AttachLoadBalancerTargetGroupsError {
+    fn from(err: io::Error) -> AttachLoadBalancerTargetGroupsError {
+        AttachLoadBalancerTargetGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AttachLoadBalancerTargetGroupsError {
@@ -7487,6 +7499,11 @@ impl From<HttpDispatchError> for AttachLoadBalancersError {
         AttachLoadBalancersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachLoadBalancersError {
+    fn from(err: io::Error) -> AttachLoadBalancersError {
+        AttachLoadBalancersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7553,6 +7570,11 @@ impl From<CredentialsError> for CompleteLifecycleActionError {
 impl From<HttpDispatchError> for CompleteLifecycleActionError {
     fn from(err: HttpDispatchError) -> CompleteLifecycleActionError {
         CompleteLifecycleActionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CompleteLifecycleActionError {
+    fn from(err: io::Error) -> CompleteLifecycleActionError {
+        CompleteLifecycleActionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CompleteLifecycleActionError {
@@ -7627,6 +7649,11 @@ impl From<CredentialsError> for CreateAutoScalingGroupError {
 impl From<HttpDispatchError> for CreateAutoScalingGroupError {
     fn from(err: HttpDispatchError) -> CreateAutoScalingGroupError {
         CreateAutoScalingGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAutoScalingGroupError {
+    fn from(err: io::Error) -> CreateAutoScalingGroupError {
+        CreateAutoScalingGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAutoScalingGroupError {
@@ -7705,6 +7732,11 @@ impl From<HttpDispatchError> for CreateLaunchConfigurationError {
         CreateLaunchConfigurationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLaunchConfigurationError {
+    fn from(err: io::Error) -> CreateLaunchConfigurationError {
+        CreateLaunchConfigurationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLaunchConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7779,6 +7811,11 @@ impl From<CredentialsError> for CreateOrUpdateTagsError {
 impl From<HttpDispatchError> for CreateOrUpdateTagsError {
     fn from(err: HttpDispatchError) -> CreateOrUpdateTagsError {
         CreateOrUpdateTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateOrUpdateTagsError {
+    fn from(err: io::Error) -> CreateOrUpdateTagsError {
+        CreateOrUpdateTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateOrUpdateTagsError {
@@ -7857,6 +7894,11 @@ impl From<HttpDispatchError> for DeleteAutoScalingGroupError {
         DeleteAutoScalingGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAutoScalingGroupError {
+    fn from(err: io::Error) -> DeleteAutoScalingGroupError {
+        DeleteAutoScalingGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAutoScalingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7930,6 +7972,11 @@ impl From<HttpDispatchError> for DeleteLaunchConfigurationError {
         DeleteLaunchConfigurationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteLaunchConfigurationError {
+    fn from(err: io::Error) -> DeleteLaunchConfigurationError {
+        DeleteLaunchConfigurationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteLaunchConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7997,6 +8044,11 @@ impl From<CredentialsError> for DeleteLifecycleHookError {
 impl From<HttpDispatchError> for DeleteLifecycleHookError {
     fn from(err: HttpDispatchError) -> DeleteLifecycleHookError {
         DeleteLifecycleHookError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteLifecycleHookError {
+    fn from(err: io::Error) -> DeleteLifecycleHookError {
+        DeleteLifecycleHookError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteLifecycleHookError {
@@ -8067,6 +8119,11 @@ impl From<HttpDispatchError> for DeleteNotificationConfigurationError {
         DeleteNotificationConfigurationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteNotificationConfigurationError {
+    fn from(err: io::Error) -> DeleteNotificationConfigurationError {
+        DeleteNotificationConfigurationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteNotificationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8135,6 +8192,11 @@ impl From<HttpDispatchError> for DeletePolicyError {
         DeletePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePolicyError {
+    fn from(err: io::Error) -> DeletePolicyError {
+        DeletePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8199,6 +8261,11 @@ impl From<CredentialsError> for DeleteScheduledActionError {
 impl From<HttpDispatchError> for DeleteScheduledActionError {
     fn from(err: HttpDispatchError) -> DeleteScheduledActionError {
         DeleteScheduledActionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteScheduledActionError {
+    fn from(err: io::Error) -> DeleteScheduledActionError {
+        DeleteScheduledActionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteScheduledActionError {
@@ -8271,6 +8338,11 @@ impl From<HttpDispatchError> for DeleteTagsError {
         DeleteTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTagsError {
+    fn from(err: io::Error) -> DeleteTagsError {
+        DeleteTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8335,6 +8407,11 @@ impl From<CredentialsError> for DescribeAccountLimitsError {
 impl From<HttpDispatchError> for DescribeAccountLimitsError {
     fn from(err: HttpDispatchError) -> DescribeAccountLimitsError {
         DescribeAccountLimitsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAccountLimitsError {
+    fn from(err: io::Error) -> DescribeAccountLimitsError {
+        DescribeAccountLimitsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAccountLimitsError {
@@ -8403,6 +8480,11 @@ impl From<CredentialsError> for DescribeAdjustmentTypesError {
 impl From<HttpDispatchError> for DescribeAdjustmentTypesError {
     fn from(err: HttpDispatchError) -> DescribeAdjustmentTypesError {
         DescribeAdjustmentTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAdjustmentTypesError {
+    fn from(err: io::Error) -> DescribeAdjustmentTypesError {
+        DescribeAdjustmentTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAdjustmentTypesError {
@@ -8474,6 +8556,11 @@ impl From<CredentialsError> for DescribeAutoScalingGroupsError {
 impl From<HttpDispatchError> for DescribeAutoScalingGroupsError {
     fn from(err: HttpDispatchError) -> DescribeAutoScalingGroupsError {
         DescribeAutoScalingGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAutoScalingGroupsError {
+    fn from(err: io::Error) -> DescribeAutoScalingGroupsError {
+        DescribeAutoScalingGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAutoScalingGroupsError {
@@ -8548,6 +8635,11 @@ impl From<HttpDispatchError> for DescribeAutoScalingInstancesError {
         DescribeAutoScalingInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAutoScalingInstancesError {
+    fn from(err: io::Error) -> DescribeAutoScalingInstancesError {
+        DescribeAutoScalingInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAutoScalingInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8615,6 +8707,11 @@ impl From<CredentialsError> for DescribeAutoScalingNotificationTypesError {
 impl From<HttpDispatchError> for DescribeAutoScalingNotificationTypesError {
     fn from(err: HttpDispatchError) -> DescribeAutoScalingNotificationTypesError {
         DescribeAutoScalingNotificationTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAutoScalingNotificationTypesError {
+    fn from(err: io::Error) -> DescribeAutoScalingNotificationTypesError {
+        DescribeAutoScalingNotificationTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAutoScalingNotificationTypesError {
@@ -8688,6 +8785,11 @@ impl From<HttpDispatchError> for DescribeLaunchConfigurationsError {
         DescribeLaunchConfigurationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLaunchConfigurationsError {
+    fn from(err: io::Error) -> DescribeLaunchConfigurationsError {
+        DescribeLaunchConfigurationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLaunchConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8755,6 +8857,11 @@ impl From<CredentialsError> for DescribeLifecycleHookTypesError {
 impl From<HttpDispatchError> for DescribeLifecycleHookTypesError {
     fn from(err: HttpDispatchError) -> DescribeLifecycleHookTypesError {
         DescribeLifecycleHookTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLifecycleHookTypesError {
+    fn from(err: io::Error) -> DescribeLifecycleHookTypesError {
+        DescribeLifecycleHookTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLifecycleHookTypesError {
@@ -8825,6 +8932,11 @@ impl From<HttpDispatchError> for DescribeLifecycleHooksError {
         DescribeLifecycleHooksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLifecycleHooksError {
+    fn from(err: io::Error) -> DescribeLifecycleHooksError {
+        DescribeLifecycleHooksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLifecycleHooksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8891,6 +9003,11 @@ impl From<CredentialsError> for DescribeLoadBalancerTargetGroupsError {
 impl From<HttpDispatchError> for DescribeLoadBalancerTargetGroupsError {
     fn from(err: HttpDispatchError) -> DescribeLoadBalancerTargetGroupsError {
         DescribeLoadBalancerTargetGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLoadBalancerTargetGroupsError {
+    fn from(err: io::Error) -> DescribeLoadBalancerTargetGroupsError {
+        DescribeLoadBalancerTargetGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLoadBalancerTargetGroupsError {
@@ -8961,6 +9078,11 @@ impl From<HttpDispatchError> for DescribeLoadBalancersError {
         DescribeLoadBalancersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLoadBalancersError {
+    fn from(err: io::Error) -> DescribeLoadBalancersError {
+        DescribeLoadBalancersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9027,6 +9149,11 @@ impl From<CredentialsError> for DescribeMetricCollectionTypesError {
 impl From<HttpDispatchError> for DescribeMetricCollectionTypesError {
     fn from(err: HttpDispatchError) -> DescribeMetricCollectionTypesError {
         DescribeMetricCollectionTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeMetricCollectionTypesError {
+    fn from(err: io::Error) -> DescribeMetricCollectionTypesError {
+        DescribeMetricCollectionTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeMetricCollectionTypesError {
@@ -9098,6 +9225,11 @@ impl From<CredentialsError> for DescribeNotificationConfigurationsError {
 impl From<HttpDispatchError> for DescribeNotificationConfigurationsError {
     fn from(err: HttpDispatchError) -> DescribeNotificationConfigurationsError {
         DescribeNotificationConfigurationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeNotificationConfigurationsError {
+    fn from(err: io::Error) -> DescribeNotificationConfigurationsError {
+        DescribeNotificationConfigurationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeNotificationConfigurationsError {
@@ -9174,6 +9306,11 @@ impl From<HttpDispatchError> for DescribePoliciesError {
         DescribePoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribePoliciesError {
+    fn from(err: io::Error) -> DescribePoliciesError {
+        DescribePoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9242,6 +9379,11 @@ impl From<CredentialsError> for DescribeScalingActivitiesError {
 impl From<HttpDispatchError> for DescribeScalingActivitiesError {
     fn from(err: HttpDispatchError) -> DescribeScalingActivitiesError {
         DescribeScalingActivitiesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeScalingActivitiesError {
+    fn from(err: io::Error) -> DescribeScalingActivitiesError {
+        DescribeScalingActivitiesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeScalingActivitiesError {
@@ -9313,6 +9455,11 @@ impl From<HttpDispatchError> for DescribeScalingProcessTypesError {
         DescribeScalingProcessTypesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeScalingProcessTypesError {
+    fn from(err: io::Error) -> DescribeScalingProcessTypesError {
+        DescribeScalingProcessTypesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeScalingProcessTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9382,6 +9529,11 @@ impl From<CredentialsError> for DescribeScheduledActionsError {
 impl From<HttpDispatchError> for DescribeScheduledActionsError {
     fn from(err: HttpDispatchError) -> DescribeScheduledActionsError {
         DescribeScheduledActionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeScheduledActionsError {
+    fn from(err: io::Error) -> DescribeScheduledActionsError {
+        DescribeScheduledActionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeScheduledActionsError {
@@ -9458,6 +9610,11 @@ impl From<HttpDispatchError> for DescribeTagsError {
         DescribeTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTagsError {
+    fn from(err: io::Error) -> DescribeTagsError {
+        DescribeTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9523,6 +9680,11 @@ impl From<CredentialsError> for DescribeTerminationPolicyTypesError {
 impl From<HttpDispatchError> for DescribeTerminationPolicyTypesError {
     fn from(err: HttpDispatchError) -> DescribeTerminationPolicyTypesError {
         DescribeTerminationPolicyTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTerminationPolicyTypesError {
+    fn from(err: io::Error) -> DescribeTerminationPolicyTypesError {
+        DescribeTerminationPolicyTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTerminationPolicyTypesError {
@@ -9593,6 +9755,11 @@ impl From<HttpDispatchError> for DetachInstancesError {
         DetachInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachInstancesError {
+    fn from(err: io::Error) -> DetachInstancesError {
+        DetachInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9657,6 +9824,11 @@ impl From<CredentialsError> for DetachLoadBalancerTargetGroupsError {
 impl From<HttpDispatchError> for DetachLoadBalancerTargetGroupsError {
     fn from(err: HttpDispatchError) -> DetachLoadBalancerTargetGroupsError {
         DetachLoadBalancerTargetGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DetachLoadBalancerTargetGroupsError {
+    fn from(err: io::Error) -> DetachLoadBalancerTargetGroupsError {
+        DetachLoadBalancerTargetGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DetachLoadBalancerTargetGroupsError {
@@ -9727,6 +9899,11 @@ impl From<HttpDispatchError> for DetachLoadBalancersError {
         DetachLoadBalancersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachLoadBalancersError {
+    fn from(err: io::Error) -> DetachLoadBalancersError {
+        DetachLoadBalancersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9793,6 +9970,11 @@ impl From<CredentialsError> for DisableMetricsCollectionError {
 impl From<HttpDispatchError> for DisableMetricsCollectionError {
     fn from(err: HttpDispatchError) -> DisableMetricsCollectionError {
         DisableMetricsCollectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableMetricsCollectionError {
+    fn from(err: io::Error) -> DisableMetricsCollectionError {
+        DisableMetricsCollectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableMetricsCollectionError {
@@ -9863,6 +10045,11 @@ impl From<HttpDispatchError> for EnableMetricsCollectionError {
         EnableMetricsCollectionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableMetricsCollectionError {
+    fn from(err: io::Error) -> EnableMetricsCollectionError {
+        EnableMetricsCollectionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableMetricsCollectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9929,6 +10116,11 @@ impl From<CredentialsError> for EnterStandbyError {
 impl From<HttpDispatchError> for EnterStandbyError {
     fn from(err: HttpDispatchError) -> EnterStandbyError {
         EnterStandbyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnterStandbyError {
+    fn from(err: io::Error) -> EnterStandbyError {
+        EnterStandbyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnterStandbyError {
@@ -10000,6 +10192,11 @@ impl From<HttpDispatchError> for ExecutePolicyError {
         ExecutePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ExecutePolicyError {
+    fn from(err: io::Error) -> ExecutePolicyError {
+        ExecutePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ExecutePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10065,6 +10262,11 @@ impl From<CredentialsError> for ExitStandbyError {
 impl From<HttpDispatchError> for ExitStandbyError {
     fn from(err: HttpDispatchError) -> ExitStandbyError {
         ExitStandbyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ExitStandbyError {
+    fn from(err: io::Error) -> ExitStandbyError {
+        ExitStandbyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ExitStandbyError {
@@ -10134,6 +10336,11 @@ impl From<CredentialsError> for PutLifecycleHookError {
 impl From<HttpDispatchError> for PutLifecycleHookError {
     fn from(err: HttpDispatchError) -> PutLifecycleHookError {
         PutLifecycleHookError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutLifecycleHookError {
+    fn from(err: io::Error) -> PutLifecycleHookError {
+        PutLifecycleHookError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutLifecycleHookError {
@@ -10206,6 +10413,11 @@ impl From<HttpDispatchError> for PutNotificationConfigurationError {
         PutNotificationConfigurationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutNotificationConfigurationError {
+    fn from(err: io::Error) -> PutNotificationConfigurationError {
+        PutNotificationConfigurationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutNotificationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10276,6 +10488,11 @@ impl From<CredentialsError> for PutScalingPolicyError {
 impl From<HttpDispatchError> for PutScalingPolicyError {
     fn from(err: HttpDispatchError) -> PutScalingPolicyError {
         PutScalingPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutScalingPolicyError {
+    fn from(err: io::Error) -> PutScalingPolicyError {
+        PutScalingPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutScalingPolicyError {
@@ -10351,6 +10568,11 @@ impl From<HttpDispatchError> for PutScheduledUpdateGroupActionError {
         PutScheduledUpdateGroupActionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutScheduledUpdateGroupActionError {
+    fn from(err: io::Error) -> PutScheduledUpdateGroupActionError {
+        PutScheduledUpdateGroupActionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutScheduledUpdateGroupActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10419,6 +10641,11 @@ impl From<CredentialsError> for RecordLifecycleActionHeartbeatError {
 impl From<HttpDispatchError> for RecordLifecycleActionHeartbeatError {
     fn from(err: HttpDispatchError) -> RecordLifecycleActionHeartbeatError {
         RecordLifecycleActionHeartbeatError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RecordLifecycleActionHeartbeatError {
+    fn from(err: io::Error) -> RecordLifecycleActionHeartbeatError {
+        RecordLifecycleActionHeartbeatError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RecordLifecycleActionHeartbeatError {
@@ -10494,6 +10721,11 @@ impl From<HttpDispatchError> for ResumeProcessesError {
         ResumeProcessesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ResumeProcessesError {
+    fn from(err: io::Error) -> ResumeProcessesError {
+        ResumeProcessesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ResumeProcessesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10562,6 +10794,11 @@ impl From<CredentialsError> for SetDesiredCapacityError {
 impl From<HttpDispatchError> for SetDesiredCapacityError {
     fn from(err: HttpDispatchError) -> SetDesiredCapacityError {
         SetDesiredCapacityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetDesiredCapacityError {
+    fn from(err: io::Error) -> SetDesiredCapacityError {
+        SetDesiredCapacityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetDesiredCapacityError {
@@ -10633,6 +10870,11 @@ impl From<HttpDispatchError> for SetInstanceHealthError {
         SetInstanceHealthError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetInstanceHealthError {
+    fn from(err: io::Error) -> SetInstanceHealthError {
+        SetInstanceHealthError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetInstanceHealthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10702,6 +10944,11 @@ impl From<CredentialsError> for SetInstanceProtectionError {
 impl From<HttpDispatchError> for SetInstanceProtectionError {
     fn from(err: HttpDispatchError) -> SetInstanceProtectionError {
         SetInstanceProtectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetInstanceProtectionError {
+    fn from(err: io::Error) -> SetInstanceProtectionError {
+        SetInstanceProtectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetInstanceProtectionError {
@@ -10776,6 +11023,11 @@ impl From<HttpDispatchError> for SuspendProcessesError {
         SuspendProcessesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SuspendProcessesError {
+    fn from(err: io::Error) -> SuspendProcessesError {
+        SuspendProcessesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SuspendProcessesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10844,6 +11096,11 @@ impl From<CredentialsError> for TerminateInstanceInAutoScalingGroupError {
 impl From<HttpDispatchError> for TerminateInstanceInAutoScalingGroupError {
     fn from(err: HttpDispatchError) -> TerminateInstanceInAutoScalingGroupError {
         TerminateInstanceInAutoScalingGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TerminateInstanceInAutoScalingGroupError {
+    fn from(err: io::Error) -> TerminateInstanceInAutoScalingGroupError {
+        TerminateInstanceInAutoScalingGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TerminateInstanceInAutoScalingGroupError {
@@ -10918,6 +11175,11 @@ impl From<CredentialsError> for UpdateAutoScalingGroupError {
 impl From<HttpDispatchError> for UpdateAutoScalingGroupError {
     fn from(err: HttpDispatchError) -> UpdateAutoScalingGroupError {
         UpdateAutoScalingGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAutoScalingGroupError {
+    fn from(err: io::Error) -> UpdateAutoScalingGroupError {
+        UpdateAutoScalingGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAutoScalingGroupError {
@@ -11292,15 +11554,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AttachInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11320,16 +11583,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AttachLoadBalancerTargetGroupsResultType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11343,8 +11608,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AttachLoadBalancerTargetGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachLoadBalancerTargetGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -11362,16 +11630,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AttachLoadBalancersResultType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11387,8 +11657,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AttachLoadBalancersError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachLoadBalancersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11408,16 +11679,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CompleteLifecycleActionAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11433,8 +11706,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CompleteLifecycleActionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CompleteLifecycleActionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -11452,15 +11728,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(CreateAutoScalingGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAutoScalingGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11479,15 +11756,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(CreateLaunchConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLaunchConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -11505,15 +11785,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(CreateOrUpdateTagsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateOrUpdateTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11532,15 +11813,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteAutoScalingGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAutoScalingGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11559,15 +11841,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteLaunchConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLaunchConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -11585,16 +11870,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteLifecycleHookAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11609,8 +11896,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteLifecycleHookError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLifecycleHookError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11629,15 +11917,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteNotificationConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteNotificationConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -11653,14 +11944,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11679,15 +11972,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteScheduledActionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteScheduledActionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11704,13 +11998,17 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11728,16 +12026,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAccountLimitsAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11752,8 +12052,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeAccountLimitsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountLimitsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11772,16 +12073,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAdjustmentTypesAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11797,8 +12100,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAdjustmentTypesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAdjustmentTypesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -11817,16 +12123,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AutoScalingGroupsType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11841,8 +12149,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAutoScalingGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAutoScalingGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -11861,16 +12172,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AutoScalingInstancesType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11885,8 +12198,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAutoScalingInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAutoScalingInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -11905,16 +12221,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAutoScalingNotificationTypesAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11928,8 +12246,10 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAutoScalingNotificationTypesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAutoScalingNotificationTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11948,16 +12268,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = LaunchConfigurationsType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11972,8 +12294,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeLaunchConfigurationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLaunchConfigurationsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -11991,16 +12316,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLifecycleHookTypesAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12016,8 +12343,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeLifecycleHookTypesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLifecycleHookTypesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -12036,16 +12366,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLifecycleHooksAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12061,8 +12393,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeLifecycleHooksError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLifecycleHooksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12082,16 +12415,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLoadBalancerTargetGroupsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12105,8 +12440,10 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeLoadBalancerTargetGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBalancerTargetGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12125,16 +12462,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLoadBalancersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12150,8 +12489,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeLoadBalancersError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBalancersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12170,16 +12510,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeMetricCollectionTypesAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12193,8 +12535,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeMetricCollectionTypesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMetricCollectionTypesError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -12214,16 +12559,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeNotificationConfigurationsAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12237,8 +12584,10 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeNotificationConfigurationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeNotificationConfigurationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12256,16 +12605,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PoliciesType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12280,8 +12631,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribePoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12300,16 +12652,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ActivitiesType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12324,8 +12678,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeScalingActivitiesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeScalingActivitiesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -12343,16 +12700,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ProcessesType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12367,8 +12726,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeScalingProcessTypesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeScalingProcessTypesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12387,16 +12749,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ScheduledActionsType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12411,8 +12775,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeScheduledActionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeScheduledActionsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -12428,16 +12795,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TagsType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12452,7 +12821,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12471,16 +12842,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeTerminationPolicyTypesAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12494,8 +12867,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeTerminationPolicyTypesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTerminationPolicyTypesError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -12513,16 +12889,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DetachInstancesAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12537,8 +12915,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DetachInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12558,16 +12937,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DetachLoadBalancerTargetGroupsResultType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12581,8 +12962,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DetachLoadBalancerTargetGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachLoadBalancerTargetGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -12600,16 +12984,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DetachLoadBalancersResultType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12625,8 +13011,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DetachLoadBalancersError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachLoadBalancersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12645,15 +13032,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DisableMetricsCollectionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableMetricsCollectionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -12671,15 +13061,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(EnableMetricsCollectionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableMetricsCollectionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -12697,16 +13090,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnterStandbyAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12721,7 +13116,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(EnterStandbyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnterStandbyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12738,14 +13135,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ExecutePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ExecutePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12764,16 +13163,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ExitStandbyAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12787,7 +13188,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ExitStandbyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ExitStandbyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12805,16 +13210,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PutLifecycleHookAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12829,8 +13236,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutLifecycleHookError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutLifecycleHookError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12849,15 +13257,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(PutNotificationConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutNotificationConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -12875,16 +13286,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PolicyARNType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12899,8 +13312,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutScalingPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutScalingPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12919,15 +13333,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(PutScheduledUpdateGroupActionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutScheduledUpdateGroupActionError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -12946,16 +13363,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RecordLifecycleActionHeartbeatAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12969,8 +13388,11 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(RecordLifecycleActionHeartbeatError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RecordLifecycleActionHeartbeatError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -12986,15 +13408,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ResumeProcessesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResumeProcessesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13013,15 +13436,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SetDesiredCapacityError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetDesiredCapacityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13040,15 +13464,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SetInstanceHealthError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetInstanceHealthError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13068,16 +13493,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetInstanceProtectionAnswer::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13092,8 +13519,9 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetInstanceProtectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetInstanceProtectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13110,15 +13538,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SuspendProcessesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SuspendProcessesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13138,16 +13567,18 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ActivityType::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13162,8 +13593,10 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(TerminateInstanceInAutoScalingGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TerminateInstanceInAutoScalingGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13181,15 +13614,16 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(UpdateAutoScalingGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAutoScalingGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -981,6 +983,11 @@ impl From<HttpDispatchError> for CancelJobError {
         CancelJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelJobError {
+    fn from(err: io::Error) -> CancelJobError {
+        CancelJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1061,6 +1068,11 @@ impl From<HttpDispatchError> for CreateComputeEnvironmentError {
         CreateComputeEnvironmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateComputeEnvironmentError {
+    fn from(err: io::Error) -> CreateComputeEnvironmentError {
+        CreateComputeEnvironmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateComputeEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1137,6 +1149,11 @@ impl From<CredentialsError> for CreateJobQueueError {
 impl From<HttpDispatchError> for CreateJobQueueError {
     fn from(err: HttpDispatchError) -> CreateJobQueueError {
         CreateJobQueueError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateJobQueueError {
+    fn from(err: io::Error) -> CreateJobQueueError {
+        CreateJobQueueError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateJobQueueError {
@@ -1219,6 +1236,11 @@ impl From<HttpDispatchError> for DeleteComputeEnvironmentError {
         DeleteComputeEnvironmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteComputeEnvironmentError {
+    fn from(err: io::Error) -> DeleteComputeEnvironmentError {
+        DeleteComputeEnvironmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteComputeEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1295,6 +1317,11 @@ impl From<CredentialsError> for DeleteJobQueueError {
 impl From<HttpDispatchError> for DeleteJobQueueError {
     fn from(err: HttpDispatchError) -> DeleteJobQueueError {
         DeleteJobQueueError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteJobQueueError {
+    fn from(err: io::Error) -> DeleteJobQueueError {
+        DeleteJobQueueError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteJobQueueError {
@@ -1375,6 +1402,11 @@ impl From<CredentialsError> for DeregisterJobDefinitionError {
 impl From<HttpDispatchError> for DeregisterJobDefinitionError {
     fn from(err: HttpDispatchError) -> DeregisterJobDefinitionError {
         DeregisterJobDefinitionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeregisterJobDefinitionError {
+    fn from(err: io::Error) -> DeregisterJobDefinitionError {
+        DeregisterJobDefinitionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeregisterJobDefinitionError {
@@ -1459,6 +1491,11 @@ impl From<HttpDispatchError> for DescribeComputeEnvironmentsError {
         DescribeComputeEnvironmentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeComputeEnvironmentsError {
+    fn from(err: io::Error) -> DescribeComputeEnvironmentsError {
+        DescribeComputeEnvironmentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeComputeEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1539,6 +1576,11 @@ impl From<CredentialsError> for DescribeJobDefinitionsError {
 impl From<HttpDispatchError> for DescribeJobDefinitionsError {
     fn from(err: HttpDispatchError) -> DescribeJobDefinitionsError {
         DescribeJobDefinitionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeJobDefinitionsError {
+    fn from(err: io::Error) -> DescribeJobDefinitionsError {
+        DescribeJobDefinitionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeJobDefinitionsError {
@@ -1623,6 +1665,11 @@ impl From<HttpDispatchError> for DescribeJobQueuesError {
         DescribeJobQueuesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeJobQueuesError {
+    fn from(err: io::Error) -> DescribeJobQueuesError {
+        DescribeJobQueuesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeJobQueuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1701,6 +1748,11 @@ impl From<HttpDispatchError> for DescribeJobsError {
         DescribeJobsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeJobsError {
+    fn from(err: io::Error) -> DescribeJobsError {
+        DescribeJobsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1773,6 +1825,11 @@ impl From<CredentialsError> for ListJobsError {
 impl From<HttpDispatchError> for ListJobsError {
     fn from(err: HttpDispatchError) -> ListJobsError {
         ListJobsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListJobsError {
+    fn from(err: io::Error) -> ListJobsError {
+        ListJobsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListJobsError {
@@ -1855,6 +1912,11 @@ impl From<HttpDispatchError> for RegisterJobDefinitionError {
         RegisterJobDefinitionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterJobDefinitionError {
+    fn from(err: io::Error) -> RegisterJobDefinitionError {
+        RegisterJobDefinitionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterJobDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1931,6 +1993,11 @@ impl From<HttpDispatchError> for SubmitJobError {
         SubmitJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SubmitJobError {
+    fn from(err: io::Error) -> SubmitJobError {
+        SubmitJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SubmitJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2005,6 +2072,11 @@ impl From<CredentialsError> for TerminateJobError {
 impl From<HttpDispatchError> for TerminateJobError {
     fn from(err: HttpDispatchError) -> TerminateJobError {
         TerminateJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TerminateJobError {
+    fn from(err: io::Error) -> TerminateJobError {
+        TerminateJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TerminateJobError {
@@ -2087,6 +2159,11 @@ impl From<HttpDispatchError> for UpdateComputeEnvironmentError {
         UpdateComputeEnvironmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateComputeEnvironmentError {
+    fn from(err: io::Error) -> UpdateComputeEnvironmentError {
+        UpdateComputeEnvironmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateComputeEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2163,6 +2240,11 @@ impl From<CredentialsError> for UpdateJobQueueError {
 impl From<HttpDispatchError> for UpdateJobQueueError {
     fn from(err: HttpDispatchError) -> UpdateJobQueueError {
         UpdateJobQueueError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateJobQueueError {
+    fn from(err: io::Error) -> UpdateJobQueueError {
+        UpdateJobQueueError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateJobQueueError {
@@ -2321,13 +2403,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2341,7 +2423,11 @@ impl<P, D> Batch for BatchClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CancelJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2363,13 +2449,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2384,7 +2470,12 @@ impl<P, D> Batch for BatchClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateComputeEnvironmentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateComputeEnvironmentError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -2405,13 +2496,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2426,8 +2517,9 @@ impl<P, D> Batch for BatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateJobQueueError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateJobQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2450,13 +2542,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2471,7 +2563,12 @@ impl<P, D> Batch for BatchClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteComputeEnvironmentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteComputeEnvironmentError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -2492,13 +2589,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2513,8 +2610,9 @@ impl<P, D> Batch for BatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteJobQueueError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteJobQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2537,13 +2635,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2558,7 +2656,12 @@ impl<P, D> Batch for BatchClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeregisterJobDefinitionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterJobDefinitionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -2580,13 +2683,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2601,7 +2704,12 @@ impl<P, D> Batch for BatchClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DescribeComputeEnvironmentsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeComputeEnvironmentsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -2623,13 +2731,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2645,8 +2753,9 @@ impl<P, D> Batch for BatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeJobDefinitionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeJobDefinitionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2668,13 +2777,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2689,8 +2798,9 @@ impl<P, D> Batch for BatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeJobQueuesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeJobQueuesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2712,13 +2822,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2733,7 +2843,9 @@ impl<P, D> Batch for BatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeJobsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2753,13 +2865,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2773,7 +2885,11 @@ impl<P, D> Batch for BatchClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListJobsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2795,13 +2911,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2817,8 +2933,9 @@ impl<P, D> Batch for BatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RegisterJobDefinitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterJobDefinitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2838,13 +2955,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2858,7 +2975,11 @@ impl<P, D> Batch for BatchClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(SubmitJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SubmitJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2879,13 +3000,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2900,7 +3021,9 @@ impl<P, D> Batch for BatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(TerminateJobError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TerminateJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2923,13 +3046,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2944,7 +3067,12 @@ impl<P, D> Batch for BatchClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateComputeEnvironmentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateComputeEnvironmentError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -2965,13 +3093,13 @@ impl<P, D> Batch for BatchClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -2986,8 +3114,9 @@ impl<P, D> Batch for BatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateJobQueueError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateJobQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -5766,6 +5768,11 @@ impl From<HttpDispatchError> for CancelUpdateStackError {
         CancelUpdateStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelUpdateStackError {
+    fn from(err: io::Error) -> CancelUpdateStackError {
+        CancelUpdateStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelUpdateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5832,6 +5839,11 @@ impl From<CredentialsError> for ContinueUpdateRollbackError {
 impl From<HttpDispatchError> for ContinueUpdateRollbackError {
     fn from(err: HttpDispatchError) -> ContinueUpdateRollbackError {
         ContinueUpdateRollbackError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ContinueUpdateRollbackError {
+    fn from(err: io::Error) -> ContinueUpdateRollbackError {
+        ContinueUpdateRollbackError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ContinueUpdateRollbackError {
@@ -5910,6 +5922,11 @@ impl From<CredentialsError> for CreateChangeSetError {
 impl From<HttpDispatchError> for CreateChangeSetError {
     fn from(err: HttpDispatchError) -> CreateChangeSetError {
         CreateChangeSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateChangeSetError {
+    fn from(err: io::Error) -> CreateChangeSetError {
+        CreateChangeSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateChangeSetError {
@@ -5995,6 +6012,11 @@ impl From<HttpDispatchError> for CreateStackError {
         CreateStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateStackError {
+    fn from(err: io::Error) -> CreateStackError {
+        CreateStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6062,6 +6084,11 @@ impl From<CredentialsError> for DeleteChangeSetError {
 impl From<HttpDispatchError> for DeleteChangeSetError {
     fn from(err: HttpDispatchError) -> DeleteChangeSetError {
         DeleteChangeSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteChangeSetError {
+    fn from(err: io::Error) -> DeleteChangeSetError {
+        DeleteChangeSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteChangeSetError {
@@ -6132,6 +6159,11 @@ impl From<HttpDispatchError> for DeleteStackError {
         DeleteStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteStackError {
+    fn from(err: io::Error) -> DeleteStackError {
+        DeleteStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6193,6 +6225,11 @@ impl From<CredentialsError> for DescribeAccountLimitsError {
 impl From<HttpDispatchError> for DescribeAccountLimitsError {
     fn from(err: HttpDispatchError) -> DescribeAccountLimitsError {
         DescribeAccountLimitsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAccountLimitsError {
+    fn from(err: io::Error) -> DescribeAccountLimitsError {
+        DescribeAccountLimitsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAccountLimitsError {
@@ -6262,6 +6299,11 @@ impl From<HttpDispatchError> for DescribeChangeSetError {
         DescribeChangeSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeChangeSetError {
+    fn from(err: io::Error) -> DescribeChangeSetError {
+        DescribeChangeSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeChangeSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6325,6 +6367,11 @@ impl From<CredentialsError> for DescribeStackEventsError {
 impl From<HttpDispatchError> for DescribeStackEventsError {
     fn from(err: HttpDispatchError) -> DescribeStackEventsError {
         DescribeStackEventsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeStackEventsError {
+    fn from(err: io::Error) -> DescribeStackEventsError {
+        DescribeStackEventsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeStackEventsError {
@@ -6391,6 +6438,11 @@ impl From<HttpDispatchError> for DescribeStackResourceError {
         DescribeStackResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeStackResourceError {
+    fn from(err: io::Error) -> DescribeStackResourceError {
+        DescribeStackResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeStackResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6453,6 +6505,11 @@ impl From<CredentialsError> for DescribeStackResourcesError {
 impl From<HttpDispatchError> for DescribeStackResourcesError {
     fn from(err: HttpDispatchError) -> DescribeStackResourcesError {
         DescribeStackResourcesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeStackResourcesError {
+    fn from(err: io::Error) -> DescribeStackResourcesError {
+        DescribeStackResourcesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeStackResourcesError {
@@ -6519,6 +6576,11 @@ impl From<HttpDispatchError> for DescribeStacksError {
         DescribeStacksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeStacksError {
+    fn from(err: io::Error) -> DescribeStacksError {
+        DescribeStacksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6579,6 +6641,11 @@ impl From<CredentialsError> for EstimateTemplateCostError {
 impl From<HttpDispatchError> for EstimateTemplateCostError {
     fn from(err: HttpDispatchError) -> EstimateTemplateCostError {
         EstimateTemplateCostError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EstimateTemplateCostError {
+    fn from(err: io::Error) -> EstimateTemplateCostError {
+        EstimateTemplateCostError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EstimateTemplateCostError {
@@ -6659,6 +6726,11 @@ impl From<HttpDispatchError> for ExecuteChangeSetError {
         ExecuteChangeSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ExecuteChangeSetError {
+    fn from(err: io::Error) -> ExecuteChangeSetError {
+        ExecuteChangeSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ExecuteChangeSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6723,6 +6795,11 @@ impl From<CredentialsError> for GetStackPolicyError {
 impl From<HttpDispatchError> for GetStackPolicyError {
     fn from(err: HttpDispatchError) -> GetStackPolicyError {
         GetStackPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetStackPolicyError {
+    fn from(err: io::Error) -> GetStackPolicyError {
+        GetStackPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetStackPolicyError {
@@ -6792,6 +6869,11 @@ impl From<HttpDispatchError> for GetTemplateError {
         GetTemplateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetTemplateError {
+    fn from(err: io::Error) -> GetTemplateError {
+        GetTemplateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6853,6 +6935,11 @@ impl From<CredentialsError> for GetTemplateSummaryError {
 impl From<HttpDispatchError> for GetTemplateSummaryError {
     fn from(err: HttpDispatchError) -> GetTemplateSummaryError {
         GetTemplateSummaryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetTemplateSummaryError {
+    fn from(err: io::Error) -> GetTemplateSummaryError {
+        GetTemplateSummaryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetTemplateSummaryError {
@@ -6919,6 +7006,11 @@ impl From<HttpDispatchError> for ListChangeSetsError {
         ListChangeSetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListChangeSetsError {
+    fn from(err: io::Error) -> ListChangeSetsError {
+        ListChangeSetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListChangeSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6979,6 +7071,11 @@ impl From<CredentialsError> for ListExportsError {
 impl From<HttpDispatchError> for ListExportsError {
     fn from(err: HttpDispatchError) -> ListExportsError {
         ListExportsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListExportsError {
+    fn from(err: io::Error) -> ListExportsError {
+        ListExportsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListExportsError {
@@ -7043,6 +7140,11 @@ impl From<HttpDispatchError> for ListImportsError {
         ListImportsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListImportsError {
+    fn from(err: io::Error) -> ListImportsError {
+        ListImportsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListImportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7103,6 +7205,11 @@ impl From<CredentialsError> for ListStackResourcesError {
 impl From<HttpDispatchError> for ListStackResourcesError {
     fn from(err: HttpDispatchError) -> ListStackResourcesError {
         ListStackResourcesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListStackResourcesError {
+    fn from(err: io::Error) -> ListStackResourcesError {
+        ListStackResourcesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListStackResourcesError {
@@ -7169,6 +7276,11 @@ impl From<HttpDispatchError> for ListStacksError {
         ListStacksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListStacksError {
+    fn from(err: io::Error) -> ListStacksError {
+        ListStacksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7231,6 +7343,11 @@ impl From<HttpDispatchError> for SetStackPolicyError {
         SetStackPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetStackPolicyError {
+    fn from(err: io::Error) -> SetStackPolicyError {
+        SetStackPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetStackPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7291,6 +7408,11 @@ impl From<CredentialsError> for SignalResourceError {
 impl From<HttpDispatchError> for SignalResourceError {
     fn from(err: HttpDispatchError) -> SignalResourceError {
         SignalResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SignalResourceError {
+    fn from(err: io::Error) -> SignalResourceError {
+        SignalResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SignalResourceError {
@@ -7363,6 +7485,11 @@ impl From<HttpDispatchError> for UpdateStackError {
         UpdateStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateStackError {
+    fn from(err: io::Error) -> UpdateStackError {
+        UpdateStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7425,6 +7552,11 @@ impl From<CredentialsError> for ValidateTemplateError {
 impl From<HttpDispatchError> for ValidateTemplateError {
     fn from(err: HttpDispatchError) -> ValidateTemplateError {
         ValidateTemplateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ValidateTemplateError {
+    fn from(err: io::Error) -> ValidateTemplateError {
+        ValidateTemplateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ValidateTemplateError {
@@ -7635,15 +7767,16 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(CancelUpdateStackError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelUpdateStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7663,16 +7796,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ContinueUpdateRollbackOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7688,8 +7823,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ContinueUpdateRollbackError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ContinueUpdateRollbackError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7708,16 +7844,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateChangeSetOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7732,8 +7870,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateChangeSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateChangeSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7752,16 +7891,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateStackOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7775,7 +7916,11 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7793,16 +7938,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteChangeSetOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7817,8 +7964,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteChangeSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteChangeSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7835,13 +7983,17 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7860,16 +8012,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAccountLimitsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7884,8 +8038,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeAccountLimitsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountLimitsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7904,16 +8059,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeChangeSetOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7928,8 +8085,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeChangeSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeChangeSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7948,16 +8106,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeStackEventsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7972,8 +8132,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeStackEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStackEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7993,16 +8154,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeStackResourceOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8017,8 +8180,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeStackResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStackResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8038,16 +8202,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeStackResourcesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8063,8 +8229,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeStackResourcesError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStackResourcesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8083,16 +8250,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeStacksOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8107,8 +8276,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeStacksError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStacksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8127,16 +8297,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EstimateTemplateCostOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8151,8 +8323,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(EstimateTemplateCostError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EstimateTemplateCostError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8171,16 +8344,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ExecuteChangeSetOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8195,8 +8370,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ExecuteChangeSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ExecuteChangeSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8215,16 +8391,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetStackPolicyOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8239,8 +8417,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetStackPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetStackPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8259,16 +8438,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetTemplateOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8282,7 +8463,11 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(GetTemplateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTemplateError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8300,16 +8485,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetTemplateSummaryOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8324,8 +8511,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetTemplateSummaryError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTemplateSummaryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8344,16 +8532,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListChangeSetsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8368,8 +8558,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListChangeSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListChangeSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8388,16 +8579,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListExportsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8411,7 +8604,11 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListExportsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListExportsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8429,16 +8626,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListImportsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8452,7 +8651,11 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListImportsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListImportsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8470,16 +8673,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListStackResourcesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8494,8 +8699,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListStackResourcesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListStackResourcesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8512,16 +8718,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListStacksOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8535,7 +8743,11 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListStacksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListStacksError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8551,15 +8763,16 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SetStackPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetStackPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8576,15 +8789,16 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SignalResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SignalResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8603,16 +8817,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateStackOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8626,7 +8842,11 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(UpdateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8644,16 +8864,18 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ValidateTemplateOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8668,8 +8890,9 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ValidateTemplateError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ValidateTemplateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -38,7 +40,7 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>A complex type that lists the AWS accounts, if any, that you included in the <code>TrustedSigners</code> complex type for this distribution. These are the accounts that you want to allow to create signed URLs for private content.</p> <p>The <code>Signer</code> complex type lists the AWS account number of the trusted signer or <code>self</code> if the signer is the AWS account that created the distribution. The <code>Signer</code> element also includes the IDs of any active CloudFront key pairs that are associated with the trusted signer's AWS account. If no <code>KeyPairId</code> element appears for a <code>Signer</code>, that signer can't create signed URLs. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ActiveTrustedSigners {
     #[doc="<p>Enabled is <code>true</code> if any of the AWS accounts listed in the <code>TrustedSigners</code> complex type for this RTMP distribution have active CloudFront key pairs. If not, <code>Enabled</code> is <code>false</code>.</p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>"]
     pub enabled: bool,
@@ -154,7 +156,7 @@ impl AliasListSerializer {
 }
 
 #[doc="<p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Aliases {
     #[doc="<p>A complex type that contains the CNAME aliases, if any, that you want to associate with this distribution.</p>"]
     pub items: Option<Vec<String>>,
@@ -224,7 +226,7 @@ impl AliasesSerializer {
 }
 
 #[doc="<p>A complex type that controls which HTTP methods CloudFront processes and forwards to your Amazon S3 bucket or your custom origin. There are three choices:</p> <ul> <li> <p>CloudFront forwards only <code>GET</code> and <code>HEAD</code> requests.</p> </li> <li> <p>CloudFront forwards only <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code> requests.</p> </li> <li> <p>CloudFront forwards <code>GET, HEAD, OPTIONS, PUT, PATCH, POST</code>, and <code>DELETE</code> requests.</p> </li> </ul> <p>If you pick the third choice, you may need to restrict access to your Amazon S3 bucket or to your custom origin so users can't perform operations that you don't want them to. For example, you might not want users to have permissions to delete objects from your origin.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AllowedMethods {
     pub cached_methods: Option<CachedMethods>,
     #[doc="<p>A complex type that contains the HTTP methods that you want CloudFront to process and forward to your origin.</p>"]
@@ -381,7 +383,7 @@ impl BooleanSerializer {
 }
 
 #[doc="<p>A complex type that describes how CloudFront processes requests.</p> <p>You must create at least as many cache behaviors (including the default cache behavior) as you have origins if you want CloudFront to distribute objects from all of the origins. Each cache behavior specifies the one origin from which you want CloudFront to get objects. If you have two origins and only the default cache behavior, the default cache behavior will cause CloudFront to get objects from one of the origins, but the other origin is never used.</p> <p>For the current limit on the number of cache behaviors that you can add to a distribution, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudfront\">Amazon CloudFront Limits</a> in the <i>AWS General Reference</i>.</p> <p>If you don't want to specify any cache behaviors, include only an empty <code>CacheBehaviors</code> element. Don't include an empty <code>CacheBehavior</code> element, or CloudFront returns a <code>MalformedXML</code> error.</p> <p>To delete all cache behaviors in an existing distribution, update the distribution configuration and include only an empty <code>CacheBehaviors</code> element.</p> <p>To add, change, or remove one or more cache behaviors, update the distribution configuration and specify all of the cache behaviors that you want to include in the updated distribution.</p> <p>For more information about cache behaviors, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesCacheBehavior\">Cache Behaviors</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CacheBehavior {
     pub allowed_methods: Option<AllowedMethods>,
     #[doc="<p>Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify true; if not, specify false. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html\">Serving Compressed Files</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
@@ -595,7 +597,7 @@ impl CacheBehaviorListSerializer {
 }
 
 #[doc="<p>A complex type that contains zero or more <code>CacheBehavior</code> elements. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CacheBehaviors {
     #[doc="<p>Optional: A complex type that contains cache behaviors for this distribution. If <code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>"]
     pub items: Option<Vec<CacheBehavior>>,
@@ -666,7 +668,7 @@ impl CacheBehaviorsSerializer {
 }
 
 #[doc="<p>A complex type that controls whether CloudFront caches the response to requests using the specified HTTP methods. There are two choices:</p> <ul> <li> <p>CloudFront caches responses to <code>GET</code> and <code>HEAD</code> requests.</p> </li> <li> <p>CloudFront caches responses to <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code> requests.</p> </li> </ul> <p>If you pick the second choice for your Amazon S3 Origin, you may need to forward Access-Control-Request-Method, Access-Control-Request-Headers, and Origin headers for the responses to be cached correctly. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CachedMethods {
     #[doc="<p>A complex type that contains the HTTP methods that you want CloudFront to cache responses to.</p>"]
     pub items: Vec<String>,
@@ -733,7 +735,7 @@ impl CachedMethodsSerializer {
 }
 
 #[doc="<p>CloudFront origin access identity.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CloudFrontOriginAccessIdentity {
     #[doc="<p>The current configuration information for the identity. </p>"]
     pub cloud_front_origin_access_identity_config: Option<CloudFrontOriginAccessIdentityConfig>,
@@ -792,7 +794,7 @@ impl CloudFrontOriginAccessIdentityDeserializer {
     }
 }
 #[doc="<p>Origin access identity configuration. Send a <code>GET</code> request to the <code>/<i>CloudFront API version</i>/CloudFront/identity ID/config</code> resource. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CloudFrontOriginAccessIdentityConfig {
     #[doc="<p>A unique number that ensures the request can't be replayed.</p> <p>If the <code>CallerReference</code> is new (no matter the content of the <code>CloudFrontOriginAccessIdentityConfig</code> object), a new origin access identity is created.</p> <p>If the <code>CallerReference</code> is a value already sent in a previous identity request, and the content of the <code>CloudFrontOriginAccessIdentityConfig</code> is identical to the original request (ignoring white space), the response includes the same information returned to the original request. </p> <p>If the <code>CallerReference</code> is a value you already sent in a previous request to create an identity, but the content of the <code>CloudFrontOriginAccessIdentityConfig</code> is different from the original request, CloudFront returns a <code>CloudFrontOriginAccessIdentityAlreadyExists</code> error. </p>"]
     pub caller_reference: String,
@@ -861,7 +863,7 @@ impl CloudFrontOriginAccessIdentityConfigSerializer {
 }
 
 #[doc="<p>Lists the origin access identities for CloudFront.Send a <code>GET</code> request to the <code>/<i>CloudFront API version</i>/origin-access-identity/cloudfront</code> resource. The response includes a <code>CloudFrontOriginAccessIdentityList</code> element with zero or more <code>CloudFrontOriginAccessIdentitySummary</code> child elements. By default, your entire list of origin access identities is returned in one single page. If the list is long, you can paginate it using the <code>MaxItems</code> and <code>Marker</code> parameters.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CloudFrontOriginAccessIdentityList {
     #[doc="<p>A flag that indicates whether more origin access identities remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more items in the list.</p>"]
     pub is_truncated: bool,
@@ -939,7 +941,7 @@ impl CloudFrontOriginAccessIdentityListDeserializer {
     }
 }
 #[doc="<p>Summary of the information about a CloudFront origin access identity.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CloudFrontOriginAccessIdentitySummary {
     #[doc="<p>The comment for this origin access identity, as originally specified when created.</p>"]
     pub comment: String,
@@ -1097,7 +1099,7 @@ impl CookieNameListSerializer {
 }
 
 #[doc="<p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html\">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CookieNames {
     #[doc="<p>A complex type that contains one <code>Name</code> element for each cookie that you want CloudFront to forward to the origin for this cache behavior.</p>"]
     pub items: Option<Vec<String>>,
@@ -1167,7 +1169,7 @@ impl CookieNamesSerializer {
 }
 
 #[doc="<p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html\">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CookiePreference {
     #[doc="<p>Specifies which cookies to forward to the origin for this cache behavior: all, none, or the list of cookies specified in the <code>WhitelistedNames</code> complex type.</p> <p>Amazon S3 doesn't process cookies. When the cache behavior is forwarding requests to an Amazon S3 origin, specify none for the <code>Forward</code> element. </p>"]
     pub forward: String,
@@ -1238,14 +1240,14 @@ impl CookiePreferenceSerializer {
 }
 
 #[doc="<p>The request to create a new origin access identity.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateCloudFrontOriginAccessIdentityRequest {
     #[doc="<p>The current configuration information for the identity.</p>"]
     pub cloud_front_origin_access_identity_config: CloudFrontOriginAccessIdentityConfig,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateCloudFrontOriginAccessIdentityResult {
     #[doc="<p>The origin access identity's information.</p>"]
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
@@ -1298,14 +1300,14 @@ impl CreateCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 #[doc="<p>The request to create a new distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateDistributionRequest {
     #[doc="<p>The distribution's configuration information.</p>"]
     pub distribution_config: DistributionConfig,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateDistributionResult {
     #[doc="<p>The distribution's information.</p>"]
     pub distribution: Option<Distribution>,
@@ -1359,14 +1361,14 @@ impl CreateDistributionResultDeserializer {
     }
 }
 #[doc="<p>The request to create a new distribution with tags. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateDistributionWithTagsRequest {
     #[doc="<p>The distribution's configuration information. </p>"]
     pub distribution_config_with_tags: DistributionConfigWithTags,
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateDistributionWithTagsResult {
     #[doc="<p>The distribution's information. </p>"]
     pub distribution: Option<Distribution>,
@@ -1421,7 +1423,7 @@ impl CreateDistributionWithTagsResultDeserializer {
     }
 }
 #[doc="<p>The request to create an invalidation.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateInvalidationRequest {
     #[doc="<p>The distribution's id.</p>"]
     pub distribution_id: String,
@@ -1430,7 +1432,7 @@ pub struct CreateInvalidationRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateInvalidationResult {
     #[doc="<p>The invalidation's information.</p>"]
     pub invalidation: Option<Invalidation>,
@@ -1482,14 +1484,14 @@ impl CreateInvalidationResultDeserializer {
     }
 }
 #[doc="<p>The request to create a new streaming distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateStreamingDistributionRequest {
     #[doc="<p>The streaming distribution's configuration information.</p>"]
     pub streaming_distribution_config: StreamingDistributionConfig,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateStreamingDistributionResult {
     #[doc="<p>The current version of the streaming distribution created.</p>"]
     pub e_tag: Option<String>,
@@ -1544,14 +1546,14 @@ impl CreateStreamingDistributionResultDeserializer {
     }
 }
 #[doc="<p>The request to create a new streaming distribution with tags.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateStreamingDistributionWithTagsRequest {
     #[doc="<p> The streaming distribution's configuration information. </p>"]
     pub streaming_distribution_config_with_tags: StreamingDistributionConfigWithTags,
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateStreamingDistributionWithTagsResult {
     pub e_tag: Option<String>,
     #[doc="<p>The fully qualified URI of the new streaming distribution resource just created. For example:<code> https://cloudfront.amazonaws.com/2010-11-01/streaming-distribution/EGTXBD79H29TRA8</code>.</p>"]
@@ -1605,7 +1607,7 @@ impl CreateStreamingDistributionWithTagsResultDeserializer {
     }
 }
 #[doc="<p>A complex type that controls:</p> <ul> <li> <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom error messages before returning the response to the viewer. </p> </li> <li> <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p> </li> </ul> <p>For more information about custom error pages, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CustomErrorResponse {
     #[doc="<p>The minimum amount of time, in seconds, that you want CloudFront to cache the HTTP status code specified in <code>ErrorCode</code>. When this time period has elapsed, CloudFront queries your origin to see whether the problem that caused the error has been resolved and the requested object is now available.</p> <p>If you don't want to specify a value, include an empty element, <code>&lt;ErrorCachingMinTTL&gt;</code>, in the XML document.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
     pub error_caching_min_ttl: Option<i64>,
@@ -1753,7 +1755,7 @@ impl CustomErrorResponseListSerializer {
 }
 
 #[doc="<p>A complex type that controls:</p> <ul> <li> <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom error messages before returning the response to the viewer.</p> </li> <li> <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p> </li> </ul> <p>For more information about custom error pages, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CustomErrorResponses {
     #[doc="<p>A complex type that contains a <code>CustomErrorResponse</code> element for each HTTP status code for which you want to specify a custom error page and/or a caching duration. </p>"]
     pub items: Option<Vec<CustomErrorResponse>>,
@@ -1824,7 +1826,7 @@ impl CustomErrorResponsesSerializer {
 }
 
 #[doc="<p>A complex type that contains the list of Custom Headers for each origin. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CustomHeaders {
     #[doc="<p> <b>Optional</b>: A list that contains one <code>OriginCustomHeader</code> element for each custom header that you want CloudFront to forward to the origin. If Quantity is <code>0</code>, omit <code>Items</code>.</p>"]
     pub items: Option<Vec<OriginCustomHeader>>,
@@ -1895,7 +1897,7 @@ impl CustomHeadersSerializer {
 }
 
 #[doc="<p>A customer origin.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CustomOriginConfig {
     #[doc="<p>The HTTP port the custom origin listens on.</p>"]
     pub http_port: i64,
@@ -2004,7 +2006,7 @@ impl CustomOriginConfigSerializer {
 }
 
 #[doc="<p>A complex type that describes the default cache behavior if you do not specify a <code>CacheBehavior</code> element or if files don't match any of the values of <code>PathPattern</code> in <code>CacheBehavior</code> elements. You must create exactly one default cache behavior.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DefaultCacheBehavior {
     pub allowed_methods: Option<AllowedMethods>,
     #[doc="<p>Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify <code>true</code>; if not, specify <code>false</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html\">Serving Compressed Files</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
@@ -2152,7 +2154,7 @@ impl DefaultCacheBehaviorSerializer {
 }
 
 #[doc="<p>Deletes a origin access identity.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteCloudFrontOriginAccessIdentityRequest {
     #[doc="<p>The origin access identity's ID.</p>"]
     pub id: String,
@@ -2161,7 +2163,7 @@ pub struct DeleteCloudFrontOriginAccessIdentityRequest {
 }
 
 #[doc="<p>This action deletes a web distribution. To delete a web distribution using the CloudFront API, perform the following steps.</p> <p> <b>To delete a web distribution using the CloudFront API:</b> </p> <ol> <li> <p>Disable the web distribution </p> </li> <li> <p>Submit a <code>GET Distribution Config</code> request to get the current configuration and the <code>Etag</code> header for the distribution.</p> </li> <li> <p>Update the XML document that was returned in the response to your <code>GET Distribution Config</code> request to change the value of <code>Enabled</code> to <code>false</code>.</p> </li> <li> <p>Submit a <code>PUT Distribution Config</code> request to update the configuration for your distribution. In the request body, include the XML document that you updated in Step 3. Set the value of the HTTP <code>If-Match</code> header to the value of the <code>ETag</code> header that CloudFront returned when you submitted the <code>GET Distribution Config</code> request in Step 2.</p> </li> <li> <p>Review the response to the <code>PUT Distribution Config</code> request to confirm that the distribution was successfully disabled.</p> </li> <li> <p>Submit a <code>GET Distribution</code> request to confirm that your changes have propagated. When propagation is complete, the value of <code>Status</code> is <code>Deployed</code>.</p> </li> <li> <p>Submit a <code>DELETE Distribution</code> request. Set the value of the HTTP <code>If-Match</code> header to the value of the <code>ETag</code> header that CloudFront returned when you submitted the <code>GET Distribution Config</code> request in Step 6.</p> </li> <li> <p>Review the response to your <code>DELETE Distribution</code> request to confirm that the distribution was successfully deleted.</p> </li> </ol> <p>For information about deleting a distribution using the CloudFront console, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HowToDeleteDistribution.html\">Deleting a Distribution</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteDistributionRequest {
     #[doc="<p>The distribution ID. </p>"]
     pub id: String,
@@ -2170,7 +2172,7 @@ pub struct DeleteDistributionRequest {
 }
 
 #[doc="<p>The request to delete a streaming distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteStreamingDistributionRequest {
     #[doc="<p>The distribution ID. </p>"]
     pub id: String,
@@ -2179,7 +2181,7 @@ pub struct DeleteStreamingDistributionRequest {
 }
 
 #[doc="<p>The distribution's information.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Distribution {
     #[doc="<p>The ARN (Amazon Resource Name) for the distribution. For example: <code>arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>"]
     pub arn: String,
@@ -2270,7 +2272,7 @@ impl DistributionDeserializer {
     }
 }
 #[doc="<p>A distribution configuration.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DistributionConfig {
     #[doc="<p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution.</p>"]
     pub aliases: Option<Aliases>,
@@ -2465,7 +2467,7 @@ impl DistributionConfigSerializer {
 }
 
 #[doc="<p>A distribution Configuration and a list of tags to be associated with the distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DistributionConfigWithTags {
     #[doc="<p>A distribution configuration.</p>"]
     pub distribution_config: DistributionConfig,
@@ -2488,7 +2490,7 @@ impl DistributionConfigWithTagsSerializer {
 }
 
 #[doc="<p>A distribution list.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DistributionList {
     #[doc="<p>A flag that indicates whether more distributions remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more distributions in the list.</p>"]
     pub is_truncated: bool,
@@ -2567,7 +2569,7 @@ impl DistributionListDeserializer {
     }
 }
 #[doc="<p>A summary of the information about a CloudFront distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DistributionSummary {
     #[doc="<p>The ARN (Amazon Resource Name) for the distribution. For example: <code>arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>"]
     pub arn: String,
@@ -2778,7 +2780,7 @@ impl EventTypeSerializer {
 }
 
 #[doc="<p>A complex type that specifies how CloudFront handles query strings and cookies.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ForwardedValues {
     #[doc="<p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html\">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
     pub cookies: CookiePreference,
@@ -2866,7 +2868,7 @@ impl ForwardedValuesSerializer {
 }
 
 #[doc="<p>A complex type that controls the countries in which your content is distributed. CloudFront determines the location of your users using <code>MaxMind</code> GeoIP databases. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GeoRestriction {
     #[doc="<p> A complex type that contains a <code>Location</code> element for each country in which you want CloudFront either to distribute your content (<code>whitelist</code>) or not distribute your content (<code>blacklist</code>).</p> <p>The <code>Location</code> element is a two-letter, uppercase country code for a country that you want to include in your <code>blacklist</code> or <code>whitelist</code>. Include one <code>Location</code> element for each country.</p> <p>CloudFront and <code>MaxMind</code> both use <code>ISO 3166</code> country codes. For the current list of countries and the corresponding codes, see <code>ISO 3166-1-alpha-2</code> code on the <i>International Organization for Standardization</i> website. You can also refer to the country list in the CloudFront console, which includes both country names and codes.</p>"]
     pub items: Option<Vec<String>>,
@@ -2970,14 +2972,14 @@ impl GeoRestrictionTypeSerializer {
 }
 
 #[doc="<p>The origin access identity's configuration information. For more information, see <a>CloudFrontOriginAccessIdentityConfigComplexType</a>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetCloudFrontOriginAccessIdentityConfigRequest {
     #[doc="<p>The identity's ID. </p>"]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetCloudFrontOriginAccessIdentityConfigResult {
     #[doc="<p>The origin access identity's configuration information. </p>"]
     pub cloud_front_origin_access_identity_config: Option<CloudFrontOriginAccessIdentityConfig>,
@@ -3028,14 +3030,14 @@ impl GetCloudFrontOriginAccessIdentityConfigResultDeserializer {
     }
 }
 #[doc="<p>The request to get an origin access identity's information.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetCloudFrontOriginAccessIdentityRequest {
     #[doc="<p>The identity's ID.</p>"]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetCloudFrontOriginAccessIdentityResult {
     #[doc="<p>The origin access identity's information.</p>"]
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
@@ -3086,14 +3088,14 @@ impl GetCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 #[doc="<p>The request to get a distribution configuration.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetDistributionConfigRequest {
     #[doc="<p>The distribution's ID.</p>"]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetDistributionConfigResult {
     #[doc="<p>The distribution's configuration information.</p>"]
     pub distribution_config: Option<DistributionConfig>,
@@ -3145,14 +3147,14 @@ impl GetDistributionConfigResultDeserializer {
     }
 }
 #[doc="<p>The request to get a distribution's information.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetDistributionRequest {
     #[doc="<p>The distribution's ID.</p>"]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetDistributionResult {
     #[doc="<p>The distribution's information.</p>"]
     pub distribution: Option<Distribution>,
@@ -3204,7 +3206,7 @@ impl GetDistributionResultDeserializer {
     }
 }
 #[doc="<p>The request to get an invalidation's information. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetInvalidationRequest {
     #[doc="<p>The distribution's ID.</p>"]
     pub distribution_id: String,
@@ -3213,7 +3215,7 @@ pub struct GetInvalidationRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetInvalidationResult {
     #[doc="<p>The invalidation's information. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/InvalidationDatatype.html\">Invalidation Complex Type</a>. </p>"]
     pub invalidation: Option<Invalidation>,
@@ -3263,14 +3265,14 @@ impl GetInvalidationResultDeserializer {
     }
 }
 #[doc="<p>To request to get a streaming distribution configuration.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetStreamingDistributionConfigRequest {
     #[doc="<p>The streaming distribution's ID.</p>"]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetStreamingDistributionConfigResult {
     #[doc="<p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>. </p>"]
     pub e_tag: Option<String>,
@@ -3321,14 +3323,14 @@ impl GetStreamingDistributionConfigResultDeserializer {
     }
 }
 #[doc="<p>The request to get a streaming distribution's information.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetStreamingDistributionRequest {
     #[doc="<p>The streaming distribution's ID.</p>"]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetStreamingDistributionResult {
     #[doc="<p>The current version of the streaming distribution's information. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
     pub e_tag: Option<String>,
@@ -3436,7 +3438,7 @@ impl HeaderListSerializer {
 }
 
 #[doc="<p>A complex type that specifies the headers that you want CloudFront to forward to the origin for this cache behavior.</p> <p>For the headers that you specify, CloudFront also caches separate versions of a specified object based on the header values in viewer requests. For example, suppose viewer requests for <code>logo.jpg</code> contain a custom <code>Product</code> header that has a value of either <code>Acme</code> or <code>Apex</code>, and you configure CloudFront to cache your content based on values in the <code>Product</code> header. CloudFront forwards the <code>Product</code> header to the origin and caches the response from the origin once for each header value. For more information about caching based on header values, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html\">How CloudFront Forwards and Caches Headers</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Headers {
     #[doc="<p>A complex type that contains one <code>Name</code> element for each header that you want CloudFront to forward to the origin and to vary on for this cache behavior. If <code>Quantity</code> is <code>0</code>, omit <code>Items</code>.</p>"]
     pub items: Option<Vec<String>>,
@@ -3556,7 +3558,7 @@ impl IntegerSerializer {
 }
 
 #[doc="<p>An invalidation. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Invalidation {
     #[doc="<p>The date and time the invalidation request was first made. </p>"]
     pub create_time: String,
@@ -3622,7 +3624,7 @@ impl InvalidationDeserializer {
     }
 }
 #[doc="<p>An invalidation batch.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct InvalidationBatch {
     #[doc="<p>A value that you specify to uniquely identify an invalidation request. CloudFront uses the value to prevent you from accidentally resubmitting an identical request. Whenever you create a new invalidation request, you must specify a new value for <code>CallerReference</code> and change other values in the request as applicable. One way to ensure that the value of <code>CallerReference</code> is unique is to use a <code>timestamp</code>, for example, <code>20120301090000</code>.</p> <p>If you make a second invalidation request with the same value for <code>CallerReference</code>, and if the rest of the request is the same, CloudFront doesn't create a new invalidation request. Instead, CloudFront returns information about the invalidation request that you previously created with the same <code>CallerReference</code>.</p> <p>If <code>CallerReference</code> is a value you already sent in a previous invalidation batch request but the content of any <code>Path</code> is different from the original request, CloudFront returns an <code>InvalidationBatchAlreadyExists</code> error.</p>"]
     pub caller_reference: String,
@@ -3690,7 +3692,7 @@ impl InvalidationBatchSerializer {
 }
 
 #[doc="<p>The <code>InvalidationList</code> complex type describes the list of invalidation objects. For more information about invalidation, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html\">Invalidating Objects (Web Distributions Only)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct InvalidationList {
     #[doc="<p>A flag that indicates whether more invalidation batch requests remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more invalidation batches in the list.</p>"]
     pub is_truncated: bool,
@@ -3769,7 +3771,7 @@ impl InvalidationListDeserializer {
     }
 }
 #[doc="<p>A summary of an invalidation request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct InvalidationSummary {
     pub create_time: String,
     #[doc="<p>The unique ID for an invalidation request.</p>"]
@@ -3934,7 +3936,7 @@ impl KeyPairIdListDeserializer {
     }
 }
 #[doc="<p>A complex type that lists the active CloudFront key pairs, if any, that are associated with <code>AwsAccountNumber</code>. </p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct KeyPairIds {
     #[doc="<p>A complex type that lists the active CloudFront key pairs, if any, that are associated with <code>AwsAccountNumber</code>.</p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>"]
     pub items: Option<Vec<String>>,
@@ -3989,7 +3991,7 @@ impl KeyPairIdsDeserializer {
     }
 }
 #[doc="<p>A complex type that contains a Lambda function association.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LambdaFunctionAssociation {
     #[doc="<p>Specifies the event type that triggers a Lambda function invocation. Valid values are:</p> <ul> <li> <p> <code>viewer-request</code> </p> </li> <li> <p> <code>origin-request</code> </p> </li> <li> <p> <code>viewer-response</code> </p> </li> <li> <p> <code>origin-response</code> </p> </li> </ul>"]
     pub event_type: Option<String>,
@@ -4119,7 +4121,7 @@ impl LambdaFunctionAssociationListSerializer {
 }
 
 #[doc="<p>A complex type that specifies a list of Lambda functions associations for a cache behavior.</p> <p>If you want to invoke one or more Lambda functions triggered by requests that match the <code>PathPattern</code> of the cache behavior, specify the applicable values for <code>Quantity</code> and <code>Items</code>. Note that there can be up to 4 <code>LambdaFunctionAssociation</code> items in this list (one for each possible value of <code>EventType</code>) and each <code>EventType</code> can be associated with the Lambda function only once.</p> <p>If you don't want to invoke any Lambda functions for the requests that match <code>PathPattern</code>, specify <code>0</code> for <code>Quantity</code> and omit <code>Items</code>. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LambdaFunctionAssociations {
     #[doc="<p> <b>Optional</b>: A complex type that contains <code>LambdaFunctionAssociation</code> items for this cache behavior. If <code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>"]
     pub items: Option<Vec<LambdaFunctionAssociation>>,
@@ -4188,7 +4190,7 @@ impl LambdaFunctionAssociationsSerializer {
 }
 
 #[doc="<p>The request to list origin access identities. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListCloudFrontOriginAccessIdentitiesRequest {
     #[doc="<p>Use this when paginating results to indicate where to begin in your list of origin access identities. The results include identities in the list that occur after the marker. To get the next page of results, set the <code>Marker</code> to the value of the <code>NextMarker</code> from the current page's response (which is also the ID of the last identity on that page).</p>"]
     pub marker: Option<String>,
@@ -4197,7 +4199,7 @@ pub struct ListCloudFrontOriginAccessIdentitiesRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListCloudFrontOriginAccessIdentitiesResult {
     #[doc="<p>The <code>CloudFrontOriginAccessIdentityList</code> type. </p>"]
     pub cloud_front_origin_access_identity_list: Option<CloudFrontOriginAccessIdentityList>,
@@ -4246,7 +4248,7 @@ impl ListCloudFrontOriginAccessIdentitiesResultDeserializer {
     }
 }
 #[doc="<p>The request to list distributions that are associated with a specified AWS WAF web ACL. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListDistributionsByWebACLIdRequest {
     #[doc="<p>Use <code>Marker</code> and <code>MaxItems</code> to control pagination of results. If you have more than <code>MaxItems</code> distributions that satisfy the request, the response includes a <code>NextMarker</code> element. To get the next page of results, submit another request. For the value of <code>Marker</code>, specify the value of <code>NextMarker</code> from the last response. (For the first request, omit <code>Marker</code>.) </p>"]
     pub marker: Option<String>,
@@ -4257,7 +4259,7 @@ pub struct ListDistributionsByWebACLIdRequest {
 }
 
 #[doc="<p>The response to a request to list the distributions that are associated with a specified AWS WAF web ACL. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListDistributionsByWebACLIdResult {
     #[doc="<p>The <code>DistributionList</code> type. </p>"]
     pub distribution_list: Option<DistributionList>,
@@ -4308,7 +4310,7 @@ impl ListDistributionsByWebACLIdResultDeserializer {
     }
 }
 #[doc="<p>The request to list your distributions. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListDistributionsRequest {
     #[doc="<p>Use this when paginating results to indicate where to begin in your list of distributions. The results include distributions in the list that occur after the marker. To get the next page of results, set the <code>Marker</code> to the value of the <code>NextMarker</code> from the current page's response (which is also the ID of the last distribution on that page).</p>"]
     pub marker: Option<String>,
@@ -4317,7 +4319,7 @@ pub struct ListDistributionsRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListDistributionsResult {
     #[doc="<p>The <code>DistributionList</code> type. </p>"]
     pub distribution_list: Option<DistributionList>,
@@ -4367,7 +4369,7 @@ impl ListDistributionsResultDeserializer {
     }
 }
 #[doc="<p>The request to list invalidations. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListInvalidationsRequest {
     #[doc="<p>The distribution's ID.</p>"]
     pub distribution_id: String,
@@ -4378,7 +4380,7 @@ pub struct ListInvalidationsRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListInvalidationsResult {
     #[doc="<p>Information about invalidation batches. </p>"]
     pub invalidation_list: Option<InvalidationList>,
@@ -4428,7 +4430,7 @@ impl ListInvalidationsResultDeserializer {
     }
 }
 #[doc="<p>The request to list your streaming distributions. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListStreamingDistributionsRequest {
     #[doc="<p>The value that you provided for the <code>Marker</code> request parameter.</p>"]
     pub marker: Option<String>,
@@ -4437,7 +4439,7 @@ pub struct ListStreamingDistributionsRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListStreamingDistributionsResult {
     #[doc="<p>The <code>StreamingDistributionList</code> type. </p>"]
     pub streaming_distribution_list: Option<StreamingDistributionList>,
@@ -4486,14 +4488,14 @@ impl ListStreamingDistributionsResultDeserializer {
     }
 }
 #[doc="<p> The request to list tags for a CloudFront resource.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p> An ARN of a CloudFront resource.</p>"]
     pub resource: String,
 }
 
 #[doc="<p> The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTagsForResourceResult {
     #[doc="<p> A complex type that contains zero or more <code>Tag</code> elements.</p>"]
     pub tags: Tags,
@@ -4597,7 +4599,7 @@ impl LocationListSerializer {
 }
 
 #[doc="<p>A complex type that controls whether access logs are written for the distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LoggingConfig {
     #[doc="<p>The Amazon S3 bucket to store the access logs in, for example, <code>myawslogbucket.s3.amazonaws.com</code>.</p>"]
     pub bucket: String,
@@ -4808,7 +4810,7 @@ impl MinimumProtocolVersionSerializer {
 }
 
 #[doc="<p>A complex type that describes the Amazon S3 bucket or the HTTP server (for example, a web server) from which CloudFront gets your files. You must create at least one origin.</p> <p>For the current limit on the number of origins that you can create for a distribution, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudfront\">Amazon CloudFront Limits</a> in the <i>AWS General Reference</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Origin {
     #[doc="<p>A complex type that contains names and values for the custom headers that you want.</p>"]
     pub custom_headers: Option<CustomHeaders>,
@@ -4914,7 +4916,7 @@ impl OriginSerializer {
 }
 
 #[doc="<p>A complex type that contains <code>HeaderName</code> and <code>HeaderValue</code> elements, if any, for this distribution. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct OriginCustomHeader {
     #[doc="<p>The name of a header that you want CloudFront to forward to your origin. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/forward-custom-headers.html\">Forwarding Custom Headers to Your Origin (Web Distributions Only)</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p>"]
     pub header_name: String,
@@ -5120,7 +5122,7 @@ impl OriginProtocolPolicySerializer {
 }
 
 #[doc="<p>A complex type that contains information about the SSL/TLS protocols that CloudFront can use when establishing an HTTPS connection with your origin. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct OriginSslProtocols {
     #[doc="<p>A list that contains allowed SSL/TLS protocols for this distribution.</p>"]
     pub items: Vec<String>,
@@ -5188,7 +5190,7 @@ impl OriginSslProtocolsSerializer {
 }
 
 #[doc="<p>A complex type that contains information about origins for this distribution. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Origins {
     #[doc="<p>A complex type that contains origins for this distribution.</p>"]
     pub items: Option<Vec<Origin>>,
@@ -5314,7 +5316,7 @@ impl PathListSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the objects that you want to invalidate. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects\">Specifying the Objects to Invalidate</a> in the <i>Amazon CloudFront Developer Guide</i>. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Paths {
     #[doc="<p>A complex type that contains a list of the paths that you want to invalidate.</p>"]
     pub items: Option<Vec<String>>,
@@ -5408,7 +5410,7 @@ impl PriceClassSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct QueryStringCacheKeys {
     #[doc="<p>(Optional) A list that contains the query string parameters that you want CloudFront to use as a basis for caching for this cache behavior. If <code>Quantity</code> is 0, you can omit <code>Items</code>. </p>"]
     pub items: Option<Vec<String>>,
@@ -5544,7 +5546,7 @@ impl ResourceARNSerializer {
 }
 
 #[doc="<p>A complex type that identifies ways in which you want to restrict distribution of your content.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Restrictions {
     pub geo_restriction: GeoRestriction,
 }
@@ -5605,7 +5607,7 @@ impl RestrictionsSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the Amazon S3 bucket from which you want CloudFront to get your media files for distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct S3Origin {
     #[doc="<p>The DNS name of the Amazon S3 origin. </p>"]
     pub domain_name: String,
@@ -5675,7 +5677,7 @@ impl S3OriginSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the Amazon S3 origin. If the origin is a custom origin, use the <code>CustomOriginConfig</code> element instead.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct S3OriginConfig {
     #[doc="<p>The CloudFront origin access identity to associate with the origin. Use an origin access identity to configure the origin so that viewers can <i>only</i> access objects in an Amazon S3 bucket through CloudFront. The format of the value is:</p> <p>origin-access-identity/cloudfront/<i>ID-of-origin-access-identity</i> </p> <p>where <code> <i>ID-of-origin-access-identity</i> </code> is the value that CloudFront returned in the <code>ID</code> element when you created the origin access identity.</p> <p>If you want viewers to be able to access objects using either the CloudFront URL or the Amazon S3 URL, specify an empty <code>OriginAccessIdentity</code> element.</p> <p>To delete the origin access identity from an existing distribution, update the distribution configuration and include an empty <code>OriginAccessIdentity</code> element.</p> <p>To replace the origin access identity, update the distribution configuration and specify the new origin access identity.</p> <p>For more information about the origin access identity, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
     pub origin_access_identity: String,
@@ -5763,7 +5765,7 @@ impl SSLSupportMethodSerializer {
 }
 
 #[doc="<p>A complex type that lists the AWS accounts that were included in the <code>TrustedSigners</code> complex type, as well as their active CloudFront key pair IDs, if any. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Signer {
     #[doc="<p>An AWS account that is included in the <code>TrustedSigners</code> complex type for this RTMP distribution. Valid values include:</p> <ul> <li> <p> <code>self</code>, which is the AWS account used to create the distribution.</p> </li> <li> <p>An AWS account number.</p> </li> </ul>"]
     pub aws_account_number: Option<String>,
@@ -5942,7 +5944,7 @@ impl SslProtocolsListSerializer {
 }
 
 #[doc="<p>A streaming distribution. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StreamingDistribution {
     pub arn: String,
     #[doc="<p>A complex type that lists the AWS accounts, if any, that you included in the <code>TrustedSigners</code> complex type for this distribution. These are the accounts that you want to allow to create signed URLs for private content.</p> <p>The <code>Signer</code> complex type lists the AWS account number of the trusted signer or <code>self</code> if the signer is the AWS account that created the distribution. The <code>Signer</code> element also includes the IDs of any active CloudFront key pairs that are associated with the trusted signer's AWS account. If no <code>KeyPairId</code> element appears for a <code>Signer</code>, that signer can't create signed URLs.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>. </p>"]
@@ -6026,7 +6028,7 @@ impl StreamingDistributionDeserializer {
     }
 }
 #[doc="<p>The RTMP distribution's configuration information.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StreamingDistributionConfig {
     #[doc="<p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this streaming distribution. </p>"]
     pub aliases: Option<Aliases>,
@@ -6144,7 +6146,7 @@ impl StreamingDistributionConfigSerializer {
 }
 
 #[doc="<p>A streaming distribution Configuration and a list of tags to be associated with the streaming distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StreamingDistributionConfigWithTags {
     #[doc="<p>A streaming distribution Configuration.</p>"]
     pub streaming_distribution_config: StreamingDistributionConfig,
@@ -6168,7 +6170,7 @@ impl StreamingDistributionConfigWithTagsSerializer {
 }
 
 #[doc="<p>A streaming distribution list. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StreamingDistributionList {
     #[doc="<p>A flag that indicates whether more streaming distributions remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more distributions in the list. </p>"]
     pub is_truncated: bool,
@@ -6245,7 +6247,7 @@ impl StreamingDistributionListDeserializer {
     }
 }
 #[doc="<p> A summary of the information for an Amazon CloudFront streaming distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StreamingDistributionSummary {
     #[doc="<p> The ARN (Amazon Resource Name) for the streaming distribution. For example: <code>arn:aws:cloudfront::123456789012:streaming-distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>"]
     pub arn: String,
@@ -6390,7 +6392,7 @@ impl StreamingDistributionSummaryListDeserializer {
     }
 }
 #[doc="<p>A complex type that controls whether access logs are written for this streaming distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StreamingLoggingConfig {
     #[doc="<p>The Amazon S3 bucket to store the access logs in, for example, <code>myawslogbucket.s3.amazonaws.com</code>.</p>"]
     pub bucket: String,
@@ -6487,7 +6489,7 @@ impl StringSerializer {
 }
 
 #[doc="<p> A complex type that contains <code>Tag</code> key and <code>Tag</code> value.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Tag {
     #[doc="<p> A string that contains <code>Tag</code> key.</p> <p>The string length should be between 1 and 128 characters. Valid characters include <code>a-z</code>, <code>A-Z</code>, <code>0-9</code>, space, and the special characters <code>_ - . : / = + @</code>.</p>"]
     pub key: String,
@@ -6596,7 +6598,7 @@ impl TagKeyListSerializer {
 }
 
 #[doc="<p> A complex type that contains zero or more <code>Tag</code> elements.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TagKeys {
     #[doc="<p> A complex type that contains <code>Tag</code> key elements.</p>"]
     pub items: Option<Vec<String>>,
@@ -6673,7 +6675,7 @@ impl TagListSerializer {
 }
 
 #[doc="<p> The request to add tags to a CloudFront resource.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TagResourceRequest {
     #[doc="<p> An ARN of a CloudFront resource.</p>"]
     pub resource: String,
@@ -6707,7 +6709,7 @@ impl TagValueSerializer {
 }
 
 #[doc="<p> A complex type that contains zero or more <code>Tag</code> elements.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Tags {
     #[doc="<p> A complex type that contains <code>Tag</code> elements.</p>"]
     pub items: Option<Vec<Tag>>,
@@ -6784,7 +6786,7 @@ impl TimestampDeserializer {
     }
 }
 #[doc="<p>A complex type that specifies the AWS accounts, if any, that you want to allow to create signed URLs for private content.</p> <p>If you want to require signed URLs in requests for objects in the target origin that match the <code>PathPattern</code> for this cache behavior, specify <code>true</code> for <code>Enabled</code>, and specify the applicable values for <code>Quantity</code> and <code>Items</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p> <p>If you don't want to require signed URLs in requests for objects that match <code>PathPattern</code>, specify <code>false</code> for <code>Enabled</code> and <code>0</code> for <code>Quantity</code>. Omit <code>Items</code>.</p> <p>To add, change, or remove one or more trusted signers, change <code>Enabled</code> to <code>true</code> (if it's currently <code>false</code>), change <code>Quantity</code> as applicable, and specify all of the trusted signers that you want to include in the updated distribution.</p> <p>For more information about updating the distribution configuration, see <a>DistributionConfig</a> .</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TrustedSigners {
     #[doc="<p>Specifies whether you want to require viewers to use signed URLs to access the files specified by <code>PathPattern</code> and <code>TargetOriginId</code>.</p>"]
     pub enabled: bool,
@@ -6861,7 +6863,7 @@ impl TrustedSignersSerializer {
 }
 
 #[doc="<p> The request to remove tags from a CloudFront resource.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UntagResourceRequest {
     #[doc="<p> An ARN of a CloudFront resource.</p>"]
     pub resource: String,
@@ -6870,7 +6872,7 @@ pub struct UntagResourceRequest {
 }
 
 #[doc="<p>The request to update an origin access identity.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateCloudFrontOriginAccessIdentityRequest {
     #[doc="<p>The identity's configuration information.</p>"]
     pub cloud_front_origin_access_identity_config: CloudFrontOriginAccessIdentityConfig,
@@ -6881,7 +6883,7 @@ pub struct UpdateCloudFrontOriginAccessIdentityRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateCloudFrontOriginAccessIdentityResult {
     #[doc="<p>The origin access identity's information.</p>"]
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
@@ -6932,7 +6934,7 @@ impl UpdateCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 #[doc="<p>The request to update a distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateDistributionRequest {
     #[doc="<p>The distribution's configuration information.</p>"]
     pub distribution_config: DistributionConfig,
@@ -6943,7 +6945,7 @@ pub struct UpdateDistributionRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateDistributionResult {
     #[doc="<p>The distribution's information.</p>"]
     pub distribution: Option<Distribution>,
@@ -6995,7 +6997,7 @@ impl UpdateDistributionResultDeserializer {
     }
 }
 #[doc="<p>The request to update a streaming distribution.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateStreamingDistributionRequest {
     #[doc="<p>The streaming distribution's id.</p>"]
     pub id: String,
@@ -7006,7 +7008,7 @@ pub struct UpdateStreamingDistributionRequest {
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateStreamingDistributionResult {
     #[doc="<p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
     pub e_tag: Option<String>,
@@ -7059,7 +7061,7 @@ impl UpdateStreamingDistributionResultDeserializer {
     }
 }
 #[doc="<p>A complex type that specifies the following:</p> <ul> <li> <p>Which SSL/TLS certificate to use when viewers request objects using HTTPS</p> </li> <li> <p>Whether you want CloudFront to use dedicated IP addresses or SNI when you're using alternate domain names in your object names</p> </li> <li> <p>The minimum protocol version that you want CloudFront to use when communicating with viewers</p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html\">Using an HTTPS Connection to Access Your Objects</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ViewerCertificate {
     pub acm_certificate_arn: Option<String>,
     pub cloud_front_default_certificate: Option<bool>,
@@ -7249,6 +7251,11 @@ impl From<CredentialsError> for CreateCloudFrontOriginAccessIdentityError {
 impl From<HttpDispatchError> for CreateCloudFrontOriginAccessIdentityError {
     fn from(err: HttpDispatchError) -> CreateCloudFrontOriginAccessIdentityError {
         CreateCloudFrontOriginAccessIdentityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateCloudFrontOriginAccessIdentityError {
+    fn from(err: io::Error) -> CreateCloudFrontOriginAccessIdentityError {
+        CreateCloudFrontOriginAccessIdentityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateCloudFrontOriginAccessIdentityError {
@@ -7454,6 +7461,11 @@ impl From<CredentialsError> for CreateDistributionError {
 impl From<HttpDispatchError> for CreateDistributionError {
     fn from(err: HttpDispatchError) -> CreateDistributionError {
         CreateDistributionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDistributionError {
+    fn from(err: io::Error) -> CreateDistributionError {
+        CreateDistributionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDistributionError {
@@ -7683,6 +7695,11 @@ impl From<HttpDispatchError> for CreateDistributionWithTagsError {
         CreateDistributionWithTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDistributionWithTagsError {
+    fn from(err: io::Error) -> CreateDistributionWithTagsError {
+        CreateDistributionWithTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDistributionWithTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7817,6 +7834,11 @@ impl From<HttpDispatchError> for CreateInvalidationError {
         CreateInvalidationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateInvalidationError {
+    fn from(err: io::Error) -> CreateInvalidationError {
+        CreateInvalidationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateInvalidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7922,6 +7944,11 @@ impl From<CredentialsError> for CreateStreamingDistributionError {
 impl From<HttpDispatchError> for CreateStreamingDistributionError {
     fn from(err: HttpDispatchError) -> CreateStreamingDistributionError {
         CreateStreamingDistributionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateStreamingDistributionError {
+    fn from(err: io::Error) -> CreateStreamingDistributionError {
+        CreateStreamingDistributionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateStreamingDistributionError {
@@ -8043,6 +8070,11 @@ impl From<HttpDispatchError> for CreateStreamingDistributionWithTagsError {
         CreateStreamingDistributionWithTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateStreamingDistributionWithTagsError {
+    fn from(err: io::Error) -> CreateStreamingDistributionWithTagsError {
+        CreateStreamingDistributionWithTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateStreamingDistributionWithTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8139,6 +8171,11 @@ impl From<HttpDispatchError> for DeleteCloudFrontOriginAccessIdentityError {
         DeleteCloudFrontOriginAccessIdentityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteCloudFrontOriginAccessIdentityError {
+    fn from(err: io::Error) -> DeleteCloudFrontOriginAccessIdentityError {
+        DeleteCloudFrontOriginAccessIdentityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteCloudFrontOriginAccessIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8225,6 +8262,11 @@ impl From<HttpDispatchError> for DeleteDistributionError {
         DeleteDistributionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDistributionError {
+    fn from(err: io::Error) -> DeleteDistributionError {
+        DeleteDistributionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8309,6 +8351,11 @@ impl From<HttpDispatchError> for DeleteStreamingDistributionError {
         DeleteStreamingDistributionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteStreamingDistributionError {
+    fn from(err: io::Error) -> DeleteStreamingDistributionError {
+        DeleteStreamingDistributionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteStreamingDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8384,6 +8431,11 @@ impl From<HttpDispatchError> for GetCloudFrontOriginAccessIdentityError {
         GetCloudFrontOriginAccessIdentityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetCloudFrontOriginAccessIdentityError {
+    fn from(err: io::Error) -> GetCloudFrontOriginAccessIdentityError {
+        GetCloudFrontOriginAccessIdentityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetCloudFrontOriginAccessIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8454,6 +8506,11 @@ impl From<CredentialsError> for GetCloudFrontOriginAccessIdentityConfigError {
 impl From<HttpDispatchError> for GetCloudFrontOriginAccessIdentityConfigError {
     fn from(err: HttpDispatchError) -> GetCloudFrontOriginAccessIdentityConfigError {
         GetCloudFrontOriginAccessIdentityConfigError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetCloudFrontOriginAccessIdentityConfigError {
+    fn from(err: io::Error) -> GetCloudFrontOriginAccessIdentityConfigError {
+        GetCloudFrontOriginAccessIdentityConfigError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetCloudFrontOriginAccessIdentityConfigError {
@@ -8532,6 +8589,11 @@ impl From<HttpDispatchError> for GetDistributionError {
         GetDistributionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDistributionError {
+    fn from(err: io::Error) -> GetDistributionError {
+        GetDistributionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8602,6 +8664,11 @@ impl From<CredentialsError> for GetDistributionConfigError {
 impl From<HttpDispatchError> for GetDistributionConfigError {
     fn from(err: HttpDispatchError) -> GetDistributionConfigError {
         GetDistributionConfigError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDistributionConfigError {
+    fn from(err: io::Error) -> GetDistributionConfigError {
+        GetDistributionConfigError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDistributionConfigError {
@@ -8685,6 +8752,11 @@ impl From<HttpDispatchError> for GetInvalidationError {
         GetInvalidationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInvalidationError {
+    fn from(err: io::Error) -> GetInvalidationError {
+        GetInvalidationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInvalidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8754,6 +8826,11 @@ impl From<CredentialsError> for GetStreamingDistributionError {
 impl From<HttpDispatchError> for GetStreamingDistributionError {
     fn from(err: HttpDispatchError) -> GetStreamingDistributionError {
         GetStreamingDistributionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetStreamingDistributionError {
+    fn from(err: io::Error) -> GetStreamingDistributionError {
+        GetStreamingDistributionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetStreamingDistributionError {
@@ -8828,6 +8905,11 @@ impl From<HttpDispatchError> for GetStreamingDistributionConfigError {
         GetStreamingDistributionConfigError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetStreamingDistributionConfigError {
+    fn from(err: io::Error) -> GetStreamingDistributionConfigError {
+        GetStreamingDistributionConfigError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetStreamingDistributionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8895,6 +8977,11 @@ impl From<CredentialsError> for ListCloudFrontOriginAccessIdentitiesError {
 impl From<HttpDispatchError> for ListCloudFrontOriginAccessIdentitiesError {
     fn from(err: HttpDispatchError) -> ListCloudFrontOriginAccessIdentitiesError {
         ListCloudFrontOriginAccessIdentitiesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListCloudFrontOriginAccessIdentitiesError {
+    fn from(err: io::Error) -> ListCloudFrontOriginAccessIdentitiesError {
+        ListCloudFrontOriginAccessIdentitiesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListCloudFrontOriginAccessIdentitiesError {
@@ -8967,6 +9054,11 @@ impl From<HttpDispatchError> for ListDistributionsError {
         ListDistributionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDistributionsError {
+    fn from(err: io::Error) -> ListDistributionsError {
+        ListDistributionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDistributionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9036,6 +9128,11 @@ impl From<CredentialsError> for ListDistributionsByWebACLIdError {
 impl From<HttpDispatchError> for ListDistributionsByWebACLIdError {
     fn from(err: HttpDispatchError) -> ListDistributionsByWebACLIdError {
         ListDistributionsByWebACLIdError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListDistributionsByWebACLIdError {
+    fn from(err: io::Error) -> ListDistributionsByWebACLIdError {
+        ListDistributionsByWebACLIdError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListDistributionsByWebACLIdError {
@@ -9117,6 +9214,11 @@ impl From<HttpDispatchError> for ListInvalidationsError {
         ListInvalidationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListInvalidationsError {
+    fn from(err: io::Error) -> ListInvalidationsError {
+        ListInvalidationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListInvalidationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9185,6 +9287,11 @@ impl From<CredentialsError> for ListStreamingDistributionsError {
 impl From<HttpDispatchError> for ListStreamingDistributionsError {
     fn from(err: HttpDispatchError) -> ListStreamingDistributionsError {
         ListStreamingDistributionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListStreamingDistributionsError {
+    fn from(err: io::Error) -> ListStreamingDistributionsError {
+        ListStreamingDistributionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListStreamingDistributionsError {
@@ -9268,6 +9375,11 @@ impl From<CredentialsError> for ListTagsForResourceError {
 impl From<HttpDispatchError> for ListTagsForResourceError {
     fn from(err: HttpDispatchError) -> ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForResourceError {
@@ -9358,6 +9470,11 @@ impl From<HttpDispatchError> for TagResourceError {
         TagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TagResourceError {
+    fn from(err: io::Error) -> TagResourceError {
+        TagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9442,6 +9559,11 @@ impl From<CredentialsError> for UntagResourceError {
 impl From<HttpDispatchError> for UntagResourceError {
     fn from(err: HttpDispatchError) -> UntagResourceError {
         UntagResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UntagResourceError {
+    fn from(err: io::Error) -> UntagResourceError {
+        UntagResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UntagResourceError {
@@ -9532,6 +9654,11 @@ impl From<CredentialsError> for UpdateCloudFrontOriginAccessIdentityError {
 impl From<HttpDispatchError> for UpdateCloudFrontOriginAccessIdentityError {
     fn from(err: HttpDispatchError) -> UpdateCloudFrontOriginAccessIdentityError {
         UpdateCloudFrontOriginAccessIdentityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateCloudFrontOriginAccessIdentityError {
+    fn from(err: io::Error) -> UpdateCloudFrontOriginAccessIdentityError {
+        UpdateCloudFrontOriginAccessIdentityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateCloudFrontOriginAccessIdentityError {
@@ -9742,6 +9869,11 @@ impl From<HttpDispatchError> for UpdateDistributionError {
         UpdateDistributionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDistributionError {
+    fn from(err: io::Error) -> UpdateDistributionError {
+        UpdateDistributionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9883,6 +10015,11 @@ impl From<CredentialsError> for UpdateStreamingDistributionError {
 impl From<HttpDispatchError> for UpdateStreamingDistributionError {
     fn from(err: HttpDispatchError) -> UpdateStreamingDistributionError {
         UpdateStreamingDistributionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateStreamingDistributionError {
+    fn from(err: io::Error) -> UpdateStreamingDistributionError {
+        UpdateStreamingDistributionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateStreamingDistributionError {
@@ -10144,7 +10281,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10152,11 +10289,13 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateCloudFrontOriginAccessIdentityResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10174,7 +10313,11 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(CreateCloudFrontOriginAccessIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCloudFrontOriginAccessIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10203,7 +10346,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10211,11 +10354,13 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDistributionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10236,8 +10381,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDistributionError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDistributionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10266,7 +10412,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10274,11 +10420,13 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDistributionWithTagsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10296,7 +10444,12 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(CreateDistributionWithTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDistributionWithTagsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -10325,7 +10478,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10333,11 +10486,13 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateInvalidationResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10354,8 +10509,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateInvalidationError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInvalidationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10384,7 +10540,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10392,11 +10548,13 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateStreamingDistributionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10414,7 +10572,12 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(CreateStreamingDistributionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStreamingDistributionError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -10443,7 +10606,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10451,11 +10614,13 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateStreamingDistributionWithTagsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10473,7 +10638,11 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(CreateStreamingDistributionWithTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStreamingDistributionWithTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10501,7 +10670,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10511,7 +10680,11 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteCloudFrontOriginAccessIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCloudFrontOriginAccessIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10538,7 +10711,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10549,8 +10722,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteDistributionError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDistributionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10578,7 +10752,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10588,7 +10762,12 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteStreamingDistributionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteStreamingDistributionError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -10613,7 +10792,7 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10621,11 +10800,13 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetCloudFrontOriginAccessIdentityResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10639,7 +10820,11 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(GetCloudFrontOriginAccessIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCloudFrontOriginAccessIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10662,7 +10847,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10670,11 +10855,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetCloudFrontOriginAccessIdentityConfigResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10688,7 +10875,11 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 };
                 Ok(result)
             }
-            _ => Err(GetCloudFrontOriginAccessIdentityConfigError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCloudFrontOriginAccessIdentityConfigError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10712,7 +10903,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10720,11 +10911,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetDistributionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10740,8 +10933,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 Ok(result)
             }
             _ => {
-                Err(GetDistributionError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDistributionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10767,7 +10961,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10775,11 +10969,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetDistributionConfigResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10794,8 +10990,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 Ok(result)
             }
             _ => {
-                Err(GetDistributionConfigError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDistributionConfigError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10822,7 +11019,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10830,11 +11027,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetInvalidationResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10847,8 +11046,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 Ok(result)
             }
             _ => {
-                Err(GetInvalidationError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInvalidationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10874,7 +11074,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10882,11 +11082,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetStreamingDistributionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10900,7 +11102,12 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 };
                 Ok(result)
             }
-            _ => Err(GetStreamingDistributionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetStreamingDistributionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -10925,7 +11132,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10933,11 +11140,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetStreamingDistributionConfigResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10951,7 +11160,12 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 };
                 Ok(result)
             }
-            _ => Err(GetStreamingDistributionConfigError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetStreamingDistributionConfigError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -10984,7 +11198,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -10992,11 +11206,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListCloudFrontOriginAccessIdentitiesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11007,7 +11223,11 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
 
                 Ok(result)
             }
-            _ => Err(ListCloudFrontOriginAccessIdentitiesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCloudFrontOriginAccessIdentitiesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11038,7 +11258,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11046,11 +11266,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListDistributionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11064,8 +11286,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 Ok(result)
             }
             _ => {
-                Err(ListDistributionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDistributionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11098,7 +11321,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11106,11 +11329,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListDistributionsByWebACLIdResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11121,7 +11346,12 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
 
                 Ok(result)
             }
-            _ => Err(ListDistributionsByWebACLIdError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDistributionsByWebACLIdError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -11152,7 +11382,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11160,11 +11390,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListInvalidationsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11178,8 +11410,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 Ok(result)
             }
             _ => {
-                Err(ListInvalidationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListInvalidationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11212,7 +11445,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11220,11 +11453,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListStreamingDistributionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11235,7 +11470,12 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
 
                 Ok(result)
             }
-            _ => Err(ListStreamingDistributionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListStreamingDistributionsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -11259,7 +11499,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11267,11 +11507,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTagsForResourceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11285,8 +11527,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 Ok(result)
             }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11312,7 +11555,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11322,7 +11565,11 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
 
                 Ok(result)
             }
-            _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11347,7 +11594,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11358,7 +11605,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 Ok(result)
             }
             _ => {
-                Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UntagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11392,7 +11641,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11400,11 +11649,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateCloudFrontOriginAccessIdentityResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11418,7 +11669,11 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 };
                 Ok(result)
             }
-            _ => Err(UpdateCloudFrontOriginAccessIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateCloudFrontOriginAccessIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11450,7 +11705,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11458,11 +11713,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateDistributionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11479,8 +11736,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 Ok(result)
             }
             _ => {
-                Err(UpdateDistributionError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDistributionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11512,7 +11770,7 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11520,11 +11778,13 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateStreamingDistributionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11538,7 +11798,12 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
                 };
                 Ok(result)
             }
-            _ => Err(UpdateStreamingDistributionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateStreamingDistributionError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -639,6 +641,11 @@ impl From<HttpDispatchError> for AddTagsToResourceError {
         AddTagsToResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToResourceError {
+    fn from(err: io::Error) -> AddTagsToResourceError {
+        AddTagsToResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -725,6 +732,11 @@ impl From<HttpDispatchError> for CreateHapgError {
         CreateHapgError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateHapgError {
+    fn from(err: io::Error) -> CreateHapgError {
+        CreateHapgError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateHapgError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -807,6 +819,11 @@ impl From<CredentialsError> for CreateHsmError {
 impl From<HttpDispatchError> for CreateHsmError {
     fn from(err: HttpDispatchError) -> CreateHsmError {
         CreateHsmError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateHsmError {
+    fn from(err: io::Error) -> CreateHsmError {
+        CreateHsmError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateHsmError {
@@ -895,6 +912,11 @@ impl From<HttpDispatchError> for CreateLunaClientError {
         CreateLunaClientError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLunaClientError {
+    fn from(err: io::Error) -> CreateLunaClientError {
+        CreateLunaClientError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLunaClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -979,6 +1001,11 @@ impl From<HttpDispatchError> for DeleteHapgError {
         DeleteHapgError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteHapgError {
+    fn from(err: io::Error) -> DeleteHapgError {
+        DeleteHapgError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteHapgError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1061,6 +1088,11 @@ impl From<CredentialsError> for DeleteHsmError {
 impl From<HttpDispatchError> for DeleteHsmError {
     fn from(err: HttpDispatchError) -> DeleteHsmError {
         DeleteHsmError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteHsmError {
+    fn from(err: io::Error) -> DeleteHsmError {
+        DeleteHsmError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteHsmError {
@@ -1149,6 +1181,11 @@ impl From<HttpDispatchError> for DeleteLunaClientError {
         DeleteLunaClientError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteLunaClientError {
+    fn from(err: io::Error) -> DeleteLunaClientError {
+        DeleteLunaClientError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteLunaClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1233,6 +1270,11 @@ impl From<CredentialsError> for DescribeHapgError {
 impl From<HttpDispatchError> for DescribeHapgError {
     fn from(err: HttpDispatchError) -> DescribeHapgError {
         DescribeHapgError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeHapgError {
+    fn from(err: io::Error) -> DescribeHapgError {
+        DescribeHapgError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeHapgError {
@@ -1321,6 +1363,11 @@ impl From<HttpDispatchError> for DescribeHsmError {
         DescribeHsmError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeHsmError {
+    fn from(err: io::Error) -> DescribeHsmError {
+        DescribeHsmError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeHsmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1405,6 +1452,11 @@ impl From<CredentialsError> for DescribeLunaClientError {
 impl From<HttpDispatchError> for DescribeLunaClientError {
     fn from(err: HttpDispatchError) -> DescribeLunaClientError {
         DescribeLunaClientError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLunaClientError {
+    fn from(err: io::Error) -> DescribeLunaClientError {
+        DescribeLunaClientError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLunaClientError {
@@ -1493,6 +1545,11 @@ impl From<HttpDispatchError> for GetConfigError {
         GetConfigError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetConfigError {
+    fn from(err: io::Error) -> GetConfigError {
+        GetConfigError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1577,6 +1634,11 @@ impl From<CredentialsError> for ListAvailableZonesError {
 impl From<HttpDispatchError> for ListAvailableZonesError {
     fn from(err: HttpDispatchError) -> ListAvailableZonesError {
         ListAvailableZonesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAvailableZonesError {
+    fn from(err: io::Error) -> ListAvailableZonesError {
+        ListAvailableZonesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAvailableZonesError {
@@ -1665,6 +1727,11 @@ impl From<HttpDispatchError> for ListHapgsError {
         ListHapgsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListHapgsError {
+    fn from(err: io::Error) -> ListHapgsError {
+        ListHapgsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListHapgsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1747,6 +1814,11 @@ impl From<CredentialsError> for ListHsmsError {
 impl From<HttpDispatchError> for ListHsmsError {
     fn from(err: HttpDispatchError) -> ListHsmsError {
         ListHsmsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListHsmsError {
+    fn from(err: io::Error) -> ListHsmsError {
+        ListHsmsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListHsmsError {
@@ -1835,6 +1907,11 @@ impl From<HttpDispatchError> for ListLunaClientsError {
         ListLunaClientsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListLunaClientsError {
+    fn from(err: io::Error) -> ListLunaClientsError {
+        ListLunaClientsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListLunaClientsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1919,6 +1996,11 @@ impl From<CredentialsError> for ListTagsForResourceError {
 impl From<HttpDispatchError> for ListTagsForResourceError {
     fn from(err: HttpDispatchError) -> ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForResourceError {
@@ -2007,6 +2089,11 @@ impl From<HttpDispatchError> for ModifyHapgError {
         ModifyHapgError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyHapgError {
+    fn from(err: io::Error) -> ModifyHapgError {
+        ModifyHapgError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyHapgError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2091,6 +2178,11 @@ impl From<HttpDispatchError> for ModifyHsmError {
         ModifyHsmError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyHsmError {
+    fn from(err: io::Error) -> ModifyHsmError {
+        ModifyHsmError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyHsmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2165,6 +2257,11 @@ impl From<CredentialsError> for ModifyLunaClientError {
 impl From<HttpDispatchError> for ModifyLunaClientError {
     fn from(err: HttpDispatchError) -> ModifyLunaClientError {
         ModifyLunaClientError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyLunaClientError {
+    fn from(err: io::Error) -> ModifyLunaClientError {
+        ModifyLunaClientError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyLunaClientError {
@@ -2249,6 +2346,11 @@ impl From<CredentialsError> for RemoveTagsFromResourceError {
 impl From<HttpDispatchError> for RemoveTagsFromResourceError {
     fn from(err: HttpDispatchError) -> RemoveTagsFromResourceError {
         RemoveTagsFromResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveTagsFromResourceError {
+    fn from(err: io::Error) -> RemoveTagsFromResourceError {
+        RemoveTagsFromResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveTagsFromResourceError {
@@ -2419,15 +2521,18 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddTagsToResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsToResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2446,13 +2551,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateHapgResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateHapgError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateHapgResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHapgError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2468,13 +2581,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateHsmResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateHsmError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateHsmResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHsmError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2492,15 +2613,20 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateLunaClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateLunaClientResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateLunaClientError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLunaClientError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2519,13 +2645,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteHapgResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteHapgError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteHapgResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteHapgError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2541,13 +2675,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteHsmResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteHsmError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteHsmResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteHsmError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2565,15 +2707,20 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteLunaClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteLunaClientResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteLunaClientError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLunaClientError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2592,14 +2739,20 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeHapgResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeHapgResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeHapgError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHapgError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2618,13 +2771,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeHsmResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeHsmError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeHsmResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHsmError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2642,15 +2803,18 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeLunaClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeLunaClientResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeLunaClientError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLunaClientError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2667,13 +2831,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetConfigResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetConfigError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetConfigResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetConfigError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2688,15 +2860,18 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAvailableZonesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAvailableZonesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListAvailableZonesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAvailableZonesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2713,13 +2888,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListHapgsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListHapgsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListHapgsResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHapgsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2735,13 +2918,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListHsmsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListHsmsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListHsmsResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHsmsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2759,15 +2950,20 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListLunaClientsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListLunaClientsResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListLunaClientsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListLunaClientsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2787,15 +2983,18 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2814,13 +3013,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyHapgResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ModifyHapgError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyHapgResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyHapgError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2836,13 +3043,21 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyHsmResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ModifyHsmError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyHsmResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyHsmError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2860,15 +3075,20 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyLunaClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyLunaClientResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ModifyLunaClientError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyLunaClientError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2889,15 +3109,18 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTagsFromResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTagsFromResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -5268,6 +5270,11 @@ impl From<HttpDispatchError> for BuildSuggestersError {
         BuildSuggestersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BuildSuggestersError {
+    fn from(err: io::Error) -> BuildSuggestersError {
+        BuildSuggestersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BuildSuggestersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5344,6 +5351,11 @@ impl From<CredentialsError> for CreateDomainError {
 impl From<HttpDispatchError> for CreateDomainError {
     fn from(err: HttpDispatchError) -> CreateDomainError {
         CreateDomainError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDomainError {
+    fn from(err: io::Error) -> CreateDomainError {
+        CreateDomainError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDomainError {
@@ -5432,6 +5444,11 @@ impl From<CredentialsError> for DefineAnalysisSchemeError {
 impl From<HttpDispatchError> for DefineAnalysisSchemeError {
     fn from(err: HttpDispatchError) -> DefineAnalysisSchemeError {
         DefineAnalysisSchemeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DefineAnalysisSchemeError {
+    fn from(err: io::Error) -> DefineAnalysisSchemeError {
+        DefineAnalysisSchemeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DefineAnalysisSchemeError {
@@ -5528,6 +5545,11 @@ impl From<HttpDispatchError> for DefineExpressionError {
         DefineExpressionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DefineExpressionError {
+    fn from(err: io::Error) -> DefineExpressionError {
+        DefineExpressionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DefineExpressionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5618,6 +5640,11 @@ impl From<CredentialsError> for DefineIndexFieldError {
 impl From<HttpDispatchError> for DefineIndexFieldError {
     fn from(err: HttpDispatchError) -> DefineIndexFieldError {
         DefineIndexFieldError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DefineIndexFieldError {
+    fn from(err: io::Error) -> DefineIndexFieldError {
+        DefineIndexFieldError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DefineIndexFieldError {
@@ -5712,6 +5739,11 @@ impl From<HttpDispatchError> for DefineSuggesterError {
         DefineSuggesterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DefineSuggesterError {
+    fn from(err: io::Error) -> DefineSuggesterError {
+        DefineSuggesterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DefineSuggesterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5797,6 +5829,11 @@ impl From<HttpDispatchError> for DeleteAnalysisSchemeError {
         DeleteAnalysisSchemeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAnalysisSchemeError {
+    fn from(err: io::Error) -> DeleteAnalysisSchemeError {
+        DeleteAnalysisSchemeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAnalysisSchemeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5871,6 +5908,11 @@ impl From<CredentialsError> for DeleteDomainError {
 impl From<HttpDispatchError> for DeleteDomainError {
     fn from(err: HttpDispatchError) -> DeleteDomainError {
         DeleteDomainError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDomainError {
+    fn from(err: io::Error) -> DeleteDomainError {
+        DeleteDomainError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDomainError {
@@ -5955,6 +5997,11 @@ impl From<CredentialsError> for DeleteExpressionError {
 impl From<HttpDispatchError> for DeleteExpressionError {
     fn from(err: HttpDispatchError) -> DeleteExpressionError {
         DeleteExpressionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteExpressionError {
+    fn from(err: io::Error) -> DeleteExpressionError {
+        DeleteExpressionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteExpressionError {
@@ -6043,6 +6090,11 @@ impl From<HttpDispatchError> for DeleteIndexFieldError {
         DeleteIndexFieldError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteIndexFieldError {
+    fn from(err: io::Error) -> DeleteIndexFieldError {
+        DeleteIndexFieldError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteIndexFieldError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6129,6 +6181,11 @@ impl From<HttpDispatchError> for DeleteSuggesterError {
         DeleteSuggesterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteSuggesterError {
+    fn from(err: io::Error) -> DeleteSuggesterError {
+        DeleteSuggesterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteSuggesterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6206,6 +6263,11 @@ impl From<CredentialsError> for DescribeAnalysisSchemesError {
 impl From<HttpDispatchError> for DescribeAnalysisSchemesError {
     fn from(err: HttpDispatchError) -> DescribeAnalysisSchemesError {
         DescribeAnalysisSchemesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAnalysisSchemesError {
+    fn from(err: io::Error) -> DescribeAnalysisSchemesError {
+        DescribeAnalysisSchemesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAnalysisSchemesError {
@@ -6295,6 +6357,11 @@ impl From<HttpDispatchError> for DescribeAvailabilityOptionsError {
         DescribeAvailabilityOptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAvailabilityOptionsError {
+    fn from(err: io::Error) -> DescribeAvailabilityOptionsError {
+        DescribeAvailabilityOptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAvailabilityOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6375,6 +6442,11 @@ impl From<HttpDispatchError> for DescribeDomainsError {
         DescribeDomainsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDomainsError {
+    fn from(err: io::Error) -> DescribeDomainsError {
+        DescribeDomainsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6450,6 +6522,11 @@ impl From<CredentialsError> for DescribeExpressionsError {
 impl From<HttpDispatchError> for DescribeExpressionsError {
     fn from(err: HttpDispatchError) -> DescribeExpressionsError {
         DescribeExpressionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeExpressionsError {
+    fn from(err: io::Error) -> DescribeExpressionsError {
+        DescribeExpressionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeExpressionsError {
@@ -6532,6 +6609,11 @@ impl From<HttpDispatchError> for DescribeIndexFieldsError {
         DescribeIndexFieldsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeIndexFieldsError {
+    fn from(err: io::Error) -> DescribeIndexFieldsError {
+        DescribeIndexFieldsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeIndexFieldsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6612,6 +6694,11 @@ impl From<HttpDispatchError> for DescribeScalingParametersError {
         DescribeScalingParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeScalingParametersError {
+    fn from(err: io::Error) -> DescribeScalingParametersError {
+        DescribeScalingParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeScalingParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6688,6 +6775,11 @@ impl From<CredentialsError> for DescribeServiceAccessPoliciesError {
 impl From<HttpDispatchError> for DescribeServiceAccessPoliciesError {
     fn from(err: HttpDispatchError) -> DescribeServiceAccessPoliciesError {
         DescribeServiceAccessPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeServiceAccessPoliciesError {
+    fn from(err: io::Error) -> DescribeServiceAccessPoliciesError {
+        DescribeServiceAccessPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeServiceAccessPoliciesError {
@@ -6768,6 +6860,11 @@ impl From<CredentialsError> for DescribeSuggestersError {
 impl From<HttpDispatchError> for DescribeSuggestersError {
     fn from(err: HttpDispatchError) -> DescribeSuggestersError {
         DescribeSuggestersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSuggestersError {
+    fn from(err: io::Error) -> DescribeSuggestersError {
+        DescribeSuggestersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSuggestersError {
@@ -6852,6 +6949,11 @@ impl From<HttpDispatchError> for IndexDocumentsError {
         IndexDocumentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for IndexDocumentsError {
+    fn from(err: io::Error) -> IndexDocumentsError {
+        IndexDocumentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for IndexDocumentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6920,6 +7022,11 @@ impl From<CredentialsError> for ListDomainNamesError {
 impl From<HttpDispatchError> for ListDomainNamesError {
     fn from(err: HttpDispatchError) -> ListDomainNamesError {
         ListDomainNamesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListDomainNamesError {
+    fn from(err: io::Error) -> ListDomainNamesError {
+        ListDomainNamesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListDomainNamesError {
@@ -7005,6 +7112,11 @@ impl From<CredentialsError> for UpdateAvailabilityOptionsError {
 impl From<HttpDispatchError> for UpdateAvailabilityOptionsError {
     fn from(err: HttpDispatchError) -> UpdateAvailabilityOptionsError {
         UpdateAvailabilityOptionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAvailabilityOptionsError {
+    fn from(err: io::Error) -> UpdateAvailabilityOptionsError {
+        UpdateAvailabilityOptionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAvailabilityOptionsError {
@@ -7096,6 +7208,11 @@ impl From<HttpDispatchError> for UpdateScalingParametersError {
         UpdateScalingParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateScalingParametersError {
+    fn from(err: io::Error) -> UpdateScalingParametersError {
+        UpdateScalingParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateScalingParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7180,6 +7297,11 @@ impl From<CredentialsError> for UpdateServiceAccessPoliciesError {
 impl From<HttpDispatchError> for UpdateServiceAccessPoliciesError {
     fn from(err: HttpDispatchError) -> UpdateServiceAccessPoliciesError {
         UpdateServiceAccessPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateServiceAccessPoliciesError {
+    fn from(err: io::Error) -> UpdateServiceAccessPoliciesError {
+        UpdateServiceAccessPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateServiceAccessPoliciesError {
@@ -7396,16 +7518,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = BuildSuggestersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7420,8 +7544,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(BuildSuggestersError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BuildSuggestersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7440,16 +7565,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDomainResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7464,7 +7591,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDomainError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7484,16 +7613,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DefineAnalysisSchemeResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7509,8 +7640,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DefineAnalysisSchemeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DefineAnalysisSchemeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7529,16 +7661,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DefineExpressionResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7553,8 +7687,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DefineExpressionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DefineExpressionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7573,16 +7708,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DefineIndexFieldResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7597,8 +7734,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DefineIndexFieldError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DefineIndexFieldError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7617,16 +7755,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DefineSuggesterResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7641,8 +7781,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DefineSuggesterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DefineSuggesterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7662,16 +7803,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteAnalysisSchemeResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7687,8 +7830,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteAnalysisSchemeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAnalysisSchemeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7707,16 +7851,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteDomainResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7731,7 +7877,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteDomainError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7750,16 +7898,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteExpressionResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7774,8 +7924,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteExpressionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteExpressionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7794,16 +7945,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteIndexFieldResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7818,8 +7971,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteIndexFieldError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIndexFieldError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7838,16 +7992,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteSuggesterResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7862,8 +8018,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteSuggesterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSuggesterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7883,16 +8040,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAnalysisSchemesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7908,8 +8067,11 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAnalysisSchemesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAnalysisSchemesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -7928,16 +8090,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAvailabilityOptionsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7951,8 +8115,11 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAvailabilityOptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAvailabilityOptionsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -7970,16 +8137,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeDomainsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7994,8 +8163,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeDomainsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDomainsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8014,16 +8184,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeExpressionsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8038,8 +8210,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeExpressionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeExpressionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8058,16 +8231,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeIndexFieldsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8082,8 +8257,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeIndexFieldsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeIndexFieldsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8103,16 +8279,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeScalingParametersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8126,8 +8304,11 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeScalingParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeScalingParametersError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -8146,16 +8327,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeServiceAccessPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8169,8 +8352,11 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeServiceAccessPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeServiceAccessPoliciesError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -8188,16 +8374,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSuggestersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8212,8 +8400,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeSuggestersError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSuggestersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8232,16 +8421,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = IndexDocumentsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8256,8 +8447,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(IndexDocumentsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(IndexDocumentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8274,16 +8466,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListDomainNamesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8298,8 +8492,9 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListDomainNamesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDomainNamesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8319,16 +8514,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateAvailabilityOptionsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8342,8 +8539,11 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(UpdateAvailabilityOptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAvailabilityOptionsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -8362,16 +8562,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateScalingParametersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8387,8 +8589,11 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(UpdateScalingParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateScalingParametersError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -8407,16 +8612,18 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateServiceAccessPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8430,8 +8637,11 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(UpdateServiceAccessPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateServiceAccessPoliciesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -801,6 +803,11 @@ impl From<HttpDispatchError> for AddTagsError {
         AddTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsError {
+    fn from(err: io::Error) -> AddTagsError {
+        AddTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -976,6 +983,11 @@ impl From<HttpDispatchError> for CreateTrailError {
         CreateTrailError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTrailError {
+    fn from(err: io::Error) -> CreateTrailError {
+        CreateTrailError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTrailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1080,6 +1092,11 @@ impl From<HttpDispatchError> for DeleteTrailError {
         DeleteTrailError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTrailError {
+    fn from(err: io::Error) -> DeleteTrailError {
+        DeleteTrailError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTrailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1159,6 +1176,11 @@ impl From<CredentialsError> for DescribeTrailsError {
 impl From<HttpDispatchError> for DescribeTrailsError {
     fn from(err: HttpDispatchError) -> DescribeTrailsError {
         DescribeTrailsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTrailsError {
+    fn from(err: io::Error) -> DescribeTrailsError {
+        DescribeTrailsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTrailsError {
@@ -1251,6 +1273,11 @@ impl From<HttpDispatchError> for GetEventSelectorsError {
         GetEventSelectorsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetEventSelectorsError {
+    fn from(err: io::Error) -> GetEventSelectorsError {
+        GetEventSelectorsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetEventSelectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1333,6 +1360,11 @@ impl From<CredentialsError> for GetTrailStatusError {
 impl From<HttpDispatchError> for GetTrailStatusError {
     fn from(err: HttpDispatchError) -> GetTrailStatusError {
         GetTrailStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetTrailStatusError {
+    fn from(err: io::Error) -> GetTrailStatusError {
+        GetTrailStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetTrailStatusError {
@@ -1423,6 +1455,11 @@ impl From<CredentialsError> for ListPublicKeysError {
 impl From<HttpDispatchError> for ListPublicKeysError {
     fn from(err: HttpDispatchError) -> ListPublicKeysError {
         ListPublicKeysError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPublicKeysError {
+    fn from(err: io::Error) -> ListPublicKeysError {
+        ListPublicKeysError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPublicKeysError {
@@ -1530,6 +1567,11 @@ impl From<HttpDispatchError> for ListTagsError {
         ListTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTagsError {
+    fn from(err: io::Error) -> ListTagsError {
+        ListTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1623,6 +1665,11 @@ impl From<CredentialsError> for LookupEventsError {
 impl From<HttpDispatchError> for LookupEventsError {
     fn from(err: HttpDispatchError) -> LookupEventsError {
         LookupEventsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for LookupEventsError {
+    fn from(err: io::Error) -> LookupEventsError {
+        LookupEventsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for LookupEventsError {
@@ -1725,6 +1772,11 @@ impl From<CredentialsError> for PutEventSelectorsError {
 impl From<HttpDispatchError> for PutEventSelectorsError {
     fn from(err: HttpDispatchError) -> PutEventSelectorsError {
         PutEventSelectorsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutEventSelectorsError {
+    fn from(err: io::Error) -> PutEventSelectorsError {
+        PutEventSelectorsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutEventSelectorsError {
@@ -1836,6 +1888,11 @@ impl From<HttpDispatchError> for RemoveTagsError {
         RemoveTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTagsError {
+    fn from(err: io::Error) -> RemoveTagsError {
+        RemoveTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1926,6 +1983,11 @@ impl From<HttpDispatchError> for StartLoggingError {
         StartLoggingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartLoggingError {
+    fn from(err: io::Error) -> StartLoggingError {
+        StartLoggingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2010,6 +2072,11 @@ impl From<CredentialsError> for StopLoggingError {
 impl From<HttpDispatchError> for StopLoggingError {
     fn from(err: HttpDispatchError) -> StopLoggingError {
         StopLoggingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopLoggingError {
+    fn from(err: io::Error) -> StopLoggingError {
+        StopLoggingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopLoggingError {
@@ -2182,6 +2249,11 @@ impl From<HttpDispatchError> for UpdateTrailError {
         UpdateTrailError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateTrailError {
+    fn from(err: io::Error) -> UpdateTrailError {
+        UpdateTrailError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateTrailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2338,15 +2410,20 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<AddTagsResponse>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AddTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2365,13 +2442,21 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateTrailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateTrailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateTrailResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTrailError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2390,13 +2475,21 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteTrailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteTrailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteTrailResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTrailError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2415,15 +2508,20 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTrailsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTrailsResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTrailsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTrailsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2442,15 +2540,18 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetEventSelectorsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetEventSelectorsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetEventSelectorsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetEventSelectorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2470,15 +2571,20 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetTrailStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetTrailStatusResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetTrailStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTrailStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2498,15 +2604,20 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPublicKeysResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPublicKeysResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListPublicKeysError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPublicKeysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2524,13 +2635,21 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2549,14 +2668,20 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<LookupEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<LookupEventsResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(LookupEventsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(LookupEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2575,15 +2700,18 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutEventSelectorsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutEventSelectorsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(PutEventSelectorsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutEventSelectorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2603,13 +2731,21 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTagsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RemoveTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTagsResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2628,14 +2764,20 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartLoggingResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartLoggingResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StartLoggingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartLoggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2655,13 +2797,21 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopLoggingResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StopLoggingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopLoggingResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopLoggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2680,13 +2830,21 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateTrailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateTrailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateTrailResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateTrailError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2201,6 +2203,11 @@ impl From<HttpDispatchError> for DeleteAlarmsError {
         DeleteAlarmsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAlarmsError {
+    fn from(err: io::Error) -> DeleteAlarmsError {
+        DeleteAlarmsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAlarmsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2265,6 +2272,11 @@ impl From<CredentialsError> for DescribeAlarmHistoryError {
 impl From<HttpDispatchError> for DescribeAlarmHistoryError {
     fn from(err: HttpDispatchError) -> DescribeAlarmHistoryError {
         DescribeAlarmHistoryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAlarmHistoryError {
+    fn from(err: io::Error) -> DescribeAlarmHistoryError {
+        DescribeAlarmHistoryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAlarmHistoryError {
@@ -2337,6 +2349,11 @@ impl From<HttpDispatchError> for DescribeAlarmsError {
         DescribeAlarmsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAlarmsError {
+    fn from(err: io::Error) -> DescribeAlarmsError {
+        DescribeAlarmsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAlarmsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2398,6 +2415,11 @@ impl From<CredentialsError> for DescribeAlarmsForMetricError {
 impl From<HttpDispatchError> for DescribeAlarmsForMetricError {
     fn from(err: HttpDispatchError) -> DescribeAlarmsForMetricError {
         DescribeAlarmsForMetricError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAlarmsForMetricError {
+    fn from(err: io::Error) -> DescribeAlarmsForMetricError {
+        DescribeAlarmsForMetricError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAlarmsForMetricError {
@@ -2464,6 +2486,11 @@ impl From<HttpDispatchError> for DisableAlarmActionsError {
         DisableAlarmActionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisableAlarmActionsError {
+    fn from(err: io::Error) -> DisableAlarmActionsError {
+        DisableAlarmActionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisableAlarmActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2526,6 +2553,11 @@ impl From<CredentialsError> for EnableAlarmActionsError {
 impl From<HttpDispatchError> for EnableAlarmActionsError {
     fn from(err: HttpDispatchError) -> EnableAlarmActionsError {
         EnableAlarmActionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnableAlarmActionsError {
+    fn from(err: io::Error) -> EnableAlarmActionsError {
+        EnableAlarmActionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnableAlarmActionsError {
@@ -2602,6 +2634,11 @@ impl From<CredentialsError> for GetMetricStatisticsError {
 impl From<HttpDispatchError> for GetMetricStatisticsError {
     fn from(err: HttpDispatchError) -> GetMetricStatisticsError {
         GetMetricStatisticsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetMetricStatisticsError {
+    fn from(err: io::Error) -> GetMetricStatisticsError {
+        GetMetricStatisticsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetMetricStatisticsError {
@@ -2682,6 +2719,11 @@ impl From<HttpDispatchError> for ListMetricsError {
         ListMetricsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListMetricsError {
+    fn from(err: io::Error) -> ListMetricsError {
+        ListMetricsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListMetricsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2749,6 +2791,11 @@ impl From<CredentialsError> for PutMetricAlarmError {
 impl From<HttpDispatchError> for PutMetricAlarmError {
     fn from(err: HttpDispatchError) -> PutMetricAlarmError {
         PutMetricAlarmError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutMetricAlarmError {
+    fn from(err: io::Error) -> PutMetricAlarmError {
+        PutMetricAlarmError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutMetricAlarmError {
@@ -2828,6 +2875,11 @@ impl From<HttpDispatchError> for PutMetricDataError {
         PutMetricDataError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutMetricDataError {
+    fn from(err: io::Error) -> PutMetricDataError {
+        PutMetricDataError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2902,6 +2954,11 @@ impl From<CredentialsError> for SetAlarmStateError {
 impl From<HttpDispatchError> for SetAlarmStateError {
     fn from(err: HttpDispatchError) -> SetAlarmStateError {
         SetAlarmStateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetAlarmStateError {
+    fn from(err: io::Error) -> SetAlarmStateError {
+        SetAlarmStateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetAlarmStateError {
@@ -3019,14 +3076,16 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteAlarmsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAlarmsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3045,16 +3104,18 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAlarmHistoryOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3069,8 +3130,9 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeAlarmHistoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAlarmHistoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3089,16 +3151,18 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAlarmsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3113,8 +3177,9 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeAlarmsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAlarmsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3134,16 +3199,18 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAlarmsForMetricOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3159,8 +3226,11 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAlarmsForMetricError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAlarmsForMetricError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -3178,15 +3248,16 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DisableAlarmActionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableAlarmActionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3205,15 +3276,16 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(EnableAlarmActionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableAlarmActionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3232,16 +3304,18 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetMetricStatisticsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3256,8 +3330,9 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetMetricStatisticsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetMetricStatisticsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3276,16 +3351,18 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListMetricsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3299,7 +3376,11 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListMetricsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListMetricsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3315,15 +3396,16 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(PutMetricAlarmError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutMetricAlarmError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3340,14 +3422,16 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(PutMetricDataError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutMetricDataError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3364,14 +3448,16 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SetAlarmStateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetAlarmStateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -640,6 +642,11 @@ impl From<HttpDispatchError> for BatchGetRepositoriesError {
         BatchGetRepositoriesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchGetRepositoriesError {
+    fn from(err: io::Error) -> BatchGetRepositoriesError {
+        BatchGetRepositoriesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchGetRepositoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -786,6 +793,11 @@ impl From<HttpDispatchError> for CreateBranchError {
         CreateBranchError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateBranchError {
+    fn from(err: io::Error) -> CreateBranchError {
+        CreateBranchError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -912,6 +924,11 @@ impl From<HttpDispatchError> for CreateRepositoryError {
         CreateRepositoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRepositoryError {
+    fn from(err: io::Error) -> CreateRepositoryError {
+        CreateRepositoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1019,6 +1036,11 @@ impl From<CredentialsError> for DeleteRepositoryError {
 impl From<HttpDispatchError> for DeleteRepositoryError {
     fn from(err: HttpDispatchError) -> DeleteRepositoryError {
         DeleteRepositoryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteRepositoryError {
+    fn from(err: io::Error) -> DeleteRepositoryError {
+        DeleteRepositoryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteRepositoryError {
@@ -1154,6 +1176,11 @@ impl From<HttpDispatchError> for GetBlobError {
         GetBlobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBlobError {
+    fn from(err: io::Error) -> GetBlobError {
+        GetBlobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBlobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1287,6 +1314,11 @@ impl From<HttpDispatchError> for GetBranchError {
         GetBranchError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBranchError {
+    fn from(err: io::Error) -> GetBranchError {
+        GetBranchError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1417,6 +1449,11 @@ impl From<CredentialsError> for GetCommitError {
 impl From<HttpDispatchError> for GetCommitError {
     fn from(err: HttpDispatchError) -> GetCommitError {
         GetCommitError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetCommitError {
+    fn from(err: io::Error) -> GetCommitError {
+        GetCommitError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetCommitError {
@@ -1576,6 +1613,11 @@ impl From<HttpDispatchError> for GetDifferencesError {
         GetDifferencesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDifferencesError {
+    fn from(err: io::Error) -> GetDifferencesError {
+        GetDifferencesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDifferencesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1698,6 +1740,11 @@ impl From<HttpDispatchError> for GetRepositoryError {
         GetRepositoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRepositoryError {
+    fn from(err: io::Error) -> GetRepositoryError {
+        GetRepositoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1796,6 +1843,11 @@ impl From<CredentialsError> for GetRepositoryTriggersError {
 impl From<HttpDispatchError> for GetRepositoryTriggersError {
     fn from(err: HttpDispatchError) -> GetRepositoryTriggersError {
         GetRepositoryTriggersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetRepositoryTriggersError {
+    fn from(err: io::Error) -> GetRepositoryTriggersError {
+        GetRepositoryTriggersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetRepositoryTriggersError {
@@ -1919,6 +1971,11 @@ impl From<HttpDispatchError> for ListBranchesError {
         ListBranchesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListBranchesError {
+    fn from(err: io::Error) -> ListBranchesError {
+        ListBranchesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListBranchesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2009,6 +2066,11 @@ impl From<CredentialsError> for ListRepositoriesError {
 impl From<HttpDispatchError> for ListRepositoriesError {
     fn from(err: HttpDispatchError) -> ListRepositoriesError {
         ListRepositoriesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRepositoriesError {
+    fn from(err: io::Error) -> ListRepositoriesError {
+        ListRepositoriesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRepositoriesError {
@@ -2143,6 +2205,11 @@ impl From<CredentialsError> for PutRepositoryTriggersError {
 impl From<HttpDispatchError> for PutRepositoryTriggersError {
     fn from(err: HttpDispatchError) -> PutRepositoryTriggersError {
         PutRepositoryTriggersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutRepositoryTriggersError {
+    fn from(err: io::Error) -> PutRepositoryTriggersError {
+        PutRepositoryTriggersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutRepositoryTriggersError {
@@ -2299,6 +2366,11 @@ impl From<HttpDispatchError> for TestRepositoryTriggersError {
         TestRepositoryTriggersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TestRepositoryTriggersError {
+    fn from(err: io::Error) -> TestRepositoryTriggersError {
+        TestRepositoryTriggersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TestRepositoryTriggersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2439,6 +2511,11 @@ impl From<HttpDispatchError> for UpdateDefaultBranchError {
         UpdateDefaultBranchError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDefaultBranchError {
+    fn from(err: io::Error) -> UpdateDefaultBranchError {
+        UpdateDefaultBranchError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDefaultBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2547,6 +2624,11 @@ impl From<HttpDispatchError> for UpdateRepositoryDescriptionError {
         UpdateRepositoryDescriptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateRepositoryDescriptionError {
+    fn from(err: io::Error) -> UpdateRepositoryDescriptionError {
+        UpdateRepositoryDescriptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateRepositoryDescriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2638,6 +2720,11 @@ impl From<CredentialsError> for UpdateRepositoryNameError {
 impl From<HttpDispatchError> for UpdateRepositoryNameError {
     fn from(err: HttpDispatchError) -> UpdateRepositoryNameError {
         UpdateRepositoryNameError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateRepositoryNameError {
+    fn from(err: io::Error) -> UpdateRepositoryNameError {
+        UpdateRepositoryNameError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateRepositoryNameError {
@@ -2799,15 +2886,18 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetRepositoriesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetRepositoriesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(BatchGetRepositoriesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetRepositoriesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2824,12 +2914,14 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(CreateBranchError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateBranchError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2848,15 +2940,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateRepositoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateRepositoryOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateRepositoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRepositoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2875,15 +2972,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRepositoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRepositoryOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteRepositoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRepositoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2900,15 +3002,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetBlobOutput>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetBlobOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetBlobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBlobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2924,15 +3031,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetBranchOutput>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetBranchOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetBranchError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBranchError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2948,15 +3060,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetCommitOutput>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetCommitOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetCommitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCommitError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2974,15 +3091,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDifferencesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDifferencesOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetDifferencesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDifferencesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3001,14 +3123,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRepositoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRepositoryOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetRepositoryError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRepositoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3028,15 +3156,18 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRepositoryTriggersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRepositoryTriggersOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetRepositoryTriggersError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRepositoryTriggersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3055,14 +3186,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListBranchesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListBranchesOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListBranchesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListBranchesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3081,15 +3218,20 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRepositoriesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRepositoriesOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListRepositoriesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRepositoriesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3109,15 +3251,18 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutRepositoryTriggersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutRepositoryTriggersOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(PutRepositoryTriggersError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRepositoryTriggersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3137,15 +3282,18 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TestRepositoryTriggersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<TestRepositoryTriggersOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(TestRepositoryTriggersError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestRepositoryTriggersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3164,13 +3312,14 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateDefaultBranchError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDefaultBranchError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3190,11 +3339,16 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(UpdateRepositoryDescriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRepositoryDescriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -3212,13 +3366,14 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateRepositoryNameError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRepositoryNameError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1724,6 +1726,11 @@ impl From<HttpDispatchError> for AddTagsToOnPremisesInstancesError {
         AddTagsToOnPremisesInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToOnPremisesInstancesError {
+    fn from(err: io::Error) -> AddTagsToOnPremisesInstancesError {
+        AddTagsToOnPremisesInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToOnPremisesInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1818,6 +1825,11 @@ impl From<HttpDispatchError> for BatchGetApplicationRevisionsError {
         BatchGetApplicationRevisionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchGetApplicationRevisionsError {
+    fn from(err: io::Error) -> BatchGetApplicationRevisionsError {
+        BatchGetApplicationRevisionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchGetApplicationRevisionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1906,6 +1918,11 @@ impl From<CredentialsError> for BatchGetApplicationsError {
 impl From<HttpDispatchError> for BatchGetApplicationsError {
     fn from(err: HttpDispatchError) -> BatchGetApplicationsError {
         BatchGetApplicationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for BatchGetApplicationsError {
+    fn from(err: io::Error) -> BatchGetApplicationsError {
+        BatchGetApplicationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for BatchGetApplicationsError {
@@ -1998,6 +2015,11 @@ impl From<CredentialsError> for BatchGetDeploymentGroupsError {
 impl From<HttpDispatchError> for BatchGetDeploymentGroupsError {
     fn from(err: HttpDispatchError) -> BatchGetDeploymentGroupsError {
         BatchGetDeploymentGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for BatchGetDeploymentGroupsError {
+    fn from(err: io::Error) -> BatchGetDeploymentGroupsError {
+        BatchGetDeploymentGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for BatchGetDeploymentGroupsError {
@@ -2094,6 +2116,11 @@ impl From<HttpDispatchError> for BatchGetDeploymentInstancesError {
         BatchGetDeploymentInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchGetDeploymentInstancesError {
+    fn from(err: io::Error) -> BatchGetDeploymentInstancesError {
+        BatchGetDeploymentInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchGetDeploymentInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2185,6 +2212,11 @@ impl From<HttpDispatchError> for BatchGetDeploymentsError {
         BatchGetDeploymentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchGetDeploymentsError {
+    fn from(err: io::Error) -> BatchGetDeploymentsError {
+        BatchGetDeploymentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchGetDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2265,6 +2297,11 @@ impl From<CredentialsError> for BatchGetOnPremisesInstancesError {
 impl From<HttpDispatchError> for BatchGetOnPremisesInstancesError {
     fn from(err: HttpDispatchError) -> BatchGetOnPremisesInstancesError {
         BatchGetOnPremisesInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for BatchGetOnPremisesInstancesError {
+    fn from(err: io::Error) -> BatchGetOnPremisesInstancesError {
+        BatchGetOnPremisesInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for BatchGetOnPremisesInstancesError {
@@ -2364,6 +2401,11 @@ impl From<HttpDispatchError> for ContinueDeploymentError {
         ContinueDeploymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ContinueDeploymentError {
+    fn from(err: io::Error) -> ContinueDeploymentError {
+        ContinueDeploymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ContinueDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2454,6 +2496,11 @@ impl From<CredentialsError> for CreateApplicationError {
 impl From<HttpDispatchError> for CreateApplicationError {
     fn from(err: HttpDispatchError) -> CreateApplicationError {
         CreateApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateApplicationError {
+    fn from(err: io::Error) -> CreateApplicationError {
+        CreateApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateApplicationError {
@@ -2601,6 +2648,11 @@ impl From<HttpDispatchError> for CreateDeploymentError {
         CreateDeploymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDeploymentError {
+    fn from(err: io::Error) -> CreateDeploymentError {
+        CreateDeploymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2699,6 +2751,11 @@ impl From<CredentialsError> for CreateDeploymentConfigError {
 impl From<HttpDispatchError> for CreateDeploymentConfigError {
     fn from(err: HttpDispatchError) -> CreateDeploymentConfigError {
         CreateDeploymentConfigError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDeploymentConfigError {
+    fn from(err: io::Error) -> CreateDeploymentConfigError {
+        CreateDeploymentConfigError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDeploymentConfigError {
@@ -2857,6 +2914,11 @@ impl From<HttpDispatchError> for CreateDeploymentGroupError {
         CreateDeploymentGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDeploymentGroupError {
+    fn from(err: io::Error) -> CreateDeploymentGroupError {
+        CreateDeploymentGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDeploymentGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2960,6 +3022,11 @@ impl From<HttpDispatchError> for DeleteApplicationError {
         DeleteApplicationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteApplicationError {
+    fn from(err: io::Error) -> DeleteApplicationError {
+        DeleteApplicationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3044,6 +3111,11 @@ impl From<CredentialsError> for DeleteDeploymentConfigError {
 impl From<HttpDispatchError> for DeleteDeploymentConfigError {
     fn from(err: HttpDispatchError) -> DeleteDeploymentConfigError {
         DeleteDeploymentConfigError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDeploymentConfigError {
+    fn from(err: io::Error) -> DeleteDeploymentConfigError {
+        DeleteDeploymentConfigError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDeploymentConfigError {
@@ -3137,6 +3209,11 @@ impl From<HttpDispatchError> for DeleteDeploymentGroupError {
         DeleteDeploymentGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDeploymentGroupError {
+    fn from(err: io::Error) -> DeleteDeploymentGroupError {
+        DeleteDeploymentGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDeploymentGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3216,6 +3293,11 @@ impl From<CredentialsError> for DeregisterOnPremisesInstanceError {
 impl From<HttpDispatchError> for DeregisterOnPremisesInstanceError {
     fn from(err: HttpDispatchError) -> DeregisterOnPremisesInstanceError {
         DeregisterOnPremisesInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeregisterOnPremisesInstanceError {
+    fn from(err: io::Error) -> DeregisterOnPremisesInstanceError {
+        DeregisterOnPremisesInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeregisterOnPremisesInstanceError {
@@ -3303,6 +3385,11 @@ impl From<CredentialsError> for GetApplicationError {
 impl From<HttpDispatchError> for GetApplicationError {
     fn from(err: HttpDispatchError) -> GetApplicationError {
         GetApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetApplicationError {
+    fn from(err: io::Error) -> GetApplicationError {
+        GetApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetApplicationError {
@@ -3398,6 +3485,11 @@ impl From<HttpDispatchError> for GetApplicationRevisionError {
         GetApplicationRevisionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetApplicationRevisionError {
+    fn from(err: io::Error) -> GetApplicationRevisionError {
+        GetApplicationRevisionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetApplicationRevisionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3489,6 +3581,11 @@ impl From<HttpDispatchError> for GetDeploymentError {
         GetDeploymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDeploymentError {
+    fn from(err: io::Error) -> GetDeploymentError {
+        GetDeploymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3567,6 +3664,11 @@ impl From<CredentialsError> for GetDeploymentConfigError {
 impl From<HttpDispatchError> for GetDeploymentConfigError {
     fn from(err: HttpDispatchError) -> GetDeploymentConfigError {
         GetDeploymentConfigError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDeploymentConfigError {
+    fn from(err: io::Error) -> GetDeploymentConfigError {
+        GetDeploymentConfigError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDeploymentConfigError {
@@ -3660,6 +3762,11 @@ impl From<CredentialsError> for GetDeploymentGroupError {
 impl From<HttpDispatchError> for GetDeploymentGroupError {
     fn from(err: HttpDispatchError) -> GetDeploymentGroupError {
         GetDeploymentGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDeploymentGroupError {
+    fn from(err: io::Error) -> GetDeploymentGroupError {
+        GetDeploymentGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDeploymentGroupError {
@@ -3762,6 +3869,11 @@ impl From<HttpDispatchError> for GetDeploymentInstanceError {
         GetDeploymentInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDeploymentInstanceError {
+    fn from(err: io::Error) -> GetDeploymentInstanceError {
+        GetDeploymentInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDeploymentInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3847,6 +3959,11 @@ impl From<CredentialsError> for GetOnPremisesInstanceError {
 impl From<HttpDispatchError> for GetOnPremisesInstanceError {
     fn from(err: HttpDispatchError) -> GetOnPremisesInstanceError {
         GetOnPremisesInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetOnPremisesInstanceError {
+    fn from(err: io::Error) -> GetOnPremisesInstanceError {
+        GetOnPremisesInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetOnPremisesInstanceError {
@@ -3958,6 +4075,11 @@ impl From<HttpDispatchError> for ListApplicationRevisionsError {
         ListApplicationRevisionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListApplicationRevisionsError {
+    fn from(err: io::Error) -> ListApplicationRevisionsError {
+        ListApplicationRevisionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListApplicationRevisionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4043,6 +4165,11 @@ impl From<HttpDispatchError> for ListApplicationsError {
         ListApplicationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListApplicationsError {
+    fn from(err: io::Error) -> ListApplicationsError {
+        ListApplicationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListApplicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4115,6 +4242,11 @@ impl From<CredentialsError> for ListDeploymentConfigsError {
 impl From<HttpDispatchError> for ListDeploymentConfigsError {
     fn from(err: HttpDispatchError) -> ListDeploymentConfigsError {
         ListDeploymentConfigsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListDeploymentConfigsError {
+    fn from(err: io::Error) -> ListDeploymentConfigsError {
+        ListDeploymentConfigsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListDeploymentConfigsError {
@@ -4200,6 +4332,11 @@ impl From<CredentialsError> for ListDeploymentGroupsError {
 impl From<HttpDispatchError> for ListDeploymentGroupsError {
     fn from(err: HttpDispatchError) -> ListDeploymentGroupsError {
         ListDeploymentGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListDeploymentGroupsError {
+    fn from(err: io::Error) -> ListDeploymentGroupsError {
+        ListDeploymentGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListDeploymentGroupsError {
@@ -4300,6 +4437,11 @@ impl From<CredentialsError> for ListDeploymentInstancesError {
 impl From<HttpDispatchError> for ListDeploymentInstancesError {
     fn from(err: HttpDispatchError) -> ListDeploymentInstancesError {
         ListDeploymentInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListDeploymentInstancesError {
+    fn from(err: io::Error) -> ListDeploymentInstancesError {
+        ListDeploymentInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListDeploymentInstancesError {
@@ -4419,6 +4561,11 @@ impl From<HttpDispatchError> for ListDeploymentsError {
         ListDeploymentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDeploymentsError {
+    fn from(err: io::Error) -> ListDeploymentsError {
+        ListDeploymentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4500,6 +4647,11 @@ impl From<CredentialsError> for ListGitHubAccountTokenNamesError {
 impl From<HttpDispatchError> for ListGitHubAccountTokenNamesError {
     fn from(err: HttpDispatchError) -> ListGitHubAccountTokenNamesError {
         ListGitHubAccountTokenNamesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListGitHubAccountTokenNamesError {
+    fn from(err: io::Error) -> ListGitHubAccountTokenNamesError {
+        ListGitHubAccountTokenNamesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListGitHubAccountTokenNamesError {
@@ -4585,6 +4737,11 @@ impl From<CredentialsError> for ListOnPremisesInstancesError {
 impl From<HttpDispatchError> for ListOnPremisesInstancesError {
     fn from(err: HttpDispatchError) -> ListOnPremisesInstancesError {
         ListOnPremisesInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListOnPremisesInstancesError {
+    fn from(err: io::Error) -> ListOnPremisesInstancesError {
+        ListOnPremisesInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListOnPremisesInstancesError {
@@ -4676,6 +4833,11 @@ impl From<CredentialsError> for RegisterApplicationRevisionError {
 impl From<HttpDispatchError> for RegisterApplicationRevisionError {
     fn from(err: HttpDispatchError) -> RegisterApplicationRevisionError {
         RegisterApplicationRevisionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterApplicationRevisionError {
+    fn from(err: io::Error) -> RegisterApplicationRevisionError {
+        RegisterApplicationRevisionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterApplicationRevisionError {
@@ -4786,6 +4948,11 @@ impl From<HttpDispatchError> for RegisterOnPremisesInstanceError {
         RegisterOnPremisesInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterOnPremisesInstanceError {
+    fn from(err: io::Error) -> RegisterOnPremisesInstanceError {
+        RegisterOnPremisesInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterOnPremisesInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4885,6 +5052,11 @@ impl From<HttpDispatchError> for RemoveTagsFromOnPremisesInstancesError {
         RemoveTagsFromOnPremisesInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTagsFromOnPremisesInstancesError {
+    fn from(err: io::Error) -> RemoveTagsFromOnPremisesInstancesError {
+        RemoveTagsFromOnPremisesInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTagsFromOnPremisesInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4978,6 +5150,11 @@ impl From<CredentialsError> for SkipWaitTimeForInstanceTerminationError {
 impl From<HttpDispatchError> for SkipWaitTimeForInstanceTerminationError {
     fn from(err: HttpDispatchError) -> SkipWaitTimeForInstanceTerminationError {
         SkipWaitTimeForInstanceTerminationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SkipWaitTimeForInstanceTerminationError {
+    fn from(err: io::Error) -> SkipWaitTimeForInstanceTerminationError {
+        SkipWaitTimeForInstanceTerminationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SkipWaitTimeForInstanceTerminationError {
@@ -5076,6 +5253,11 @@ impl From<HttpDispatchError> for StopDeploymentError {
         StopDeploymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StopDeploymentError {
+    fn from(err: io::Error) -> StopDeploymentError {
+        StopDeploymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StopDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5164,6 +5346,11 @@ impl From<CredentialsError> for UpdateApplicationError {
 impl From<HttpDispatchError> for UpdateApplicationError {
     fn from(err: HttpDispatchError) -> UpdateApplicationError {
         UpdateApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateApplicationError {
+    fn from(err: io::Error) -> UpdateApplicationError {
+        UpdateApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateApplicationError {
@@ -5314,6 +5501,11 @@ impl From<CredentialsError> for UpdateDeploymentGroupError {
 impl From<HttpDispatchError> for UpdateDeploymentGroupError {
     fn from(err: HttpDispatchError) -> UpdateDeploymentGroupError {
         UpdateDeploymentGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateDeploymentGroupError {
+    fn from(err: io::Error) -> UpdateDeploymentGroupError {
+        UpdateDeploymentGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateDeploymentGroupError {
@@ -5643,11 +5835,16 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(AddTagsToOnPremisesInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToOnPremisesInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -5667,13 +5864,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetApplicationRevisionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(BatchGetApplicationRevisionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetApplicationRevisionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetApplicationRevisionsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -5691,15 +5895,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetApplicationsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetApplicationsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(BatchGetApplicationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetApplicationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5720,13 +5927,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetDeploymentGroupsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(BatchGetDeploymentGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetDeploymentGroupsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetDeploymentGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -5746,13 +5960,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetDeploymentInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(BatchGetDeploymentInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetDeploymentInstancesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetDeploymentInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -5770,15 +5991,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetDeploymentsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetDeploymentsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(BatchGetDeploymentsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetDeploymentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5799,13 +6023,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetOnPremisesInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(BatchGetOnPremisesInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetOnPremisesInstancesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetOnPremisesInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -5823,13 +6054,14 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(ContinueDeploymentError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ContinueDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5848,15 +6080,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateApplicationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateApplicationOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5875,15 +6112,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDeploymentOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDeploymentOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateDeploymentError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5903,15 +6145,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDeploymentConfigOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDeploymentConfigOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateDeploymentConfigError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDeploymentConfigError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5931,15 +6176,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDeploymentGroupOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDeploymentGroupOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateDeploymentGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDeploymentGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5958,13 +6206,14 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5983,13 +6232,14 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteDeploymentConfigError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDeploymentConfigError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6009,15 +6259,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteDeploymentGroupOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteDeploymentGroupOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteDeploymentGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDeploymentGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6037,11 +6290,16 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeregisterOnPremisesInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterOnPremisesInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -6059,15 +6317,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetApplicationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetApplicationOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6087,15 +6350,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetApplicationRevisionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetApplicationRevisionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetApplicationRevisionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetApplicationRevisionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6114,14 +6380,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDeploymentOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDeploymentOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetDeploymentError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6140,15 +6412,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDeploymentConfigOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDeploymentConfigOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetDeploymentConfigError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeploymentConfigError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6167,15 +6442,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDeploymentGroupOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDeploymentGroupOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetDeploymentGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeploymentGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6195,15 +6475,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDeploymentInstanceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDeploymentInstanceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetDeploymentInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeploymentInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6223,15 +6506,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetOnPremisesInstanceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetOnPremisesInstanceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetOnPremisesInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOnPremisesInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6252,13 +6538,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListApplicationRevisionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListApplicationRevisionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListApplicationRevisionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListApplicationRevisionsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -6276,15 +6569,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListApplicationsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListApplicationsOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListApplicationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListApplicationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6304,15 +6602,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDeploymentConfigsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDeploymentConfigsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListDeploymentConfigsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDeploymentConfigsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6331,15 +6632,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDeploymentGroupsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDeploymentGroupsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListDeploymentGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDeploymentGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6360,13 +6664,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDeploymentInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListDeploymentInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDeploymentInstancesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDeploymentInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6384,15 +6695,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDeploymentsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDeploymentsOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListDeploymentsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDeploymentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6413,13 +6729,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListGitHubAccountTokenNamesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListGitHubAccountTokenNamesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListGitHubAccountTokenNamesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListGitHubAccountTokenNamesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -6439,13 +6762,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListOnPremisesInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListOnPremisesInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListOnPremisesInstancesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOnPremisesInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6464,11 +6794,16 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RegisterApplicationRevisionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterApplicationRevisionError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -6487,11 +6822,16 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RegisterOnPremisesInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterOnPremisesInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6511,11 +6851,15 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RemoveTagsFromOnPremisesInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromOnPremisesInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6535,11 +6879,15 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(SkipWaitTimeForInstanceTerminationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SkipWaitTimeForInstanceTerminationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6557,15 +6905,20 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopDeploymentOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopDeploymentOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StopDeploymentError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6584,13 +6937,14 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6610,15 +6964,18 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDeploymentGroupOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDeploymentGroupOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateDeploymentGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDeploymentGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1423,6 +1425,11 @@ impl From<HttpDispatchError> for AcknowledgeJobError {
         AcknowledgeJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AcknowledgeJobError {
+    fn from(err: io::Error) -> AcknowledgeJobError {
+        AcknowledgeJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AcknowledgeJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1506,6 +1513,11 @@ impl From<HttpDispatchError> for AcknowledgeThirdPartyJobError {
         AcknowledgeThirdPartyJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AcknowledgeThirdPartyJobError {
+    fn from(err: io::Error) -> AcknowledgeThirdPartyJobError {
+        AcknowledgeThirdPartyJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AcknowledgeThirdPartyJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1582,6 +1594,11 @@ impl From<CredentialsError> for CreateCustomActionTypeError {
 impl From<HttpDispatchError> for CreateCustomActionTypeError {
     fn from(err: HttpDispatchError) -> CreateCustomActionTypeError {
         CreateCustomActionTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateCustomActionTypeError {
+    fn from(err: io::Error) -> CreateCustomActionTypeError {
+        CreateCustomActionTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateCustomActionTypeError {
@@ -1685,6 +1702,11 @@ impl From<HttpDispatchError> for CreatePipelineError {
         CreatePipelineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreatePipelineError {
+    fn from(err: io::Error) -> CreatePipelineError {
+        CreatePipelineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1759,6 +1781,11 @@ impl From<HttpDispatchError> for DeleteCustomActionTypeError {
         DeleteCustomActionTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteCustomActionTypeError {
+    fn from(err: io::Error) -> DeleteCustomActionTypeError {
+        DeleteCustomActionTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteCustomActionTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1827,6 +1854,11 @@ impl From<CredentialsError> for DeletePipelineError {
 impl From<HttpDispatchError> for DeletePipelineError {
     fn from(err: HttpDispatchError) -> DeletePipelineError {
         DeletePipelineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeletePipelineError {
+    fn from(err: io::Error) -> DeletePipelineError {
+        DeletePipelineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeletePipelineError {
@@ -1905,6 +1937,11 @@ impl From<CredentialsError> for DisableStageTransitionError {
 impl From<HttpDispatchError> for DisableStageTransitionError {
     fn from(err: HttpDispatchError) -> DisableStageTransitionError {
         DisableStageTransitionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableStageTransitionError {
+    fn from(err: io::Error) -> DisableStageTransitionError {
+        DisableStageTransitionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableStageTransitionError {
@@ -1989,6 +2026,11 @@ impl From<HttpDispatchError> for EnableStageTransitionError {
         EnableStageTransitionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableStageTransitionError {
+    fn from(err: io::Error) -> EnableStageTransitionError {
+        EnableStageTransitionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableStageTransitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2064,6 +2106,11 @@ impl From<CredentialsError> for GetJobDetailsError {
 impl From<HttpDispatchError> for GetJobDetailsError {
     fn from(err: HttpDispatchError) -> GetJobDetailsError {
         GetJobDetailsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetJobDetailsError {
+    fn from(err: io::Error) -> GetJobDetailsError {
+        GetJobDetailsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetJobDetailsError {
@@ -2145,6 +2192,11 @@ impl From<HttpDispatchError> for GetPipelineError {
         GetPipelineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetPipelineError {
+    fn from(err: io::Error) -> GetPipelineError {
+        GetPipelineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetPipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2223,6 +2275,11 @@ impl From<HttpDispatchError> for GetPipelineExecutionError {
         GetPipelineExecutionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetPipelineExecutionError {
+    fn from(err: io::Error) -> GetPipelineExecutionError {
+        GetPipelineExecutionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetPipelineExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2298,6 +2355,11 @@ impl From<CredentialsError> for GetPipelineStateError {
 impl From<HttpDispatchError> for GetPipelineStateError {
     fn from(err: HttpDispatchError) -> GetPipelineStateError {
         GetPipelineStateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetPipelineStateError {
+    fn from(err: io::Error) -> GetPipelineStateError {
+        GetPipelineStateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetPipelineStateError {
@@ -2382,6 +2444,11 @@ impl From<HttpDispatchError> for GetThirdPartyJobDetailsError {
         GetThirdPartyJobDetailsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetThirdPartyJobDetailsError {
+    fn from(err: io::Error) -> GetThirdPartyJobDetailsError {
+        GetThirdPartyJobDetailsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetThirdPartyJobDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2458,6 +2525,11 @@ impl From<CredentialsError> for ListActionTypesError {
 impl From<HttpDispatchError> for ListActionTypesError {
     fn from(err: HttpDispatchError) -> ListActionTypesError {
         ListActionTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListActionTypesError {
+    fn from(err: io::Error) -> ListActionTypesError {
+        ListActionTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListActionTypesError {
@@ -2539,6 +2611,11 @@ impl From<HttpDispatchError> for ListPipelineExecutionsError {
         ListPipelineExecutionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPipelineExecutionsError {
+    fn from(err: io::Error) -> ListPipelineExecutionsError {
+        ListPipelineExecutionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPipelineExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2616,6 +2693,11 @@ impl From<HttpDispatchError> for ListPipelinesError {
         ListPipelinesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPipelinesError {
+    fn from(err: io::Error) -> ListPipelinesError {
+        ListPipelinesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPipelinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2690,6 +2772,11 @@ impl From<HttpDispatchError> for PollForJobsError {
         PollForJobsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PollForJobsError {
+    fn from(err: io::Error) -> PollForJobsError {
+        PollForJobsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PollForJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2762,6 +2849,11 @@ impl From<CredentialsError> for PollForThirdPartyJobsError {
 impl From<HttpDispatchError> for PollForThirdPartyJobsError {
     fn from(err: HttpDispatchError) -> PollForThirdPartyJobsError {
         PollForThirdPartyJobsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PollForThirdPartyJobsError {
+    fn from(err: io::Error) -> PollForThirdPartyJobsError {
+        PollForThirdPartyJobsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PollForThirdPartyJobsError {
@@ -2848,6 +2940,11 @@ impl From<CredentialsError> for PutActionRevisionError {
 impl From<HttpDispatchError> for PutActionRevisionError {
     fn from(err: HttpDispatchError) -> PutActionRevisionError {
         PutActionRevisionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutActionRevisionError {
+    fn from(err: io::Error) -> PutActionRevisionError {
+        PutActionRevisionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutActionRevisionError {
@@ -2946,6 +3043,11 @@ impl From<HttpDispatchError> for PutApprovalResultError {
         PutApprovalResultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutApprovalResultError {
+    fn from(err: io::Error) -> PutApprovalResultError {
+        PutApprovalResultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutApprovalResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3031,6 +3133,11 @@ impl From<HttpDispatchError> for PutJobFailureResultError {
         PutJobFailureResultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutJobFailureResultError {
+    fn from(err: io::Error) -> PutJobFailureResultError {
+        PutJobFailureResultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutJobFailureResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3111,6 +3218,11 @@ impl From<CredentialsError> for PutJobSuccessResultError {
 impl From<HttpDispatchError> for PutJobSuccessResultError {
     fn from(err: HttpDispatchError) -> PutJobSuccessResultError {
         PutJobSuccessResultError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutJobSuccessResultError {
+    fn from(err: io::Error) -> PutJobSuccessResultError {
+        PutJobSuccessResultError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutJobSuccessResultError {
@@ -3196,6 +3308,11 @@ impl From<HttpDispatchError> for PutThirdPartyJobFailureResultError {
         PutThirdPartyJobFailureResultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutThirdPartyJobFailureResultError {
+    fn from(err: io::Error) -> PutThirdPartyJobFailureResultError {
+        PutThirdPartyJobFailureResultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutThirdPartyJobFailureResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3278,6 +3395,11 @@ impl From<CredentialsError> for PutThirdPartyJobSuccessResultError {
 impl From<HttpDispatchError> for PutThirdPartyJobSuccessResultError {
     fn from(err: HttpDispatchError) -> PutThirdPartyJobSuccessResultError {
         PutThirdPartyJobSuccessResultError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutThirdPartyJobSuccessResultError {
+    fn from(err: io::Error) -> PutThirdPartyJobSuccessResultError {
+        PutThirdPartyJobSuccessResultError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutThirdPartyJobSuccessResultError {
@@ -3371,6 +3493,11 @@ impl From<HttpDispatchError> for RetryStageExecutionError {
         RetryStageExecutionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RetryStageExecutionError {
+    fn from(err: io::Error) -> RetryStageExecutionError {
+        RetryStageExecutionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RetryStageExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3448,6 +3575,11 @@ impl From<CredentialsError> for StartPipelineExecutionError {
 impl From<HttpDispatchError> for StartPipelineExecutionError {
     fn from(err: HttpDispatchError) -> StartPipelineExecutionError {
         StartPipelineExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StartPipelineExecutionError {
+    fn from(err: io::Error) -> StartPipelineExecutionError {
+        StartPipelineExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StartPipelineExecutionError {
@@ -3539,6 +3671,11 @@ impl From<CredentialsError> for UpdatePipelineError {
 impl From<HttpDispatchError> for UpdatePipelineError {
     fn from(err: HttpDispatchError) -> UpdatePipelineError {
         UpdatePipelineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdatePipelineError {
+    fn from(err: io::Error) -> UpdatePipelineError {
+        UpdatePipelineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdatePipelineError {
@@ -3767,15 +3904,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AcknowledgeJobOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AcknowledgeJobOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AcknowledgeJobError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AcknowledgeJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3796,13 +3938,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AcknowledgeThirdPartyJobOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AcknowledgeThirdPartyJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AcknowledgeThirdPartyJobOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AcknowledgeThirdPartyJobError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -3822,15 +3971,18 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateCustomActionTypeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateCustomActionTypeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateCustomActionTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCustomActionTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3849,15 +4001,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreatePipelineOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreatePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3877,13 +4034,14 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteCustomActionTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCustomActionTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3900,13 +4058,14 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeletePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3926,13 +4085,14 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DisableStageTransitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableStageTransitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3952,13 +4112,14 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(EnableStageTransitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableStageTransitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3977,14 +4138,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetJobDetailsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetJobDetailsOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetJobDetailsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetJobDetailsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4003,13 +4170,21 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetPipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetPipelineError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetPipelineOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4027,15 +4202,18 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetPipelineExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetPipelineExecutionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetPipelineExecutionError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPipelineExecutionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4054,15 +4232,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetPipelineStateOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetPipelineStateOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetPipelineStateError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPipelineStateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4083,13 +4266,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetThirdPartyJobDetailsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetThirdPartyJobDetailsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetThirdPartyJobDetailsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetThirdPartyJobDetailsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4107,15 +4297,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListActionTypesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListActionTypesOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListActionTypesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListActionTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4136,15 +4331,18 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPipelineExecutionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPipelineExecutionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListPipelineExecutionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPipelineExecutionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4163,14 +4361,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPipelinesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPipelinesOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListPipelinesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPipelinesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4189,13 +4393,21 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PollForJobsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(PollForJobsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PollForJobsOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PollForJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4215,15 +4427,18 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PollForThirdPartyJobsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PollForThirdPartyJobsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(PollForThirdPartyJobsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PollForThirdPartyJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4242,15 +4457,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutActionRevisionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutActionRevisionOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutActionRevisionError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutActionRevisionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4269,15 +4489,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutApprovalResultOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutApprovalResultOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutApprovalResultError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutApprovalResultError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4296,13 +4521,14 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutJobFailureResultError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutJobFailureResultError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4321,13 +4547,14 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutJobSuccessResultError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutJobSuccessResultError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4347,11 +4574,16 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(PutThirdPartyJobFailureResultError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutThirdPartyJobFailureResultError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -4370,11 +4602,16 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(PutThirdPartyJobSuccessResultError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutThirdPartyJobSuccessResultError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -4392,15 +4629,18 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RetryStageExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RetryStageExecutionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RetryStageExecutionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RetryStageExecutionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4421,15 +4661,18 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartPipelineExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartPipelineExecutionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(StartPipelineExecutionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartPipelineExecutionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4448,15 +4691,20 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdatePipelineOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdatePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -651,6 +653,11 @@ impl From<HttpDispatchError> for CreateIdentityPoolError {
         CreateIdentityPoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateIdentityPoolError {
+    fn from(err: io::Error) -> CreateIdentityPoolError {
+        CreateIdentityPoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateIdentityPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -740,6 +747,11 @@ impl From<CredentialsError> for DeleteIdentitiesError {
 impl From<HttpDispatchError> for DeleteIdentitiesError {
     fn from(err: HttpDispatchError) -> DeleteIdentitiesError {
         DeleteIdentitiesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteIdentitiesError {
+    fn from(err: io::Error) -> DeleteIdentitiesError {
+        DeleteIdentitiesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteIdentitiesError {
@@ -836,6 +848,11 @@ impl From<CredentialsError> for DeleteIdentityPoolError {
 impl From<HttpDispatchError> for DeleteIdentityPoolError {
     fn from(err: HttpDispatchError) -> DeleteIdentityPoolError {
         DeleteIdentityPoolError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteIdentityPoolError {
+    fn from(err: io::Error) -> DeleteIdentityPoolError {
+        DeleteIdentityPoolError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteIdentityPoolError {
@@ -938,6 +955,11 @@ impl From<HttpDispatchError> for DescribeIdentityError {
         DescribeIdentityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeIdentityError {
+    fn from(err: io::Error) -> DescribeIdentityError {
+        DescribeIdentityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1034,6 +1056,11 @@ impl From<CredentialsError> for DescribeIdentityPoolError {
 impl From<HttpDispatchError> for DescribeIdentityPoolError {
     fn from(err: HttpDispatchError) -> DescribeIdentityPoolError {
         DescribeIdentityPoolError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeIdentityPoolError {
+    fn from(err: io::Error) -> DescribeIdentityPoolError {
+        DescribeIdentityPoolError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeIdentityPoolError {
@@ -1141,6 +1168,11 @@ impl From<CredentialsError> for GetCredentialsForIdentityError {
 impl From<HttpDispatchError> for GetCredentialsForIdentityError {
     fn from(err: HttpDispatchError) -> GetCredentialsForIdentityError {
         GetCredentialsForIdentityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetCredentialsForIdentityError {
+    fn from(err: io::Error) -> GetCredentialsForIdentityError {
+        GetCredentialsForIdentityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetCredentialsForIdentityError {
@@ -1259,6 +1291,11 @@ impl From<HttpDispatchError> for GetIdError {
         GetIdError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetIdError {
+    fn from(err: io::Error) -> GetIdError {
+        GetIdError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetIdError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1363,6 +1400,11 @@ impl From<CredentialsError> for GetIdentityPoolRolesError {
 impl From<HttpDispatchError> for GetIdentityPoolRolesError {
     fn from(err: HttpDispatchError) -> GetIdentityPoolRolesError {
         GetIdentityPoolRolesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetIdentityPoolRolesError {
+    fn from(err: io::Error) -> GetIdentityPoolRolesError {
+        GetIdentityPoolRolesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetIdentityPoolRolesError {
@@ -1476,6 +1518,11 @@ impl From<HttpDispatchError> for GetOpenIdTokenError {
         GetOpenIdTokenError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetOpenIdTokenError {
+    fn from(err: io::Error) -> GetOpenIdTokenError {
+        GetOpenIdTokenError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetOpenIdTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1571,6 +1618,11 @@ impl From<CredentialsError> for GetOpenIdTokenForDeveloperIdentityError {
 impl From<HttpDispatchError> for GetOpenIdTokenForDeveloperIdentityError {
     fn from(err: HttpDispatchError) -> GetOpenIdTokenForDeveloperIdentityError {
         GetOpenIdTokenForDeveloperIdentityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetOpenIdTokenForDeveloperIdentityError {
+    fn from(err: io::Error) -> GetOpenIdTokenForDeveloperIdentityError {
+        GetOpenIdTokenForDeveloperIdentityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetOpenIdTokenForDeveloperIdentityError {
@@ -1677,6 +1729,11 @@ impl From<HttpDispatchError> for ListIdentitiesError {
         ListIdentitiesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListIdentitiesError {
+    fn from(err: io::Error) -> ListIdentitiesError {
+        ListIdentitiesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListIdentitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1768,6 +1825,11 @@ impl From<CredentialsError> for ListIdentityPoolsError {
 impl From<HttpDispatchError> for ListIdentityPoolsError {
     fn from(err: HttpDispatchError) -> ListIdentityPoolsError {
         ListIdentityPoolsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListIdentityPoolsError {
+    fn from(err: io::Error) -> ListIdentityPoolsError {
+        ListIdentityPoolsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListIdentityPoolsError {
@@ -1874,6 +1936,11 @@ impl From<HttpDispatchError> for LookupDeveloperIdentityError {
         LookupDeveloperIdentityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for LookupDeveloperIdentityError {
+    fn from(err: io::Error) -> LookupDeveloperIdentityError {
+        LookupDeveloperIdentityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for LookupDeveloperIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1978,6 +2045,11 @@ impl From<CredentialsError> for MergeDeveloperIdentitiesError {
 impl From<HttpDispatchError> for MergeDeveloperIdentitiesError {
     fn from(err: HttpDispatchError) -> MergeDeveloperIdentitiesError {
         MergeDeveloperIdentitiesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for MergeDeveloperIdentitiesError {
+    fn from(err: io::Error) -> MergeDeveloperIdentitiesError {
+        MergeDeveloperIdentitiesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for MergeDeveloperIdentitiesError {
@@ -2089,6 +2161,11 @@ impl From<HttpDispatchError> for SetIdentityPoolRolesError {
         SetIdentityPoolRolesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetIdentityPoolRolesError {
+    fn from(err: io::Error) -> SetIdentityPoolRolesError {
+        SetIdentityPoolRolesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetIdentityPoolRolesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2194,6 +2271,11 @@ impl From<CredentialsError> for UnlinkDeveloperIdentityError {
 impl From<HttpDispatchError> for UnlinkDeveloperIdentityError {
     fn from(err: HttpDispatchError) -> UnlinkDeveloperIdentityError {
         UnlinkDeveloperIdentityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UnlinkDeveloperIdentityError {
+    fn from(err: io::Error) -> UnlinkDeveloperIdentityError {
+        UnlinkDeveloperIdentityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UnlinkDeveloperIdentityError {
@@ -2305,6 +2387,11 @@ impl From<CredentialsError> for UnlinkIdentityError {
 impl From<HttpDispatchError> for UnlinkIdentityError {
     fn from(err: HttpDispatchError) -> UnlinkIdentityError {
         UnlinkIdentityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UnlinkIdentityError {
+    fn from(err: io::Error) -> UnlinkIdentityError {
+        UnlinkIdentityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UnlinkIdentityError {
@@ -2420,6 +2507,11 @@ impl From<CredentialsError> for UpdateIdentityPoolError {
 impl From<HttpDispatchError> for UpdateIdentityPoolError {
     fn from(err: HttpDispatchError) -> UpdateIdentityPoolError {
         UpdateIdentityPoolError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateIdentityPoolError {
+    fn from(err: io::Error) -> UpdateIdentityPoolError {
+        UpdateIdentityPoolError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateIdentityPoolError {
@@ -2599,17 +2691,19 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(CreateIdentityPoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateIdentityPoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2628,15 +2722,20 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteIdentitiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteIdentitiesResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteIdentitiesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIdentitiesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2656,13 +2755,14 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteIdentityPoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIdentityPoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2681,15 +2781,20 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<IdentityDescription>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<IdentityDescription>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeIdentityError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2709,17 +2814,19 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(DescribeIdentityPoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeIdentityPoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2740,13 +2847,20 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetCredentialsForIdentityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetCredentialsForIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetCredentialsForIdentityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCredentialsForIdentityError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -2762,15 +2876,20 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetIdResponse>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetIdResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetIdError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIdError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2790,15 +2909,18 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetIdentityPoolRolesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetIdentityPoolRolesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetIdentityPoolRolesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIdentityPoolRolesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2817,15 +2939,20 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetOpenIdTokenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetOpenIdTokenResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetOpenIdTokenError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOpenIdTokenError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2847,13 +2974,19 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetOpenIdTokenForDeveloperIdentityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetOpenIdTokenForDeveloperIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetOpenIdTokenForDeveloperIdentityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOpenIdTokenForDeveloperIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2871,15 +3004,20 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListIdentitiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListIdentitiesResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListIdentitiesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListIdentitiesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2899,15 +3037,18 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListIdentityPoolsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListIdentityPoolsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListIdentityPoolsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListIdentityPoolsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2928,13 +3069,20 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<LookupDeveloperIdentityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(LookupDeveloperIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<LookupDeveloperIdentityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(LookupDeveloperIdentityError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -2954,13 +3102,20 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<MergeDeveloperIdentitiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(MergeDeveloperIdentitiesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<MergeDeveloperIdentitiesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(MergeDeveloperIdentitiesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -2979,13 +3134,14 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(SetIdentityPoolRolesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetIdentityPoolRolesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3005,11 +3161,16 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(UnlinkDeveloperIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnlinkDeveloperIdentityError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -3025,13 +3186,14 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UnlinkIdentityError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnlinkIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3051,17 +3213,19 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(UpdateIdentityPoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateIdentityPoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2686,6 +2688,11 @@ impl From<HttpDispatchError> for AddCustomAttributesError {
         AddCustomAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddCustomAttributesError {
+    fn from(err: io::Error) -> AddCustomAttributesError {
+        AddCustomAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddCustomAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2790,6 +2797,11 @@ impl From<CredentialsError> for AdminAddUserToGroupError {
 impl From<HttpDispatchError> for AdminAddUserToGroupError {
     fn from(err: HttpDispatchError) -> AdminAddUserToGroupError {
         AdminAddUserToGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminAddUserToGroupError {
+    fn from(err: io::Error) -> AdminAddUserToGroupError {
+        AdminAddUserToGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminAddUserToGroupError {
@@ -2921,6 +2933,11 @@ impl From<CredentialsError> for AdminConfirmSignUpError {
 impl From<HttpDispatchError> for AdminConfirmSignUpError {
     fn from(err: HttpDispatchError) -> AdminConfirmSignUpError {
         AdminConfirmSignUpError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminConfirmSignUpError {
+    fn from(err: io::Error) -> AdminConfirmSignUpError {
+        AdminConfirmSignUpError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminConfirmSignUpError {
@@ -3080,6 +3097,11 @@ impl From<HttpDispatchError> for AdminCreateUserError {
         AdminCreateUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminCreateUserError {
+    fn from(err: io::Error) -> AdminCreateUserError {
+        AdminCreateUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminCreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3194,6 +3216,11 @@ impl From<HttpDispatchError> for AdminDeleteUserError {
         AdminDeleteUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminDeleteUserError {
+    fn from(err: io::Error) -> AdminDeleteUserError {
+        AdminDeleteUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminDeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3292,6 +3319,11 @@ impl From<CredentialsError> for AdminDeleteUserAttributesError {
 impl From<HttpDispatchError> for AdminDeleteUserAttributesError {
     fn from(err: HttpDispatchError) -> AdminDeleteUserAttributesError {
         AdminDeleteUserAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminDeleteUserAttributesError {
+    fn from(err: io::Error) -> AdminDeleteUserAttributesError {
+        AdminDeleteUserAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminDeleteUserAttributesError {
@@ -3400,6 +3432,11 @@ impl From<HttpDispatchError> for AdminDisableUserError {
         AdminDisableUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminDisableUserError {
+    fn from(err: io::Error) -> AdminDisableUserError {
+        AdminDisableUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminDisableUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3502,6 +3539,11 @@ impl From<CredentialsError> for AdminEnableUserError {
 impl From<HttpDispatchError> for AdminEnableUserError {
     fn from(err: HttpDispatchError) -> AdminEnableUserError {
         AdminEnableUserError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminEnableUserError {
+    fn from(err: io::Error) -> AdminEnableUserError {
+        AdminEnableUserError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminEnableUserError {
@@ -3611,6 +3653,11 @@ impl From<HttpDispatchError> for AdminForgetDeviceError {
         AdminForgetDeviceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminForgetDeviceError {
+    fn from(err: io::Error) -> AdminForgetDeviceError {
+        AdminForgetDeviceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminForgetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3716,6 +3763,11 @@ impl From<HttpDispatchError> for AdminGetDeviceError {
         AdminGetDeviceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminGetDeviceError {
+    fn from(err: io::Error) -> AdminGetDeviceError {
+        AdminGetDeviceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminGetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3818,6 +3870,11 @@ impl From<CredentialsError> for AdminGetUserError {
 impl From<HttpDispatchError> for AdminGetUserError {
     fn from(err: HttpDispatchError) -> AdminGetUserError {
         AdminGetUserError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminGetUserError {
+    fn from(err: io::Error) -> AdminGetUserError {
+        AdminGetUserError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminGetUserError {
@@ -3963,6 +4020,11 @@ impl From<HttpDispatchError> for AdminInitiateAuthError {
         AdminInitiateAuthError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminInitiateAuthError {
+    fn from(err: io::Error) -> AdminInitiateAuthError {
+        AdminInitiateAuthError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminInitiateAuthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4076,6 +4138,11 @@ impl From<HttpDispatchError> for AdminListDevicesError {
         AdminListDevicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminListDevicesError {
+    fn from(err: io::Error) -> AdminListDevicesError {
+        AdminListDevicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminListDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4178,6 +4245,11 @@ impl From<CredentialsError> for AdminListGroupsForUserError {
 impl From<HttpDispatchError> for AdminListGroupsForUserError {
     fn from(err: HttpDispatchError) -> AdminListGroupsForUserError {
         AdminListGroupsForUserError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminListGroupsForUserError {
+    fn from(err: io::Error) -> AdminListGroupsForUserError {
+        AdminListGroupsForUserError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminListGroupsForUserError {
@@ -4284,6 +4356,11 @@ impl From<CredentialsError> for AdminRemoveUserFromGroupError {
 impl From<HttpDispatchError> for AdminRemoveUserFromGroupError {
     fn from(err: HttpDispatchError) -> AdminRemoveUserFromGroupError {
         AdminRemoveUserFromGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminRemoveUserFromGroupError {
+    fn from(err: io::Error) -> AdminRemoveUserFromGroupError {
+        AdminRemoveUserFromGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminRemoveUserFromGroupError {
@@ -4406,6 +4483,11 @@ impl From<CredentialsError> for AdminResetUserPasswordError {
 impl From<HttpDispatchError> for AdminResetUserPasswordError {
     fn from(err: HttpDispatchError) -> AdminResetUserPasswordError {
         AdminResetUserPasswordError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminResetUserPasswordError {
+    fn from(err: io::Error) -> AdminResetUserPasswordError {
+        AdminResetUserPasswordError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminResetUserPasswordError {
@@ -4557,6 +4639,11 @@ impl From<HttpDispatchError> for AdminRespondToAuthChallengeError {
         AdminRespondToAuthChallengeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminRespondToAuthChallengeError {
+    fn from(err: io::Error) -> AdminRespondToAuthChallengeError {
+        AdminRespondToAuthChallengeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminRespondToAuthChallengeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4671,6 +4758,11 @@ impl From<HttpDispatchError> for AdminSetUserSettingsError {
         AdminSetUserSettingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminSetUserSettingsError {
+    fn from(err: io::Error) -> AdminSetUserSettingsError {
+        AdminSetUserSettingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminSetUserSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4777,6 +4869,11 @@ impl From<CredentialsError> for AdminUpdateDeviceStatusError {
 impl From<HttpDispatchError> for AdminUpdateDeviceStatusError {
     fn from(err: HttpDispatchError) -> AdminUpdateDeviceStatusError {
         AdminUpdateDeviceStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminUpdateDeviceStatusError {
+    fn from(err: io::Error) -> AdminUpdateDeviceStatusError {
+        AdminUpdateDeviceStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminUpdateDeviceStatusError {
@@ -4896,6 +4993,11 @@ impl From<HttpDispatchError> for AdminUpdateUserAttributesError {
         AdminUpdateUserAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AdminUpdateUserAttributesError {
+    fn from(err: io::Error) -> AdminUpdateUserAttributesError {
+        AdminUpdateUserAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AdminUpdateUserAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5004,6 +5106,11 @@ impl From<CredentialsError> for AdminUserGlobalSignOutError {
 impl From<HttpDispatchError> for AdminUserGlobalSignOutError {
     fn from(err: HttpDispatchError) -> AdminUserGlobalSignOutError {
         AdminUserGlobalSignOutError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AdminUserGlobalSignOutError {
+    fn from(err: io::Error) -> AdminUserGlobalSignOutError {
+        AdminUserGlobalSignOutError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AdminUserGlobalSignOutError {
@@ -5130,6 +5237,11 @@ impl From<CredentialsError> for ChangePasswordError {
 impl From<HttpDispatchError> for ChangePasswordError {
     fn from(err: HttpDispatchError) -> ChangePasswordError {
         ChangePasswordError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ChangePasswordError {
+    fn from(err: io::Error) -> ChangePasswordError {
+        ChangePasswordError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ChangePasswordError {
@@ -5266,6 +5378,11 @@ impl From<CredentialsError> for ConfirmDeviceError {
 impl From<HttpDispatchError> for ConfirmDeviceError {
     fn from(err: HttpDispatchError) -> ConfirmDeviceError {
         ConfirmDeviceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ConfirmDeviceError {
+    fn from(err: io::Error) -> ConfirmDeviceError {
+        ConfirmDeviceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ConfirmDeviceError {
@@ -5415,6 +5532,11 @@ impl From<CredentialsError> for ConfirmForgotPasswordError {
 impl From<HttpDispatchError> for ConfirmForgotPasswordError {
     fn from(err: HttpDispatchError) -> ConfirmForgotPasswordError {
         ConfirmForgotPasswordError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ConfirmForgotPasswordError {
+    fn from(err: io::Error) -> ConfirmForgotPasswordError {
+        ConfirmForgotPasswordError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ConfirmForgotPasswordError {
@@ -5572,6 +5694,11 @@ impl From<HttpDispatchError> for ConfirmSignUpError {
         ConfirmSignUpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ConfirmSignUpError {
+    fn from(err: io::Error) -> ConfirmSignUpError {
+        ConfirmSignUpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ConfirmSignUpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5689,6 +5816,11 @@ impl From<HttpDispatchError> for CreateGroupError {
         CreateGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateGroupError {
+    fn from(err: io::Error) -> CreateGroupError {
+        CreateGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5797,6 +5929,11 @@ impl From<CredentialsError> for CreateIdentityProviderError {
 impl From<HttpDispatchError> for CreateIdentityProviderError {
     fn from(err: HttpDispatchError) -> CreateIdentityProviderError {
         CreateIdentityProviderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateIdentityProviderError {
+    fn from(err: io::Error) -> CreateIdentityProviderError {
+        CreateIdentityProviderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateIdentityProviderError {
@@ -5909,6 +6046,11 @@ impl From<CredentialsError> for CreateUserImportJobError {
 impl From<HttpDispatchError> for CreateUserImportJobError {
     fn from(err: HttpDispatchError) -> CreateUserImportJobError {
         CreateUserImportJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateUserImportJobError {
+    fn from(err: io::Error) -> CreateUserImportJobError {
+        CreateUserImportJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateUserImportJobError {
@@ -6029,6 +6171,11 @@ impl From<HttpDispatchError> for CreateUserPoolError {
         CreateUserPoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateUserPoolError {
+    fn from(err: io::Error) -> CreateUserPoolError {
+        CreateUserPoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateUserPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6146,6 +6293,11 @@ impl From<HttpDispatchError> for CreateUserPoolClientError {
         CreateUserPoolClientError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateUserPoolClientError {
+    fn from(err: io::Error) -> CreateUserPoolClientError {
+        CreateUserPoolClientError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateUserPoolClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6242,6 +6394,11 @@ impl From<CredentialsError> for CreateUserPoolDomainError {
 impl From<HttpDispatchError> for CreateUserPoolDomainError {
     fn from(err: HttpDispatchError) -> CreateUserPoolDomainError {
         CreateUserPoolDomainError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateUserPoolDomainError {
+    fn from(err: io::Error) -> CreateUserPoolDomainError {
+        CreateUserPoolDomainError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateUserPoolDomainError {
@@ -6343,6 +6500,11 @@ impl From<HttpDispatchError> for DeleteGroupError {
         DeleteGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteGroupError {
+    fn from(err: io::Error) -> DeleteGroupError {
+        DeleteGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6442,6 +6604,11 @@ impl From<CredentialsError> for DeleteIdentityProviderError {
 impl From<HttpDispatchError> for DeleteIdentityProviderError {
     fn from(err: HttpDispatchError) -> DeleteIdentityProviderError {
         DeleteIdentityProviderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteIdentityProviderError {
+    fn from(err: io::Error) -> DeleteIdentityProviderError {
+        DeleteIdentityProviderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteIdentityProviderError {
@@ -6558,6 +6725,11 @@ impl From<HttpDispatchError> for DeleteUserError {
         DeleteUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteUserError {
+    fn from(err: io::Error) -> DeleteUserError {
+        DeleteUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6672,6 +6844,11 @@ impl From<HttpDispatchError> for DeleteUserAttributesError {
         DeleteUserAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteUserAttributesError {
+    fn from(err: io::Error) -> DeleteUserAttributesError {
+        DeleteUserAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteUserAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6780,6 +6957,11 @@ impl From<HttpDispatchError> for DeleteUserPoolError {
         DeleteUserPoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteUserPoolError {
+    fn from(err: io::Error) -> DeleteUserPoolError {
+        DeleteUserPoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteUserPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6879,6 +7061,11 @@ impl From<HttpDispatchError> for DeleteUserPoolClientError {
         DeleteUserPoolClientError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteUserPoolClientError {
+    fn from(err: io::Error) -> DeleteUserPoolClientError {
+        DeleteUserPoolClientError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteUserPoolClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6972,6 +7159,11 @@ impl From<CredentialsError> for DeleteUserPoolDomainError {
 impl From<HttpDispatchError> for DeleteUserPoolDomainError {
     fn from(err: HttpDispatchError) -> DeleteUserPoolDomainError {
         DeleteUserPoolDomainError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteUserPoolDomainError {
+    fn from(err: io::Error) -> DeleteUserPoolDomainError {
+        DeleteUserPoolDomainError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteUserPoolDomainError {
@@ -7073,6 +7265,11 @@ impl From<HttpDispatchError> for DescribeIdentityProviderError {
         DescribeIdentityProviderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeIdentityProviderError {
+    fn from(err: io::Error) -> DescribeIdentityProviderError {
+        DescribeIdentityProviderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeIdentityProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7171,6 +7368,11 @@ impl From<CredentialsError> for DescribeUserImportJobError {
 impl From<HttpDispatchError> for DescribeUserImportJobError {
     fn from(err: HttpDispatchError) -> DescribeUserImportJobError {
         DescribeUserImportJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeUserImportJobError {
+    fn from(err: io::Error) -> DescribeUserImportJobError {
+        DescribeUserImportJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeUserImportJobError {
@@ -7278,6 +7480,11 @@ impl From<HttpDispatchError> for DescribeUserPoolError {
         DescribeUserPoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeUserPoolError {
+    fn from(err: io::Error) -> DescribeUserPoolError {
+        DescribeUserPoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeUserPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7377,6 +7584,11 @@ impl From<HttpDispatchError> for DescribeUserPoolClientError {
         DescribeUserPoolClientError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeUserPoolClientError {
+    fn from(err: io::Error) -> DescribeUserPoolClientError {
+        DescribeUserPoolClientError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeUserPoolClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7470,6 +7682,11 @@ impl From<CredentialsError> for DescribeUserPoolDomainError {
 impl From<HttpDispatchError> for DescribeUserPoolDomainError {
     fn from(err: HttpDispatchError) -> DescribeUserPoolDomainError {
         DescribeUserPoolDomainError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeUserPoolDomainError {
+    fn from(err: io::Error) -> DescribeUserPoolDomainError {
+        DescribeUserPoolDomainError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeUserPoolDomainError {
@@ -7589,6 +7806,11 @@ impl From<CredentialsError> for ForgetDeviceError {
 impl From<HttpDispatchError> for ForgetDeviceError {
     fn from(err: HttpDispatchError) -> ForgetDeviceError {
         ForgetDeviceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ForgetDeviceError {
+    fn from(err: io::Error) -> ForgetDeviceError {
+        ForgetDeviceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ForgetDeviceError {
@@ -7739,6 +7961,11 @@ impl From<HttpDispatchError> for ForgotPasswordError {
         ForgotPasswordError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ForgotPasswordError {
+    fn from(err: io::Error) -> ForgotPasswordError {
+        ForgotPasswordError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ForgotPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7845,6 +8072,11 @@ impl From<CredentialsError> for GetCSVHeaderError {
 impl From<HttpDispatchError> for GetCSVHeaderError {
     fn from(err: HttpDispatchError) -> GetCSVHeaderError {
         GetCSVHeaderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetCSVHeaderError {
+    fn from(err: io::Error) -> GetCSVHeaderError {
+        GetCSVHeaderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetCSVHeaderError {
@@ -7963,6 +8195,11 @@ impl From<HttpDispatchError> for GetDeviceError {
         GetDeviceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDeviceError {
+    fn from(err: io::Error) -> GetDeviceError {
+        GetDeviceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8063,6 +8300,11 @@ impl From<HttpDispatchError> for GetGroupError {
         GetGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetGroupError {
+    fn from(err: io::Error) -> GetGroupError {
+        GetGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8149,6 +8391,11 @@ impl From<CredentialsError> for GetIdentityProviderByIdentifierError {
 impl From<HttpDispatchError> for GetIdentityProviderByIdentifierError {
     fn from(err: HttpDispatchError) -> GetIdentityProviderByIdentifierError {
         GetIdentityProviderByIdentifierError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetIdentityProviderByIdentifierError {
+    fn from(err: io::Error) -> GetIdentityProviderByIdentifierError {
+        GetIdentityProviderByIdentifierError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetIdentityProviderByIdentifierError {
@@ -8262,6 +8509,11 @@ impl From<CredentialsError> for GetUserError {
 impl From<HttpDispatchError> for GetUserError {
     fn from(err: HttpDispatchError) -> GetUserError {
         GetUserError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetUserError {
+    fn from(err: io::Error) -> GetUserError {
+        GetUserError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetUserError {
@@ -8388,6 +8640,11 @@ impl From<HttpDispatchError> for GetUserAttributeVerificationCodeError {
         GetUserAttributeVerificationCodeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetUserAttributeVerificationCodeError {
+    fn from(err: io::Error) -> GetUserAttributeVerificationCodeError {
+        GetUserAttributeVerificationCodeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetUserAttributeVerificationCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8509,6 +8766,11 @@ impl From<CredentialsError> for GlobalSignOutError {
 impl From<HttpDispatchError> for GlobalSignOutError {
     fn from(err: HttpDispatchError) -> GlobalSignOutError {
         GlobalSignOutError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GlobalSignOutError {
+    fn from(err: io::Error) -> GlobalSignOutError {
+        GlobalSignOutError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GlobalSignOutError {
@@ -8646,6 +8908,11 @@ impl From<HttpDispatchError> for InitiateAuthError {
         InitiateAuthError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for InitiateAuthError {
+    fn from(err: io::Error) -> InitiateAuthError {
+        InitiateAuthError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for InitiateAuthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8771,6 +9038,11 @@ impl From<HttpDispatchError> for ListDevicesError {
         ListDevicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDevicesError {
+    fn from(err: io::Error) -> ListDevicesError {
+        ListDevicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8871,6 +9143,11 @@ impl From<HttpDispatchError> for ListGroupsError {
         ListGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListGroupsError {
+    fn from(err: io::Error) -> ListGroupsError {
+        ListGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8967,6 +9244,11 @@ impl From<CredentialsError> for ListIdentityProvidersError {
 impl From<HttpDispatchError> for ListIdentityProvidersError {
     fn from(err: HttpDispatchError) -> ListIdentityProvidersError {
         ListIdentityProvidersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListIdentityProvidersError {
+    fn from(err: io::Error) -> ListIdentityProvidersError {
+        ListIdentityProvidersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListIdentityProvidersError {
@@ -9069,6 +9351,11 @@ impl From<HttpDispatchError> for ListUserImportJobsError {
         ListUserImportJobsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListUserImportJobsError {
+    fn from(err: io::Error) -> ListUserImportJobsError {
+        ListUserImportJobsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListUserImportJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9169,6 +9456,11 @@ impl From<HttpDispatchError> for ListUserPoolClientsError {
         ListUserPoolClientsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListUserPoolClientsError {
+    fn from(err: io::Error) -> ListUserPoolClientsError {
+        ListUserPoolClientsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListUserPoolClientsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9264,6 +9556,11 @@ impl From<HttpDispatchError> for ListUserPoolsError {
         ListUserPoolsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListUserPoolsError {
+    fn from(err: io::Error) -> ListUserPoolsError {
+        ListUserPoolsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListUserPoolsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9357,6 +9654,11 @@ impl From<CredentialsError> for ListUsersError {
 impl From<HttpDispatchError> for ListUsersError {
     fn from(err: HttpDispatchError) -> ListUsersError {
         ListUsersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListUsersError {
+    fn from(err: io::Error) -> ListUsersError {
+        ListUsersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListUsersError {
@@ -9455,6 +9757,11 @@ impl From<CredentialsError> for ListUsersInGroupError {
 impl From<HttpDispatchError> for ListUsersInGroupError {
     fn from(err: HttpDispatchError) -> ListUsersInGroupError {
         ListUsersInGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListUsersInGroupError {
+    fn from(err: io::Error) -> ListUsersInGroupError {
+        ListUsersInGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListUsersInGroupError {
@@ -9586,6 +9893,11 @@ impl From<CredentialsError> for ResendConfirmationCodeError {
 impl From<HttpDispatchError> for ResendConfirmationCodeError {
     fn from(err: HttpDispatchError) -> ResendConfirmationCodeError {
         ResendConfirmationCodeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResendConfirmationCodeError {
+    fn from(err: io::Error) -> ResendConfirmationCodeError {
+        ResendConfirmationCodeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResendConfirmationCodeError {
@@ -9755,6 +10067,11 @@ impl From<HttpDispatchError> for RespondToAuthChallengeError {
         RespondToAuthChallengeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RespondToAuthChallengeError {
+    fn from(err: io::Error) -> RespondToAuthChallengeError {
+        RespondToAuthChallengeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RespondToAuthChallengeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9877,6 +10194,11 @@ impl From<CredentialsError> for SetUserSettingsError {
 impl From<HttpDispatchError> for SetUserSettingsError {
     fn from(err: HttpDispatchError) -> SetUserSettingsError {
         SetUserSettingsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetUserSettingsError {
+    fn from(err: io::Error) -> SetUserSettingsError {
+        SetUserSettingsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetUserSettingsError {
@@ -10022,6 +10344,11 @@ impl From<HttpDispatchError> for SignUpError {
         SignUpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SignUpError {
+    fn from(err: io::Error) -> SignUpError {
+        SignUpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SignUpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10134,6 +10461,11 @@ impl From<HttpDispatchError> for StartUserImportJobError {
         StartUserImportJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartUserImportJobError {
+    fn from(err: io::Error) -> StartUserImportJobError {
+        StartUserImportJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartUserImportJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10238,6 +10570,11 @@ impl From<CredentialsError> for StopUserImportJobError {
 impl From<HttpDispatchError> for StopUserImportJobError {
     fn from(err: HttpDispatchError) -> StopUserImportJobError {
         StopUserImportJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopUserImportJobError {
+    fn from(err: io::Error) -> StopUserImportJobError {
+        StopUserImportJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopUserImportJobError {
@@ -10359,6 +10696,11 @@ impl From<HttpDispatchError> for UpdateDeviceStatusError {
         UpdateDeviceStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDeviceStatusError {
+    fn from(err: io::Error) -> UpdateDeviceStatusError {
+        UpdateDeviceStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDeviceStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10463,6 +10805,11 @@ impl From<HttpDispatchError> for UpdateGroupError {
         UpdateGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateGroupError {
+    fn from(err: io::Error) -> UpdateGroupError {
+        UpdateGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10562,6 +10909,11 @@ impl From<CredentialsError> for UpdateIdentityProviderError {
 impl From<HttpDispatchError> for UpdateIdentityProviderError {
     fn from(err: HttpDispatchError) -> UpdateIdentityProviderError {
         UpdateIdentityProviderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateIdentityProviderError {
+    fn from(err: io::Error) -> UpdateIdentityProviderError {
+        UpdateIdentityProviderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateIdentityProviderError {
@@ -10720,6 +11072,11 @@ impl From<HttpDispatchError> for UpdateUserAttributesError {
         UpdateUserAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateUserAttributesError {
+    fn from(err: io::Error) -> UpdateUserAttributesError {
+        UpdateUserAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateUserAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10859,6 +11216,11 @@ impl From<HttpDispatchError> for UpdateUserPoolError {
         UpdateUserPoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateUserPoolError {
+    fn from(err: io::Error) -> UpdateUserPoolError {
+        UpdateUserPoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateUserPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10971,6 +11333,11 @@ impl From<CredentialsError> for UpdateUserPoolClientError {
 impl From<HttpDispatchError> for UpdateUserPoolClientError {
     fn from(err: HttpDispatchError) -> UpdateUserPoolClientError {
         UpdateUserPoolClientError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateUserPoolClientError {
+    fn from(err: io::Error) -> UpdateUserPoolClientError {
+        UpdateUserPoolClientError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateUserPoolClientError {
@@ -11103,6 +11470,11 @@ impl From<CredentialsError> for VerifyUserAttributeError {
 impl From<HttpDispatchError> for VerifyUserAttributeError {
     fn from(err: HttpDispatchError) -> VerifyUserAttributeError {
         VerifyUserAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for VerifyUserAttributeError {
+    fn from(err: io::Error) -> VerifyUserAttributeError {
+        VerifyUserAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for VerifyUserAttributeError {
@@ -11627,15 +11999,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddCustomAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddCustomAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AddCustomAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddCustomAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11655,13 +12030,14 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AdminAddUserToGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminAddUserToGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11681,15 +12057,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminConfirmSignUpResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminConfirmSignUpResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AdminConfirmSignUpError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminConfirmSignUpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11709,15 +12088,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminCreateUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminCreateUserResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AdminCreateUserError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminCreateUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11737,13 +12121,14 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AdminDeleteUserError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminDeleteUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11764,13 +12149,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminDeleteUserAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AdminDeleteUserAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminDeleteUserAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminDeleteUserAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -11789,15 +12181,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminDisableUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminDisableUserResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AdminDisableUserError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminDisableUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11817,15 +12214,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminEnableUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminEnableUserResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AdminEnableUserError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminEnableUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11845,13 +12247,14 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AdminForgetDeviceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminForgetDeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11871,15 +12274,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminGetDeviceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminGetDeviceResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AdminGetDeviceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminGetDeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11899,14 +12307,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminGetUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminGetUserResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AdminGetUserError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminGetUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11926,15 +12340,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminInitiateAuthResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminInitiateAuthResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AdminInitiateAuthError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminInitiateAuthError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11954,15 +12371,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminListDevicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminListDevicesResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AdminListDevicesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminListDevicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11983,15 +12405,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminListGroupsForUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminListGroupsForUserResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AdminListGroupsForUserError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminListGroupsForUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12011,11 +12436,16 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(AdminRemoveUserFromGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminRemoveUserFromGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -12035,15 +12465,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminResetUserPasswordResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminResetUserPasswordResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AdminResetUserPasswordError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminResetUserPasswordError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12064,13 +12497,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminRespondToAuthChallengeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AdminRespondToAuthChallengeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminRespondToAuthChallengeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminRespondToAuthChallengeError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12090,15 +12530,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminSetUserSettingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminSetUserSettingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AdminSetUserSettingsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminSetUserSettingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12119,13 +12562,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminUpdateDeviceStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AdminUpdateDeviceStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminUpdateDeviceStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminUpdateDeviceStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -12145,13 +12595,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminUpdateUserAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AdminUpdateUserAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminUpdateUserAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminUpdateUserAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -12171,15 +12628,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AdminUserGlobalSignOutResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AdminUserGlobalSignOutResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AdminUserGlobalSignOutError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AdminUserGlobalSignOutError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12199,15 +12659,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ChangePasswordResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ChangePasswordResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ChangePasswordError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ChangePasswordError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12227,14 +12692,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ConfirmDeviceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ConfirmDeviceResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ConfirmDeviceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfirmDeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12255,15 +12726,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ConfirmForgotPasswordResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ConfirmForgotPasswordResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ConfirmForgotPasswordError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfirmForgotPasswordError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12283,14 +12757,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ConfirmSignUpResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ConfirmSignUpResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ConfirmSignUpError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfirmSignUpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12310,13 +12790,21 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateGroupResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12336,15 +12824,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateIdentityProviderResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateIdentityProviderResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateIdentityProviderError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateIdentityProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12364,15 +12855,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateUserImportJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateUserImportJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateUserImportJobError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUserImportJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12392,15 +12886,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateUserPoolResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateUserPoolResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateUserPoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUserPoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12421,15 +12920,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateUserPoolClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateUserPoolClientResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateUserPoolClientError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUserPoolClientError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12450,15 +12952,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateUserPoolDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateUserPoolDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateUserPoolDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUserPoolDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12476,11 +12981,15 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12499,13 +13008,14 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteIdentityProviderError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIdentityProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12523,11 +13033,15 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteUserError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12547,15 +13061,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteUserAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteUserAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteUserAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUserAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12573,13 +13090,14 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteUserPoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUserPoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12599,13 +13117,14 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteUserPoolClientError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUserPoolClientError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12626,15 +13145,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteUserPoolDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteUserPoolDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteUserPoolDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUserPoolDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12655,13 +13177,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeIdentityProviderResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeIdentityProviderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeIdentityProviderResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeIdentityProviderError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -12681,15 +13210,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeUserImportJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeUserImportJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeUserImportJobError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeUserImportJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12709,15 +13241,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeUserPoolResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeUserPoolResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeUserPoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeUserPoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12738,15 +13275,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeUserPoolClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeUserPoolClientResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeUserPoolClientError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeUserPoolClientError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12767,15 +13307,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeUserPoolDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeUserPoolDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeUserPoolDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeUserPoolDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12793,12 +13336,14 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(ForgetDeviceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ForgetDeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12818,15 +13363,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ForgotPasswordResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ForgotPasswordResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ForgotPasswordError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ForgotPasswordError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12846,14 +13396,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetCSVHeaderResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetCSVHeaderResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetCSVHeaderError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCSVHeaderError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12871,13 +13427,21 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDeviceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetDeviceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDeviceResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12893,13 +13457,21 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetGroupResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12919,13 +13491,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetIdentityProviderByIdentifierResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetIdentityProviderByIdentifierError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetIdentityProviderByIdentifierResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIdentityProviderByIdentifierError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -12941,15 +13520,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetUserResponse>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetUserResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetUserError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12969,13 +13553,19 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetUserAttributeVerificationCodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetUserAttributeVerificationCodeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetUserAttributeVerificationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUserAttributeVerificationCodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12994,14 +13584,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GlobalSignOutResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GlobalSignOutResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GlobalSignOutError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GlobalSignOutError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13021,14 +13617,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<InitiateAuthResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<InitiateAuthResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(InitiateAuthError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InitiateAuthError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13048,13 +13650,21 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDevicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListDevicesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDevicesResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDevicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13073,13 +13683,21 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListGroupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListGroupsResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13099,15 +13717,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListIdentityProvidersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListIdentityProvidersResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListIdentityProvidersError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListIdentityProvidersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13127,15 +13748,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListUserImportJobsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListUserImportJobsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListUserImportJobsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUserImportJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13155,15 +13779,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListUserPoolClientsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListUserPoolClientsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListUserPoolClientsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUserPoolClientsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13183,14 +13810,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListUserPoolsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListUserPoolsResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListUserPoolsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUserPoolsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13208,13 +13841,21 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListUsersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListUsersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListUsersResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUsersError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13233,15 +13874,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListUsersInGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListUsersInGroupResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListUsersInGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUsersInGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13262,15 +13908,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ResendConfirmationCodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ResendConfirmationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ResendConfirmationCodeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResendConfirmationCodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13291,15 +13940,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RespondToAuthChallengeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RespondToAuthChallengeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RespondToAuthChallengeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RespondToAuthChallengeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13319,15 +13971,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SetUserSettingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SetUserSettingsResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(SetUserSettingsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetUserSettingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13344,15 +14001,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<SignUpResponse>(String::from_utf8_lossy(&response.body)
-                                                              .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SignUpResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(SignUpError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SignUpError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13371,15 +14033,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartUserImportJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartUserImportJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(StartUserImportJobError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartUserImportJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13399,15 +14064,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopUserImportJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopUserImportJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(StopUserImportJobError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopUserImportJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13427,15 +14095,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDeviceStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDeviceStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateDeviceStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDeviceStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13455,13 +14126,21 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateGroupResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13481,15 +14160,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateIdentityProviderResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateIdentityProviderResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateIdentityProviderError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateIdentityProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13510,15 +14192,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateUserAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateUserAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateUserAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateUserAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13538,15 +14223,20 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateUserPoolResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateUserPoolResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateUserPoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateUserPoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13567,15 +14257,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateUserPoolClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateUserPoolClientResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateUserPoolClientError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateUserPoolClientError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13595,15 +14288,18 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<VerifyUserAttributeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VerifyUserAttributeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(VerifyUserAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(VerifyUserAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1195,6 +1197,11 @@ impl From<HttpDispatchError> for DeleteConfigRuleError {
         DeleteConfigRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteConfigRuleError {
+    fn from(err: io::Error) -> DeleteConfigRuleError {
+        DeleteConfigRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1266,6 +1273,11 @@ impl From<CredentialsError> for DeleteConfigurationRecorderError {
 impl From<HttpDispatchError> for DeleteConfigurationRecorderError {
     fn from(err: HttpDispatchError) -> DeleteConfigurationRecorderError {
         DeleteConfigurationRecorderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteConfigurationRecorderError {
+    fn from(err: io::Error) -> DeleteConfigurationRecorderError {
+        DeleteConfigurationRecorderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteConfigurationRecorderError {
@@ -1343,6 +1355,11 @@ impl From<CredentialsError> for DeleteDeliveryChannelError {
 impl From<HttpDispatchError> for DeleteDeliveryChannelError {
     fn from(err: HttpDispatchError) -> DeleteDeliveryChannelError {
         DeleteDeliveryChannelError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDeliveryChannelError {
+    fn from(err: io::Error) -> DeleteDeliveryChannelError {
+        DeleteDeliveryChannelError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDeliveryChannelError {
@@ -1427,6 +1444,11 @@ impl From<HttpDispatchError> for DeleteEvaluationResultsError {
         DeleteEvaluationResultsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteEvaluationResultsError {
+    fn from(err: io::Error) -> DeleteEvaluationResultsError {
+        DeleteEvaluationResultsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteEvaluationResultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1506,6 +1528,11 @@ impl From<CredentialsError> for DeliverConfigSnapshotError {
 impl From<HttpDispatchError> for DeliverConfigSnapshotError {
     fn from(err: HttpDispatchError) -> DeliverConfigSnapshotError {
         DeliverConfigSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeliverConfigSnapshotError {
+    fn from(err: io::Error) -> DeliverConfigSnapshotError {
+        DeliverConfigSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeliverConfigSnapshotError {
@@ -1590,6 +1617,11 @@ impl From<HttpDispatchError> for DescribeComplianceByConfigRuleError {
         DescribeComplianceByConfigRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeComplianceByConfigRuleError {
+    fn from(err: io::Error) -> DescribeComplianceByConfigRuleError {
+        DescribeComplianceByConfigRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeComplianceByConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1667,6 +1699,11 @@ impl From<CredentialsError> for DescribeComplianceByResourceError {
 impl From<HttpDispatchError> for DescribeComplianceByResourceError {
     fn from(err: HttpDispatchError) -> DescribeComplianceByResourceError {
         DescribeComplianceByResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeComplianceByResourceError {
+    fn from(err: io::Error) -> DescribeComplianceByResourceError {
+        DescribeComplianceByResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeComplianceByResourceError {
@@ -1749,6 +1786,11 @@ impl From<CredentialsError> for DescribeConfigRuleEvaluationStatusError {
 impl From<HttpDispatchError> for DescribeConfigRuleEvaluationStatusError {
     fn from(err: HttpDispatchError) -> DescribeConfigRuleEvaluationStatusError {
         DescribeConfigRuleEvaluationStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeConfigRuleEvaluationStatusError {
+    fn from(err: io::Error) -> DescribeConfigRuleEvaluationStatusError {
+        DescribeConfigRuleEvaluationStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeConfigRuleEvaluationStatusError {
@@ -1834,6 +1876,11 @@ impl From<HttpDispatchError> for DescribeConfigRulesError {
         DescribeConfigRulesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeConfigRulesError {
+    fn from(err: io::Error) -> DescribeConfigRulesError {
+        DescribeConfigRulesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeConfigRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1908,6 +1955,11 @@ impl From<CredentialsError> for DescribeConfigurationRecorderStatusError {
 impl From<HttpDispatchError> for DescribeConfigurationRecorderStatusError {
     fn from(err: HttpDispatchError) -> DescribeConfigurationRecorderStatusError {
         DescribeConfigurationRecorderStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeConfigurationRecorderStatusError {
+    fn from(err: io::Error) -> DescribeConfigurationRecorderStatusError {
+        DescribeConfigurationRecorderStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeConfigurationRecorderStatusError {
@@ -1986,6 +2038,11 @@ impl From<HttpDispatchError> for DescribeConfigurationRecordersError {
         DescribeConfigurationRecordersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeConfigurationRecordersError {
+    fn from(err: io::Error) -> DescribeConfigurationRecordersError {
+        DescribeConfigurationRecordersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeConfigurationRecordersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2060,6 +2117,11 @@ impl From<HttpDispatchError> for DescribeDeliveryChannelStatusError {
         DescribeDeliveryChannelStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDeliveryChannelStatusError {
+    fn from(err: io::Error) -> DescribeDeliveryChannelStatusError {
+        DescribeDeliveryChannelStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDeliveryChannelStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2132,6 +2194,11 @@ impl From<CredentialsError> for DescribeDeliveryChannelsError {
 impl From<HttpDispatchError> for DescribeDeliveryChannelsError {
     fn from(err: HttpDispatchError) -> DescribeDeliveryChannelsError {
         DescribeDeliveryChannelsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDeliveryChannelsError {
+    fn from(err: io::Error) -> DescribeDeliveryChannelsError {
+        DescribeDeliveryChannelsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDeliveryChannelsError {
@@ -2214,6 +2281,11 @@ impl From<HttpDispatchError> for GetComplianceDetailsByConfigRuleError {
         GetComplianceDetailsByConfigRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetComplianceDetailsByConfigRuleError {
+    fn from(err: io::Error) -> GetComplianceDetailsByConfigRuleError {
+        GetComplianceDetailsByConfigRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetComplianceDetailsByConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2290,6 +2362,11 @@ impl From<HttpDispatchError> for GetComplianceDetailsByResourceError {
         GetComplianceDetailsByResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetComplianceDetailsByResourceError {
+    fn from(err: io::Error) -> GetComplianceDetailsByResourceError {
+        GetComplianceDetailsByResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetComplianceDetailsByResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2359,6 +2436,11 @@ impl From<CredentialsError> for GetComplianceSummaryByConfigRuleError {
 impl From<HttpDispatchError> for GetComplianceSummaryByConfigRuleError {
     fn from(err: HttpDispatchError) -> GetComplianceSummaryByConfigRuleError {
         GetComplianceSummaryByConfigRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetComplianceSummaryByConfigRuleError {
+    fn from(err: io::Error) -> GetComplianceSummaryByConfigRuleError {
+        GetComplianceSummaryByConfigRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetComplianceSummaryByConfigRuleError {
@@ -2433,6 +2515,11 @@ impl From<CredentialsError> for GetComplianceSummaryByResourceTypeError {
 impl From<HttpDispatchError> for GetComplianceSummaryByResourceTypeError {
     fn from(err: HttpDispatchError) -> GetComplianceSummaryByResourceTypeError {
         GetComplianceSummaryByResourceTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetComplianceSummaryByResourceTypeError {
+    fn from(err: io::Error) -> GetComplianceSummaryByResourceTypeError {
+        GetComplianceSummaryByResourceTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetComplianceSummaryByResourceTypeError {
@@ -2527,6 +2614,11 @@ impl From<HttpDispatchError> for GetResourceConfigHistoryError {
         GetResourceConfigHistoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetResourceConfigHistoryError {
+    fn from(err: io::Error) -> GetResourceConfigHistoryError {
+        GetResourceConfigHistoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetResourceConfigHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2613,6 +2705,11 @@ impl From<CredentialsError> for ListDiscoveredResourcesError {
 impl From<HttpDispatchError> for ListDiscoveredResourcesError {
     fn from(err: HttpDispatchError) -> ListDiscoveredResourcesError {
         ListDiscoveredResourcesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListDiscoveredResourcesError {
+    fn from(err: io::Error) -> ListDiscoveredResourcesError {
+        ListDiscoveredResourcesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListDiscoveredResourcesError {
@@ -2709,6 +2806,11 @@ impl From<HttpDispatchError> for PutConfigRuleError {
         PutConfigRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutConfigRuleError {
+    fn from(err: io::Error) -> PutConfigRuleError {
+        PutConfigRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2794,6 +2896,11 @@ impl From<CredentialsError> for PutConfigurationRecorderError {
 impl From<HttpDispatchError> for PutConfigurationRecorderError {
     fn from(err: HttpDispatchError) -> PutConfigurationRecorderError {
         PutConfigurationRecorderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutConfigurationRecorderError {
+    fn from(err: io::Error) -> PutConfigurationRecorderError {
+        PutConfigurationRecorderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutConfigurationRecorderError {
@@ -2899,6 +3006,11 @@ impl From<HttpDispatchError> for PutDeliveryChannelError {
         PutDeliveryChannelError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutDeliveryChannelError {
+    fn from(err: io::Error) -> PutDeliveryChannelError {
+        PutDeliveryChannelError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutDeliveryChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2991,6 +3103,11 @@ impl From<HttpDispatchError> for PutEvaluationsError {
         PutEvaluationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutEvaluationsError {
+    fn from(err: io::Error) -> PutEvaluationsError {
+        PutEvaluationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutEvaluationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3078,6 +3195,11 @@ impl From<HttpDispatchError> for StartConfigRulesEvaluationError {
         StartConfigRulesEvaluationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartConfigRulesEvaluationError {
+    fn from(err: io::Error) -> StartConfigRulesEvaluationError {
+        StartConfigRulesEvaluationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartConfigRulesEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3158,6 +3280,11 @@ impl From<HttpDispatchError> for StartConfigurationRecorderError {
         StartConfigurationRecorderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartConfigurationRecorderError {
+    fn from(err: io::Error) -> StartConfigurationRecorderError {
+        StartConfigurationRecorderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartConfigurationRecorderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3231,6 +3358,11 @@ impl From<CredentialsError> for StopConfigurationRecorderError {
 impl From<HttpDispatchError> for StopConfigurationRecorderError {
     fn from(err: HttpDispatchError) -> StopConfigurationRecorderError {
         StopConfigurationRecorderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopConfigurationRecorderError {
+    fn from(err: io::Error) -> StopConfigurationRecorderError {
+        StopConfigurationRecorderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopConfigurationRecorderError {
@@ -3464,13 +3596,14 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteConfigRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteConfigRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3490,11 +3623,16 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteConfigurationRecorderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteConfigurationRecorderError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -3512,13 +3650,14 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteDeliveryChannelError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDeliveryChannelError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3539,13 +3678,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteEvaluationResultsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteEvaluationResultsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteEvaluationResultsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEvaluationResultsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -3564,15 +3710,18 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeliverConfigSnapshotResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeliverConfigSnapshotResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeliverConfigSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeliverConfigSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3593,13 +3742,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeComplianceByConfigRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeComplianceByConfigRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeComplianceByConfigRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeComplianceByConfigRuleError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -3619,13 +3775,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeComplianceByResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeComplianceByResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeComplianceByResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeComplianceByResourceError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -3646,13 +3809,19 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeConfigRuleEvaluationStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeConfigRuleEvaluationStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeConfigRuleEvaluationStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConfigRuleEvaluationStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3670,15 +3839,18 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeConfigRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeConfigRulesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeConfigRulesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConfigRulesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3700,13 +3872,19 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeConfigurationRecorderStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeConfigurationRecorderStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeConfigurationRecorderStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConfigurationRecorderStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3726,13 +3904,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeConfigurationRecordersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeConfigurationRecordersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeConfigurationRecordersResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConfigurationRecordersError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -3752,13 +3937,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDeliveryChannelStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeDeliveryChannelStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDeliveryChannelStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDeliveryChannelStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -3778,13 +3970,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDeliveryChannelsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeDeliveryChannelsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDeliveryChannelsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDeliveryChannelsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -3804,13 +4003,19 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetComplianceDetailsByConfigRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetComplianceDetailsByConfigRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetComplianceDetailsByConfigRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetComplianceDetailsByConfigRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3830,13 +4035,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetComplianceDetailsByResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetComplianceDetailsByResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetComplianceDetailsByResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetComplianceDetailsByResourceError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -3854,13 +4066,19 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetComplianceSummaryByConfigRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetComplianceSummaryByConfigRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetComplianceSummaryByConfigRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetComplianceSummaryByConfigRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3881,13 +4099,19 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetComplianceSummaryByResourceTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetComplianceSummaryByResourceTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetComplianceSummaryByResourceTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetComplianceSummaryByResourceTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3907,13 +4131,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetResourceConfigHistoryResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetResourceConfigHistoryError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetResourceConfigHistoryResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetResourceConfigHistoryError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -3933,13 +4164,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDiscoveredResourcesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListDiscoveredResourcesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDiscoveredResourcesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDiscoveredResourcesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -3955,12 +4193,14 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutConfigRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutConfigRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3980,11 +4220,16 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(PutConfigurationRecorderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutConfigurationRecorderError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4002,13 +4247,14 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutDeliveryChannelError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutDeliveryChannelError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4027,15 +4273,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutEvaluationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutEvaluationsResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutEvaluationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutEvaluationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4056,13 +4307,20 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartConfigRulesEvaluationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StartConfigRulesEvaluationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartConfigRulesEvaluationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartConfigRulesEvaluationError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -4081,11 +4339,16 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(StartConfigurationRecorderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartConfigurationRecorderError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -4104,11 +4367,16 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(StopConfigurationRecorderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopConfigurationRecorderError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -157,6 +159,11 @@ impl From<HttpDispatchError> for DeleteReportDefinitionError {
         DeleteReportDefinitionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteReportDefinitionError {
+    fn from(err: io::Error) -> DeleteReportDefinitionError {
+        DeleteReportDefinitionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteReportDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -231,6 +238,11 @@ impl From<CredentialsError> for DescribeReportDefinitionsError {
 impl From<HttpDispatchError> for DescribeReportDefinitionsError {
     fn from(err: HttpDispatchError) -> DescribeReportDefinitionsError {
         DescribeReportDefinitionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeReportDefinitionsError {
+    fn from(err: io::Error) -> DescribeReportDefinitionsError {
+        DescribeReportDefinitionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeReportDefinitionsError {
@@ -319,6 +331,11 @@ impl From<HttpDispatchError> for PutReportDefinitionError {
         PutReportDefinitionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutReportDefinitionError {
+    fn from(err: io::Error) -> PutReportDefinitionError {
+        PutReportDefinitionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutReportDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -402,15 +419,18 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteReportDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteReportDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteReportDefinitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReportDefinitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -431,13 +451,20 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeReportDefinitionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeReportDefinitionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeReportDefinitionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReportDefinitionsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -456,15 +483,18 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutReportDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutReportDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(PutReportDefinitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutReportDefinitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -750,6 +752,11 @@ impl From<HttpDispatchError> for ActivatePipelineError {
         ActivatePipelineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ActivatePipelineError {
+    fn from(err: io::Error) -> ActivatePipelineError {
+        ActivatePipelineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ActivatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -840,6 +847,11 @@ impl From<HttpDispatchError> for AddTagsError {
         AddTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsError {
+    fn from(err: io::Error) -> AddTagsError {
+        AddTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -920,6 +932,11 @@ impl From<CredentialsError> for CreatePipelineError {
 impl From<HttpDispatchError> for CreatePipelineError {
     fn from(err: HttpDispatchError) -> CreatePipelineError {
         CreatePipelineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePipelineError {
+    fn from(err: io::Error) -> CreatePipelineError {
+        CreatePipelineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePipelineError {
@@ -1012,6 +1029,11 @@ impl From<HttpDispatchError> for DeactivatePipelineError {
         DeactivatePipelineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeactivatePipelineError {
+    fn from(err: io::Error) -> DeactivatePipelineError {
+        DeactivatePipelineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeactivatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1099,6 +1121,11 @@ impl From<CredentialsError> for DeletePipelineError {
 impl From<HttpDispatchError> for DeletePipelineError {
     fn from(err: HttpDispatchError) -> DeletePipelineError {
         DeletePipelineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeletePipelineError {
+    fn from(err: io::Error) -> DeletePipelineError {
+        DeletePipelineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeletePipelineError {
@@ -1192,6 +1219,11 @@ impl From<HttpDispatchError> for DescribeObjectsError {
         DescribeObjectsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeObjectsError {
+    fn from(err: io::Error) -> DescribeObjectsError {
+        DescribeObjectsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeObjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1282,6 +1314,11 @@ impl From<CredentialsError> for DescribePipelinesError {
 impl From<HttpDispatchError> for DescribePipelinesError {
     fn from(err: HttpDispatchError) -> DescribePipelinesError {
         DescribePipelinesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribePipelinesError {
+    fn from(err: io::Error) -> DescribePipelinesError {
+        DescribePipelinesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribePipelinesError {
@@ -1383,6 +1420,11 @@ impl From<HttpDispatchError> for EvaluateExpressionError {
         EvaluateExpressionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EvaluateExpressionError {
+    fn from(err: io::Error) -> EvaluateExpressionError {
+        EvaluateExpressionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EvaluateExpressionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1476,6 +1518,11 @@ impl From<HttpDispatchError> for GetPipelineDefinitionError {
         GetPipelineDefinitionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetPipelineDefinitionError {
+    fn from(err: io::Error) -> GetPipelineDefinitionError {
+        GetPipelineDefinitionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetPipelineDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1558,6 +1605,11 @@ impl From<CredentialsError> for ListPipelinesError {
 impl From<HttpDispatchError> for ListPipelinesError {
     fn from(err: HttpDispatchError) -> ListPipelinesError {
         ListPipelinesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPipelinesError {
+    fn from(err: io::Error) -> ListPipelinesError {
+        ListPipelinesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPipelinesError {
@@ -1643,6 +1695,11 @@ impl From<CredentialsError> for PollForTaskError {
 impl From<HttpDispatchError> for PollForTaskError {
     fn from(err: HttpDispatchError) -> PollForTaskError {
         PollForTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PollForTaskError {
+    fn from(err: io::Error) -> PollForTaskError {
+        PollForTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PollForTaskError {
@@ -1732,6 +1789,11 @@ impl From<CredentialsError> for PutPipelineDefinitionError {
 impl From<HttpDispatchError> for PutPipelineDefinitionError {
     fn from(err: HttpDispatchError) -> PutPipelineDefinitionError {
         PutPipelineDefinitionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutPipelineDefinitionError {
+    fn from(err: io::Error) -> PutPipelineDefinitionError {
+        PutPipelineDefinitionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutPipelineDefinitionError {
@@ -1828,6 +1890,11 @@ impl From<HttpDispatchError> for QueryObjectsError {
         QueryObjectsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for QueryObjectsError {
+    fn from(err: io::Error) -> QueryObjectsError {
+        QueryObjectsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for QueryObjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1916,6 +1983,11 @@ impl From<CredentialsError> for RemoveTagsError {
 impl From<HttpDispatchError> for RemoveTagsError {
     fn from(err: HttpDispatchError) -> RemoveTagsError {
         RemoveTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveTagsError {
+    fn from(err: io::Error) -> RemoveTagsError {
+        RemoveTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveTagsError {
@@ -2015,6 +2087,11 @@ impl From<HttpDispatchError> for ReportTaskProgressError {
         ReportTaskProgressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReportTaskProgressError {
+    fn from(err: io::Error) -> ReportTaskProgressError {
+        ReportTaskProgressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReportTaskProgressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2096,6 +2173,11 @@ impl From<CredentialsError> for ReportTaskRunnerHeartbeatError {
 impl From<HttpDispatchError> for ReportTaskRunnerHeartbeatError {
     fn from(err: HttpDispatchError) -> ReportTaskRunnerHeartbeatError {
         ReportTaskRunnerHeartbeatError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ReportTaskRunnerHeartbeatError {
+    fn from(err: io::Error) -> ReportTaskRunnerHeartbeatError {
+        ReportTaskRunnerHeartbeatError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ReportTaskRunnerHeartbeatError {
@@ -2186,6 +2268,11 @@ impl From<CredentialsError> for SetStatusError {
 impl From<HttpDispatchError> for SetStatusError {
     fn from(err: HttpDispatchError) -> SetStatusError {
         SetStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetStatusError {
+    fn from(err: io::Error) -> SetStatusError {
+        SetStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetStatusError {
@@ -2285,6 +2372,11 @@ impl From<HttpDispatchError> for SetTaskStatusError {
         SetTaskStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetTaskStatusError {
+    fn from(err: io::Error) -> SetTaskStatusError {
+        SetTaskStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetTaskStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2370,6 +2462,11 @@ impl From<CredentialsError> for ValidatePipelineDefinitionError {
 impl From<HttpDispatchError> for ValidatePipelineDefinitionError {
     fn from(err: HttpDispatchError) -> ValidatePipelineDefinitionError {
         ValidatePipelineDefinitionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ValidatePipelineDefinitionError {
+    fn from(err: io::Error) -> ValidatePipelineDefinitionError {
+        ValidatePipelineDefinitionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ValidatePipelineDefinitionError {
@@ -2544,15 +2641,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ActivatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ActivatePipelineOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ActivatePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ActivatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2569,15 +2671,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AddTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2595,15 +2702,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreatePipelineOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreatePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2622,15 +2734,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeactivatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeactivatePipelineOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeactivatePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeactivatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2647,13 +2764,14 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeletePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2672,15 +2790,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeObjectsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeObjectsOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeObjectsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeObjectsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2699,15 +2822,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribePipelinesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribePipelinesOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribePipelinesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePipelinesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2726,15 +2854,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EvaluateExpressionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EvaluateExpressionOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(EvaluateExpressionError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EvaluateExpressionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2754,15 +2887,18 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetPipelineDefinitionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetPipelineDefinitionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetPipelineDefinitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPipelineDefinitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2781,14 +2917,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPipelinesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPipelinesOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListPipelinesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPipelinesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2807,13 +2949,21 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PollForTaskOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(PollForTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PollForTaskOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PollForTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2832,15 +2982,18 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutPipelineDefinitionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutPipelineDefinitionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(PutPipelineDefinitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutPipelineDefinitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2859,14 +3012,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<QueryObjectsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<QueryObjectsOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(QueryObjectsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(QueryObjectsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2883,13 +3042,21 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTagsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RemoveTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTagsOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2907,15 +3074,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ReportTaskProgressOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ReportTaskProgressOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ReportTaskProgressError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReportTaskProgressError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2935,13 +3107,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ReportTaskRunnerHeartbeatOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ReportTaskRunnerHeartbeatError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ReportTaskRunnerHeartbeatOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReportTaskRunnerHeartbeatError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -2957,11 +3136,15 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(SetStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2979,14 +3162,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SetTaskStatusOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SetTaskStatusOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(SetTaskStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetTaskStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3006,13 +3195,20 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ValidatePipelineDefinitionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ValidatePipelineDefinitionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ValidatePipelineDefinitionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ValidatePipelineDefinitionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2205,6 +2207,11 @@ impl From<HttpDispatchError> for CreateDevicePoolError {
         CreateDevicePoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDevicePoolError {
+    fn from(err: io::Error) -> CreateDevicePoolError {
+        CreateDevicePoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDevicePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2295,6 +2302,11 @@ impl From<CredentialsError> for CreateNetworkProfileError {
 impl From<HttpDispatchError> for CreateNetworkProfileError {
     fn from(err: HttpDispatchError) -> CreateNetworkProfileError {
         CreateNetworkProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateNetworkProfileError {
+    fn from(err: io::Error) -> CreateNetworkProfileError {
+        CreateNetworkProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateNetworkProfileError {
@@ -2391,6 +2403,11 @@ impl From<HttpDispatchError> for CreateProjectError {
         CreateProjectError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateProjectError {
+    fn from(err: io::Error) -> CreateProjectError {
+        CreateProjectError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2483,6 +2500,11 @@ impl From<HttpDispatchError> for CreateRemoteAccessSessionError {
         CreateRemoteAccessSessionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRemoteAccessSessionError {
+    fn from(err: io::Error) -> CreateRemoteAccessSessionError {
+        CreateRemoteAccessSessionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2571,6 +2593,11 @@ impl From<CredentialsError> for CreateUploadError {
 impl From<HttpDispatchError> for CreateUploadError {
     fn from(err: HttpDispatchError) -> CreateUploadError {
         CreateUploadError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateUploadError {
+    fn from(err: io::Error) -> CreateUploadError {
+        CreateUploadError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateUploadError {
@@ -2665,6 +2692,11 @@ impl From<HttpDispatchError> for DeleteDevicePoolError {
         DeleteDevicePoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDevicePoolError {
+    fn from(err: io::Error) -> DeleteDevicePoolError {
+        DeleteDevicePoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDevicePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2755,6 +2787,11 @@ impl From<CredentialsError> for DeleteNetworkProfileError {
 impl From<HttpDispatchError> for DeleteNetworkProfileError {
     fn from(err: HttpDispatchError) -> DeleteNetworkProfileError {
         DeleteNetworkProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteNetworkProfileError {
+    fn from(err: io::Error) -> DeleteNetworkProfileError {
+        DeleteNetworkProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteNetworkProfileError {
@@ -2851,6 +2888,11 @@ impl From<HttpDispatchError> for DeleteProjectError {
         DeleteProjectError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteProjectError {
+    fn from(err: io::Error) -> DeleteProjectError {
+        DeleteProjectError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2943,6 +2985,11 @@ impl From<HttpDispatchError> for DeleteRemoteAccessSessionError {
         DeleteRemoteAccessSessionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRemoteAccessSessionError {
+    fn from(err: io::Error) -> DeleteRemoteAccessSessionError {
+        DeleteRemoteAccessSessionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3031,6 +3078,11 @@ impl From<HttpDispatchError> for DeleteRunError {
         DeleteRunError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRunError {
+    fn from(err: io::Error) -> DeleteRunError {
+        DeleteRunError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3117,6 +3169,11 @@ impl From<CredentialsError> for DeleteUploadError {
 impl From<HttpDispatchError> for DeleteUploadError {
     fn from(err: HttpDispatchError) -> DeleteUploadError {
         DeleteUploadError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteUploadError {
+    fn from(err: io::Error) -> DeleteUploadError {
+        DeleteUploadError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteUploadError {
@@ -3211,6 +3268,11 @@ impl From<HttpDispatchError> for GetAccountSettingsError {
         GetAccountSettingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAccountSettingsError {
+    fn from(err: io::Error) -> GetAccountSettingsError {
+        GetAccountSettingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAccountSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3297,6 +3359,11 @@ impl From<CredentialsError> for GetDeviceError {
 impl From<HttpDispatchError> for GetDeviceError {
     fn from(err: HttpDispatchError) -> GetDeviceError {
         GetDeviceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDeviceError {
+    fn from(err: io::Error) -> GetDeviceError {
+        GetDeviceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDeviceError {
@@ -3391,6 +3458,11 @@ impl From<HttpDispatchError> for GetDevicePoolError {
         GetDevicePoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDevicePoolError {
+    fn from(err: io::Error) -> GetDevicePoolError {
+        GetDevicePoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDevicePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3483,6 +3555,11 @@ impl From<HttpDispatchError> for GetDevicePoolCompatibilityError {
         GetDevicePoolCompatibilityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDevicePoolCompatibilityError {
+    fn from(err: io::Error) -> GetDevicePoolCompatibilityError {
+        GetDevicePoolCompatibilityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDevicePoolCompatibilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3569,6 +3646,11 @@ impl From<CredentialsError> for GetJobError {
 impl From<HttpDispatchError> for GetJobError {
     fn from(err: HttpDispatchError) -> GetJobError {
         GetJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetJobError {
+    fn from(err: io::Error) -> GetJobError {
+        GetJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetJobError {
@@ -3661,6 +3743,11 @@ impl From<CredentialsError> for GetNetworkProfileError {
 impl From<HttpDispatchError> for GetNetworkProfileError {
     fn from(err: HttpDispatchError) -> GetNetworkProfileError {
         GetNetworkProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetNetworkProfileError {
+    fn from(err: io::Error) -> GetNetworkProfileError {
+        GetNetworkProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetNetworkProfileError {
@@ -3762,6 +3849,11 @@ impl From<HttpDispatchError> for GetOfferingStatusError {
         GetOfferingStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetOfferingStatusError {
+    fn from(err: io::Error) -> GetOfferingStatusError {
+        GetOfferingStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetOfferingStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3849,6 +3941,11 @@ impl From<CredentialsError> for GetProjectError {
 impl From<HttpDispatchError> for GetProjectError {
     fn from(err: HttpDispatchError) -> GetProjectError {
         GetProjectError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetProjectError {
+    fn from(err: io::Error) -> GetProjectError {
+        GetProjectError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetProjectError {
@@ -3943,6 +4040,11 @@ impl From<HttpDispatchError> for GetRemoteAccessSessionError {
         GetRemoteAccessSessionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRemoteAccessSessionError {
+    fn from(err: io::Error) -> GetRemoteAccessSessionError {
+        GetRemoteAccessSessionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4031,6 +4133,11 @@ impl From<HttpDispatchError> for GetRunError {
         GetRunError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRunError {
+    fn from(err: io::Error) -> GetRunError {
+        GetRunError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4115,6 +4222,11 @@ impl From<CredentialsError> for GetSuiteError {
 impl From<HttpDispatchError> for GetSuiteError {
     fn from(err: HttpDispatchError) -> GetSuiteError {
         GetSuiteError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSuiteError {
+    fn from(err: io::Error) -> GetSuiteError {
+        GetSuiteError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSuiteError {
@@ -4203,6 +4315,11 @@ impl From<HttpDispatchError> for GetTestError {
         GetTestError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetTestError {
+    fn from(err: io::Error) -> GetTestError {
+        GetTestError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetTestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4287,6 +4404,11 @@ impl From<CredentialsError> for GetUploadError {
 impl From<HttpDispatchError> for GetUploadError {
     fn from(err: HttpDispatchError) -> GetUploadError {
         GetUploadError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetUploadError {
+    fn from(err: io::Error) -> GetUploadError {
+        GetUploadError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetUploadError {
@@ -4375,6 +4497,11 @@ impl From<CredentialsError> for InstallToRemoteAccessSessionError {
 impl From<HttpDispatchError> for InstallToRemoteAccessSessionError {
     fn from(err: HttpDispatchError) -> InstallToRemoteAccessSessionError {
         InstallToRemoteAccessSessionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for InstallToRemoteAccessSessionError {
+    fn from(err: io::Error) -> InstallToRemoteAccessSessionError {
+        InstallToRemoteAccessSessionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for InstallToRemoteAccessSessionError {
@@ -4471,6 +4598,11 @@ impl From<HttpDispatchError> for ListArtifactsError {
         ListArtifactsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListArtifactsError {
+    fn from(err: io::Error) -> ListArtifactsError {
+        ListArtifactsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListArtifactsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4563,6 +4695,11 @@ impl From<HttpDispatchError> for ListDevicePoolsError {
         ListDevicePoolsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDevicePoolsError {
+    fn from(err: io::Error) -> ListDevicePoolsError {
+        ListDevicePoolsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDevicePoolsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4651,6 +4788,11 @@ impl From<HttpDispatchError> for ListDevicesError {
         ListDevicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDevicesError {
+    fn from(err: io::Error) -> ListDevicesError {
+        ListDevicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4735,6 +4877,11 @@ impl From<CredentialsError> for ListJobsError {
 impl From<HttpDispatchError> for ListJobsError {
     fn from(err: HttpDispatchError) -> ListJobsError {
         ListJobsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListJobsError {
+    fn from(err: io::Error) -> ListJobsError {
+        ListJobsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListJobsError {
@@ -4827,6 +4974,11 @@ impl From<CredentialsError> for ListNetworkProfilesError {
 impl From<HttpDispatchError> for ListNetworkProfilesError {
     fn from(err: HttpDispatchError) -> ListNetworkProfilesError {
         ListNetworkProfilesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListNetworkProfilesError {
+    fn from(err: io::Error) -> ListNetworkProfilesError {
+        ListNetworkProfilesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListNetworkProfilesError {
@@ -4926,6 +5078,11 @@ impl From<CredentialsError> for ListOfferingPromotionsError {
 impl From<HttpDispatchError> for ListOfferingPromotionsError {
     fn from(err: HttpDispatchError) -> ListOfferingPromotionsError {
         ListOfferingPromotionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListOfferingPromotionsError {
+    fn from(err: io::Error) -> ListOfferingPromotionsError {
+        ListOfferingPromotionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListOfferingPromotionsError {
@@ -5028,6 +5185,11 @@ impl From<HttpDispatchError> for ListOfferingTransactionsError {
         ListOfferingTransactionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListOfferingTransactionsError {
+    fn from(err: io::Error) -> ListOfferingTransactionsError {
+        ListOfferingTransactionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListOfferingTransactionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5128,6 +5290,11 @@ impl From<HttpDispatchError> for ListOfferingsError {
         ListOfferingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListOfferingsError {
+    fn from(err: io::Error) -> ListOfferingsError {
+        ListOfferingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5215,6 +5382,11 @@ impl From<CredentialsError> for ListProjectsError {
 impl From<HttpDispatchError> for ListProjectsError {
     fn from(err: HttpDispatchError) -> ListProjectsError {
         ListProjectsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListProjectsError {
+    fn from(err: io::Error) -> ListProjectsError {
+        ListProjectsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListProjectsError {
@@ -5309,6 +5481,11 @@ impl From<HttpDispatchError> for ListRemoteAccessSessionsError {
         ListRemoteAccessSessionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListRemoteAccessSessionsError {
+    fn from(err: io::Error) -> ListRemoteAccessSessionsError {
+        ListRemoteAccessSessionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListRemoteAccessSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5395,6 +5572,11 @@ impl From<CredentialsError> for ListRunsError {
 impl From<HttpDispatchError> for ListRunsError {
     fn from(err: HttpDispatchError) -> ListRunsError {
         ListRunsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRunsError {
+    fn from(err: io::Error) -> ListRunsError {
+        ListRunsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRunsError {
@@ -5485,6 +5667,11 @@ impl From<HttpDispatchError> for ListSamplesError {
         ListSamplesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListSamplesError {
+    fn from(err: io::Error) -> ListSamplesError {
+        ListSamplesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListSamplesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5571,6 +5758,11 @@ impl From<HttpDispatchError> for ListSuitesError {
         ListSuitesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListSuitesError {
+    fn from(err: io::Error) -> ListSuitesError {
+        ListSuitesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListSuitesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5655,6 +5847,11 @@ impl From<CredentialsError> for ListTestsError {
 impl From<HttpDispatchError> for ListTestsError {
     fn from(err: HttpDispatchError) -> ListTestsError {
         ListTestsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTestsError {
+    fn from(err: io::Error) -> ListTestsError {
+        ListTestsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTestsError {
@@ -5749,6 +5946,11 @@ impl From<HttpDispatchError> for ListUniqueProblemsError {
         ListUniqueProblemsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListUniqueProblemsError {
+    fn from(err: io::Error) -> ListUniqueProblemsError {
+        ListUniqueProblemsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListUniqueProblemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5837,6 +6039,11 @@ impl From<CredentialsError> for ListUploadsError {
 impl From<HttpDispatchError> for ListUploadsError {
     fn from(err: HttpDispatchError) -> ListUploadsError {
         ListUploadsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListUploadsError {
+    fn from(err: io::Error) -> ListUploadsError {
+        ListUploadsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListUploadsError {
@@ -5934,6 +6141,11 @@ impl From<CredentialsError> for PurchaseOfferingError {
 impl From<HttpDispatchError> for PurchaseOfferingError {
     fn from(err: HttpDispatchError) -> PurchaseOfferingError {
         PurchaseOfferingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PurchaseOfferingError {
+    fn from(err: io::Error) -> PurchaseOfferingError {
+        PurchaseOfferingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PurchaseOfferingError {
@@ -6034,6 +6246,11 @@ impl From<HttpDispatchError> for RenewOfferingError {
         RenewOfferingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RenewOfferingError {
+    fn from(err: io::Error) -> RenewOfferingError {
+        RenewOfferingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RenewOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6126,6 +6343,11 @@ impl From<CredentialsError> for ScheduleRunError {
 impl From<HttpDispatchError> for ScheduleRunError {
     fn from(err: HttpDispatchError) -> ScheduleRunError {
         ScheduleRunError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ScheduleRunError {
+    fn from(err: io::Error) -> ScheduleRunError {
+        ScheduleRunError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ScheduleRunError {
@@ -6221,6 +6443,11 @@ impl From<HttpDispatchError> for StopRemoteAccessSessionError {
         StopRemoteAccessSessionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StopRemoteAccessSessionError {
+    fn from(err: io::Error) -> StopRemoteAccessSessionError {
+        StopRemoteAccessSessionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StopRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6307,6 +6534,11 @@ impl From<CredentialsError> for StopRunError {
 impl From<HttpDispatchError> for StopRunError {
     fn from(err: HttpDispatchError) -> StopRunError {
         StopRunError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopRunError {
+    fn from(err: io::Error) -> StopRunError {
+        StopRunError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopRunError {
@@ -6401,6 +6633,11 @@ impl From<HttpDispatchError> for UpdateDevicePoolError {
         UpdateDevicePoolError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDevicePoolError {
+    fn from(err: io::Error) -> UpdateDevicePoolError {
+        UpdateDevicePoolError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDevicePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6491,6 +6728,11 @@ impl From<CredentialsError> for UpdateNetworkProfileError {
 impl From<HttpDispatchError> for UpdateNetworkProfileError {
     fn from(err: HttpDispatchError) -> UpdateNetworkProfileError {
         UpdateNetworkProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateNetworkProfileError {
+    fn from(err: io::Error) -> UpdateNetworkProfileError {
+        UpdateNetworkProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateNetworkProfileError {
@@ -6585,6 +6827,11 @@ impl From<CredentialsError> for UpdateProjectError {
 impl From<HttpDispatchError> for UpdateProjectError {
     fn from(err: HttpDispatchError) -> UpdateProjectError {
         UpdateProjectError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateProjectError {
+    fn from(err: io::Error) -> UpdateProjectError {
+        UpdateProjectError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateProjectError {
@@ -6922,15 +7169,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDevicePoolResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDevicePoolResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateDevicePoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDevicePoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6949,15 +7201,18 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateNetworkProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateNetworkProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateNetworkProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateNetworkProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6976,14 +7231,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateProjectResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateProjectResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateProjectError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateProjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7004,13 +7265,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRemoteAccessSessionError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -7028,14 +7296,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateUploadResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateUploadResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateUploadError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUploadError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7054,15 +7328,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteDevicePoolResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteDevicePoolResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteDevicePoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDevicePoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7081,15 +7360,18 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteNetworkProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteNetworkProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteNetworkProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteNetworkProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7108,14 +7390,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteProjectResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteProjectResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteProjectError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteProjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7136,13 +7424,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRemoteAccessSessionError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -7158,15 +7453,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DeleteRunResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRunResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(DeleteRunError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRunError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7184,14 +7484,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteUploadResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteUploadResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteUploadError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUploadError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7207,15 +7513,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetAccountSettingsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetAccountSettingsResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetAccountSettingsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAccountSettingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7232,15 +7543,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetDeviceResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDeviceResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetDeviceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7258,14 +7574,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDevicePoolResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDevicePoolResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetDevicePoolError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDevicePoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7286,13 +7608,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDevicePoolCompatibilityResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetDevicePoolCompatibilityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDevicePoolCompatibilityResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDevicePoolCompatibilityError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -7308,15 +7637,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetJobResult>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetJobResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7334,15 +7668,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetNetworkProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetNetworkProfileResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetNetworkProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetNetworkProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7361,15 +7700,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetOfferingStatusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetOfferingStatusResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetOfferingStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOfferingStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7386,13 +7730,21 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetProjectResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetProjectError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetProjectResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetProjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7411,15 +7763,18 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRemoteAccessSessionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7436,15 +7791,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetRunResult>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRunResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetRunError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRunError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7460,15 +7820,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetSuiteResult>(String::from_utf8_lossy(&response.body)
-                                                              .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSuiteResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetSuiteError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSuiteError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7484,15 +7849,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetTestResult>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetTestResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetTestError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTestError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7508,15 +7878,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetUploadResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetUploadResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetUploadError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUploadError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7536,13 +7911,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<InstallToRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(InstallToRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<InstallToRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InstallToRemoteAccessSessionError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -7560,14 +7942,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListArtifactsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListArtifactsResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListArtifactsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListArtifactsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7586,15 +7974,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDevicePoolsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDevicePoolsResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListDevicePoolsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDevicePoolsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7613,13 +8006,21 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDevicesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListDevicesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDevicesResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDevicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7635,15 +8036,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListJobsResult>(String::from_utf8_lossy(&response.body)
-                                                              .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListJobsResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ListJobsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7661,15 +8067,18 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListNetworkProfilesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListNetworkProfilesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListNetworkProfilesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListNetworkProfilesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7689,15 +8098,18 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListOfferingPromotionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListOfferingPromotionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListOfferingPromotionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOfferingPromotionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7718,13 +8130,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListOfferingTransactionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListOfferingTransactionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListOfferingTransactionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOfferingTransactionsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7742,14 +8161,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListOfferingsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListOfferingsResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListOfferingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOfferingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7768,14 +8193,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListProjectsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListProjectsResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListProjectsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListProjectsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7796,13 +8227,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRemoteAccessSessionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListRemoteAccessSessionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRemoteAccessSessionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRemoteAccessSessionsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7818,15 +8256,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListRunsResult>(String::from_utf8_lossy(&response.body)
-                                                              .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRunsResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ListRunsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRunsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7844,13 +8287,21 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListSamplesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListSamplesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListSamplesResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSamplesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7866,13 +8317,21 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListSuitesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListSuitesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListSuitesResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSuitesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7888,15 +8347,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListTestsResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTestsResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ListTestsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTestsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7914,15 +8378,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListUniqueProblemsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListUniqueProblemsResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListUniqueProblemsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUniqueProblemsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7941,13 +8410,21 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListUploadsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListUploadsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListUploadsResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUploadsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7965,15 +8442,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PurchaseOfferingResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PurchaseOfferingResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PurchaseOfferingError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurchaseOfferingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7992,14 +8474,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RenewOfferingResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RenewOfferingResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RenewOfferingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RenewOfferingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8018,13 +8506,21 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ScheduleRunResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ScheduleRunError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ScheduleRunResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ScheduleRunError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8044,13 +8540,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StopRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopRemoteAccessSessionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -8066,15 +8569,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<StopRunResult>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopRunResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(StopRunError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopRunError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8092,15 +8600,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDevicePoolResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDevicePoolResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateDevicePoolError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDevicePoolError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8119,15 +8632,18 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateNetworkProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateNetworkProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateNetworkProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateNetworkProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8146,14 +8662,20 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateProjectResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateProjectResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateProjectError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateProjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1041,6 +1043,11 @@ impl From<HttpDispatchError> for AllocateConnectionOnInterconnectError {
         AllocateConnectionOnInterconnectError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AllocateConnectionOnInterconnectError {
+    fn from(err: io::Error) -> AllocateConnectionOnInterconnectError {
+        AllocateConnectionOnInterconnectError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AllocateConnectionOnInterconnectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1117,6 +1124,11 @@ impl From<CredentialsError> for AllocateHostedConnectionError {
 impl From<HttpDispatchError> for AllocateHostedConnectionError {
     fn from(err: HttpDispatchError) -> AllocateHostedConnectionError {
         AllocateHostedConnectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AllocateHostedConnectionError {
+    fn from(err: io::Error) -> AllocateHostedConnectionError {
+        AllocateHostedConnectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AllocateHostedConnectionError {
@@ -1197,6 +1209,11 @@ impl From<HttpDispatchError> for AllocatePrivateVirtualInterfaceError {
         AllocatePrivateVirtualInterfaceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AllocatePrivateVirtualInterfaceError {
+    fn from(err: io::Error) -> AllocatePrivateVirtualInterfaceError {
+        AllocatePrivateVirtualInterfaceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AllocatePrivateVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1273,6 +1290,11 @@ impl From<CredentialsError> for AllocatePublicVirtualInterfaceError {
 impl From<HttpDispatchError> for AllocatePublicVirtualInterfaceError {
     fn from(err: HttpDispatchError) -> AllocatePublicVirtualInterfaceError {
         AllocatePublicVirtualInterfaceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AllocatePublicVirtualInterfaceError {
+    fn from(err: io::Error) -> AllocatePublicVirtualInterfaceError {
+        AllocatePublicVirtualInterfaceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AllocatePublicVirtualInterfaceError {
@@ -1353,6 +1375,11 @@ impl From<HttpDispatchError> for AssociateConnectionWithLagError {
         AssociateConnectionWithLagError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateConnectionWithLagError {
+    fn from(err: io::Error) -> AssociateConnectionWithLagError {
+        AssociateConnectionWithLagError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateConnectionWithLagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1431,6 +1458,11 @@ impl From<HttpDispatchError> for AssociateHostedConnectionError {
         AssociateHostedConnectionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateHostedConnectionError {
+    fn from(err: io::Error) -> AssociateHostedConnectionError {
+        AssociateHostedConnectionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateHostedConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1507,6 +1539,11 @@ impl From<CredentialsError> for AssociateVirtualInterfaceError {
 impl From<HttpDispatchError> for AssociateVirtualInterfaceError {
     fn from(err: HttpDispatchError) -> AssociateVirtualInterfaceError {
         AssociateVirtualInterfaceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AssociateVirtualInterfaceError {
+    fn from(err: io::Error) -> AssociateVirtualInterfaceError {
+        AssociateVirtualInterfaceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AssociateVirtualInterfaceError {
@@ -1591,6 +1628,11 @@ impl From<HttpDispatchError> for ConfirmConnectionError {
         ConfirmConnectionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ConfirmConnectionError {
+    fn from(err: io::Error) -> ConfirmConnectionError {
+        ConfirmConnectionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ConfirmConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1669,6 +1711,11 @@ impl From<HttpDispatchError> for ConfirmPrivateVirtualInterfaceError {
         ConfirmPrivateVirtualInterfaceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ConfirmPrivateVirtualInterfaceError {
+    fn from(err: io::Error) -> ConfirmPrivateVirtualInterfaceError {
+        ConfirmPrivateVirtualInterfaceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ConfirmPrivateVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1745,6 +1792,11 @@ impl From<CredentialsError> for ConfirmPublicVirtualInterfaceError {
 impl From<HttpDispatchError> for ConfirmPublicVirtualInterfaceError {
     fn from(err: HttpDispatchError) -> ConfirmPublicVirtualInterfaceError {
         ConfirmPublicVirtualInterfaceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ConfirmPublicVirtualInterfaceError {
+    fn from(err: io::Error) -> ConfirmPublicVirtualInterfaceError {
+        ConfirmPublicVirtualInterfaceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ConfirmPublicVirtualInterfaceError {
@@ -1829,6 +1881,11 @@ impl From<HttpDispatchError> for CreateBGPPeerError {
         CreateBGPPeerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateBGPPeerError {
+    fn from(err: io::Error) -> CreateBGPPeerError {
+        CreateBGPPeerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateBGPPeerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1907,6 +1964,11 @@ impl From<CredentialsError> for CreateConnectionError {
 impl From<HttpDispatchError> for CreateConnectionError {
     fn from(err: HttpDispatchError) -> CreateConnectionError {
         CreateConnectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateConnectionError {
+    fn from(err: io::Error) -> CreateConnectionError {
+        CreateConnectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateConnectionError {
@@ -1989,6 +2051,11 @@ impl From<HttpDispatchError> for CreateInterconnectError {
         CreateInterconnectError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateInterconnectError {
+    fn from(err: io::Error) -> CreateInterconnectError {
+        CreateInterconnectError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateInterconnectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2069,6 +2136,11 @@ impl From<HttpDispatchError> for CreateLagError {
         CreateLagError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLagError {
+    fn from(err: io::Error) -> CreateLagError {
+        CreateLagError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2143,6 +2215,11 @@ impl From<CredentialsError> for CreatePrivateVirtualInterfaceError {
 impl From<HttpDispatchError> for CreatePrivateVirtualInterfaceError {
     fn from(err: HttpDispatchError) -> CreatePrivateVirtualInterfaceError {
         CreatePrivateVirtualInterfaceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePrivateVirtualInterfaceError {
+    fn from(err: io::Error) -> CreatePrivateVirtualInterfaceError {
+        CreatePrivateVirtualInterfaceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePrivateVirtualInterfaceError {
@@ -2221,6 +2298,11 @@ impl From<CredentialsError> for CreatePublicVirtualInterfaceError {
 impl From<HttpDispatchError> for CreatePublicVirtualInterfaceError {
     fn from(err: HttpDispatchError) -> CreatePublicVirtualInterfaceError {
         CreatePublicVirtualInterfaceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePublicVirtualInterfaceError {
+    fn from(err: io::Error) -> CreatePublicVirtualInterfaceError {
+        CreatePublicVirtualInterfaceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePublicVirtualInterfaceError {
@@ -2305,6 +2387,11 @@ impl From<HttpDispatchError> for DeleteBGPPeerError {
         DeleteBGPPeerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteBGPPeerError {
+    fn from(err: io::Error) -> DeleteBGPPeerError {
+        DeleteBGPPeerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteBGPPeerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2383,6 +2470,11 @@ impl From<CredentialsError> for DeleteConnectionError {
 impl From<HttpDispatchError> for DeleteConnectionError {
     fn from(err: HttpDispatchError) -> DeleteConnectionError {
         DeleteConnectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteConnectionError {
+    fn from(err: io::Error) -> DeleteConnectionError {
+        DeleteConnectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteConnectionError {
@@ -2465,6 +2557,11 @@ impl From<HttpDispatchError> for DeleteInterconnectError {
         DeleteInterconnectError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteInterconnectError {
+    fn from(err: io::Error) -> DeleteInterconnectError {
+        DeleteInterconnectError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteInterconnectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2545,6 +2642,11 @@ impl From<HttpDispatchError> for DeleteLagError {
         DeleteLagError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteLagError {
+    fn from(err: io::Error) -> DeleteLagError {
+        DeleteLagError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteLagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2619,6 +2721,11 @@ impl From<CredentialsError> for DeleteVirtualInterfaceError {
 impl From<HttpDispatchError> for DeleteVirtualInterfaceError {
     fn from(err: HttpDispatchError) -> DeleteVirtualInterfaceError {
         DeleteVirtualInterfaceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteVirtualInterfaceError {
+    fn from(err: io::Error) -> DeleteVirtualInterfaceError {
+        DeleteVirtualInterfaceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteVirtualInterfaceError {
@@ -2703,6 +2810,11 @@ impl From<HttpDispatchError> for DescribeConnectionLoaError {
         DescribeConnectionLoaError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeConnectionLoaError {
+    fn from(err: io::Error) -> DescribeConnectionLoaError {
+        DescribeConnectionLoaError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeConnectionLoaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2785,6 +2897,11 @@ impl From<HttpDispatchError> for DescribeConnectionsError {
         DescribeConnectionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeConnectionsError {
+    fn from(err: io::Error) -> DescribeConnectionsError {
+        DescribeConnectionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeConnectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2862,6 +2979,11 @@ impl From<CredentialsError> for DescribeConnectionsOnInterconnectError {
 impl From<HttpDispatchError> for DescribeConnectionsOnInterconnectError {
     fn from(err: HttpDispatchError) -> DescribeConnectionsOnInterconnectError {
         DescribeConnectionsOnInterconnectError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeConnectionsOnInterconnectError {
+    fn from(err: io::Error) -> DescribeConnectionsOnInterconnectError {
+        DescribeConnectionsOnInterconnectError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeConnectionsOnInterconnectError {
@@ -2942,6 +3064,11 @@ impl From<HttpDispatchError> for DescribeHostedConnectionsError {
         DescribeHostedConnectionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeHostedConnectionsError {
+    fn from(err: io::Error) -> DescribeHostedConnectionsError {
+        DescribeHostedConnectionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeHostedConnectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3018,6 +3145,11 @@ impl From<CredentialsError> for DescribeInterconnectLoaError {
 impl From<HttpDispatchError> for DescribeInterconnectLoaError {
     fn from(err: HttpDispatchError) -> DescribeInterconnectLoaError {
         DescribeInterconnectLoaError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeInterconnectLoaError {
+    fn from(err: io::Error) -> DescribeInterconnectLoaError {
+        DescribeInterconnectLoaError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeInterconnectLoaError {
@@ -3102,6 +3234,11 @@ impl From<HttpDispatchError> for DescribeInterconnectsError {
         DescribeInterconnectsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeInterconnectsError {
+    fn from(err: io::Error) -> DescribeInterconnectsError {
+        DescribeInterconnectsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeInterconnectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3184,6 +3321,11 @@ impl From<HttpDispatchError> for DescribeLagsError {
         DescribeLagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLagsError {
+    fn from(err: io::Error) -> DescribeLagsError {
+        DescribeLagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3264,6 +3406,11 @@ impl From<HttpDispatchError> for DescribeLoaError {
         DescribeLoaError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLoaError {
+    fn from(err: io::Error) -> DescribeLoaError {
+        DescribeLoaError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLoaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3342,6 +3489,11 @@ impl From<CredentialsError> for DescribeLocationsError {
 impl From<HttpDispatchError> for DescribeLocationsError {
     fn from(err: HttpDispatchError) -> DescribeLocationsError {
         DescribeLocationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLocationsError {
+    fn from(err: io::Error) -> DescribeLocationsError {
+        DescribeLocationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLocationsError {
@@ -3426,6 +3578,11 @@ impl From<HttpDispatchError> for DescribeTagsError {
         DescribeTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTagsError {
+    fn from(err: io::Error) -> DescribeTagsError {
+        DescribeTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3500,6 +3657,11 @@ impl From<CredentialsError> for DescribeVirtualGatewaysError {
 impl From<HttpDispatchError> for DescribeVirtualGatewaysError {
     fn from(err: HttpDispatchError) -> DescribeVirtualGatewaysError {
         DescribeVirtualGatewaysError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeVirtualGatewaysError {
+    fn from(err: io::Error) -> DescribeVirtualGatewaysError {
+        DescribeVirtualGatewaysError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeVirtualGatewaysError {
@@ -3580,6 +3742,11 @@ impl From<HttpDispatchError> for DescribeVirtualInterfacesError {
         DescribeVirtualInterfacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVirtualInterfacesError {
+    fn from(err: io::Error) -> DescribeVirtualInterfacesError {
+        DescribeVirtualInterfacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVirtualInterfacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3656,6 +3823,11 @@ impl From<CredentialsError> for DisassociateConnectionFromLagError {
 impl From<HttpDispatchError> for DisassociateConnectionFromLagError {
     fn from(err: HttpDispatchError) -> DisassociateConnectionFromLagError {
         DisassociateConnectionFromLagError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisassociateConnectionFromLagError {
+    fn from(err: io::Error) -> DisassociateConnectionFromLagError {
+        DisassociateConnectionFromLagError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisassociateConnectionFromLagError {
@@ -3750,6 +3922,11 @@ impl From<HttpDispatchError> for TagResourceError {
         TagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TagResourceError {
+    fn from(err: io::Error) -> TagResourceError {
+        TagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3832,6 +4009,11 @@ impl From<HttpDispatchError> for UntagResourceError {
         UntagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UntagResourceError {
+    fn from(err: io::Error) -> UntagResourceError {
+        UntagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3908,6 +4090,11 @@ impl From<CredentialsError> for UpdateLagError {
 impl From<HttpDispatchError> for UpdateLagError {
     fn from(err: HttpDispatchError) -> UpdateLagError {
         UpdateLagError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateLagError {
+    fn from(err: io::Error) -> UpdateLagError {
+        UpdateLagError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateLagError {
@@ -4190,15 +4377,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
-                                                          .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AllocateConnectionOnInterconnectError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AllocateConnectionOnInterconnectError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4216,15 +4408,21 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
-                                                          .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AllocateHostedConnectionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AllocateHostedConnectionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4244,13 +4442,22 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AllocatePrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AllocatePrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -4270,13 +4477,22 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AllocatePublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AllocatePublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -4294,15 +4510,21 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
-                                                          .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AssociateConnectionWithLagError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateConnectionWithLagError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -4320,15 +4542,21 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
-                                                          .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AssociateHostedConnectionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateHostedConnectionError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -4346,13 +4574,22 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AssociateVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateVirtualInterfaceError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -4370,15 +4607,18 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ConfirmConnectionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ConfirmConnectionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ConfirmConnectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfirmConnectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4399,13 +4639,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ConfirmPrivateVirtualInterfaceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ConfirmPrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ConfirmPrivateVirtualInterfaceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfirmPrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -4425,13 +4672,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ConfirmPublicVirtualInterfaceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ConfirmPublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ConfirmPublicVirtualInterfaceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfirmPublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -4449,14 +4703,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateBGPPeerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateBGPPeerResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateBGPPeerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateBGPPeerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4475,17 +4735,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
-                                                          .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(CreateConnectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateConnectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4504,17 +4766,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Interconnect>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Interconnect>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(CreateInterconnectError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInterconnectError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4531,14 +4795,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&response.body).as_ref())
-                       .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&body).as_ref()).unwrap())
             }
-            _ => Err(CreateLagError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLagError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4558,13 +4827,22 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreatePrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -4584,13 +4862,22 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreatePublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -4608,14 +4895,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteBGPPeerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteBGPPeerResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteBGPPeerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBGPPeerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4634,17 +4927,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
-                                                          .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(DeleteConnectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteConnectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4663,15 +4958,18 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteInterconnectResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteInterconnectResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteInterconnectError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteInterconnectError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4688,14 +4986,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&response.body).as_ref())
-                       .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&body).as_ref()).unwrap())
             }
-            _ => Err(DeleteLagError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLagError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4714,15 +5017,18 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteVirtualInterfaceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteVirtualInterfaceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVirtualInterfaceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4742,15 +5048,18 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeConnectionLoaResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeConnectionLoaResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeConnectionLoaError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConnectionLoaError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4769,17 +5078,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&response.body)
-                                                           .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(DescribeConnectionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConnectionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4800,15 +5111,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&response.body)
-                                                           .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(DescribeConnectionsOnInterconnectError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConnectionsOnInterconnectError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4826,15 +5142,21 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&response.body)
-                                                           .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(DescribeHostedConnectionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHostedConnectionsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -4853,13 +5175,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeInterconnectLoaResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeInterconnectLoaError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeInterconnectLoaResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInterconnectLoaError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4877,17 +5206,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Interconnects>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Interconnects>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(DescribeInterconnectsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInterconnectsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4904,15 +5235,18 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Lags>(String::from_utf8_lossy(&response.body).as_ref())
-                       .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Lags>(String::from_utf8_lossy(&body).as_ref()).unwrap())
             }
             _ => {
-                Err(DescribeLagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4929,14 +5263,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Loa>(String::from_utf8_lossy(&response.body).as_ref())
-                       .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Loa>(String::from_utf8_lossy(&body).as_ref()).unwrap())
             }
-            _ => Err(DescribeLoaError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoaError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4951,17 +5290,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Locations>(String::from_utf8_lossy(&response.body)
-                                                         .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Locations>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(DescribeLocationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLocationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4980,14 +5321,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTagsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTagsResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5003,15 +5350,21 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<VirtualGateways>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VirtualGateways>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(DescribeVirtualGatewaysError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVirtualGatewaysError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -5029,13 +5382,22 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<VirtualInterfaces>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeVirtualInterfacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VirtualInterfaces>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVirtualInterfacesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5055,15 +5417,21 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
-                                                          .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(DisassociateConnectionFromLagError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateConnectionFromLagError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -5081,13 +5449,21 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TagResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<TagResourceResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5105,14 +5481,20 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UntagResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UntagResourceResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UntagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5129,14 +5511,19 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&response.body).as_ref())
-                       .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&body).as_ref()).unwrap())
             }
-            _ => Err(UpdateLagError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateLagError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2020,6 +2022,11 @@ impl From<HttpDispatchError> for AddTagsToResourceError {
         AddTagsToResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToResourceError {
+    fn from(err: io::Error) -> AddTagsToResourceError {
+        AddTagsToResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2121,6 +2128,11 @@ impl From<HttpDispatchError> for CreateEndpointError {
         CreateEndpointError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateEndpointError {
+    fn from(err: io::Error) -> CreateEndpointError {
+        CreateEndpointError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2208,6 +2220,11 @@ impl From<CredentialsError> for CreateEventSubscriptionError {
 impl From<HttpDispatchError> for CreateEventSubscriptionError {
     fn from(err: HttpDispatchError) -> CreateEventSubscriptionError {
         CreateEventSubscriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateEventSubscriptionError {
+    fn from(err: io::Error) -> CreateEventSubscriptionError {
+        CreateEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateEventSubscriptionError {
@@ -2317,6 +2334,11 @@ impl From<HttpDispatchError> for CreateReplicationInstanceError {
         CreateReplicationInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReplicationInstanceError {
+    fn from(err: io::Error) -> CreateReplicationInstanceError {
+        CreateReplicationInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReplicationInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2415,6 +2437,11 @@ impl From<HttpDispatchError> for CreateReplicationSubnetGroupError {
         CreateReplicationSubnetGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReplicationSubnetGroupError {
+    fn from(err: io::Error) -> CreateReplicationSubnetGroupError {
+        CreateReplicationSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReplicationSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2511,6 +2538,11 @@ impl From<HttpDispatchError> for CreateReplicationTaskError {
         CreateReplicationTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReplicationTaskError {
+    fn from(err: io::Error) -> CreateReplicationTaskError {
+        CreateReplicationTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReplicationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2595,6 +2627,11 @@ impl From<HttpDispatchError> for DeleteCertificateError {
         DeleteCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteCertificateError {
+    fn from(err: io::Error) -> DeleteCertificateError {
+        DeleteCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2677,6 +2714,11 @@ impl From<HttpDispatchError> for DeleteEndpointError {
         DeleteEndpointError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteEndpointError {
+    fn from(err: io::Error) -> DeleteEndpointError {
+        DeleteEndpointError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2751,6 +2793,11 @@ impl From<CredentialsError> for DeleteEventSubscriptionError {
 impl From<HttpDispatchError> for DeleteEventSubscriptionError {
     fn from(err: HttpDispatchError) -> DeleteEventSubscriptionError {
         DeleteEventSubscriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteEventSubscriptionError {
+    fn from(err: io::Error) -> DeleteEventSubscriptionError {
+        DeleteEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteEventSubscriptionError {
@@ -2831,6 +2878,11 @@ impl From<HttpDispatchError> for DeleteReplicationInstanceError {
         DeleteReplicationInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteReplicationInstanceError {
+    fn from(err: io::Error) -> DeleteReplicationInstanceError {
+        DeleteReplicationInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteReplicationInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2907,6 +2959,11 @@ impl From<CredentialsError> for DeleteReplicationSubnetGroupError {
 impl From<HttpDispatchError> for DeleteReplicationSubnetGroupError {
     fn from(err: HttpDispatchError) -> DeleteReplicationSubnetGroupError {
         DeleteReplicationSubnetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteReplicationSubnetGroupError {
+    fn from(err: io::Error) -> DeleteReplicationSubnetGroupError {
+        DeleteReplicationSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteReplicationSubnetGroupError {
@@ -2987,6 +3044,11 @@ impl From<HttpDispatchError> for DeleteReplicationTaskError {
         DeleteReplicationTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteReplicationTaskError {
+    fn from(err: io::Error) -> DeleteReplicationTaskError {
+        DeleteReplicationTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteReplicationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3057,6 +3119,11 @@ impl From<CredentialsError> for DescribeAccountAttributesError {
 impl From<HttpDispatchError> for DescribeAccountAttributesError {
     fn from(err: HttpDispatchError) -> DescribeAccountAttributesError {
         DescribeAccountAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAccountAttributesError {
+    fn from(err: io::Error) -> DescribeAccountAttributesError {
+        DescribeAccountAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAccountAttributesError {
@@ -3130,6 +3197,11 @@ impl From<CredentialsError> for DescribeCertificatesError {
 impl From<HttpDispatchError> for DescribeCertificatesError {
     fn from(err: HttpDispatchError) -> DescribeCertificatesError {
         DescribeCertificatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCertificatesError {
+    fn from(err: io::Error) -> DescribeCertificatesError {
+        DescribeCertificatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCertificatesError {
@@ -3208,6 +3280,11 @@ impl From<HttpDispatchError> for DescribeConnectionsError {
         DescribeConnectionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeConnectionsError {
+    fn from(err: io::Error) -> DescribeConnectionsError {
+        DescribeConnectionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeConnectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3277,6 +3354,11 @@ impl From<CredentialsError> for DescribeEndpointTypesError {
 impl From<HttpDispatchError> for DescribeEndpointTypesError {
     fn from(err: HttpDispatchError) -> DescribeEndpointTypesError {
         DescribeEndpointTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEndpointTypesError {
+    fn from(err: io::Error) -> DescribeEndpointTypesError {
+        DescribeEndpointTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEndpointTypesError {
@@ -3354,6 +3436,11 @@ impl From<HttpDispatchError> for DescribeEndpointsError {
         DescribeEndpointsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEndpointsError {
+    fn from(err: io::Error) -> DescribeEndpointsError {
+        DescribeEndpointsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3423,6 +3510,11 @@ impl From<CredentialsError> for DescribeEventCategoriesError {
 impl From<HttpDispatchError> for DescribeEventCategoriesError {
     fn from(err: HttpDispatchError) -> DescribeEventCategoriesError {
         DescribeEventCategoriesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventCategoriesError {
+    fn from(err: io::Error) -> DescribeEventCategoriesError {
+        DescribeEventCategoriesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventCategoriesError {
@@ -3498,6 +3590,11 @@ impl From<HttpDispatchError> for DescribeEventSubscriptionsError {
         DescribeEventSubscriptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEventSubscriptionsError {
+    fn from(err: io::Error) -> DescribeEventSubscriptionsError {
+        DescribeEventSubscriptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3569,6 +3666,11 @@ impl From<HttpDispatchError> for DescribeEventsError {
         DescribeEventsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEventsError {
+    fn from(err: io::Error) -> DescribeEventsError {
+        DescribeEventsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3636,6 +3738,11 @@ impl From<CredentialsError> for DescribeOrderableReplicationInstancesError {
 impl From<HttpDispatchError> for DescribeOrderableReplicationInstancesError {
     fn from(err: HttpDispatchError) -> DescribeOrderableReplicationInstancesError {
         DescribeOrderableReplicationInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeOrderableReplicationInstancesError {
+    fn from(err: io::Error) -> DescribeOrderableReplicationInstancesError {
+        DescribeOrderableReplicationInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeOrderableReplicationInstancesError {
@@ -3714,6 +3821,11 @@ impl From<HttpDispatchError> for DescribeRefreshSchemasStatusError {
         DescribeRefreshSchemasStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeRefreshSchemasStatusError {
+    fn from(err: io::Error) -> DescribeRefreshSchemasStatusError {
+        DescribeRefreshSchemasStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeRefreshSchemasStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3787,6 +3899,11 @@ impl From<CredentialsError> for DescribeReplicationInstancesError {
 impl From<HttpDispatchError> for DescribeReplicationInstancesError {
     fn from(err: HttpDispatchError) -> DescribeReplicationInstancesError {
         DescribeReplicationInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeReplicationInstancesError {
+    fn from(err: io::Error) -> DescribeReplicationInstancesError {
+        DescribeReplicationInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeReplicationInstancesError {
@@ -3863,6 +3980,11 @@ impl From<HttpDispatchError> for DescribeReplicationSubnetGroupsError {
         DescribeReplicationSubnetGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReplicationSubnetGroupsError {
+    fn from(err: io::Error) -> DescribeReplicationSubnetGroupsError {
+        DescribeReplicationSubnetGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReplicationSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3935,6 +4057,11 @@ impl From<CredentialsError> for DescribeReplicationTasksError {
 impl From<HttpDispatchError> for DescribeReplicationTasksError {
     fn from(err: HttpDispatchError) -> DescribeReplicationTasksError {
         DescribeReplicationTasksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeReplicationTasksError {
+    fn from(err: io::Error) -> DescribeReplicationTasksError {
+        DescribeReplicationTasksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeReplicationTasksError {
@@ -4018,6 +4145,11 @@ impl From<HttpDispatchError> for DescribeSchemasError {
         DescribeSchemasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSchemasError {
+    fn from(err: io::Error) -> DescribeSchemasError {
+        DescribeSchemasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSchemasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4092,6 +4224,11 @@ impl From<CredentialsError> for DescribeTableStatisticsError {
 impl From<HttpDispatchError> for DescribeTableStatisticsError {
     fn from(err: HttpDispatchError) -> DescribeTableStatisticsError {
         DescribeTableStatisticsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTableStatisticsError {
+    fn from(err: io::Error) -> DescribeTableStatisticsError {
+        DescribeTableStatisticsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTableStatisticsError {
@@ -4174,6 +4311,11 @@ impl From<HttpDispatchError> for ImportCertificateError {
         ImportCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportCertificateError {
+    fn from(err: io::Error) -> ImportCertificateError {
+        ImportCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4249,6 +4391,11 @@ impl From<CredentialsError> for ListTagsForResourceError {
 impl From<HttpDispatchError> for ListTagsForResourceError {
     fn from(err: HttpDispatchError) -> ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForResourceError {
@@ -4347,6 +4494,11 @@ impl From<HttpDispatchError> for ModifyEndpointError {
         ModifyEndpointError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyEndpointError {
+    fn from(err: io::Error) -> ModifyEndpointError {
+        ModifyEndpointError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4430,6 +4582,11 @@ impl From<CredentialsError> for ModifyEventSubscriptionError {
 impl From<HttpDispatchError> for ModifyEventSubscriptionError {
     fn from(err: HttpDispatchError) -> ModifyEventSubscriptionError {
         ModifyEventSubscriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyEventSubscriptionError {
+    fn from(err: io::Error) -> ModifyEventSubscriptionError {
+        ModifyEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyEventSubscriptionError {
@@ -4522,6 +4679,11 @@ impl From<CredentialsError> for ModifyReplicationInstanceError {
 impl From<HttpDispatchError> for ModifyReplicationInstanceError {
     fn from(err: HttpDispatchError) -> ModifyReplicationInstanceError {
         ModifyReplicationInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyReplicationInstanceError {
+    fn from(err: io::Error) -> ModifyReplicationInstanceError {
+        ModifyReplicationInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyReplicationInstanceError {
@@ -4618,6 +4780,11 @@ impl From<HttpDispatchError> for ModifyReplicationSubnetGroupError {
         ModifyReplicationSubnetGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyReplicationSubnetGroupError {
+    fn from(err: io::Error) -> ModifyReplicationSubnetGroupError {
+        ModifyReplicationSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyReplicationSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4704,6 +4871,11 @@ impl From<CredentialsError> for ModifyReplicationTaskError {
 impl From<HttpDispatchError> for ModifyReplicationTaskError {
     fn from(err: HttpDispatchError) -> ModifyReplicationTaskError {
         ModifyReplicationTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyReplicationTaskError {
+    fn from(err: io::Error) -> ModifyReplicationTaskError {
+        ModifyReplicationTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyReplicationTaskError {
@@ -4800,6 +4972,11 @@ impl From<HttpDispatchError> for RefreshSchemasError {
         RefreshSchemasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RefreshSchemasError {
+    fn from(err: io::Error) -> RefreshSchemasError {
+        RefreshSchemasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RefreshSchemasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4882,6 +5059,11 @@ impl From<HttpDispatchError> for ReloadTablesError {
         ReloadTablesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReloadTablesError {
+    fn from(err: io::Error) -> ReloadTablesError {
+        ReloadTablesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReloadTablesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4953,6 +5135,11 @@ impl From<CredentialsError> for RemoveTagsFromResourceError {
 impl From<HttpDispatchError> for RemoveTagsFromResourceError {
     fn from(err: HttpDispatchError) -> RemoveTagsFromResourceError {
         RemoveTagsFromResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveTagsFromResourceError {
+    fn from(err: io::Error) -> RemoveTagsFromResourceError {
+        RemoveTagsFromResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveTagsFromResourceError {
@@ -5030,6 +5217,11 @@ impl From<CredentialsError> for StartReplicationTaskError {
 impl From<HttpDispatchError> for StartReplicationTaskError {
     fn from(err: HttpDispatchError) -> StartReplicationTaskError {
         StartReplicationTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StartReplicationTaskError {
+    fn from(err: io::Error) -> StartReplicationTaskError {
+        StartReplicationTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StartReplicationTaskError {
@@ -5110,6 +5302,11 @@ impl From<CredentialsError> for StopReplicationTaskError {
 impl From<HttpDispatchError> for StopReplicationTaskError {
     fn from(err: HttpDispatchError) -> StopReplicationTaskError {
         StopReplicationTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopReplicationTaskError {
+    fn from(err: io::Error) -> StopReplicationTaskError {
+        StopReplicationTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopReplicationTaskError {
@@ -5202,6 +5399,11 @@ impl From<CredentialsError> for TestConnectionError {
 impl From<HttpDispatchError> for TestConnectionError {
     fn from(err: HttpDispatchError) -> TestConnectionError {
         TestConnectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TestConnectionError {
+    fn from(err: io::Error) -> TestConnectionError {
+        TestConnectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TestConnectionError {
@@ -5524,15 +5726,18 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddTagsToResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsToResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5551,15 +5756,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateEndpointResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateEndpointResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5579,13 +5789,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateEventSubscriptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateEventSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -5605,13 +5822,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateReplicationInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateReplicationInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateReplicationInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReplicationInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5631,13 +5855,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateReplicationSubnetGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateReplicationSubnetGroupResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -5656,15 +5887,18 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateReplicationTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReplicationTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5683,15 +5917,18 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5710,15 +5947,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteEndpointResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteEndpointResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5738,13 +5980,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteEventSubscriptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteEventSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -5764,13 +6013,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteReplicationInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteReplicationInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteReplicationInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReplicationInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5790,13 +6046,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteReplicationSubnetGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteReplicationSubnetGroupResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -5815,15 +6078,18 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteReplicationTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReplicationTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5842,13 +6108,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAccountAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAccountAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5866,15 +6139,18 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCertificatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeCertificatesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCertificatesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5893,15 +6169,18 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeConnectionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeConnectionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeConnectionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConnectionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5921,15 +6200,18 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEndpointTypesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEndpointTypesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeEndpointTypesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEndpointTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5948,15 +6230,18 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEndpointsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEndpointsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeEndpointsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEndpointsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5976,13 +6261,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventCategoriesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeEventCategoriesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventCategoriesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventCategoriesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6002,13 +6294,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventSubscriptionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeEventSubscriptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventSubscriptionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventSubscriptionsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6026,15 +6325,20 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6052,13 +6356,19 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeOrderableReplicationInstancesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeOrderableReplicationInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeOrderableReplicationInstancesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeOrderableReplicationInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6078,13 +6388,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeRefreshSchemasStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeRefreshSchemasStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeRefreshSchemasStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRefreshSchemasStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -6104,13 +6421,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeReplicationInstancesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeReplicationInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeReplicationInstancesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReplicationInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -6130,13 +6454,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeReplicationSubnetGroupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeReplicationSubnetGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeReplicationSubnetGroupsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReplicationSubnetGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -6156,13 +6487,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeReplicationTasksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeReplicationTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeReplicationTasksResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReplicationTasksError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -6180,15 +6518,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeSchemasResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeSchemasResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeSchemasError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSchemasError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6208,13 +6551,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTableStatisticsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeTableStatisticsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTableStatisticsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTableStatisticsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6232,15 +6582,18 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ImportCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ImportCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ImportCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6259,15 +6612,18 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6286,15 +6642,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyEndpointResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyEndpointResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ModifyEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6314,13 +6675,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyEventSubscriptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ModifyEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyEventSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6340,13 +6708,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyReplicationInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ModifyReplicationInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyReplicationInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyReplicationInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -6366,13 +6741,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyReplicationSubnetGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ModifyReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyReplicationSubnetGroupResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -6391,15 +6773,18 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ModifyReplicationTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyReplicationTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6418,15 +6803,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RefreshSchemasResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RefreshSchemasResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RefreshSchemasError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RefreshSchemasError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6445,14 +6835,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ReloadTablesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ReloadTablesResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ReloadTablesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReloadTablesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6472,15 +6868,18 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTagsFromResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTagsFromResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6500,15 +6899,18 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(StartReplicationTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartReplicationTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6527,15 +6929,18 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(StopReplicationTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopReplicationTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6554,15 +6959,20 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TestConnectionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<TestConnectionResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(TestConnectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestConnectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1393,6 +1395,11 @@ impl From<HttpDispatchError> for AddIpRoutesError {
         AddIpRoutesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddIpRoutesError {
+    fn from(err: io::Error) -> AddIpRoutesError {
+        AddIpRoutesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddIpRoutesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1493,6 +1500,11 @@ impl From<HttpDispatchError> for AddTagsToResourceError {
         AddTagsToResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToResourceError {
+    fn from(err: io::Error) -> AddTagsToResourceError {
+        AddTagsToResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1581,6 +1593,11 @@ impl From<CredentialsError> for CancelSchemaExtensionError {
 impl From<HttpDispatchError> for CancelSchemaExtensionError {
     fn from(err: HttpDispatchError) -> CancelSchemaExtensionError {
         CancelSchemaExtensionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CancelSchemaExtensionError {
+    fn from(err: io::Error) -> CancelSchemaExtensionError {
+        CancelSchemaExtensionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CancelSchemaExtensionError {
@@ -1674,6 +1691,11 @@ impl From<HttpDispatchError> for ConnectDirectoryError {
         ConnectDirectoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ConnectDirectoryError {
+    fn from(err: io::Error) -> ConnectDirectoryError {
+        ConnectDirectoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ConnectDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1765,6 +1787,11 @@ impl From<CredentialsError> for CreateAliasError {
 impl From<HttpDispatchError> for CreateAliasError {
     fn from(err: HttpDispatchError) -> CreateAliasError {
         CreateAliasError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAliasError {
+    fn from(err: io::Error) -> CreateAliasError {
+        CreateAliasError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAliasError {
@@ -1876,6 +1903,11 @@ impl From<HttpDispatchError> for CreateComputerError {
         CreateComputerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateComputerError {
+    fn from(err: io::Error) -> CreateComputerError {
+        CreateComputerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateComputerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1977,6 +2009,11 @@ impl From<HttpDispatchError> for CreateConditionalForwarderError {
         CreateConditionalForwarderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateConditionalForwarderError {
+    fn from(err: io::Error) -> CreateConditionalForwarderError {
+        CreateConditionalForwarderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateConditionalForwarderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2070,6 +2107,11 @@ impl From<CredentialsError> for CreateDirectoryError {
 impl From<HttpDispatchError> for CreateDirectoryError {
     fn from(err: HttpDispatchError) -> CreateDirectoryError {
         CreateDirectoryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDirectoryError {
+    fn from(err: io::Error) -> CreateDirectoryError {
+        CreateDirectoryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDirectoryError {
@@ -2169,6 +2211,11 @@ impl From<HttpDispatchError> for CreateMicrosoftADError {
         CreateMicrosoftADError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateMicrosoftADError {
+    fn from(err: io::Error) -> CreateMicrosoftADError {
+        CreateMicrosoftADError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateMicrosoftADError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2263,6 +2310,11 @@ impl From<CredentialsError> for CreateSnapshotError {
 impl From<HttpDispatchError> for CreateSnapshotError {
     fn from(err: HttpDispatchError) -> CreateSnapshotError {
         CreateSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateSnapshotError {
+    fn from(err: io::Error) -> CreateSnapshotError {
+        CreateSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateSnapshotError {
@@ -2364,6 +2416,11 @@ impl From<HttpDispatchError> for CreateTrustError {
         CreateTrustError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTrustError {
+    fn from(err: io::Error) -> CreateTrustError {
+        CreateTrustError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTrustError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2460,6 +2517,11 @@ impl From<HttpDispatchError> for DeleteConditionalForwarderError {
         DeleteConditionalForwarderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteConditionalForwarderError {
+    fn from(err: io::Error) -> DeleteConditionalForwarderError {
+        DeleteConditionalForwarderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteConditionalForwarderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2549,6 +2611,11 @@ impl From<HttpDispatchError> for DeleteDirectoryError {
         DeleteDirectoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDirectoryError {
+    fn from(err: io::Error) -> DeleteDirectoryError {
+        DeleteDirectoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2634,6 +2701,11 @@ impl From<CredentialsError> for DeleteSnapshotError {
 impl From<HttpDispatchError> for DeleteSnapshotError {
     fn from(err: HttpDispatchError) -> DeleteSnapshotError {
         DeleteSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSnapshotError {
+    fn from(err: io::Error) -> DeleteSnapshotError {
+        DeleteSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSnapshotError {
@@ -2729,6 +2801,11 @@ impl From<HttpDispatchError> for DeleteTrustError {
         DeleteTrustError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTrustError {
+    fn from(err: io::Error) -> DeleteTrustError {
+        DeleteTrustError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTrustError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2820,6 +2897,11 @@ impl From<CredentialsError> for DeregisterEventTopicError {
 impl From<HttpDispatchError> for DeregisterEventTopicError {
     fn from(err: HttpDispatchError) -> DeregisterEventTopicError {
         DeregisterEventTopicError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeregisterEventTopicError {
+    fn from(err: io::Error) -> DeregisterEventTopicError {
+        DeregisterEventTopicError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeregisterEventTopicError {
@@ -2916,6 +2998,11 @@ impl From<CredentialsError> for DescribeConditionalForwardersError {
 impl From<HttpDispatchError> for DescribeConditionalForwardersError {
     fn from(err: HttpDispatchError) -> DescribeConditionalForwardersError {
         DescribeConditionalForwardersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeConditionalForwardersError {
+    fn from(err: io::Error) -> DescribeConditionalForwardersError {
+        DescribeConditionalForwardersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeConditionalForwardersError {
@@ -3019,6 +3106,11 @@ impl From<HttpDispatchError> for DescribeDirectoriesError {
         DescribeDirectoriesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDirectoriesError {
+    fn from(err: io::Error) -> DescribeDirectoriesError {
+        DescribeDirectoriesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDirectoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3112,6 +3204,11 @@ impl From<CredentialsError> for DescribeEventTopicsError {
 impl From<HttpDispatchError> for DescribeEventTopicsError {
     fn from(err: HttpDispatchError) -> DescribeEventTopicsError {
         DescribeEventTopicsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventTopicsError {
+    fn from(err: io::Error) -> DescribeEventTopicsError {
+        DescribeEventTopicsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventTopicsError {
@@ -3211,6 +3308,11 @@ impl From<CredentialsError> for DescribeSnapshotsError {
 impl From<HttpDispatchError> for DescribeSnapshotsError {
     fn from(err: HttpDispatchError) -> DescribeSnapshotsError {
         DescribeSnapshotsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSnapshotsError {
+    fn from(err: io::Error) -> DescribeSnapshotsError {
+        DescribeSnapshotsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSnapshotsError {
@@ -3314,6 +3416,11 @@ impl From<HttpDispatchError> for DescribeTrustsError {
         DescribeTrustsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTrustsError {
+    fn from(err: io::Error) -> DescribeTrustsError {
+        DescribeTrustsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTrustsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3397,6 +3504,11 @@ impl From<CredentialsError> for DisableRadiusError {
 impl From<HttpDispatchError> for DisableRadiusError {
     fn from(err: HttpDispatchError) -> DisableRadiusError {
         DisableRadiusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableRadiusError {
+    fn from(err: io::Error) -> DisableRadiusError {
+        DisableRadiusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableRadiusError {
@@ -3487,6 +3599,11 @@ impl From<CredentialsError> for DisableSsoError {
 impl From<HttpDispatchError> for DisableSsoError {
     fn from(err: HttpDispatchError) -> DisableSsoError {
         DisableSsoError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableSsoError {
+    fn from(err: io::Error) -> DisableSsoError {
+        DisableSsoError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableSsoError {
@@ -3583,6 +3700,11 @@ impl From<HttpDispatchError> for EnableRadiusError {
         EnableRadiusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableRadiusError {
+    fn from(err: io::Error) -> EnableRadiusError {
+        EnableRadiusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableRadiusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3675,6 +3797,11 @@ impl From<HttpDispatchError> for EnableSsoError {
         EnableSsoError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableSsoError {
+    fn from(err: io::Error) -> EnableSsoError {
+        EnableSsoError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableSsoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3763,6 +3890,11 @@ impl From<HttpDispatchError> for GetDirectoryLimitsError {
         GetDirectoryLimitsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDirectoryLimitsError {
+    fn from(err: io::Error) -> GetDirectoryLimitsError {
+        GetDirectoryLimitsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDirectoryLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3849,6 +3981,11 @@ impl From<CredentialsError> for GetSnapshotLimitsError {
 impl From<HttpDispatchError> for GetSnapshotLimitsError {
     fn from(err: HttpDispatchError) -> GetSnapshotLimitsError {
         GetSnapshotLimitsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSnapshotLimitsError {
+    fn from(err: io::Error) -> GetSnapshotLimitsError {
+        GetSnapshotLimitsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSnapshotLimitsError {
@@ -3945,6 +4082,11 @@ impl From<HttpDispatchError> for ListIpRoutesError {
         ListIpRoutesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListIpRoutesError {
+    fn from(err: io::Error) -> ListIpRoutesError {
+        ListIpRoutesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListIpRoutesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4036,6 +4178,11 @@ impl From<CredentialsError> for ListSchemaExtensionsError {
 impl From<HttpDispatchError> for ListSchemaExtensionsError {
     fn from(err: HttpDispatchError) -> ListSchemaExtensionsError {
         ListSchemaExtensionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListSchemaExtensionsError {
+    fn from(err: io::Error) -> ListSchemaExtensionsError {
+        ListSchemaExtensionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListSchemaExtensionsError {
@@ -4137,6 +4284,11 @@ impl From<HttpDispatchError> for ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4230,6 +4382,11 @@ impl From<CredentialsError> for RegisterEventTopicError {
 impl From<HttpDispatchError> for RegisterEventTopicError {
     fn from(err: HttpDispatchError) -> RegisterEventTopicError {
         RegisterEventTopicError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterEventTopicError {
+    fn from(err: io::Error) -> RegisterEventTopicError {
+        RegisterEventTopicError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterEventTopicError {
@@ -4327,6 +4484,11 @@ impl From<HttpDispatchError> for RemoveIpRoutesError {
         RemoveIpRoutesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveIpRoutesError {
+    fn from(err: io::Error) -> RemoveIpRoutesError {
+        RemoveIpRoutesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveIpRoutesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4418,6 +4580,11 @@ impl From<CredentialsError> for RemoveTagsFromResourceError {
 impl From<HttpDispatchError> for RemoveTagsFromResourceError {
     fn from(err: HttpDispatchError) -> RemoveTagsFromResourceError {
         RemoveTagsFromResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveTagsFromResourceError {
+    fn from(err: io::Error) -> RemoveTagsFromResourceError {
+        RemoveTagsFromResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveTagsFromResourceError {
@@ -4512,6 +4679,11 @@ impl From<CredentialsError> for RestoreFromSnapshotError {
 impl From<HttpDispatchError> for RestoreFromSnapshotError {
     fn from(err: HttpDispatchError) -> RestoreFromSnapshotError {
         RestoreFromSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RestoreFromSnapshotError {
+    fn from(err: io::Error) -> RestoreFromSnapshotError {
+        RestoreFromSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RestoreFromSnapshotError {
@@ -4616,6 +4788,11 @@ impl From<HttpDispatchError> for StartSchemaExtensionError {
         StartSchemaExtensionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartSchemaExtensionError {
+    fn from(err: io::Error) -> StartSchemaExtensionError {
+        StartSchemaExtensionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartSchemaExtensionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4714,6 +4891,11 @@ impl From<HttpDispatchError> for UpdateConditionalForwarderError {
         UpdateConditionalForwarderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateConditionalForwarderError {
+    fn from(err: io::Error) -> UpdateConditionalForwarderError {
+        UpdateConditionalForwarderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateConditionalForwarderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4804,6 +4986,11 @@ impl From<CredentialsError> for UpdateRadiusError {
 impl From<HttpDispatchError> for UpdateRadiusError {
     fn from(err: HttpDispatchError) -> UpdateRadiusError {
         UpdateRadiusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateRadiusError {
+    fn from(err: io::Error) -> UpdateRadiusError {
+        UpdateRadiusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateRadiusError {
@@ -4897,6 +5084,11 @@ impl From<CredentialsError> for VerifyTrustError {
 impl From<HttpDispatchError> for VerifyTrustError {
     fn from(err: HttpDispatchError) -> VerifyTrustError {
         VerifyTrustError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for VerifyTrustError {
+    fn from(err: io::Error) -> VerifyTrustError {
+        VerifyTrustError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for VerifyTrustError {
@@ -5188,13 +5380,21 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddIpRoutesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AddIpRoutesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddIpRoutesResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddIpRoutesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5213,15 +5413,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddTagsToResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsToResourceResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5242,15 +5447,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CancelSchemaExtensionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelSchemaExtensionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CancelSchemaExtensionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelSchemaExtensionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5269,15 +5477,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ConnectDirectoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ConnectDirectoryResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ConnectDirectoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConnectDirectoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5296,13 +5509,21 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAliasResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAliasResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5320,15 +5541,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateComputerResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateComputerResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateComputerError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateComputerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5349,13 +5575,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateConditionalForwarderResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateConditionalForwarderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateConditionalForwarderResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateConditionalForwarderError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5373,15 +5606,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDirectoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDirectoryResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateDirectoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDirectoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5401,15 +5639,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateMicrosoftADResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateMicrosoftADResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateMicrosoftADError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateMicrosoftADError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5428,15 +5671,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateSnapshotResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5455,13 +5703,21 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateTrustResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateTrustError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateTrustResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTrustError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5481,13 +5737,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteConditionalForwarderResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteConditionalForwarderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteConditionalForwarderResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteConditionalForwarderError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5505,15 +5768,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteDirectoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteDirectoryResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteDirectoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDirectoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5532,15 +5800,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteSnapshotResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5559,13 +5832,21 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteTrustResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteTrustError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteTrustResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTrustError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5584,15 +5865,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeregisterEventTopicResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeregisterEventTopicResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeregisterEventTopicError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterEventTopicError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5613,13 +5897,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeConditionalForwardersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeConditionalForwardersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeConditionalForwardersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConditionalForwardersError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -5638,15 +5929,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDirectoriesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDirectoriesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeDirectoriesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDirectoriesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5666,15 +5960,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventTopicsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventTopicsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeEventTopicsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventTopicsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5694,15 +5991,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeSnapshotsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeSnapshotsResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeSnapshotsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSnapshotsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5721,15 +6023,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTrustsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTrustsResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTrustsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTrustsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5748,14 +6055,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisableRadiusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisableRadiusResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DisableRadiusError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableRadiusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5772,13 +6085,21 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisableSsoResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DisableSsoError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisableSsoResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableSsoError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5796,14 +6117,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EnableRadiusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EnableRadiusResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(EnableRadiusError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableRadiusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5820,15 +6147,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<EnableSsoResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EnableSsoResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(EnableSsoError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableSsoError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5844,15 +6176,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDirectoryLimitsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDirectoryLimitsResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetDirectoryLimitsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDirectoryLimitsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5872,15 +6209,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetSnapshotLimitsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSnapshotLimitsResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetSnapshotLimitsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSnapshotLimitsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5899,14 +6241,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListIpRoutesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListIpRoutesResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListIpRoutesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListIpRoutesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5926,15 +6274,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListSchemaExtensionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListSchemaExtensionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListSchemaExtensionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSchemaExtensionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5954,15 +6305,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5982,15 +6336,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterEventTopicResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterEventTopicResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RegisterEventTopicError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterEventTopicError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6009,15 +6368,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveIpRoutesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveIpRoutesResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RemoveIpRoutesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveIpRoutesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6038,15 +6402,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTagsFromResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTagsFromResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6066,15 +6433,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RestoreFromSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RestoreFromSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RestoreFromSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreFromSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6094,15 +6464,18 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartSchemaExtensionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartSchemaExtensionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(StartSchemaExtensionError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartSchemaExtensionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6123,13 +6496,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateConditionalForwarderResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateConditionalForwarderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateConditionalForwarderResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateConditionalForwarderError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6147,14 +6527,20 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateRadiusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateRadiusResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateRadiusError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRadiusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6173,13 +6559,21 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<VerifyTrustResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(VerifyTrustError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<VerifyTrustResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(VerifyTrustError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1339,6 +1341,11 @@ impl From<HttpDispatchError> for BatchGetItemError {
         BatchGetItemError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchGetItemError {
+    fn from(err: io::Error) -> BatchGetItemError {
+        BatchGetItemError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchGetItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1426,6 +1433,11 @@ impl From<HttpDispatchError> for BatchWriteItemError {
         BatchWriteItemError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchWriteItemError {
+    fn from(err: io::Error) -> BatchWriteItemError {
+        BatchWriteItemError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchWriteItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1511,6 +1523,11 @@ impl From<CredentialsError> for CreateTableError {
 impl From<HttpDispatchError> for CreateTableError {
     fn from(err: HttpDispatchError) -> CreateTableError {
         CreateTableError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateTableError {
+    fn from(err: io::Error) -> CreateTableError {
+        CreateTableError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateTableError {
@@ -1603,6 +1620,11 @@ impl From<CredentialsError> for DeleteItemError {
 impl From<HttpDispatchError> for DeleteItemError {
     fn from(err: HttpDispatchError) -> DeleteItemError {
         DeleteItemError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteItemError {
+    fn from(err: io::Error) -> DeleteItemError {
+        DeleteItemError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteItemError {
@@ -1698,6 +1720,11 @@ impl From<HttpDispatchError> for DeleteTableError {
         DeleteTableError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTableError {
+    fn from(err: io::Error) -> DeleteTableError {
+        DeleteTableError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1773,6 +1800,11 @@ impl From<CredentialsError> for DescribeLimitsError {
 impl From<HttpDispatchError> for DescribeLimitsError {
     fn from(err: HttpDispatchError) -> DescribeLimitsError {
         DescribeLimitsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLimitsError {
+    fn from(err: io::Error) -> DescribeLimitsError {
+        DescribeLimitsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLimitsError {
@@ -1854,6 +1886,11 @@ impl From<HttpDispatchError> for DescribeTableError {
         DescribeTableError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTableError {
+    fn from(err: io::Error) -> DescribeTableError {
+        DescribeTableError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1932,6 +1969,11 @@ impl From<CredentialsError> for DescribeTimeToLiveError {
 impl From<HttpDispatchError> for DescribeTimeToLiveError {
     fn from(err: HttpDispatchError) -> DescribeTimeToLiveError {
         DescribeTimeToLiveError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTimeToLiveError {
+    fn from(err: io::Error) -> DescribeTimeToLiveError {
+        DescribeTimeToLiveError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTimeToLiveError {
@@ -2019,6 +2061,11 @@ impl From<HttpDispatchError> for GetItemError {
         GetItemError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetItemError {
+    fn from(err: io::Error) -> GetItemError {
+        GetItemError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2091,6 +2138,11 @@ impl From<CredentialsError> for ListTablesError {
 impl From<HttpDispatchError> for ListTablesError {
     fn from(err: HttpDispatchError) -> ListTablesError {
         ListTablesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTablesError {
+    fn from(err: io::Error) -> ListTablesError {
+        ListTablesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTablesError {
@@ -2170,6 +2222,11 @@ impl From<CredentialsError> for ListTagsOfResourceError {
 impl From<HttpDispatchError> for ListTagsOfResourceError {
     fn from(err: HttpDispatchError) -> ListTagsOfResourceError {
         ListTagsOfResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsOfResourceError {
+    fn from(err: io::Error) -> ListTagsOfResourceError {
+        ListTagsOfResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsOfResourceError {
@@ -2267,6 +2324,11 @@ impl From<HttpDispatchError> for PutItemError {
         PutItemError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutItemError {
+    fn from(err: io::Error) -> PutItemError {
+        PutItemError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2353,6 +2415,11 @@ impl From<HttpDispatchError> for QueryError {
         QueryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for QueryError {
+    fn from(err: io::Error) -> QueryError {
+        QueryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for QueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2435,6 +2502,11 @@ impl From<CredentialsError> for ScanError {
 impl From<HttpDispatchError> for ScanError {
     fn from(err: HttpDispatchError) -> ScanError {
         ScanError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ScanError {
+    fn from(err: io::Error) -> ScanError {
+        ScanError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ScanError {
@@ -2528,6 +2600,11 @@ impl From<HttpDispatchError> for TagResourceError {
         TagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TagResourceError {
+    fn from(err: io::Error) -> TagResourceError {
+        TagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2618,6 +2695,11 @@ impl From<CredentialsError> for UntagResourceError {
 impl From<HttpDispatchError> for UntagResourceError {
     fn from(err: HttpDispatchError) -> UntagResourceError {
         UntagResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UntagResourceError {
+    fn from(err: io::Error) -> UntagResourceError {
+        UntagResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UntagResourceError {
@@ -2713,6 +2795,11 @@ impl From<HttpDispatchError> for UpdateItemError {
         UpdateItemError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateItemError {
+    fn from(err: io::Error) -> UpdateItemError {
+        UpdateItemError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2806,6 +2893,11 @@ impl From<HttpDispatchError> for UpdateTableError {
         UpdateTableError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateTableError {
+    fn from(err: io::Error) -> UpdateTableError {
+        UpdateTableError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2896,6 +2988,11 @@ impl From<CredentialsError> for UpdateTimeToLiveError {
 impl From<HttpDispatchError> for UpdateTimeToLiveError {
     fn from(err: HttpDispatchError) -> UpdateTimeToLiveError {
         UpdateTimeToLiveError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateTimeToLiveError {
+    fn from(err: io::Error) -> UpdateTimeToLiveError {
+        UpdateTimeToLiveError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateTimeToLiveError {
@@ -3052,14 +3149,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetItemOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetItemOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(BatchGetItemError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetItemError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3078,15 +3181,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchWriteItemOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchWriteItemOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(BatchWriteItemError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchWriteItemError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3105,13 +3213,21 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateTableOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateTableError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateTableOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTableError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3127,13 +3243,21 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteItemOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteItemError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteItemOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteItemError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3151,13 +3275,21 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteTableOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteTableError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteTableOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTableError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3172,15 +3304,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeLimitsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeLimitsOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeLimitsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLimitsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3199,14 +3336,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTableOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTableOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTableError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTableError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3225,15 +3368,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTimeToLiveOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTimeToLiveOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTimeToLiveError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTimeToLiveError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3250,15 +3398,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetItemOutput>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetItemOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetItemError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetItemError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3274,13 +3427,21 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTablesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListTablesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTablesOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTablesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3298,15 +3459,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsOfResourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsOfResourceOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListTagsOfResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsOfResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3323,15 +3489,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<PutItemOutput>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutItemOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(PutItemError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutItemError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3347,15 +3518,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<QueryOutput>(String::from_utf8_lossy(&response.body)
-                                                           .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<QueryOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(QueryError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(QueryError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3371,15 +3547,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ScanOutput>(String::from_utf8_lossy(&response.body)
-                                                          .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ScanOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ScanError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ScanError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3395,11 +3576,15 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3415,12 +3600,14 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UntagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3437,13 +3624,21 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateItemOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateItemError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateItemOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateItemError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3461,13 +3656,21 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateTableOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateTableError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateTableOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateTableError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3485,15 +3688,20 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateTimeToLiveOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateTimeToLiveOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateTimeToLiveError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateTimeToLiveError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -41563,6 +41565,11 @@ impl From<HttpDispatchError> for AcceptReservedInstancesExchangeQuoteError {
         AcceptReservedInstancesExchangeQuoteError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AcceptReservedInstancesExchangeQuoteError {
+    fn from(err: io::Error) -> AcceptReservedInstancesExchangeQuoteError {
+        AcceptReservedInstancesExchangeQuoteError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AcceptReservedInstancesExchangeQuoteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -41625,6 +41632,11 @@ impl From<CredentialsError> for AcceptVpcPeeringConnectionError {
 impl From<HttpDispatchError> for AcceptVpcPeeringConnectionError {
     fn from(err: HttpDispatchError) -> AcceptVpcPeeringConnectionError {
         AcceptVpcPeeringConnectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AcceptVpcPeeringConnectionError {
+    fn from(err: io::Error) -> AcceptVpcPeeringConnectionError {
+        AcceptVpcPeeringConnectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AcceptVpcPeeringConnectionError {
@@ -41691,6 +41703,11 @@ impl From<HttpDispatchError> for AllocateAddressError {
         AllocateAddressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AllocateAddressError {
+    fn from(err: io::Error) -> AllocateAddressError {
+        AllocateAddressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AllocateAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -41753,6 +41770,11 @@ impl From<HttpDispatchError> for AllocateHostsError {
         AllocateHostsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AllocateHostsError {
+    fn from(err: io::Error) -> AllocateHostsError {
+        AllocateHostsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AllocateHostsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -41813,6 +41835,11 @@ impl From<CredentialsError> for AssignIpv6AddressesError {
 impl From<HttpDispatchError> for AssignIpv6AddressesError {
     fn from(err: HttpDispatchError) -> AssignIpv6AddressesError {
         AssignIpv6AddressesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AssignIpv6AddressesError {
+    fn from(err: io::Error) -> AssignIpv6AddressesError {
+        AssignIpv6AddressesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AssignIpv6AddressesError {
@@ -41879,6 +41906,11 @@ impl From<HttpDispatchError> for AssignPrivateIpAddressesError {
         AssignPrivateIpAddressesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssignPrivateIpAddressesError {
+    fn from(err: io::Error) -> AssignPrivateIpAddressesError {
+        AssignPrivateIpAddressesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssignPrivateIpAddressesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -41943,6 +41975,11 @@ impl From<HttpDispatchError> for AssociateAddressError {
         AssociateAddressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateAddressError {
+    fn from(err: io::Error) -> AssociateAddressError {
+        AssociateAddressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42003,6 +42040,11 @@ impl From<CredentialsError> for AssociateDhcpOptionsError {
 impl From<HttpDispatchError> for AssociateDhcpOptionsError {
     fn from(err: HttpDispatchError) -> AssociateDhcpOptionsError {
         AssociateDhcpOptionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AssociateDhcpOptionsError {
+    fn from(err: io::Error) -> AssociateDhcpOptionsError {
+        AssociateDhcpOptionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AssociateDhcpOptionsError {
@@ -42069,6 +42111,11 @@ impl From<HttpDispatchError> for AssociateIamInstanceProfileError {
         AssociateIamInstanceProfileError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateIamInstanceProfileError {
+    fn from(err: io::Error) -> AssociateIamInstanceProfileError {
+        AssociateIamInstanceProfileError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateIamInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42131,6 +42178,11 @@ impl From<CredentialsError> for AssociateRouteTableError {
 impl From<HttpDispatchError> for AssociateRouteTableError {
     fn from(err: HttpDispatchError) -> AssociateRouteTableError {
         AssociateRouteTableError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AssociateRouteTableError {
+    fn from(err: io::Error) -> AssociateRouteTableError {
+        AssociateRouteTableError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AssociateRouteTableError {
@@ -42197,6 +42249,11 @@ impl From<HttpDispatchError> for AssociateSubnetCidrBlockError {
         AssociateSubnetCidrBlockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateSubnetCidrBlockError {
+    fn from(err: io::Error) -> AssociateSubnetCidrBlockError {
+        AssociateSubnetCidrBlockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateSubnetCidrBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42259,6 +42316,11 @@ impl From<CredentialsError> for AssociateVpcCidrBlockError {
 impl From<HttpDispatchError> for AssociateVpcCidrBlockError {
     fn from(err: HttpDispatchError) -> AssociateVpcCidrBlockError {
         AssociateVpcCidrBlockError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AssociateVpcCidrBlockError {
+    fn from(err: io::Error) -> AssociateVpcCidrBlockError {
+        AssociateVpcCidrBlockError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AssociateVpcCidrBlockError {
@@ -42325,6 +42387,11 @@ impl From<HttpDispatchError> for AttachClassicLinkVpcError {
         AttachClassicLinkVpcError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachClassicLinkVpcError {
+    fn from(err: io::Error) -> AttachClassicLinkVpcError {
+        AttachClassicLinkVpcError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachClassicLinkVpcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42387,6 +42454,11 @@ impl From<CredentialsError> for AttachInternetGatewayError {
 impl From<HttpDispatchError> for AttachInternetGatewayError {
     fn from(err: HttpDispatchError) -> AttachInternetGatewayError {
         AttachInternetGatewayError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AttachInternetGatewayError {
+    fn from(err: io::Error) -> AttachInternetGatewayError {
+        AttachInternetGatewayError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AttachInternetGatewayError {
@@ -42453,6 +42525,11 @@ impl From<HttpDispatchError> for AttachNetworkInterfaceError {
         AttachNetworkInterfaceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachNetworkInterfaceError {
+    fn from(err: io::Error) -> AttachNetworkInterfaceError {
+        AttachNetworkInterfaceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachNetworkInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42517,6 +42594,11 @@ impl From<HttpDispatchError> for AttachVolumeError {
         AttachVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachVolumeError {
+    fn from(err: io::Error) -> AttachVolumeError {
+        AttachVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42579,6 +42661,11 @@ impl From<HttpDispatchError> for AttachVpnGatewayError {
         AttachVpnGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachVpnGatewayError {
+    fn from(err: io::Error) -> AttachVpnGatewayError {
+        AttachVpnGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachVpnGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42639,6 +42726,11 @@ impl From<CredentialsError> for AuthorizeSecurityGroupEgressError {
 impl From<HttpDispatchError> for AuthorizeSecurityGroupEgressError {
     fn from(err: HttpDispatchError) -> AuthorizeSecurityGroupEgressError {
         AuthorizeSecurityGroupEgressError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AuthorizeSecurityGroupEgressError {
+    fn from(err: io::Error) -> AuthorizeSecurityGroupEgressError {
+        AuthorizeSecurityGroupEgressError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AuthorizeSecurityGroupEgressError {
@@ -42705,6 +42797,11 @@ impl From<HttpDispatchError> for AuthorizeSecurityGroupIngressError {
         AuthorizeSecurityGroupIngressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AuthorizeSecurityGroupIngressError {
+    fn from(err: io::Error) -> AuthorizeSecurityGroupIngressError {
+        AuthorizeSecurityGroupIngressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AuthorizeSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42769,6 +42866,11 @@ impl From<HttpDispatchError> for BundleInstanceError {
         BundleInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BundleInstanceError {
+    fn from(err: io::Error) -> BundleInstanceError {
+        BundleInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BundleInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42831,6 +42933,11 @@ impl From<HttpDispatchError> for CancelBundleTaskError {
         CancelBundleTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelBundleTaskError {
+    fn from(err: io::Error) -> CancelBundleTaskError {
+        CancelBundleTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelBundleTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -42891,6 +42998,11 @@ impl From<CredentialsError> for CancelConversionTaskError {
 impl From<HttpDispatchError> for CancelConversionTaskError {
     fn from(err: HttpDispatchError) -> CancelConversionTaskError {
         CancelConversionTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CancelConversionTaskError {
+    fn from(err: io::Error) -> CancelConversionTaskError {
+        CancelConversionTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CancelConversionTaskError {
@@ -42957,6 +43069,11 @@ impl From<HttpDispatchError> for CancelExportTaskError {
         CancelExportTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelExportTaskError {
+    fn from(err: io::Error) -> CancelExportTaskError {
+        CancelExportTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelExportTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43019,6 +43136,11 @@ impl From<HttpDispatchError> for CancelImportTaskError {
         CancelImportTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelImportTaskError {
+    fn from(err: io::Error) -> CancelImportTaskError {
+        CancelImportTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelImportTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43079,6 +43201,11 @@ impl From<CredentialsError> for CancelReservedInstancesListingError {
 impl From<HttpDispatchError> for CancelReservedInstancesListingError {
     fn from(err: HttpDispatchError) -> CancelReservedInstancesListingError {
         CancelReservedInstancesListingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CancelReservedInstancesListingError {
+    fn from(err: io::Error) -> CancelReservedInstancesListingError {
+        CancelReservedInstancesListingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CancelReservedInstancesListingError {
@@ -43145,6 +43272,11 @@ impl From<HttpDispatchError> for EC2CancelSpotFleetRequestsError {
         EC2CancelSpotFleetRequestsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EC2CancelSpotFleetRequestsError {
+    fn from(err: io::Error) -> EC2CancelSpotFleetRequestsError {
+        EC2CancelSpotFleetRequestsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EC2CancelSpotFleetRequestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43207,6 +43339,11 @@ impl From<CredentialsError> for CancelSpotInstanceRequestsError {
 impl From<HttpDispatchError> for CancelSpotInstanceRequestsError {
     fn from(err: HttpDispatchError) -> CancelSpotInstanceRequestsError {
         CancelSpotInstanceRequestsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CancelSpotInstanceRequestsError {
+    fn from(err: io::Error) -> CancelSpotInstanceRequestsError {
+        CancelSpotInstanceRequestsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CancelSpotInstanceRequestsError {
@@ -43273,6 +43410,11 @@ impl From<HttpDispatchError> for ConfirmProductInstanceError {
         ConfirmProductInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ConfirmProductInstanceError {
+    fn from(err: io::Error) -> ConfirmProductInstanceError {
+        ConfirmProductInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ConfirmProductInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43337,6 +43479,11 @@ impl From<HttpDispatchError> for CopyImageError {
         CopyImageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CopyImageError {
+    fn from(err: io::Error) -> CopyImageError {
+        CopyImageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CopyImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43399,6 +43546,11 @@ impl From<HttpDispatchError> for CopySnapshotError {
         CopySnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CopySnapshotError {
+    fn from(err: io::Error) -> CopySnapshotError {
+        CopySnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CopySnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43459,6 +43611,11 @@ impl From<CredentialsError> for CreateCustomerGatewayError {
 impl From<HttpDispatchError> for CreateCustomerGatewayError {
     fn from(err: HttpDispatchError) -> CreateCustomerGatewayError {
         CreateCustomerGatewayError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateCustomerGatewayError {
+    fn from(err: io::Error) -> CreateCustomerGatewayError {
+        CreateCustomerGatewayError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateCustomerGatewayError {
@@ -43525,6 +43682,11 @@ impl From<HttpDispatchError> for CreateDhcpOptionsError {
         CreateDhcpOptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDhcpOptionsError {
+    fn from(err: io::Error) -> CreateDhcpOptionsError {
+        CreateDhcpOptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDhcpOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43587,6 +43749,11 @@ impl From<CredentialsError> for CreateEgressOnlyInternetGatewayError {
 impl From<HttpDispatchError> for CreateEgressOnlyInternetGatewayError {
     fn from(err: HttpDispatchError) -> CreateEgressOnlyInternetGatewayError {
         CreateEgressOnlyInternetGatewayError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateEgressOnlyInternetGatewayError {
+    fn from(err: io::Error) -> CreateEgressOnlyInternetGatewayError {
+        CreateEgressOnlyInternetGatewayError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateEgressOnlyInternetGatewayError {
@@ -43653,6 +43820,11 @@ impl From<HttpDispatchError> for CreateFlowLogsError {
         CreateFlowLogsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateFlowLogsError {
+    fn from(err: io::Error) -> CreateFlowLogsError {
+        CreateFlowLogsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateFlowLogsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43713,6 +43885,11 @@ impl From<CredentialsError> for CreateFpgaImageError {
 impl From<HttpDispatchError> for CreateFpgaImageError {
     fn from(err: HttpDispatchError) -> CreateFpgaImageError {
         CreateFpgaImageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateFpgaImageError {
+    fn from(err: io::Error) -> CreateFpgaImageError {
+        CreateFpgaImageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateFpgaImageError {
@@ -43777,6 +43954,11 @@ impl From<HttpDispatchError> for CreateImageError {
         CreateImageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateImageError {
+    fn from(err: io::Error) -> CreateImageError {
+        CreateImageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43837,6 +44019,11 @@ impl From<CredentialsError> for CreateInstanceExportTaskError {
 impl From<HttpDispatchError> for CreateInstanceExportTaskError {
     fn from(err: HttpDispatchError) -> CreateInstanceExportTaskError {
         CreateInstanceExportTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateInstanceExportTaskError {
+    fn from(err: io::Error) -> CreateInstanceExportTaskError {
+        CreateInstanceExportTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateInstanceExportTaskError {
@@ -43903,6 +44090,11 @@ impl From<HttpDispatchError> for CreateInternetGatewayError {
         CreateInternetGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateInternetGatewayError {
+    fn from(err: io::Error) -> CreateInternetGatewayError {
+        CreateInternetGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateInternetGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -43967,6 +44159,11 @@ impl From<HttpDispatchError> for CreateKeyPairError {
         CreateKeyPairError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateKeyPairError {
+    fn from(err: io::Error) -> CreateKeyPairError {
+        CreateKeyPairError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44027,6 +44224,11 @@ impl From<CredentialsError> for CreateNatGatewayError {
 impl From<HttpDispatchError> for CreateNatGatewayError {
     fn from(err: HttpDispatchError) -> CreateNatGatewayError {
         CreateNatGatewayError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateNatGatewayError {
+    fn from(err: io::Error) -> CreateNatGatewayError {
+        CreateNatGatewayError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateNatGatewayError {
@@ -44091,6 +44293,11 @@ impl From<HttpDispatchError> for CreateNetworkAclError {
         CreateNetworkAclError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateNetworkAclError {
+    fn from(err: io::Error) -> CreateNetworkAclError {
+        CreateNetworkAclError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateNetworkAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44151,6 +44358,11 @@ impl From<CredentialsError> for CreateNetworkAclEntryError {
 impl From<HttpDispatchError> for CreateNetworkAclEntryError {
     fn from(err: HttpDispatchError) -> CreateNetworkAclEntryError {
         CreateNetworkAclEntryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateNetworkAclEntryError {
+    fn from(err: io::Error) -> CreateNetworkAclEntryError {
+        CreateNetworkAclEntryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateNetworkAclEntryError {
@@ -44217,6 +44429,11 @@ impl From<HttpDispatchError> for CreateNetworkInterfaceError {
         CreateNetworkInterfaceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateNetworkInterfaceError {
+    fn from(err: io::Error) -> CreateNetworkInterfaceError {
+        CreateNetworkInterfaceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateNetworkInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44279,6 +44496,11 @@ impl From<CredentialsError> for CreatePlacementGroupError {
 impl From<HttpDispatchError> for CreatePlacementGroupError {
     fn from(err: HttpDispatchError) -> CreatePlacementGroupError {
         CreatePlacementGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePlacementGroupError {
+    fn from(err: io::Error) -> CreatePlacementGroupError {
+        CreatePlacementGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePlacementGroupError {
@@ -44345,6 +44567,11 @@ impl From<HttpDispatchError> for CreateReservedInstancesListingError {
         CreateReservedInstancesListingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReservedInstancesListingError {
+    fn from(err: io::Error) -> CreateReservedInstancesListingError {
+        CreateReservedInstancesListingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReservedInstancesListingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44409,6 +44636,11 @@ impl From<HttpDispatchError> for CreateRouteError {
         CreateRouteError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRouteError {
+    fn from(err: io::Error) -> CreateRouteError {
+        CreateRouteError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44471,6 +44703,11 @@ impl From<HttpDispatchError> for CreateRouteTableError {
         CreateRouteTableError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRouteTableError {
+    fn from(err: io::Error) -> CreateRouteTableError {
+        CreateRouteTableError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRouteTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44531,6 +44768,11 @@ impl From<CredentialsError> for CreateSecurityGroupError {
 impl From<HttpDispatchError> for CreateSecurityGroupError {
     fn from(err: HttpDispatchError) -> CreateSecurityGroupError {
         CreateSecurityGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateSecurityGroupError {
+    fn from(err: io::Error) -> CreateSecurityGroupError {
+        CreateSecurityGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateSecurityGroupError {
@@ -44597,6 +44839,11 @@ impl From<HttpDispatchError> for CreateSnapshotError {
         CreateSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateSnapshotError {
+    fn from(err: io::Error) -> CreateSnapshotError {
+        CreateSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44657,6 +44904,11 @@ impl From<CredentialsError> for CreateSpotDatafeedSubscriptionError {
 impl From<HttpDispatchError> for CreateSpotDatafeedSubscriptionError {
     fn from(err: HttpDispatchError) -> CreateSpotDatafeedSubscriptionError {
         CreateSpotDatafeedSubscriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateSpotDatafeedSubscriptionError {
+    fn from(err: io::Error) -> CreateSpotDatafeedSubscriptionError {
+        CreateSpotDatafeedSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateSpotDatafeedSubscriptionError {
@@ -44723,6 +44975,11 @@ impl From<HttpDispatchError> for CreateSubnetError {
         CreateSubnetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateSubnetError {
+    fn from(err: io::Error) -> CreateSubnetError {
+        CreateSubnetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateSubnetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44783,6 +45040,11 @@ impl From<CredentialsError> for CreateTagsError {
 impl From<HttpDispatchError> for CreateTagsError {
     fn from(err: HttpDispatchError) -> CreateTagsError {
         CreateTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateTagsError {
+    fn from(err: io::Error) -> CreateTagsError {
+        CreateTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateTagsError {
@@ -44847,6 +45109,11 @@ impl From<HttpDispatchError> for CreateVolumeError {
         CreateVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateVolumeError {
+    fn from(err: io::Error) -> CreateVolumeError {
+        CreateVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44909,6 +45176,11 @@ impl From<HttpDispatchError> for CreateVpcError {
         CreateVpcError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateVpcError {
+    fn from(err: io::Error) -> CreateVpcError {
+        CreateVpcError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateVpcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -44969,6 +45241,11 @@ impl From<CredentialsError> for CreateVpcEndpointError {
 impl From<HttpDispatchError> for CreateVpcEndpointError {
     fn from(err: HttpDispatchError) -> CreateVpcEndpointError {
         CreateVpcEndpointError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateVpcEndpointError {
+    fn from(err: io::Error) -> CreateVpcEndpointError {
+        CreateVpcEndpointError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateVpcEndpointError {
@@ -45035,6 +45312,11 @@ impl From<HttpDispatchError> for CreateVpcPeeringConnectionError {
         CreateVpcPeeringConnectionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateVpcPeeringConnectionError {
+    fn from(err: io::Error) -> CreateVpcPeeringConnectionError {
+        CreateVpcPeeringConnectionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateVpcPeeringConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -45097,6 +45379,11 @@ impl From<CredentialsError> for CreateVpnConnectionError {
 impl From<HttpDispatchError> for CreateVpnConnectionError {
     fn from(err: HttpDispatchError) -> CreateVpnConnectionError {
         CreateVpnConnectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateVpnConnectionError {
+    fn from(err: io::Error) -> CreateVpnConnectionError {
+        CreateVpnConnectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateVpnConnectionError {
@@ -45163,6 +45450,11 @@ impl From<HttpDispatchError> for CreateVpnConnectionRouteError {
         CreateVpnConnectionRouteError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateVpnConnectionRouteError {
+    fn from(err: io::Error) -> CreateVpnConnectionRouteError {
+        CreateVpnConnectionRouteError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateVpnConnectionRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -45227,6 +45519,11 @@ impl From<HttpDispatchError> for CreateVpnGatewayError {
         CreateVpnGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateVpnGatewayError {
+    fn from(err: io::Error) -> CreateVpnGatewayError {
+        CreateVpnGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateVpnGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -45287,6 +45584,11 @@ impl From<CredentialsError> for DeleteCustomerGatewayError {
 impl From<HttpDispatchError> for DeleteCustomerGatewayError {
     fn from(err: HttpDispatchError) -> DeleteCustomerGatewayError {
         DeleteCustomerGatewayError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteCustomerGatewayError {
+    fn from(err: io::Error) -> DeleteCustomerGatewayError {
+        DeleteCustomerGatewayError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteCustomerGatewayError {
@@ -45353,6 +45655,11 @@ impl From<HttpDispatchError> for DeleteDhcpOptionsError {
         DeleteDhcpOptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDhcpOptionsError {
+    fn from(err: io::Error) -> DeleteDhcpOptionsError {
+        DeleteDhcpOptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDhcpOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -45415,6 +45722,11 @@ impl From<CredentialsError> for DeleteEgressOnlyInternetGatewayError {
 impl From<HttpDispatchError> for DeleteEgressOnlyInternetGatewayError {
     fn from(err: HttpDispatchError) -> DeleteEgressOnlyInternetGatewayError {
         DeleteEgressOnlyInternetGatewayError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteEgressOnlyInternetGatewayError {
+    fn from(err: io::Error) -> DeleteEgressOnlyInternetGatewayError {
+        DeleteEgressOnlyInternetGatewayError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteEgressOnlyInternetGatewayError {
@@ -45481,6 +45793,11 @@ impl From<HttpDispatchError> for DeleteFlowLogsError {
         DeleteFlowLogsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteFlowLogsError {
+    fn from(err: io::Error) -> DeleteFlowLogsError {
+        DeleteFlowLogsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteFlowLogsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -45541,6 +45858,11 @@ impl From<CredentialsError> for DeleteInternetGatewayError {
 impl From<HttpDispatchError> for DeleteInternetGatewayError {
     fn from(err: HttpDispatchError) -> DeleteInternetGatewayError {
         DeleteInternetGatewayError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteInternetGatewayError {
+    fn from(err: io::Error) -> DeleteInternetGatewayError {
+        DeleteInternetGatewayError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteInternetGatewayError {
@@ -45607,6 +45929,11 @@ impl From<HttpDispatchError> for DeleteKeyPairError {
         DeleteKeyPairError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteKeyPairError {
+    fn from(err: io::Error) -> DeleteKeyPairError {
+        DeleteKeyPairError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -45667,6 +45994,11 @@ impl From<CredentialsError> for DeleteNatGatewayError {
 impl From<HttpDispatchError> for DeleteNatGatewayError {
     fn from(err: HttpDispatchError) -> DeleteNatGatewayError {
         DeleteNatGatewayError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteNatGatewayError {
+    fn from(err: io::Error) -> DeleteNatGatewayError {
+        DeleteNatGatewayError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteNatGatewayError {
@@ -45731,6 +46063,11 @@ impl From<HttpDispatchError> for DeleteNetworkAclError {
         DeleteNetworkAclError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteNetworkAclError {
+    fn from(err: io::Error) -> DeleteNetworkAclError {
+        DeleteNetworkAclError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteNetworkAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -45791,6 +46128,11 @@ impl From<CredentialsError> for DeleteNetworkAclEntryError {
 impl From<HttpDispatchError> for DeleteNetworkAclEntryError {
     fn from(err: HttpDispatchError) -> DeleteNetworkAclEntryError {
         DeleteNetworkAclEntryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteNetworkAclEntryError {
+    fn from(err: io::Error) -> DeleteNetworkAclEntryError {
+        DeleteNetworkAclEntryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteNetworkAclEntryError {
@@ -45857,6 +46199,11 @@ impl From<HttpDispatchError> for DeleteNetworkInterfaceError {
         DeleteNetworkInterfaceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteNetworkInterfaceError {
+    fn from(err: io::Error) -> DeleteNetworkInterfaceError {
+        DeleteNetworkInterfaceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteNetworkInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -45919,6 +46266,11 @@ impl From<CredentialsError> for DeletePlacementGroupError {
 impl From<HttpDispatchError> for DeletePlacementGroupError {
     fn from(err: HttpDispatchError) -> DeletePlacementGroupError {
         DeletePlacementGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeletePlacementGroupError {
+    fn from(err: io::Error) -> DeletePlacementGroupError {
+        DeletePlacementGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeletePlacementGroupError {
@@ -45985,6 +46337,11 @@ impl From<HttpDispatchError> for DeleteRouteError {
         DeleteRouteError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRouteError {
+    fn from(err: io::Error) -> DeleteRouteError {
+        DeleteRouteError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46047,6 +46404,11 @@ impl From<HttpDispatchError> for DeleteRouteTableError {
         DeleteRouteTableError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRouteTableError {
+    fn from(err: io::Error) -> DeleteRouteTableError {
+        DeleteRouteTableError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRouteTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46107,6 +46469,11 @@ impl From<CredentialsError> for DeleteSecurityGroupError {
 impl From<HttpDispatchError> for DeleteSecurityGroupError {
     fn from(err: HttpDispatchError) -> DeleteSecurityGroupError {
         DeleteSecurityGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSecurityGroupError {
+    fn from(err: io::Error) -> DeleteSecurityGroupError {
+        DeleteSecurityGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSecurityGroupError {
@@ -46173,6 +46540,11 @@ impl From<HttpDispatchError> for DeleteSnapshotError {
         DeleteSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteSnapshotError {
+    fn from(err: io::Error) -> DeleteSnapshotError {
+        DeleteSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46233,6 +46605,11 @@ impl From<CredentialsError> for DeleteSpotDatafeedSubscriptionError {
 impl From<HttpDispatchError> for DeleteSpotDatafeedSubscriptionError {
     fn from(err: HttpDispatchError) -> DeleteSpotDatafeedSubscriptionError {
         DeleteSpotDatafeedSubscriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSpotDatafeedSubscriptionError {
+    fn from(err: io::Error) -> DeleteSpotDatafeedSubscriptionError {
+        DeleteSpotDatafeedSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSpotDatafeedSubscriptionError {
@@ -46299,6 +46676,11 @@ impl From<HttpDispatchError> for DeleteSubnetError {
         DeleteSubnetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteSubnetError {
+    fn from(err: io::Error) -> DeleteSubnetError {
+        DeleteSubnetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteSubnetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46359,6 +46741,11 @@ impl From<CredentialsError> for DeleteTagsError {
 impl From<HttpDispatchError> for DeleteTagsError {
     fn from(err: HttpDispatchError) -> DeleteTagsError {
         DeleteTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteTagsError {
+    fn from(err: io::Error) -> DeleteTagsError {
+        DeleteTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteTagsError {
@@ -46423,6 +46810,11 @@ impl From<HttpDispatchError> for DeleteVolumeError {
         DeleteVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteVolumeError {
+    fn from(err: io::Error) -> DeleteVolumeError {
+        DeleteVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46485,6 +46877,11 @@ impl From<HttpDispatchError> for DeleteVpcError {
         DeleteVpcError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteVpcError {
+    fn from(err: io::Error) -> DeleteVpcError {
+        DeleteVpcError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteVpcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46545,6 +46942,11 @@ impl From<CredentialsError> for DeleteVpcEndpointsError {
 impl From<HttpDispatchError> for DeleteVpcEndpointsError {
     fn from(err: HttpDispatchError) -> DeleteVpcEndpointsError {
         DeleteVpcEndpointsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteVpcEndpointsError {
+    fn from(err: io::Error) -> DeleteVpcEndpointsError {
+        DeleteVpcEndpointsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteVpcEndpointsError {
@@ -46611,6 +47013,11 @@ impl From<HttpDispatchError> for DeleteVpcPeeringConnectionError {
         DeleteVpcPeeringConnectionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteVpcPeeringConnectionError {
+    fn from(err: io::Error) -> DeleteVpcPeeringConnectionError {
+        DeleteVpcPeeringConnectionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteVpcPeeringConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46673,6 +47080,11 @@ impl From<CredentialsError> for DeleteVpnConnectionError {
 impl From<HttpDispatchError> for DeleteVpnConnectionError {
     fn from(err: HttpDispatchError) -> DeleteVpnConnectionError {
         DeleteVpnConnectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteVpnConnectionError {
+    fn from(err: io::Error) -> DeleteVpnConnectionError {
+        DeleteVpnConnectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteVpnConnectionError {
@@ -46739,6 +47151,11 @@ impl From<HttpDispatchError> for DeleteVpnConnectionRouteError {
         DeleteVpnConnectionRouteError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteVpnConnectionRouteError {
+    fn from(err: io::Error) -> DeleteVpnConnectionRouteError {
+        DeleteVpnConnectionRouteError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteVpnConnectionRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46803,6 +47220,11 @@ impl From<HttpDispatchError> for DeleteVpnGatewayError {
         DeleteVpnGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteVpnGatewayError {
+    fn from(err: io::Error) -> DeleteVpnGatewayError {
+        DeleteVpnGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteVpnGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46865,6 +47287,11 @@ impl From<HttpDispatchError> for DeregisterImageError {
         DeregisterImageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterImageError {
+    fn from(err: io::Error) -> DeregisterImageError {
+        DeregisterImageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -46925,6 +47352,11 @@ impl From<CredentialsError> for DescribeAccountAttributesError {
 impl From<HttpDispatchError> for DescribeAccountAttributesError {
     fn from(err: HttpDispatchError) -> DescribeAccountAttributesError {
         DescribeAccountAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAccountAttributesError {
+    fn from(err: io::Error) -> DescribeAccountAttributesError {
+        DescribeAccountAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAccountAttributesError {
@@ -46991,6 +47423,11 @@ impl From<HttpDispatchError> for DescribeAddressesError {
         DescribeAddressesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAddressesError {
+    fn from(err: io::Error) -> DescribeAddressesError {
+        DescribeAddressesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAddressesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -47053,6 +47490,11 @@ impl From<CredentialsError> for DescribeAvailabilityZonesError {
 impl From<HttpDispatchError> for DescribeAvailabilityZonesError {
     fn from(err: HttpDispatchError) -> DescribeAvailabilityZonesError {
         DescribeAvailabilityZonesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAvailabilityZonesError {
+    fn from(err: io::Error) -> DescribeAvailabilityZonesError {
+        DescribeAvailabilityZonesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAvailabilityZonesError {
@@ -47119,6 +47561,11 @@ impl From<HttpDispatchError> for DescribeBundleTasksError {
         DescribeBundleTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeBundleTasksError {
+    fn from(err: io::Error) -> DescribeBundleTasksError {
+        DescribeBundleTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeBundleTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -47181,6 +47628,11 @@ impl From<CredentialsError> for DescribeClassicLinkInstancesError {
 impl From<HttpDispatchError> for DescribeClassicLinkInstancesError {
     fn from(err: HttpDispatchError) -> DescribeClassicLinkInstancesError {
         DescribeClassicLinkInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeClassicLinkInstancesError {
+    fn from(err: io::Error) -> DescribeClassicLinkInstancesError {
+        DescribeClassicLinkInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeClassicLinkInstancesError {
@@ -47247,6 +47699,11 @@ impl From<HttpDispatchError> for DescribeConversionTasksError {
         DescribeConversionTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeConversionTasksError {
+    fn from(err: io::Error) -> DescribeConversionTasksError {
+        DescribeConversionTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeConversionTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -47309,6 +47766,11 @@ impl From<CredentialsError> for DescribeCustomerGatewaysError {
 impl From<HttpDispatchError> for DescribeCustomerGatewaysError {
     fn from(err: HttpDispatchError) -> DescribeCustomerGatewaysError {
         DescribeCustomerGatewaysError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCustomerGatewaysError {
+    fn from(err: io::Error) -> DescribeCustomerGatewaysError {
+        DescribeCustomerGatewaysError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCustomerGatewaysError {
@@ -47375,6 +47837,11 @@ impl From<HttpDispatchError> for DescribeDhcpOptionsError {
         DescribeDhcpOptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDhcpOptionsError {
+    fn from(err: io::Error) -> DescribeDhcpOptionsError {
+        DescribeDhcpOptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDhcpOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -47437,6 +47904,11 @@ impl From<CredentialsError> for DescribeEgressOnlyInternetGatewaysError {
 impl From<HttpDispatchError> for DescribeEgressOnlyInternetGatewaysError {
     fn from(err: HttpDispatchError) -> DescribeEgressOnlyInternetGatewaysError {
         DescribeEgressOnlyInternetGatewaysError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEgressOnlyInternetGatewaysError {
+    fn from(err: io::Error) -> DescribeEgressOnlyInternetGatewaysError {
+        DescribeEgressOnlyInternetGatewaysError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEgressOnlyInternetGatewaysError {
@@ -47503,6 +47975,11 @@ impl From<HttpDispatchError> for DescribeExportTasksError {
         DescribeExportTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeExportTasksError {
+    fn from(err: io::Error) -> DescribeExportTasksError {
+        DescribeExportTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeExportTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -47567,6 +48044,11 @@ impl From<HttpDispatchError> for DescribeFlowLogsError {
         DescribeFlowLogsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeFlowLogsError {
+    fn from(err: io::Error) -> DescribeFlowLogsError {
+        DescribeFlowLogsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeFlowLogsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -47627,6 +48109,11 @@ impl From<CredentialsError> for DescribeFpgaImagesError {
 impl From<HttpDispatchError> for DescribeFpgaImagesError {
     fn from(err: HttpDispatchError) -> DescribeFpgaImagesError {
         DescribeFpgaImagesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeFpgaImagesError {
+    fn from(err: io::Error) -> DescribeFpgaImagesError {
+        DescribeFpgaImagesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeFpgaImagesError {
@@ -47693,6 +48180,11 @@ impl From<HttpDispatchError> for DescribeHostReservationOfferingsError {
         DescribeHostReservationOfferingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeHostReservationOfferingsError {
+    fn from(err: io::Error) -> DescribeHostReservationOfferingsError {
+        DescribeHostReservationOfferingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeHostReservationOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -47755,6 +48247,11 @@ impl From<CredentialsError> for DescribeHostReservationsError {
 impl From<HttpDispatchError> for DescribeHostReservationsError {
     fn from(err: HttpDispatchError) -> DescribeHostReservationsError {
         DescribeHostReservationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeHostReservationsError {
+    fn from(err: io::Error) -> DescribeHostReservationsError {
+        DescribeHostReservationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeHostReservationsError {
@@ -47821,6 +48318,11 @@ impl From<HttpDispatchError> for DescribeHostsError {
         DescribeHostsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeHostsError {
+    fn from(err: io::Error) -> DescribeHostsError {
+        DescribeHostsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeHostsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -47881,6 +48383,11 @@ impl From<CredentialsError> for DescribeIamInstanceProfileAssociationsError {
 impl From<HttpDispatchError> for DescribeIamInstanceProfileAssociationsError {
     fn from(err: HttpDispatchError) -> DescribeIamInstanceProfileAssociationsError {
         DescribeIamInstanceProfileAssociationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeIamInstanceProfileAssociationsError {
+    fn from(err: io::Error) -> DescribeIamInstanceProfileAssociationsError {
+        DescribeIamInstanceProfileAssociationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeIamInstanceProfileAssociationsError {
@@ -47947,6 +48454,11 @@ impl From<HttpDispatchError> for DescribeIdFormatError {
         DescribeIdFormatError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeIdFormatError {
+    fn from(err: io::Error) -> DescribeIdFormatError {
+        DescribeIdFormatError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeIdFormatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48007,6 +48519,11 @@ impl From<CredentialsError> for DescribeIdentityIdFormatError {
 impl From<HttpDispatchError> for DescribeIdentityIdFormatError {
     fn from(err: HttpDispatchError) -> DescribeIdentityIdFormatError {
         DescribeIdentityIdFormatError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeIdentityIdFormatError {
+    fn from(err: io::Error) -> DescribeIdentityIdFormatError {
+        DescribeIdentityIdFormatError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeIdentityIdFormatError {
@@ -48073,6 +48590,11 @@ impl From<HttpDispatchError> for DescribeImageAttributeError {
         DescribeImageAttributeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeImageAttributeError {
+    fn from(err: io::Error) -> DescribeImageAttributeError {
+        DescribeImageAttributeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeImageAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48137,6 +48659,11 @@ impl From<HttpDispatchError> for DescribeImagesError {
         DescribeImagesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeImagesError {
+    fn from(err: io::Error) -> DescribeImagesError {
+        DescribeImagesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48197,6 +48724,11 @@ impl From<CredentialsError> for DescribeImportImageTasksError {
 impl From<HttpDispatchError> for DescribeImportImageTasksError {
     fn from(err: HttpDispatchError) -> DescribeImportImageTasksError {
         DescribeImportImageTasksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeImportImageTasksError {
+    fn from(err: io::Error) -> DescribeImportImageTasksError {
+        DescribeImportImageTasksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeImportImageTasksError {
@@ -48263,6 +48795,11 @@ impl From<HttpDispatchError> for DescribeImportSnapshotTasksError {
         DescribeImportSnapshotTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeImportSnapshotTasksError {
+    fn from(err: io::Error) -> DescribeImportSnapshotTasksError {
+        DescribeImportSnapshotTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeImportSnapshotTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48325,6 +48862,11 @@ impl From<CredentialsError> for DescribeInstanceAttributeError {
 impl From<HttpDispatchError> for DescribeInstanceAttributeError {
     fn from(err: HttpDispatchError) -> DescribeInstanceAttributeError {
         DescribeInstanceAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeInstanceAttributeError {
+    fn from(err: io::Error) -> DescribeInstanceAttributeError {
+        DescribeInstanceAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeInstanceAttributeError {
@@ -48391,6 +48933,11 @@ impl From<HttpDispatchError> for DescribeInstanceStatusError {
         DescribeInstanceStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeInstanceStatusError {
+    fn from(err: io::Error) -> DescribeInstanceStatusError {
+        DescribeInstanceStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeInstanceStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48453,6 +49000,11 @@ impl From<CredentialsError> for DescribeInstancesError {
 impl From<HttpDispatchError> for DescribeInstancesError {
     fn from(err: HttpDispatchError) -> DescribeInstancesError {
         DescribeInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeInstancesError {
+    fn from(err: io::Error) -> DescribeInstancesError {
+        DescribeInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeInstancesError {
@@ -48519,6 +49071,11 @@ impl From<HttpDispatchError> for DescribeInternetGatewaysError {
         DescribeInternetGatewaysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeInternetGatewaysError {
+    fn from(err: io::Error) -> DescribeInternetGatewaysError {
+        DescribeInternetGatewaysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeInternetGatewaysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48583,6 +49140,11 @@ impl From<HttpDispatchError> for DescribeKeyPairsError {
         DescribeKeyPairsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeKeyPairsError {
+    fn from(err: io::Error) -> DescribeKeyPairsError {
+        DescribeKeyPairsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeKeyPairsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48643,6 +49205,11 @@ impl From<CredentialsError> for DescribeMovingAddressesError {
 impl From<HttpDispatchError> for DescribeMovingAddressesError {
     fn from(err: HttpDispatchError) -> DescribeMovingAddressesError {
         DescribeMovingAddressesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeMovingAddressesError {
+    fn from(err: io::Error) -> DescribeMovingAddressesError {
+        DescribeMovingAddressesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeMovingAddressesError {
@@ -48709,6 +49276,11 @@ impl From<HttpDispatchError> for DescribeNatGatewaysError {
         DescribeNatGatewaysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeNatGatewaysError {
+    fn from(err: io::Error) -> DescribeNatGatewaysError {
+        DescribeNatGatewaysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeNatGatewaysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48771,6 +49343,11 @@ impl From<CredentialsError> for DescribeNetworkAclsError {
 impl From<HttpDispatchError> for DescribeNetworkAclsError {
     fn from(err: HttpDispatchError) -> DescribeNetworkAclsError {
         DescribeNetworkAclsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeNetworkAclsError {
+    fn from(err: io::Error) -> DescribeNetworkAclsError {
+        DescribeNetworkAclsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeNetworkAclsError {
@@ -48837,6 +49414,11 @@ impl From<HttpDispatchError> for DescribeNetworkInterfaceAttributeError {
         DescribeNetworkInterfaceAttributeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeNetworkInterfaceAttributeError {
+    fn from(err: io::Error) -> DescribeNetworkInterfaceAttributeError {
+        DescribeNetworkInterfaceAttributeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeNetworkInterfaceAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -48899,6 +49481,11 @@ impl From<CredentialsError> for DescribeNetworkInterfacesError {
 impl From<HttpDispatchError> for DescribeNetworkInterfacesError {
     fn from(err: HttpDispatchError) -> DescribeNetworkInterfacesError {
         DescribeNetworkInterfacesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeNetworkInterfacesError {
+    fn from(err: io::Error) -> DescribeNetworkInterfacesError {
+        DescribeNetworkInterfacesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeNetworkInterfacesError {
@@ -48965,6 +49552,11 @@ impl From<HttpDispatchError> for DescribePlacementGroupsError {
         DescribePlacementGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribePlacementGroupsError {
+    fn from(err: io::Error) -> DescribePlacementGroupsError {
+        DescribePlacementGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribePlacementGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -49027,6 +49619,11 @@ impl From<CredentialsError> for DescribePrefixListsError {
 impl From<HttpDispatchError> for DescribePrefixListsError {
     fn from(err: HttpDispatchError) -> DescribePrefixListsError {
         DescribePrefixListsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribePrefixListsError {
+    fn from(err: io::Error) -> DescribePrefixListsError {
+        DescribePrefixListsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribePrefixListsError {
@@ -49093,6 +49690,11 @@ impl From<HttpDispatchError> for DescribeRegionsError {
         DescribeRegionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeRegionsError {
+    fn from(err: io::Error) -> DescribeRegionsError {
+        DescribeRegionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeRegionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -49153,6 +49755,11 @@ impl From<CredentialsError> for DescribeReservedInstancesError {
 impl From<HttpDispatchError> for DescribeReservedInstancesError {
     fn from(err: HttpDispatchError) -> DescribeReservedInstancesError {
         DescribeReservedInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeReservedInstancesError {
+    fn from(err: io::Error) -> DescribeReservedInstancesError {
+        DescribeReservedInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeReservedInstancesError {
@@ -49219,6 +49826,11 @@ impl From<HttpDispatchError> for DescribeReservedInstancesListingsError {
         DescribeReservedInstancesListingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReservedInstancesListingsError {
+    fn from(err: io::Error) -> DescribeReservedInstancesListingsError {
+        DescribeReservedInstancesListingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReservedInstancesListingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -49281,6 +49893,11 @@ impl From<CredentialsError> for DescribeReservedInstancesModificationsError {
 impl From<HttpDispatchError> for DescribeReservedInstancesModificationsError {
     fn from(err: HttpDispatchError) -> DescribeReservedInstancesModificationsError {
         DescribeReservedInstancesModificationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeReservedInstancesModificationsError {
+    fn from(err: io::Error) -> DescribeReservedInstancesModificationsError {
+        DescribeReservedInstancesModificationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeReservedInstancesModificationsError {
@@ -49347,6 +49964,11 @@ impl From<HttpDispatchError> for DescribeReservedInstancesOfferingsError {
         DescribeReservedInstancesOfferingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReservedInstancesOfferingsError {
+    fn from(err: io::Error) -> DescribeReservedInstancesOfferingsError {
+        DescribeReservedInstancesOfferingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReservedInstancesOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -49409,6 +50031,11 @@ impl From<CredentialsError> for DescribeRouteTablesError {
 impl From<HttpDispatchError> for DescribeRouteTablesError {
     fn from(err: HttpDispatchError) -> DescribeRouteTablesError {
         DescribeRouteTablesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeRouteTablesError {
+    fn from(err: io::Error) -> DescribeRouteTablesError {
+        DescribeRouteTablesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeRouteTablesError {
@@ -49475,6 +50102,11 @@ impl From<HttpDispatchError> for DescribeScheduledInstanceAvailabilityError {
         DescribeScheduledInstanceAvailabilityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeScheduledInstanceAvailabilityError {
+    fn from(err: io::Error) -> DescribeScheduledInstanceAvailabilityError {
+        DescribeScheduledInstanceAvailabilityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeScheduledInstanceAvailabilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -49537,6 +50169,11 @@ impl From<CredentialsError> for DescribeScheduledInstancesError {
 impl From<HttpDispatchError> for DescribeScheduledInstancesError {
     fn from(err: HttpDispatchError) -> DescribeScheduledInstancesError {
         DescribeScheduledInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeScheduledInstancesError {
+    fn from(err: io::Error) -> DescribeScheduledInstancesError {
+        DescribeScheduledInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeScheduledInstancesError {
@@ -49603,6 +50240,11 @@ impl From<HttpDispatchError> for DescribeSecurityGroupReferencesError {
         DescribeSecurityGroupReferencesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSecurityGroupReferencesError {
+    fn from(err: io::Error) -> DescribeSecurityGroupReferencesError {
+        DescribeSecurityGroupReferencesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSecurityGroupReferencesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -49665,6 +50307,11 @@ impl From<CredentialsError> for DescribeSecurityGroupsError {
 impl From<HttpDispatchError> for DescribeSecurityGroupsError {
     fn from(err: HttpDispatchError) -> DescribeSecurityGroupsError {
         DescribeSecurityGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSecurityGroupsError {
+    fn from(err: io::Error) -> DescribeSecurityGroupsError {
+        DescribeSecurityGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSecurityGroupsError {
@@ -49731,6 +50378,11 @@ impl From<HttpDispatchError> for DescribeSnapshotAttributeError {
         DescribeSnapshotAttributeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSnapshotAttributeError {
+    fn from(err: io::Error) -> DescribeSnapshotAttributeError {
+        DescribeSnapshotAttributeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSnapshotAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -49793,6 +50445,11 @@ impl From<CredentialsError> for DescribeSnapshotsError {
 impl From<HttpDispatchError> for DescribeSnapshotsError {
     fn from(err: HttpDispatchError) -> DescribeSnapshotsError {
         DescribeSnapshotsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSnapshotsError {
+    fn from(err: io::Error) -> DescribeSnapshotsError {
+        DescribeSnapshotsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSnapshotsError {
@@ -49859,6 +50516,11 @@ impl From<HttpDispatchError> for DescribeSpotDatafeedSubscriptionError {
         DescribeSpotDatafeedSubscriptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSpotDatafeedSubscriptionError {
+    fn from(err: io::Error) -> DescribeSpotDatafeedSubscriptionError {
+        DescribeSpotDatafeedSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSpotDatafeedSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -49921,6 +50583,11 @@ impl From<CredentialsError> for DescribeSpotFleetInstancesError {
 impl From<HttpDispatchError> for DescribeSpotFleetInstancesError {
     fn from(err: HttpDispatchError) -> DescribeSpotFleetInstancesError {
         DescribeSpotFleetInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSpotFleetInstancesError {
+    fn from(err: io::Error) -> DescribeSpotFleetInstancesError {
+        DescribeSpotFleetInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSpotFleetInstancesError {
@@ -49987,6 +50654,11 @@ impl From<HttpDispatchError> for DescribeSpotFleetRequestHistoryError {
         DescribeSpotFleetRequestHistoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSpotFleetRequestHistoryError {
+    fn from(err: io::Error) -> DescribeSpotFleetRequestHistoryError {
+        DescribeSpotFleetRequestHistoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSpotFleetRequestHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50049,6 +50721,11 @@ impl From<CredentialsError> for DescribeSpotFleetRequestsError {
 impl From<HttpDispatchError> for DescribeSpotFleetRequestsError {
     fn from(err: HttpDispatchError) -> DescribeSpotFleetRequestsError {
         DescribeSpotFleetRequestsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSpotFleetRequestsError {
+    fn from(err: io::Error) -> DescribeSpotFleetRequestsError {
+        DescribeSpotFleetRequestsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSpotFleetRequestsError {
@@ -50115,6 +50792,11 @@ impl From<HttpDispatchError> for DescribeSpotInstanceRequestsError {
         DescribeSpotInstanceRequestsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSpotInstanceRequestsError {
+    fn from(err: io::Error) -> DescribeSpotInstanceRequestsError {
+        DescribeSpotInstanceRequestsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSpotInstanceRequestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50177,6 +50859,11 @@ impl From<CredentialsError> for DescribeSpotPriceHistoryError {
 impl From<HttpDispatchError> for DescribeSpotPriceHistoryError {
     fn from(err: HttpDispatchError) -> DescribeSpotPriceHistoryError {
         DescribeSpotPriceHistoryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSpotPriceHistoryError {
+    fn from(err: io::Error) -> DescribeSpotPriceHistoryError {
+        DescribeSpotPriceHistoryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSpotPriceHistoryError {
@@ -50243,6 +50930,11 @@ impl From<HttpDispatchError> for DescribeStaleSecurityGroupsError {
         DescribeStaleSecurityGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeStaleSecurityGroupsError {
+    fn from(err: io::Error) -> DescribeStaleSecurityGroupsError {
+        DescribeStaleSecurityGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeStaleSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50307,6 +50999,11 @@ impl From<HttpDispatchError> for DescribeSubnetsError {
         DescribeSubnetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSubnetsError {
+    fn from(err: io::Error) -> DescribeSubnetsError {
+        DescribeSubnetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSubnetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50369,6 +51066,11 @@ impl From<HttpDispatchError> for DescribeTagsError {
         DescribeTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTagsError {
+    fn from(err: io::Error) -> DescribeTagsError {
+        DescribeTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50429,6 +51131,11 @@ impl From<CredentialsError> for DescribeVolumeAttributeError {
 impl From<HttpDispatchError> for DescribeVolumeAttributeError {
     fn from(err: HttpDispatchError) -> DescribeVolumeAttributeError {
         DescribeVolumeAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeVolumeAttributeError {
+    fn from(err: io::Error) -> DescribeVolumeAttributeError {
+        DescribeVolumeAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeVolumeAttributeError {
@@ -50495,6 +51202,11 @@ impl From<HttpDispatchError> for DescribeVolumeStatusError {
         DescribeVolumeStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVolumeStatusError {
+    fn from(err: io::Error) -> DescribeVolumeStatusError {
+        DescribeVolumeStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVolumeStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50559,6 +51271,11 @@ impl From<HttpDispatchError> for DescribeVolumesError {
         DescribeVolumesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVolumesError {
+    fn from(err: io::Error) -> DescribeVolumesError {
+        DescribeVolumesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVolumesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50619,6 +51336,11 @@ impl From<CredentialsError> for DescribeVolumesModificationsError {
 impl From<HttpDispatchError> for DescribeVolumesModificationsError {
     fn from(err: HttpDispatchError) -> DescribeVolumesModificationsError {
         DescribeVolumesModificationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeVolumesModificationsError {
+    fn from(err: io::Error) -> DescribeVolumesModificationsError {
+        DescribeVolumesModificationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeVolumesModificationsError {
@@ -50685,6 +51407,11 @@ impl From<HttpDispatchError> for DescribeVpcAttributeError {
         DescribeVpcAttributeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVpcAttributeError {
+    fn from(err: io::Error) -> DescribeVpcAttributeError {
+        DescribeVpcAttributeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVpcAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50747,6 +51474,11 @@ impl From<CredentialsError> for DescribeVpcClassicLinkError {
 impl From<HttpDispatchError> for DescribeVpcClassicLinkError {
     fn from(err: HttpDispatchError) -> DescribeVpcClassicLinkError {
         DescribeVpcClassicLinkError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeVpcClassicLinkError {
+    fn from(err: io::Error) -> DescribeVpcClassicLinkError {
+        DescribeVpcClassicLinkError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeVpcClassicLinkError {
@@ -50813,6 +51545,11 @@ impl From<HttpDispatchError> for DescribeVpcClassicLinkDnsSupportError {
         DescribeVpcClassicLinkDnsSupportError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVpcClassicLinkDnsSupportError {
+    fn from(err: io::Error) -> DescribeVpcClassicLinkDnsSupportError {
+        DescribeVpcClassicLinkDnsSupportError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVpcClassicLinkDnsSupportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -50875,6 +51612,11 @@ impl From<CredentialsError> for DescribeVpcEndpointServicesError {
 impl From<HttpDispatchError> for DescribeVpcEndpointServicesError {
     fn from(err: HttpDispatchError) -> DescribeVpcEndpointServicesError {
         DescribeVpcEndpointServicesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeVpcEndpointServicesError {
+    fn from(err: io::Error) -> DescribeVpcEndpointServicesError {
+        DescribeVpcEndpointServicesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeVpcEndpointServicesError {
@@ -50941,6 +51683,11 @@ impl From<HttpDispatchError> for DescribeVpcEndpointsError {
         DescribeVpcEndpointsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVpcEndpointsError {
+    fn from(err: io::Error) -> DescribeVpcEndpointsError {
+        DescribeVpcEndpointsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVpcEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51003,6 +51750,11 @@ impl From<CredentialsError> for DescribeVpcPeeringConnectionsError {
 impl From<HttpDispatchError> for DescribeVpcPeeringConnectionsError {
     fn from(err: HttpDispatchError) -> DescribeVpcPeeringConnectionsError {
         DescribeVpcPeeringConnectionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeVpcPeeringConnectionsError {
+    fn from(err: io::Error) -> DescribeVpcPeeringConnectionsError {
+        DescribeVpcPeeringConnectionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeVpcPeeringConnectionsError {
@@ -51069,6 +51821,11 @@ impl From<HttpDispatchError> for DescribeVpcsError {
         DescribeVpcsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVpcsError {
+    fn from(err: io::Error) -> DescribeVpcsError {
+        DescribeVpcsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVpcsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51129,6 +51886,11 @@ impl From<CredentialsError> for DescribeVpnConnectionsError {
 impl From<HttpDispatchError> for DescribeVpnConnectionsError {
     fn from(err: HttpDispatchError) -> DescribeVpnConnectionsError {
         DescribeVpnConnectionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeVpnConnectionsError {
+    fn from(err: io::Error) -> DescribeVpnConnectionsError {
+        DescribeVpnConnectionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeVpnConnectionsError {
@@ -51195,6 +51957,11 @@ impl From<HttpDispatchError> for DescribeVpnGatewaysError {
         DescribeVpnGatewaysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVpnGatewaysError {
+    fn from(err: io::Error) -> DescribeVpnGatewaysError {
+        DescribeVpnGatewaysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVpnGatewaysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51257,6 +52024,11 @@ impl From<CredentialsError> for DetachClassicLinkVpcError {
 impl From<HttpDispatchError> for DetachClassicLinkVpcError {
     fn from(err: HttpDispatchError) -> DetachClassicLinkVpcError {
         DetachClassicLinkVpcError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DetachClassicLinkVpcError {
+    fn from(err: io::Error) -> DetachClassicLinkVpcError {
+        DetachClassicLinkVpcError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DetachClassicLinkVpcError {
@@ -51323,6 +52095,11 @@ impl From<HttpDispatchError> for DetachInternetGatewayError {
         DetachInternetGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachInternetGatewayError {
+    fn from(err: io::Error) -> DetachInternetGatewayError {
+        DetachInternetGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachInternetGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51385,6 +52162,11 @@ impl From<CredentialsError> for DetachNetworkInterfaceError {
 impl From<HttpDispatchError> for DetachNetworkInterfaceError {
     fn from(err: HttpDispatchError) -> DetachNetworkInterfaceError {
         DetachNetworkInterfaceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DetachNetworkInterfaceError {
+    fn from(err: io::Error) -> DetachNetworkInterfaceError {
+        DetachNetworkInterfaceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DetachNetworkInterfaceError {
@@ -51451,6 +52233,11 @@ impl From<HttpDispatchError> for DetachVolumeError {
         DetachVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachVolumeError {
+    fn from(err: io::Error) -> DetachVolumeError {
+        DetachVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51513,6 +52300,11 @@ impl From<HttpDispatchError> for DetachVpnGatewayError {
         DetachVpnGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachVpnGatewayError {
+    fn from(err: io::Error) -> DetachVpnGatewayError {
+        DetachVpnGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachVpnGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51573,6 +52365,11 @@ impl From<CredentialsError> for DisableVgwRoutePropagationError {
 impl From<HttpDispatchError> for DisableVgwRoutePropagationError {
     fn from(err: HttpDispatchError) -> DisableVgwRoutePropagationError {
         DisableVgwRoutePropagationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableVgwRoutePropagationError {
+    fn from(err: io::Error) -> DisableVgwRoutePropagationError {
+        DisableVgwRoutePropagationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableVgwRoutePropagationError {
@@ -51639,6 +52436,11 @@ impl From<HttpDispatchError> for DisableVpcClassicLinkError {
         DisableVpcClassicLinkError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisableVpcClassicLinkError {
+    fn from(err: io::Error) -> DisableVpcClassicLinkError {
+        DisableVpcClassicLinkError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisableVpcClassicLinkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51701,6 +52503,11 @@ impl From<CredentialsError> for DisableVpcClassicLinkDnsSupportError {
 impl From<HttpDispatchError> for DisableVpcClassicLinkDnsSupportError {
     fn from(err: HttpDispatchError) -> DisableVpcClassicLinkDnsSupportError {
         DisableVpcClassicLinkDnsSupportError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableVpcClassicLinkDnsSupportError {
+    fn from(err: io::Error) -> DisableVpcClassicLinkDnsSupportError {
+        DisableVpcClassicLinkDnsSupportError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableVpcClassicLinkDnsSupportError {
@@ -51767,6 +52574,11 @@ impl From<HttpDispatchError> for DisassociateAddressError {
         DisassociateAddressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateAddressError {
+    fn from(err: io::Error) -> DisassociateAddressError {
+        DisassociateAddressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51829,6 +52641,11 @@ impl From<CredentialsError> for DisassociateIamInstanceProfileError {
 impl From<HttpDispatchError> for DisassociateIamInstanceProfileError {
     fn from(err: HttpDispatchError) -> DisassociateIamInstanceProfileError {
         DisassociateIamInstanceProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisassociateIamInstanceProfileError {
+    fn from(err: io::Error) -> DisassociateIamInstanceProfileError {
+        DisassociateIamInstanceProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisassociateIamInstanceProfileError {
@@ -51895,6 +52712,11 @@ impl From<HttpDispatchError> for DisassociateRouteTableError {
         DisassociateRouteTableError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateRouteTableError {
+    fn from(err: io::Error) -> DisassociateRouteTableError {
+        DisassociateRouteTableError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateRouteTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -51957,6 +52779,11 @@ impl From<CredentialsError> for DisassociateSubnetCidrBlockError {
 impl From<HttpDispatchError> for DisassociateSubnetCidrBlockError {
     fn from(err: HttpDispatchError) -> DisassociateSubnetCidrBlockError {
         DisassociateSubnetCidrBlockError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisassociateSubnetCidrBlockError {
+    fn from(err: io::Error) -> DisassociateSubnetCidrBlockError {
+        DisassociateSubnetCidrBlockError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisassociateSubnetCidrBlockError {
@@ -52023,6 +52850,11 @@ impl From<HttpDispatchError> for DisassociateVpcCidrBlockError {
         DisassociateVpcCidrBlockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateVpcCidrBlockError {
+    fn from(err: io::Error) -> DisassociateVpcCidrBlockError {
+        DisassociateVpcCidrBlockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateVpcCidrBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52085,6 +52917,11 @@ impl From<CredentialsError> for EnableVgwRoutePropagationError {
 impl From<HttpDispatchError> for EnableVgwRoutePropagationError {
     fn from(err: HttpDispatchError) -> EnableVgwRoutePropagationError {
         EnableVgwRoutePropagationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnableVgwRoutePropagationError {
+    fn from(err: io::Error) -> EnableVgwRoutePropagationError {
+        EnableVgwRoutePropagationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnableVgwRoutePropagationError {
@@ -52151,6 +52988,11 @@ impl From<HttpDispatchError> for EnableVolumeIOError {
         EnableVolumeIOError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableVolumeIOError {
+    fn from(err: io::Error) -> EnableVolumeIOError {
+        EnableVolumeIOError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableVolumeIOError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52211,6 +53053,11 @@ impl From<CredentialsError> for EnableVpcClassicLinkError {
 impl From<HttpDispatchError> for EnableVpcClassicLinkError {
     fn from(err: HttpDispatchError) -> EnableVpcClassicLinkError {
         EnableVpcClassicLinkError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnableVpcClassicLinkError {
+    fn from(err: io::Error) -> EnableVpcClassicLinkError {
+        EnableVpcClassicLinkError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnableVpcClassicLinkError {
@@ -52277,6 +53124,11 @@ impl From<HttpDispatchError> for EnableVpcClassicLinkDnsSupportError {
         EnableVpcClassicLinkDnsSupportError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableVpcClassicLinkDnsSupportError {
+    fn from(err: io::Error) -> EnableVpcClassicLinkDnsSupportError {
+        EnableVpcClassicLinkDnsSupportError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableVpcClassicLinkDnsSupportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52341,6 +53193,11 @@ impl From<HttpDispatchError> for GetConsoleOutputError {
         GetConsoleOutputError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetConsoleOutputError {
+    fn from(err: io::Error) -> GetConsoleOutputError {
+        GetConsoleOutputError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetConsoleOutputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52401,6 +53258,11 @@ impl From<CredentialsError> for GetConsoleScreenshotError {
 impl From<HttpDispatchError> for GetConsoleScreenshotError {
     fn from(err: HttpDispatchError) -> GetConsoleScreenshotError {
         GetConsoleScreenshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetConsoleScreenshotError {
+    fn from(err: io::Error) -> GetConsoleScreenshotError {
+        GetConsoleScreenshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetConsoleScreenshotError {
@@ -52467,6 +53329,11 @@ impl From<HttpDispatchError> for GetHostReservationPurchasePreviewError {
         GetHostReservationPurchasePreviewError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetHostReservationPurchasePreviewError {
+    fn from(err: io::Error) -> GetHostReservationPurchasePreviewError {
+        GetHostReservationPurchasePreviewError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetHostReservationPurchasePreviewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52531,6 +53398,11 @@ impl From<HttpDispatchError> for GetPasswordDataError {
         GetPasswordDataError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetPasswordDataError {
+    fn from(err: io::Error) -> GetPasswordDataError {
+        GetPasswordDataError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetPasswordDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52591,6 +53463,11 @@ impl From<CredentialsError> for GetReservedInstancesExchangeQuoteError {
 impl From<HttpDispatchError> for GetReservedInstancesExchangeQuoteError {
     fn from(err: HttpDispatchError) -> GetReservedInstancesExchangeQuoteError {
         GetReservedInstancesExchangeQuoteError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetReservedInstancesExchangeQuoteError {
+    fn from(err: io::Error) -> GetReservedInstancesExchangeQuoteError {
+        GetReservedInstancesExchangeQuoteError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetReservedInstancesExchangeQuoteError {
@@ -52657,6 +53534,11 @@ impl From<HttpDispatchError> for ImportImageError {
         ImportImageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportImageError {
+    fn from(err: io::Error) -> ImportImageError {
+        ImportImageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52717,6 +53599,11 @@ impl From<CredentialsError> for ImportInstanceError {
 impl From<HttpDispatchError> for ImportInstanceError {
     fn from(err: HttpDispatchError) -> ImportInstanceError {
         ImportInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ImportInstanceError {
+    fn from(err: io::Error) -> ImportInstanceError {
+        ImportInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ImportInstanceError {
@@ -52781,6 +53668,11 @@ impl From<HttpDispatchError> for ImportKeyPairError {
         ImportKeyPairError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportKeyPairError {
+    fn from(err: io::Error) -> ImportKeyPairError {
+        ImportKeyPairError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52841,6 +53733,11 @@ impl From<CredentialsError> for ImportSnapshotError {
 impl From<HttpDispatchError> for ImportSnapshotError {
     fn from(err: HttpDispatchError) -> ImportSnapshotError {
         ImportSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ImportSnapshotError {
+    fn from(err: io::Error) -> ImportSnapshotError {
+        ImportSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ImportSnapshotError {
@@ -52905,6 +53802,11 @@ impl From<HttpDispatchError> for ImportVolumeError {
         ImportVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportVolumeError {
+    fn from(err: io::Error) -> ImportVolumeError {
+        ImportVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -52965,6 +53867,11 @@ impl From<CredentialsError> for ModifyHostsError {
 impl From<HttpDispatchError> for ModifyHostsError {
     fn from(err: HttpDispatchError) -> ModifyHostsError {
         ModifyHostsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyHostsError {
+    fn from(err: io::Error) -> ModifyHostsError {
+        ModifyHostsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyHostsError {
@@ -53029,6 +53936,11 @@ impl From<HttpDispatchError> for ModifyIdFormatError {
         ModifyIdFormatError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyIdFormatError {
+    fn from(err: io::Error) -> ModifyIdFormatError {
+        ModifyIdFormatError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyIdFormatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -53089,6 +54001,11 @@ impl From<CredentialsError> for ModifyIdentityIdFormatError {
 impl From<HttpDispatchError> for ModifyIdentityIdFormatError {
     fn from(err: HttpDispatchError) -> ModifyIdentityIdFormatError {
         ModifyIdentityIdFormatError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyIdentityIdFormatError {
+    fn from(err: io::Error) -> ModifyIdentityIdFormatError {
+        ModifyIdentityIdFormatError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyIdentityIdFormatError {
@@ -53155,6 +54072,11 @@ impl From<HttpDispatchError> for ModifyImageAttributeError {
         ModifyImageAttributeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyImageAttributeError {
+    fn from(err: io::Error) -> ModifyImageAttributeError {
+        ModifyImageAttributeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyImageAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -53217,6 +54139,11 @@ impl From<CredentialsError> for ModifyInstanceAttributeError {
 impl From<HttpDispatchError> for ModifyInstanceAttributeError {
     fn from(err: HttpDispatchError) -> ModifyInstanceAttributeError {
         ModifyInstanceAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyInstanceAttributeError {
+    fn from(err: io::Error) -> ModifyInstanceAttributeError {
+        ModifyInstanceAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyInstanceAttributeError {
@@ -53283,6 +54210,11 @@ impl From<HttpDispatchError> for ModifyInstancePlacementError {
         ModifyInstancePlacementError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyInstancePlacementError {
+    fn from(err: io::Error) -> ModifyInstancePlacementError {
+        ModifyInstancePlacementError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyInstancePlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -53345,6 +54277,11 @@ impl From<CredentialsError> for ModifyNetworkInterfaceAttributeError {
 impl From<HttpDispatchError> for ModifyNetworkInterfaceAttributeError {
     fn from(err: HttpDispatchError) -> ModifyNetworkInterfaceAttributeError {
         ModifyNetworkInterfaceAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyNetworkInterfaceAttributeError {
+    fn from(err: io::Error) -> ModifyNetworkInterfaceAttributeError {
+        ModifyNetworkInterfaceAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyNetworkInterfaceAttributeError {
@@ -53411,6 +54348,11 @@ impl From<HttpDispatchError> for ModifyReservedInstancesError {
         ModifyReservedInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyReservedInstancesError {
+    fn from(err: io::Error) -> ModifyReservedInstancesError {
+        ModifyReservedInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyReservedInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -53473,6 +54415,11 @@ impl From<CredentialsError> for ModifySnapshotAttributeError {
 impl From<HttpDispatchError> for ModifySnapshotAttributeError {
     fn from(err: HttpDispatchError) -> ModifySnapshotAttributeError {
         ModifySnapshotAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifySnapshotAttributeError {
+    fn from(err: io::Error) -> ModifySnapshotAttributeError {
+        ModifySnapshotAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifySnapshotAttributeError {
@@ -53539,6 +54486,11 @@ impl From<HttpDispatchError> for ModifySpotFleetRequestError {
         ModifySpotFleetRequestError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifySpotFleetRequestError {
+    fn from(err: io::Error) -> ModifySpotFleetRequestError {
+        ModifySpotFleetRequestError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifySpotFleetRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -53601,6 +54553,11 @@ impl From<CredentialsError> for ModifySubnetAttributeError {
 impl From<HttpDispatchError> for ModifySubnetAttributeError {
     fn from(err: HttpDispatchError) -> ModifySubnetAttributeError {
         ModifySubnetAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifySubnetAttributeError {
+    fn from(err: io::Error) -> ModifySubnetAttributeError {
+        ModifySubnetAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifySubnetAttributeError {
@@ -53667,6 +54624,11 @@ impl From<HttpDispatchError> for ModifyVolumeError {
         ModifyVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyVolumeError {
+    fn from(err: io::Error) -> ModifyVolumeError {
+        ModifyVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -53727,6 +54689,11 @@ impl From<CredentialsError> for ModifyVolumeAttributeError {
 impl From<HttpDispatchError> for ModifyVolumeAttributeError {
     fn from(err: HttpDispatchError) -> ModifyVolumeAttributeError {
         ModifyVolumeAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyVolumeAttributeError {
+    fn from(err: io::Error) -> ModifyVolumeAttributeError {
+        ModifyVolumeAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyVolumeAttributeError {
@@ -53793,6 +54760,11 @@ impl From<HttpDispatchError> for ModifyVpcAttributeError {
         ModifyVpcAttributeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyVpcAttributeError {
+    fn from(err: io::Error) -> ModifyVpcAttributeError {
+        ModifyVpcAttributeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyVpcAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -53855,6 +54827,11 @@ impl From<CredentialsError> for ModifyVpcEndpointError {
 impl From<HttpDispatchError> for ModifyVpcEndpointError {
     fn from(err: HttpDispatchError) -> ModifyVpcEndpointError {
         ModifyVpcEndpointError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyVpcEndpointError {
+    fn from(err: io::Error) -> ModifyVpcEndpointError {
+        ModifyVpcEndpointError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyVpcEndpointError {
@@ -53921,6 +54898,11 @@ impl From<HttpDispatchError> for ModifyVpcPeeringConnectionOptionsError {
         ModifyVpcPeeringConnectionOptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyVpcPeeringConnectionOptionsError {
+    fn from(err: io::Error) -> ModifyVpcPeeringConnectionOptionsError {
+        ModifyVpcPeeringConnectionOptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyVpcPeeringConnectionOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -53985,6 +54967,11 @@ impl From<HttpDispatchError> for MonitorInstancesError {
         MonitorInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for MonitorInstancesError {
+    fn from(err: io::Error) -> MonitorInstancesError {
+        MonitorInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for MonitorInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54047,6 +55034,11 @@ impl From<HttpDispatchError> for MoveAddressToVpcError {
         MoveAddressToVpcError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for MoveAddressToVpcError {
+    fn from(err: io::Error) -> MoveAddressToVpcError {
+        MoveAddressToVpcError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for MoveAddressToVpcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54107,6 +55099,11 @@ impl From<CredentialsError> for PurchaseHostReservationError {
 impl From<HttpDispatchError> for PurchaseHostReservationError {
     fn from(err: HttpDispatchError) -> PurchaseHostReservationError {
         PurchaseHostReservationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PurchaseHostReservationError {
+    fn from(err: io::Error) -> PurchaseHostReservationError {
+        PurchaseHostReservationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PurchaseHostReservationError {
@@ -54173,6 +55170,11 @@ impl From<HttpDispatchError> for PurchaseReservedInstancesOfferingError {
         PurchaseReservedInstancesOfferingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PurchaseReservedInstancesOfferingError {
+    fn from(err: io::Error) -> PurchaseReservedInstancesOfferingError {
+        PurchaseReservedInstancesOfferingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PurchaseReservedInstancesOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54235,6 +55237,11 @@ impl From<CredentialsError> for PurchaseScheduledInstancesError {
 impl From<HttpDispatchError> for PurchaseScheduledInstancesError {
     fn from(err: HttpDispatchError) -> PurchaseScheduledInstancesError {
         PurchaseScheduledInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PurchaseScheduledInstancesError {
+    fn from(err: io::Error) -> PurchaseScheduledInstancesError {
+        PurchaseScheduledInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PurchaseScheduledInstancesError {
@@ -54301,6 +55308,11 @@ impl From<HttpDispatchError> for RebootInstancesError {
         RebootInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RebootInstancesError {
+    fn from(err: io::Error) -> RebootInstancesError {
+        RebootInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RebootInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54363,6 +55375,11 @@ impl From<HttpDispatchError> for RegisterImageError {
         RegisterImageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterImageError {
+    fn from(err: io::Error) -> RegisterImageError {
+        RegisterImageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54423,6 +55440,11 @@ impl From<CredentialsError> for RejectVpcPeeringConnectionError {
 impl From<HttpDispatchError> for RejectVpcPeeringConnectionError {
     fn from(err: HttpDispatchError) -> RejectVpcPeeringConnectionError {
         RejectVpcPeeringConnectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RejectVpcPeeringConnectionError {
+    fn from(err: io::Error) -> RejectVpcPeeringConnectionError {
+        RejectVpcPeeringConnectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RejectVpcPeeringConnectionError {
@@ -54489,6 +55511,11 @@ impl From<HttpDispatchError> for ReleaseAddressError {
         ReleaseAddressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReleaseAddressError {
+    fn from(err: io::Error) -> ReleaseAddressError {
+        ReleaseAddressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReleaseAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54551,6 +55578,11 @@ impl From<HttpDispatchError> for ReleaseHostsError {
         ReleaseHostsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReleaseHostsError {
+    fn from(err: io::Error) -> ReleaseHostsError {
+        ReleaseHostsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReleaseHostsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54611,6 +55643,11 @@ impl From<CredentialsError> for ReplaceIamInstanceProfileAssociationError {
 impl From<HttpDispatchError> for ReplaceIamInstanceProfileAssociationError {
     fn from(err: HttpDispatchError) -> ReplaceIamInstanceProfileAssociationError {
         ReplaceIamInstanceProfileAssociationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ReplaceIamInstanceProfileAssociationError {
+    fn from(err: io::Error) -> ReplaceIamInstanceProfileAssociationError {
+        ReplaceIamInstanceProfileAssociationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ReplaceIamInstanceProfileAssociationError {
@@ -54677,6 +55714,11 @@ impl From<HttpDispatchError> for ReplaceNetworkAclAssociationError {
         ReplaceNetworkAclAssociationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReplaceNetworkAclAssociationError {
+    fn from(err: io::Error) -> ReplaceNetworkAclAssociationError {
+        ReplaceNetworkAclAssociationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReplaceNetworkAclAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54739,6 +55781,11 @@ impl From<CredentialsError> for ReplaceNetworkAclEntryError {
 impl From<HttpDispatchError> for ReplaceNetworkAclEntryError {
     fn from(err: HttpDispatchError) -> ReplaceNetworkAclEntryError {
         ReplaceNetworkAclEntryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ReplaceNetworkAclEntryError {
+    fn from(err: io::Error) -> ReplaceNetworkAclEntryError {
+        ReplaceNetworkAclEntryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ReplaceNetworkAclEntryError {
@@ -54805,6 +55852,11 @@ impl From<HttpDispatchError> for ReplaceRouteError {
         ReplaceRouteError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReplaceRouteError {
+    fn from(err: io::Error) -> ReplaceRouteError {
+        ReplaceRouteError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReplaceRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54865,6 +55917,11 @@ impl From<CredentialsError> for ReplaceRouteTableAssociationError {
 impl From<HttpDispatchError> for ReplaceRouteTableAssociationError {
     fn from(err: HttpDispatchError) -> ReplaceRouteTableAssociationError {
         ReplaceRouteTableAssociationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ReplaceRouteTableAssociationError {
+    fn from(err: io::Error) -> ReplaceRouteTableAssociationError {
+        ReplaceRouteTableAssociationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ReplaceRouteTableAssociationError {
@@ -54931,6 +55988,11 @@ impl From<HttpDispatchError> for ReportInstanceStatusError {
         ReportInstanceStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReportInstanceStatusError {
+    fn from(err: io::Error) -> ReportInstanceStatusError {
+        ReportInstanceStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReportInstanceStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -54995,6 +56057,11 @@ impl From<HttpDispatchError> for RequestSpotFleetError {
         RequestSpotFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RequestSpotFleetError {
+    fn from(err: io::Error) -> RequestSpotFleetError {
+        RequestSpotFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RequestSpotFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55055,6 +56122,11 @@ impl From<CredentialsError> for RequestSpotInstancesError {
 impl From<HttpDispatchError> for RequestSpotInstancesError {
     fn from(err: HttpDispatchError) -> RequestSpotInstancesError {
         RequestSpotInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RequestSpotInstancesError {
+    fn from(err: io::Error) -> RequestSpotInstancesError {
+        RequestSpotInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RequestSpotInstancesError {
@@ -55121,6 +56193,11 @@ impl From<HttpDispatchError> for ResetImageAttributeError {
         ResetImageAttributeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ResetImageAttributeError {
+    fn from(err: io::Error) -> ResetImageAttributeError {
+        ResetImageAttributeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ResetImageAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55183,6 +56260,11 @@ impl From<CredentialsError> for ResetInstanceAttributeError {
 impl From<HttpDispatchError> for ResetInstanceAttributeError {
     fn from(err: HttpDispatchError) -> ResetInstanceAttributeError {
         ResetInstanceAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResetInstanceAttributeError {
+    fn from(err: io::Error) -> ResetInstanceAttributeError {
+        ResetInstanceAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResetInstanceAttributeError {
@@ -55249,6 +56331,11 @@ impl From<HttpDispatchError> for ResetNetworkInterfaceAttributeError {
         ResetNetworkInterfaceAttributeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ResetNetworkInterfaceAttributeError {
+    fn from(err: io::Error) -> ResetNetworkInterfaceAttributeError {
+        ResetNetworkInterfaceAttributeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ResetNetworkInterfaceAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55311,6 +56398,11 @@ impl From<CredentialsError> for ResetSnapshotAttributeError {
 impl From<HttpDispatchError> for ResetSnapshotAttributeError {
     fn from(err: HttpDispatchError) -> ResetSnapshotAttributeError {
         ResetSnapshotAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResetSnapshotAttributeError {
+    fn from(err: io::Error) -> ResetSnapshotAttributeError {
+        ResetSnapshotAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResetSnapshotAttributeError {
@@ -55377,6 +56469,11 @@ impl From<HttpDispatchError> for RestoreAddressToClassicError {
         RestoreAddressToClassicError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RestoreAddressToClassicError {
+    fn from(err: io::Error) -> RestoreAddressToClassicError {
+        RestoreAddressToClassicError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RestoreAddressToClassicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55439,6 +56536,11 @@ impl From<CredentialsError> for RevokeSecurityGroupEgressError {
 impl From<HttpDispatchError> for RevokeSecurityGroupEgressError {
     fn from(err: HttpDispatchError) -> RevokeSecurityGroupEgressError {
         RevokeSecurityGroupEgressError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RevokeSecurityGroupEgressError {
+    fn from(err: io::Error) -> RevokeSecurityGroupEgressError {
+        RevokeSecurityGroupEgressError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RevokeSecurityGroupEgressError {
@@ -55505,6 +56607,11 @@ impl From<HttpDispatchError> for RevokeSecurityGroupIngressError {
         RevokeSecurityGroupIngressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RevokeSecurityGroupIngressError {
+    fn from(err: io::Error) -> RevokeSecurityGroupIngressError {
+        RevokeSecurityGroupIngressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RevokeSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55569,6 +56676,11 @@ impl From<HttpDispatchError> for RunInstancesError {
         RunInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RunInstancesError {
+    fn from(err: io::Error) -> RunInstancesError {
+        RunInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RunInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55629,6 +56741,11 @@ impl From<CredentialsError> for RunScheduledInstancesError {
 impl From<HttpDispatchError> for RunScheduledInstancesError {
     fn from(err: HttpDispatchError) -> RunScheduledInstancesError {
         RunScheduledInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RunScheduledInstancesError {
+    fn from(err: io::Error) -> RunScheduledInstancesError {
+        RunScheduledInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RunScheduledInstancesError {
@@ -55695,6 +56812,11 @@ impl From<HttpDispatchError> for StartInstancesError {
         StartInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartInstancesError {
+    fn from(err: io::Error) -> StartInstancesError {
+        StartInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55757,6 +56879,11 @@ impl From<HttpDispatchError> for StopInstancesError {
         StopInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StopInstancesError {
+    fn from(err: io::Error) -> StopInstancesError {
+        StopInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StopInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55817,6 +56944,11 @@ impl From<CredentialsError> for TerminateInstancesError {
 impl From<HttpDispatchError> for TerminateInstancesError {
     fn from(err: HttpDispatchError) -> TerminateInstancesError {
         TerminateInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TerminateInstancesError {
+    fn from(err: io::Error) -> TerminateInstancesError {
+        TerminateInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TerminateInstancesError {
@@ -55883,6 +57015,11 @@ impl From<HttpDispatchError> for UnassignIpv6AddressesError {
         UnassignIpv6AddressesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UnassignIpv6AddressesError {
+    fn from(err: io::Error) -> UnassignIpv6AddressesError {
+        UnassignIpv6AddressesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UnassignIpv6AddressesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -55947,6 +57084,11 @@ impl From<HttpDispatchError> for UnassignPrivateIpAddressesError {
         UnassignPrivateIpAddressesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UnassignPrivateIpAddressesError {
+    fn from(err: io::Error) -> UnassignPrivateIpAddressesError {
+        UnassignPrivateIpAddressesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UnassignPrivateIpAddressesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -56009,6 +57151,11 @@ impl From<CredentialsError> for UnmonitorInstancesError {
 impl From<HttpDispatchError> for UnmonitorInstancesError {
     fn from(err: HttpDispatchError) -> UnmonitorInstancesError {
         UnmonitorInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UnmonitorInstancesError {
+    fn from(err: io::Error) -> UnmonitorInstancesError {
+        UnmonitorInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UnmonitorInstancesError {
@@ -57485,16 +58632,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AcceptReservedInstancesExchangeQuoteResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57505,8 +58654,10 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AcceptReservedInstancesExchangeQuoteError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AcceptReservedInstancesExchangeQuoteError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -57525,16 +58676,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AcceptVpcPeeringConnectionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57545,8 +58698,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AcceptVpcPeeringConnectionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AcceptVpcPeeringConnectionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -57564,16 +58720,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AllocateAddressResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57585,8 +58743,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AllocateAddressError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AllocateAddressError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -57605,16 +58764,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AllocateHostsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57626,7 +58787,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AllocateHostsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AllocateHostsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -57645,16 +58808,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AssignIpv6AddressesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57667,8 +58832,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AssignIpv6AddressesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssignIpv6AddressesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -57687,15 +58853,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(AssignPrivateIpAddressesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssignPrivateIpAddressesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -57713,16 +58882,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AssociateAddressResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57735,8 +58906,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AssociateAddressError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateAddressError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -57755,15 +58927,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AssociateDhcpOptionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateDhcpOptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -57783,16 +58956,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AssociateIamInstanceProfileResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57803,8 +58978,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AssociateIamInstanceProfileError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateIamInstanceProfileError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -57822,16 +59000,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AssociateRouteTableResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57844,8 +59024,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AssociateRouteTableError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateRouteTableError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -57865,16 +59046,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AssociateSubnetCidrBlockResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57885,8 +59068,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AssociateSubnetCidrBlockError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateSubnetCidrBlockError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -57905,16 +59091,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AssociateVpcCidrBlockResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57925,8 +59113,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AssociateVpcCidrBlockError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateVpcCidrBlockError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -57945,16 +59134,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AttachClassicLinkVpcResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -57967,8 +59158,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AttachClassicLinkVpcError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachClassicLinkVpcError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -57987,15 +59179,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AttachInternetGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachInternetGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58015,16 +59208,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AttachNetworkInterfaceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58035,8 +59230,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AttachNetworkInterfaceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachNetworkInterfaceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58055,16 +59251,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = VolumeAttachment::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58076,7 +59274,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AttachVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58095,16 +59295,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AttachVpnGatewayResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58117,8 +59319,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AttachVpnGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachVpnGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58137,15 +59340,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(AuthorizeSecurityGroupEgressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AuthorizeSecurityGroupEgressError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -58163,15 +59369,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(AuthorizeSecurityGroupIngressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AuthorizeSecurityGroupIngressError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -58189,16 +59398,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = BundleInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58210,8 +59421,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(BundleInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BundleInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58230,16 +59442,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CancelBundleTaskResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58252,8 +59466,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CancelBundleTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelBundleTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58272,15 +59487,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(CancelConversionTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelConversionTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58299,15 +59515,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(CancelExportTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelExportTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58326,16 +59543,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CancelImportTaskResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58348,8 +59567,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CancelImportTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelImportTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58369,16 +59589,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CancelReservedInstancesListingResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58389,8 +59611,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CancelReservedInstancesListingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelReservedInstancesListingError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -58409,16 +59634,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CancelSpotFleetRequestsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58429,8 +59656,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(EC2CancelSpotFleetRequestsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EC2CancelSpotFleetRequestsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -58449,16 +59679,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CancelSpotInstanceRequestsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58469,8 +59701,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CancelSpotInstanceRequestsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelSpotInstanceRequestsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -58489,16 +59724,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ConfirmProductInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58509,8 +59746,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ConfirmProductInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfirmProductInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58527,16 +59765,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopyImageResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58547,7 +59787,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CopyImageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopyImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -58565,16 +59809,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopySnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58586,7 +59832,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CopySnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopySnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58606,16 +59854,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateCustomerGatewayResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58626,8 +59876,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateCustomerGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCustomerGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58646,16 +59897,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDhcpOptionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58668,8 +59921,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDhcpOptionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDhcpOptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58689,16 +59943,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateEgressOnlyInternetGatewayResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58709,8 +59965,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateEgressOnlyInternetGatewayError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateEgressOnlyInternetGatewayError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -58728,16 +59987,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateFlowLogsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58749,8 +60010,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateFlowLogsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateFlowLogsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58769,16 +60031,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateFpgaImageResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58790,8 +60054,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateFpgaImageError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateFpgaImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58810,16 +60075,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateImageResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58830,7 +60097,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateImageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -58849,16 +60120,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateInstanceExportTaskResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58869,8 +60142,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateInstanceExportTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInstanceExportTaskError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -58889,16 +60165,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateInternetGatewayResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58909,8 +60187,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateInternetGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInternetGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58927,16 +60206,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = KeyPair::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58947,7 +60228,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateKeyPairError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateKeyPairError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -58966,16 +60249,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateNatGatewayResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -58988,8 +60273,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateNatGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateNatGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59008,16 +60294,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateNetworkAclResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59030,8 +60318,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateNetworkAclError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateNetworkAclError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59050,15 +60339,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(CreateNetworkAclEntryError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateNetworkAclEntryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59078,16 +60368,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateNetworkInterfaceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59098,8 +60390,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateNetworkInterfaceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateNetworkInterfaceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59118,15 +60411,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(CreatePlacementGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePlacementGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59146,16 +60440,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateReservedInstancesListingResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59166,8 +60462,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateReservedInstancesListingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReservedInstancesListingError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -59185,16 +60484,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateRouteResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59205,7 +60506,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateRouteError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRouteError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -59223,16 +60528,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateRouteTableResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59245,8 +60552,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateRouteTableError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRouteTableError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59265,16 +60573,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateSecurityGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59287,8 +60597,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateSecurityGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSecurityGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59307,16 +60618,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = Snapshot::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59327,8 +60640,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59348,16 +60662,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateSpotDatafeedSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59368,8 +60684,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateSpotDatafeedSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSpotDatafeedSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -59387,16 +60706,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateSubnetResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59408,7 +60729,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateSubnetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSubnetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59425,13 +60748,17 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(CreateTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -59447,16 +60774,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = Volume::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59467,7 +60796,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59484,16 +60815,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateVpcResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59504,7 +60837,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateVpcError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVpcError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -59522,16 +60859,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateVpcEndpointResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59544,8 +60883,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateVpcEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVpcEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59565,16 +60905,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateVpcPeeringConnectionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59585,8 +60927,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateVpcPeeringConnectionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVpcPeeringConnectionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -59604,16 +60949,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateVpnConnectionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59626,8 +60973,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateVpnConnectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVpnConnectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59646,15 +60994,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(CreateVpnConnectionRouteError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVpnConnectionRouteError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -59672,16 +61023,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateVpnGatewayResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59694,8 +61047,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateVpnGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVpnGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59714,15 +61068,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteCustomerGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCustomerGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59741,15 +61096,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteDhcpOptionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDhcpOptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59769,16 +61125,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteEgressOnlyInternetGatewayResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59789,8 +61147,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DeleteEgressOnlyInternetGatewayError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEgressOnlyInternetGatewayError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -59808,16 +61169,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteFlowLogsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59829,8 +61192,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteFlowLogsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteFlowLogsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59849,15 +61213,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteInternetGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteInternetGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59874,14 +61239,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteKeyPairError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteKeyPairError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59900,16 +61267,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteNatGatewayResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -59922,8 +61291,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteNatGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteNatGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59942,15 +61312,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteNetworkAclError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteNetworkAclError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59969,15 +61340,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteNetworkAclEntryError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteNetworkAclEntryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -59996,15 +61368,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteNetworkInterfaceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteNetworkInterfaceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60023,15 +61396,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeletePlacementGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePlacementGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60048,13 +61422,17 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteRouteError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRouteError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -60072,15 +61450,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteRouteTableError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRouteTableError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60099,15 +61478,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteSecurityGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSecurityGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60124,15 +61504,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60151,15 +61532,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteSpotDatafeedSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSpotDatafeedSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -60175,14 +61559,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteSubnetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSubnetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60199,13 +61585,17 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -60221,14 +61611,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60245,13 +61637,17 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteVpcError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVpcError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -60269,16 +61665,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteVpcEndpointsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60291,8 +61689,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteVpcEndpointsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVpcEndpointsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60312,16 +61711,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteVpcPeeringConnectionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60332,8 +61733,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DeleteVpcPeeringConnectionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVpcPeeringConnectionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -60351,15 +61755,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteVpnConnectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVpnConnectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60378,15 +61783,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteVpnConnectionRouteError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVpnConnectionRouteError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -60404,15 +61812,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteVpnGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVpnGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60429,15 +61838,16 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeregisterImageError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60457,16 +61867,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAccountAttributesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60477,8 +61889,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -60496,16 +61911,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAddressesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60518,8 +61935,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeAddressesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAddressesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60539,16 +61957,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAvailabilityZonesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60559,8 +61979,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAvailabilityZonesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAvailabilityZonesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -60578,16 +62001,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeBundleTasksResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60600,8 +62025,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeBundleTasksError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeBundleTasksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60621,16 +62047,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeClassicLinkInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60641,8 +62069,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeClassicLinkInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClassicLinkInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -60661,16 +62092,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeConversionTasksResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60681,8 +62114,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeConversionTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConversionTasksError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -60701,16 +62137,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeCustomerGatewaysResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60721,8 +62159,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeCustomerGatewaysError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCustomerGatewaysError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -60740,16 +62181,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeDhcpOptionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60762,8 +62205,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeDhcpOptionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDhcpOptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60784,16 +62228,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeEgressOnlyInternetGatewaysResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60804,8 +62250,10 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEgressOnlyInternetGatewaysError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEgressOnlyInternetGatewaysError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -60823,16 +62271,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeExportTasksResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60845,8 +62295,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeExportTasksError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeExportTasksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60865,16 +62316,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeFlowLogsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60887,8 +62340,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeFlowLogsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFlowLogsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60907,16 +62361,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeFpgaImagesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60929,8 +62385,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeFpgaImagesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFpgaImagesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -60950,16 +62407,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeHostReservationOfferingsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -60970,8 +62429,10 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeHostReservationOfferingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHostReservationOfferingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -60990,16 +62451,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeHostReservationsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61010,8 +62473,11 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeHostReservationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHostReservationsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -61029,16 +62495,18 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeHostsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61050,7 +62518,9 @@ impl<P, D> Ec2 for Ec2Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeHostsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHostsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61067,16 +62537,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeIamInstanceProfileAssociationsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61087,8 +62559,10 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeIamInstanceProfileAssociationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeIamInstanceProfileAssociationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -61106,16 +62580,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeIdFormatResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61128,8 +62604,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeIdFormatError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeIdFormatError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61149,16 +62626,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeIdentityIdFormatResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61169,8 +62648,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeIdentityIdFormatError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeIdentityIdFormatError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -61188,16 +62670,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ImageAttribute::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61209,8 +62693,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeImageAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeImageAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61229,16 +62714,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeImagesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61250,8 +62737,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeImagesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeImagesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61271,16 +62759,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeImportImageTasksResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61291,8 +62781,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeImportImageTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeImportImageTasksError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -61311,16 +62804,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeImportSnapshotTasksResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61331,8 +62826,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeImportSnapshotTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeImportSnapshotTasksError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -61350,16 +62848,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = InstanceAttribute::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61371,8 +62871,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeInstanceAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstanceAttributeError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -61391,16 +62894,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeInstanceStatusResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61411,8 +62916,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeInstanceStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstanceStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61431,16 +62937,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61453,8 +62961,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61474,16 +62983,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeInternetGatewaysResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61494,8 +63005,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeInternetGatewaysError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInternetGatewaysError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -61513,16 +63027,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeKeyPairsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61535,8 +63051,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeKeyPairsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeKeyPairsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61556,16 +63073,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeMovingAddressesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61576,8 +63095,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeMovingAddressesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMovingAddressesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -61595,16 +63117,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeNatGatewaysResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61617,8 +63141,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeNatGatewaysError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeNatGatewaysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61637,16 +63162,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeNetworkAclsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61659,8 +63186,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeNetworkAclsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeNetworkAclsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61680,16 +63208,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeNetworkInterfaceAttributeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61700,8 +63230,10 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeNetworkInterfaceAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeNetworkInterfaceAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -61720,16 +63252,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeNetworkInterfacesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61740,8 +63274,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeNetworkInterfacesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeNetworkInterfacesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -61760,16 +63297,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribePlacementGroupsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61780,8 +63319,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribePlacementGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePlacementGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -61799,16 +63341,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribePrefixListsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61821,8 +63365,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribePrefixListsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePrefixListsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61841,16 +63386,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeRegionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61862,8 +63409,9 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                Err(DescribeRegionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRegionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -61883,16 +63431,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeReservedInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61903,8 +63453,11 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -61923,16 +63476,18 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeReservedInstancesListingsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61943,8 +63498,10 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedInstancesListingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedInstancesListingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -61960,16 +63517,18 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeReservedInstancesModificationsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -61980,8 +63539,10 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedInstancesModificationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedInstancesModificationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -62001,16 +63562,18 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeReservedInstancesOfferingsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62021,8 +63584,10 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedInstancesOfferingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedInstancesOfferingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -62040,16 +63605,18 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeRouteTablesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62062,8 +63629,9 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeRouteTablesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRouteTablesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62080,16 +63648,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeScheduledInstanceAvailabilityResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62100,8 +63670,10 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeScheduledInstanceAvailabilityError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeScheduledInstanceAvailabilityError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -62120,16 +63692,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeScheduledInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62140,8 +63714,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeScheduledInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeScheduledInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -62160,16 +63737,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSecurityGroupReferencesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62180,8 +63759,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSecurityGroupReferencesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSecurityGroupReferencesError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -62200,16 +63782,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSecurityGroupsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62220,8 +63804,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeSecurityGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSecurityGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62241,16 +63826,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSnapshotAttributeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62261,8 +63848,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSnapshotAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSnapshotAttributeError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -62280,16 +63870,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSnapshotsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62302,8 +63894,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeSnapshotsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSnapshotsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62323,16 +63916,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSpotDatafeedSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62343,8 +63938,10 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSpotDatafeedSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSpotDatafeedSubscriptionError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -62363,16 +63960,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSpotFleetInstancesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62383,8 +63982,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSpotFleetInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSpotFleetInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -62403,16 +64005,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSpotFleetRequestHistoryResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62423,8 +64027,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSpotFleetRequestHistoryError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSpotFleetRequestHistoryError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -62443,16 +64050,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSpotFleetRequestsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62463,8 +64072,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSpotFleetRequestsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSpotFleetRequestsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -62483,16 +64095,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSpotInstanceRequestsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62503,8 +64117,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSpotInstanceRequestsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSpotInstanceRequestsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -62523,16 +64140,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSpotPriceHistoryResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62543,8 +64162,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSpotPriceHistoryError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSpotPriceHistoryError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -62563,16 +64185,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeStaleSecurityGroupsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62583,8 +64207,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeStaleSecurityGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStaleSecurityGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -62602,16 +64229,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSubnetsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62623,8 +64252,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeSubnetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSubnetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62643,16 +64273,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeTagsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62664,7 +64296,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62684,16 +64318,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVolumeAttributeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62704,8 +64340,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeVolumeAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVolumeAttributeError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -62723,16 +64362,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVolumeStatusResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62745,8 +64386,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeVolumeStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVolumeStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62765,16 +64407,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVolumesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62786,8 +64430,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeVolumesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVolumesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62807,16 +64452,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVolumesModificationsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62827,8 +64474,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeVolumesModificationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVolumesModificationsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -62846,16 +64496,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpcAttributeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62868,8 +64520,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeVpcAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpcAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62889,16 +64542,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpcClassicLinkResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62909,8 +64564,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeVpcClassicLinkError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpcClassicLinkError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -62930,16 +64586,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpcClassicLinkDnsSupportResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62950,8 +64608,10 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeVpcClassicLinkDnsSupportError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpcClassicLinkDnsSupportError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -62970,16 +64630,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpcEndpointServicesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -62990,8 +64652,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeVpcEndpointServicesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpcEndpointServicesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -63009,16 +64674,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpcEndpointsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63031,8 +64698,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeVpcEndpointsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpcEndpointsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63052,16 +64720,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpcPeeringConnectionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63072,8 +64742,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DescribeVpcPeeringConnectionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpcPeeringConnectionsError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -63091,16 +64764,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpcsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63112,7 +64787,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeVpcsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpcsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63132,16 +64809,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpnConnectionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63152,8 +64831,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeVpnConnectionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpnConnectionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63172,16 +64852,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeVpnGatewaysResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63194,8 +64876,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DescribeVpnGatewaysError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVpnGatewaysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63214,16 +64897,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DetachClassicLinkVpcResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63236,8 +64921,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DetachClassicLinkVpcError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachClassicLinkVpcError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63256,15 +64942,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DetachInternetGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachInternetGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63283,15 +64970,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DetachNetworkInterfaceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachNetworkInterfaceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63310,16 +64998,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = VolumeAttachment::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63331,7 +65021,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DetachVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63350,15 +65042,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DetachVpnGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachVpnGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63377,15 +65070,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DisableVgwRoutePropagationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableVgwRoutePropagationError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -63404,16 +65100,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DisableVpcClassicLinkResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63424,8 +65122,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(DisableVpcClassicLinkError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableVpcClassicLinkError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63445,16 +65144,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DisableVpcClassicLinkDnsSupportResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63465,8 +65166,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DisableVpcClassicLinkDnsSupportError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableVpcClassicLinkDnsSupportError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -63484,15 +65188,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DisassociateAddressError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateAddressError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63512,16 +65217,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DisassociateIamInstanceProfileResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63532,8 +65239,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DisassociateIamInstanceProfileError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateIamInstanceProfileError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -63551,15 +65261,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DisassociateRouteTableError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateRouteTableError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63579,16 +65290,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DisassociateSubnetCidrBlockResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63599,8 +65312,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DisassociateSubnetCidrBlockError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateSubnetCidrBlockError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -63619,16 +65335,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DisassociateVpcCidrBlockResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63639,8 +65357,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(DisassociateVpcCidrBlockError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateVpcCidrBlockError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -63658,15 +65379,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(EnableVgwRoutePropagationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableVgwRoutePropagationError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -63682,15 +65406,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(EnableVolumeIOError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableVolumeIOError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63709,16 +65434,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnableVpcClassicLinkResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63731,8 +65458,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(EnableVpcClassicLinkError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableVpcClassicLinkError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63752,16 +65480,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnableVpcClassicLinkDnsSupportResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63772,8 +65502,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(EnableVpcClassicLinkDnsSupportError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableVpcClassicLinkDnsSupportError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -63791,16 +65524,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetConsoleOutputResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63813,8 +65548,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(GetConsoleOutputError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetConsoleOutputError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63833,16 +65569,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetConsoleScreenshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63855,8 +65593,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(GetConsoleScreenshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetConsoleScreenshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63876,16 +65615,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetHostReservationPurchasePreviewResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63896,8 +65637,10 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(GetHostReservationPurchasePreviewError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHostReservationPurchasePreviewError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -63915,16 +65658,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetPasswordDataResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63936,8 +65681,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(GetPasswordDataError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPasswordDataError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -63957,16 +65703,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetReservedInstancesExchangeQuoteResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -63977,8 +65725,10 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(GetReservedInstancesExchangeQuoteError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetReservedInstancesExchangeQuoteError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -63996,16 +65746,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ImportImageResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64016,7 +65768,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 }
                 Ok(result)
             }
-            _ => Err(ImportImageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -64034,16 +65790,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ImportInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64055,8 +65813,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(ImportInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64075,16 +65834,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ImportKeyPairResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64096,7 +65857,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(ImportKeyPairError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportKeyPairError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64115,16 +65878,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ImportSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64136,8 +65901,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(ImportSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64156,16 +65922,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ImportVolumeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64177,7 +65945,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(ImportVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64196,16 +65966,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyHostsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64216,7 +65988,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 }
                 Ok(result)
             }
-            _ => Err(ModifyHostsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyHostsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -64232,15 +66008,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ModifyIdFormatError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyIdFormatError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64259,15 +66036,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ModifyIdentityIdFormatError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyIdentityIdFormatError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64286,15 +66064,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ModifyImageAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyImageAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64313,15 +66092,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(ModifyInstanceAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyInstanceAttributeError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -64340,16 +66122,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyInstancePlacementResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64360,8 +66144,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(ModifyInstancePlacementError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyInstancePlacementError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -64379,15 +66166,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(ModifyNetworkInterfaceAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyNetworkInterfaceAttributeError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -64406,16 +66196,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyReservedInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64426,8 +66218,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(ModifyReservedInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyReservedInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -64445,15 +66240,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(ModifySnapshotAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifySnapshotAttributeError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -64472,16 +66270,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifySpotFleetRequestResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64492,8 +66292,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(ModifySpotFleetRequestError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifySpotFleetRequestError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64512,15 +66313,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ModifySubnetAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifySubnetAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64539,16 +66341,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyVolumeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64560,7 +66364,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(ModifyVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64579,15 +66385,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ModifyVolumeAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyVolumeAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64606,15 +66413,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ModifyVpcAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyVpcAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64633,16 +66441,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyVpcEndpointResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64655,8 +66465,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(ModifyVpcEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyVpcEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64676,16 +66487,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyVpcPeeringConnectionOptionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64696,8 +66509,10 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(ModifyVpcPeeringConnectionOptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyVpcPeeringConnectionOptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -64715,16 +66530,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = MonitorInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64737,8 +66554,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(MonitorInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(MonitorInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64757,16 +66575,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = MoveAddressToVpcResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64779,8 +66599,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(MoveAddressToVpcError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(MoveAddressToVpcError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64800,16 +66621,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PurchaseHostReservationResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64820,8 +66643,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(PurchaseHostReservationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurchaseHostReservationError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -64840,16 +66666,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PurchaseReservedInstancesOfferingResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64860,8 +66688,10 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(PurchaseReservedInstancesOfferingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurchaseReservedInstancesOfferingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -64880,16 +66710,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PurchaseScheduledInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64900,8 +66732,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(PurchaseScheduledInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurchaseScheduledInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -64917,15 +66752,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(RebootInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebootInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64944,16 +66780,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RegisterImageResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -64965,7 +66803,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(RegisterImageError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -64985,16 +66825,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RejectVpcPeeringConnectionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65005,8 +66847,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(RejectVpcPeeringConnectionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RejectVpcPeeringConnectionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -65022,15 +66867,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ReleaseAddressError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReleaseAddressError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65049,16 +66895,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReleaseHostsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65070,7 +66918,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(ReleaseHostsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReleaseHostsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65091,16 +66941,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReplaceIamInstanceProfileAssociationResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65111,8 +66963,10 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(ReplaceIamInstanceProfileAssociationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReplaceIamInstanceProfileAssociationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -65131,16 +66985,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReplaceNetworkAclAssociationResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65151,8 +67007,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(ReplaceNetworkAclAssociationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReplaceNetworkAclAssociationError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -65170,15 +67029,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ReplaceNetworkAclEntryError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReplaceNetworkAclEntryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65195,14 +67055,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ReplaceRouteError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReplaceRouteError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65222,16 +67084,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReplaceRouteTableAssociationResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65242,8 +67106,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(ReplaceRouteTableAssociationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReplaceRouteTableAssociationError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -65261,15 +67128,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ReportInstanceStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReportInstanceStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65288,16 +67156,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RequestSpotFleetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65310,8 +67180,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(RequestSpotFleetError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RequestSpotFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65330,16 +67201,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RequestSpotInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65352,8 +67225,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(RequestSpotInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RequestSpotInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65372,15 +67246,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ResetImageAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetImageAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65399,15 +67274,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ResetInstanceAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetInstanceAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65426,15 +67302,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(ResetNetworkInterfaceAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetNetworkInterfaceAttributeError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -65452,15 +67331,16 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ResetSnapshotAttributeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetSnapshotAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65480,16 +67360,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreAddressToClassicResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65500,8 +67382,11 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                            Err(RestoreAddressToClassicError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreAddressToClassicError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -65519,15 +67404,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(RevokeSecurityGroupEgressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RevokeSecurityGroupEgressError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -65545,15 +67433,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(RevokeSecurityGroupIngressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RevokeSecurityGroupIngressError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -65569,16 +67460,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = Reservation::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65590,7 +67483,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(RunInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RunInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65610,16 +67505,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RunScheduledInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65630,8 +67527,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(RunScheduledInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RunScheduledInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65650,16 +67548,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = StartInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65671,8 +67571,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(StartInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65691,16 +67592,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = StopInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65712,7 +67615,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(StopInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65731,16 +67636,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TerminateInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65753,8 +67660,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(TerminateInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TerminateInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65774,16 +67682,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UnassignIpv6AddressesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65794,8 +67704,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(UnassignIpv6AddressesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnassignIpv6AddressesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -65814,15 +67725,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(UnassignPrivateIpAddressesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnassignPrivateIpAddressesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -65840,16 +67754,18 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UnmonitorInstancesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -65862,8 +67778,9 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
                 Ok(result)
             }
             _ => {
-                Err(UnmonitorInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnmonitorInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -759,6 +761,11 @@ impl From<HttpDispatchError> for BatchCheckLayerAvailabilityError {
         BatchCheckLayerAvailabilityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchCheckLayerAvailabilityError {
+    fn from(err: io::Error) -> BatchCheckLayerAvailabilityError {
+        BatchCheckLayerAvailabilityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchCheckLayerAvailabilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -845,6 +852,11 @@ impl From<HttpDispatchError> for BatchDeleteImageError {
         BatchDeleteImageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchDeleteImageError {
+    fn from(err: io::Error) -> BatchDeleteImageError {
+        BatchDeleteImageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchDeleteImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -927,6 +939,11 @@ impl From<CredentialsError> for BatchGetImageError {
 impl From<HttpDispatchError> for BatchGetImageError {
     fn from(err: HttpDispatchError) -> BatchGetImageError {
         BatchGetImageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for BatchGetImageError {
+    fn from(err: io::Error) -> BatchGetImageError {
+        BatchGetImageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for BatchGetImageError {
@@ -1040,6 +1057,11 @@ impl From<HttpDispatchError> for CompleteLayerUploadError {
         CompleteLayerUploadError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CompleteLayerUploadError {
+    fn from(err: io::Error) -> CompleteLayerUploadError {
+        CompleteLayerUploadError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CompleteLayerUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1136,6 +1158,11 @@ impl From<HttpDispatchError> for CreateRepositoryError {
         CreateRepositoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRepositoryError {
+    fn from(err: io::Error) -> CreateRepositoryError {
+        CreateRepositoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1226,6 +1253,11 @@ impl From<HttpDispatchError> for DeleteRepositoryError {
         DeleteRepositoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRepositoryError {
+    fn from(err: io::Error) -> DeleteRepositoryError {
+        DeleteRepositoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1314,6 +1346,11 @@ impl From<CredentialsError> for DeleteRepositoryPolicyError {
 impl From<HttpDispatchError> for DeleteRepositoryPolicyError {
     fn from(err: HttpDispatchError) -> DeleteRepositoryPolicyError {
         DeleteRepositoryPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteRepositoryPolicyError {
+    fn from(err: io::Error) -> DeleteRepositoryPolicyError {
+        DeleteRepositoryPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteRepositoryPolicyError {
@@ -1408,6 +1445,11 @@ impl From<HttpDispatchError> for DescribeImagesError {
         DescribeImagesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeImagesError {
+    fn from(err: io::Error) -> DescribeImagesError {
+        DescribeImagesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1495,6 +1537,11 @@ impl From<HttpDispatchError> for DescribeRepositoriesError {
         DescribeRepositoriesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeRepositoriesError {
+    fn from(err: io::Error) -> DescribeRepositoriesError {
+        DescribeRepositoriesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeRepositoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1576,6 +1623,11 @@ impl From<CredentialsError> for GetAuthorizationTokenError {
 impl From<HttpDispatchError> for GetAuthorizationTokenError {
     fn from(err: HttpDispatchError) -> GetAuthorizationTokenError {
         GetAuthorizationTokenError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetAuthorizationTokenError {
+    fn from(err: io::Error) -> GetAuthorizationTokenError {
+        GetAuthorizationTokenError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetAuthorizationTokenError {
@@ -1675,6 +1727,11 @@ impl From<HttpDispatchError> for GetDownloadUrlForLayerError {
         GetDownloadUrlForLayerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDownloadUrlForLayerError {
+    fn from(err: io::Error) -> GetDownloadUrlForLayerError {
+        GetDownloadUrlForLayerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDownloadUrlForLayerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1768,6 +1825,11 @@ impl From<HttpDispatchError> for GetRepositoryPolicyError {
         GetRepositoryPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRepositoryPolicyError {
+    fn from(err: io::Error) -> GetRepositoryPolicyError {
+        GetRepositoryPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRepositoryPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1857,6 +1919,11 @@ impl From<HttpDispatchError> for InitiateLayerUploadError {
         InitiateLayerUploadError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for InitiateLayerUploadError {
+    fn from(err: io::Error) -> InitiateLayerUploadError {
+        InitiateLayerUploadError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for InitiateLayerUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1939,6 +2006,11 @@ impl From<CredentialsError> for ListImagesError {
 impl From<HttpDispatchError> for ListImagesError {
     fn from(err: HttpDispatchError) -> ListImagesError {
         ListImagesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListImagesError {
+    fn from(err: io::Error) -> ListImagesError {
+        ListImagesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListImagesError {
@@ -2038,6 +2110,11 @@ impl From<HttpDispatchError> for PutImageError {
         PutImageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutImageError {
+    fn from(err: io::Error) -> PutImageError {
+        PutImageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2125,6 +2202,11 @@ impl From<CredentialsError> for SetRepositoryPolicyError {
 impl From<HttpDispatchError> for SetRepositoryPolicyError {
     fn from(err: HttpDispatchError) -> SetRepositoryPolicyError {
         SetRepositoryPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetRepositoryPolicyError {
+    fn from(err: io::Error) -> SetRepositoryPolicyError {
+        SetRepositoryPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetRepositoryPolicyError {
@@ -2226,6 +2308,11 @@ impl From<CredentialsError> for UploadLayerPartError {
 impl From<HttpDispatchError> for UploadLayerPartError {
     fn from(err: HttpDispatchError) -> UploadLayerPartError {
         UploadLayerPartError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UploadLayerPartError {
+    fn from(err: io::Error) -> UploadLayerPartError {
+        UploadLayerPartError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UploadLayerPartError {
@@ -2396,13 +2483,20 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchCheckLayerAvailabilityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(BatchCheckLayerAvailabilityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchCheckLayerAvailabilityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchCheckLayerAvailabilityError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -2421,15 +2515,20 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchDeleteImageResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchDeleteImageResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(BatchDeleteImageError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchDeleteImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2449,14 +2548,20 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchGetImageResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchGetImageResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(BatchGetImageError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchGetImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2476,15 +2581,18 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CompleteLayerUploadResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CompleteLayerUploadResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CompleteLayerUploadError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CompleteLayerUploadError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2504,15 +2612,20 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateRepositoryResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateRepositoryResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateRepositoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRepositoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2532,15 +2645,20 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRepositoryResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRepositoryResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteRepositoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRepositoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2561,15 +2679,18 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRepositoryPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRepositoryPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteRepositoryPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRepositoryPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2589,15 +2710,20 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeImagesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeImagesResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeImagesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeImagesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2617,15 +2743,18 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeRepositoriesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeRepositoriesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeRepositoriesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRepositoriesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2646,15 +2775,18 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetAuthorizationTokenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetAuthorizationTokenResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetAuthorizationTokenError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAuthorizationTokenError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2675,15 +2807,18 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDownloadUrlForLayerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDownloadUrlForLayerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetDownloadUrlForLayerError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDownloadUrlForLayerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2703,15 +2838,18 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRepositoryPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRepositoryPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetRepositoryPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRepositoryPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2731,15 +2869,18 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<InitiateLayerUploadResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<InitiateLayerUploadResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(InitiateLayerUploadError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InitiateLayerUploadError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2759,13 +2900,21 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListImagesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListImagesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListImagesResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListImagesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2782,13 +2931,21 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutImageResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(PutImageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutImageResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2807,15 +2964,18 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SetRepositoryPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SetRepositoryPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(SetRepositoryPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetRepositoryPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2835,15 +2995,20 @@ impl<P, D> Ecr for EcrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UploadLayerPartResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UploadLayerPartResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UploadLayerPartError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UploadLayerPartError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1761,6 +1763,11 @@ impl From<HttpDispatchError> for CreateClusterError {
         CreateClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateClusterError {
+    fn from(err: io::Error) -> CreateClusterError {
+        CreateClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1848,6 +1855,11 @@ impl From<HttpDispatchError> for CreateServiceError {
         CreateServiceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateServiceError {
+    fn from(err: io::Error) -> CreateServiceError {
+        CreateServiceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1933,6 +1945,11 @@ impl From<CredentialsError> for DeleteAttributesError {
 impl From<HttpDispatchError> for DeleteAttributesError {
     fn from(err: HttpDispatchError) -> DeleteAttributesError {
         DeleteAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteAttributesError {
+    fn from(err: io::Error) -> DeleteAttributesError {
+        DeleteAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteAttributesError {
@@ -2030,6 +2047,11 @@ impl From<HttpDispatchError> for DeleteClusterError {
         DeleteClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteClusterError {
+    fn from(err: io::Error) -> DeleteClusterError {
+        DeleteClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2125,6 +2147,11 @@ impl From<HttpDispatchError> for DeleteServiceError {
         DeleteServiceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteServiceError {
+    fn from(err: io::Error) -> DeleteServiceError {
+        DeleteServiceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2212,6 +2239,11 @@ impl From<CredentialsError> for DeregisterContainerInstanceError {
 impl From<HttpDispatchError> for DeregisterContainerInstanceError {
     fn from(err: HttpDispatchError) -> DeregisterContainerInstanceError {
         DeregisterContainerInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeregisterContainerInstanceError {
+    fn from(err: io::Error) -> DeregisterContainerInstanceError {
+        DeregisterContainerInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeregisterContainerInstanceError {
@@ -2303,6 +2335,11 @@ impl From<HttpDispatchError> for DeregisterTaskDefinitionError {
         DeregisterTaskDefinitionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterTaskDefinitionError {
+    fn from(err: io::Error) -> DeregisterTaskDefinitionError {
+        DeregisterTaskDefinitionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterTaskDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2385,6 +2422,11 @@ impl From<CredentialsError> for DescribeClustersError {
 impl From<HttpDispatchError> for DescribeClustersError {
     fn from(err: HttpDispatchError) -> DescribeClustersError {
         DescribeClustersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeClustersError {
+    fn from(err: io::Error) -> DescribeClustersError {
+        DescribeClustersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeClustersError {
@@ -2472,6 +2514,11 @@ impl From<CredentialsError> for DescribeContainerInstancesError {
 impl From<HttpDispatchError> for DescribeContainerInstancesError {
     fn from(err: HttpDispatchError) -> DescribeContainerInstancesError {
         DescribeContainerInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeContainerInstancesError {
+    fn from(err: io::Error) -> DescribeContainerInstancesError {
+        DescribeContainerInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeContainerInstancesError {
@@ -2564,6 +2611,11 @@ impl From<HttpDispatchError> for DescribeServicesError {
         DescribeServicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeServicesError {
+    fn from(err: io::Error) -> DescribeServicesError {
+        DescribeServicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2649,6 +2701,11 @@ impl From<CredentialsError> for DescribeTaskDefinitionError {
 impl From<HttpDispatchError> for DescribeTaskDefinitionError {
     fn from(err: HttpDispatchError) -> DescribeTaskDefinitionError {
         DescribeTaskDefinitionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTaskDefinitionError {
+    fn from(err: io::Error) -> DescribeTaskDefinitionError {
+        DescribeTaskDefinitionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTaskDefinitionError {
@@ -2740,6 +2797,11 @@ impl From<HttpDispatchError> for DescribeTasksError {
         DescribeTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTasksError {
+    fn from(err: io::Error) -> DescribeTasksError {
+        DescribeTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2820,6 +2882,11 @@ impl From<CredentialsError> for DiscoverPollEndpointError {
 impl From<HttpDispatchError> for DiscoverPollEndpointError {
     fn from(err: HttpDispatchError) -> DiscoverPollEndpointError {
         DiscoverPollEndpointError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DiscoverPollEndpointError {
+    fn from(err: io::Error) -> DiscoverPollEndpointError {
+        DiscoverPollEndpointError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DiscoverPollEndpointError {
@@ -2904,6 +2971,11 @@ impl From<HttpDispatchError> for ListAttributesError {
         ListAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListAttributesError {
+    fn from(err: io::Error) -> ListAttributesError {
+        ListAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2983,6 +3055,11 @@ impl From<CredentialsError> for ListClustersError {
 impl From<HttpDispatchError> for ListClustersError {
     fn from(err: HttpDispatchError) -> ListClustersError {
         ListClustersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListClustersError {
+    fn from(err: io::Error) -> ListClustersError {
+        ListClustersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListClustersError {
@@ -3076,6 +3153,11 @@ impl From<HttpDispatchError> for ListContainerInstancesError {
         ListContainerInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListContainerInstancesError {
+    fn from(err: io::Error) -> ListContainerInstancesError {
+        ListContainerInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListContainerInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3166,6 +3248,11 @@ impl From<HttpDispatchError> for ListServicesError {
         ListServicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListServicesError {
+    fn from(err: io::Error) -> ListServicesError {
+        ListServicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3249,6 +3336,11 @@ impl From<CredentialsError> for ListTaskDefinitionFamiliesError {
 impl From<HttpDispatchError> for ListTaskDefinitionFamiliesError {
     fn from(err: HttpDispatchError) -> ListTaskDefinitionFamiliesError {
         ListTaskDefinitionFamiliesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTaskDefinitionFamiliesError {
+    fn from(err: io::Error) -> ListTaskDefinitionFamiliesError {
+        ListTaskDefinitionFamiliesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTaskDefinitionFamiliesError {
@@ -3337,6 +3429,11 @@ impl From<CredentialsError> for ListTaskDefinitionsError {
 impl From<HttpDispatchError> for ListTaskDefinitionsError {
     fn from(err: HttpDispatchError) -> ListTaskDefinitionsError {
         ListTaskDefinitionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTaskDefinitionsError {
+    fn from(err: io::Error) -> ListTaskDefinitionsError {
+        ListTaskDefinitionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTaskDefinitionsError {
@@ -3429,6 +3526,11 @@ impl From<CredentialsError> for ListTasksError {
 impl From<HttpDispatchError> for ListTasksError {
     fn from(err: HttpDispatchError) -> ListTasksError {
         ListTasksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTasksError {
+    fn from(err: io::Error) -> ListTasksError {
+        ListTasksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTasksError {
@@ -3524,6 +3626,11 @@ impl From<HttpDispatchError> for PutAttributesError {
         PutAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutAttributesError {
+    fn from(err: io::Error) -> PutAttributesError {
+        PutAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3604,6 +3711,11 @@ impl From<CredentialsError> for RegisterContainerInstanceError {
 impl From<HttpDispatchError> for RegisterContainerInstanceError {
     fn from(err: HttpDispatchError) -> RegisterContainerInstanceError {
         RegisterContainerInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterContainerInstanceError {
+    fn from(err: io::Error) -> RegisterContainerInstanceError {
+        RegisterContainerInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterContainerInstanceError {
@@ -3693,6 +3805,11 @@ impl From<HttpDispatchError> for RegisterTaskDefinitionError {
         RegisterTaskDefinitionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterTaskDefinitionError {
+    fn from(err: io::Error) -> RegisterTaskDefinitionError {
+        RegisterTaskDefinitionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterTaskDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3778,6 +3895,11 @@ impl From<CredentialsError> for RunTaskError {
 impl From<HttpDispatchError> for RunTaskError {
     fn from(err: HttpDispatchError) -> RunTaskError {
         RunTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RunTaskError {
+    fn from(err: io::Error) -> RunTaskError {
+        RunTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RunTaskError {
@@ -3866,6 +3988,11 @@ impl From<HttpDispatchError> for StartTaskError {
         StartTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartTaskError {
+    fn from(err: io::Error) -> StartTaskError {
+        StartTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3952,6 +4079,11 @@ impl From<HttpDispatchError> for StopTaskError {
         StopTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StopTaskError {
+    fn from(err: io::Error) -> StopTaskError {
+        StopTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StopTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4034,6 +4166,11 @@ impl From<HttpDispatchError> for SubmitContainerStateChangeError {
         SubmitContainerStateChangeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SubmitContainerStateChangeError {
+    fn from(err: io::Error) -> SubmitContainerStateChangeError {
+        SubmitContainerStateChangeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SubmitContainerStateChangeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4114,6 +4251,11 @@ impl From<CredentialsError> for SubmitTaskStateChangeError {
 impl From<HttpDispatchError> for SubmitTaskStateChangeError {
     fn from(err: HttpDispatchError) -> SubmitTaskStateChangeError {
         SubmitTaskStateChangeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SubmitTaskStateChangeError {
+    fn from(err: io::Error) -> SubmitTaskStateChangeError {
+        SubmitTaskStateChangeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SubmitTaskStateChangeError {
@@ -4223,6 +4365,11 @@ impl From<HttpDispatchError> for UpdateContainerAgentError {
         UpdateContainerAgentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateContainerAgentError {
+    fn from(err: io::Error) -> UpdateContainerAgentError {
+        UpdateContainerAgentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateContainerAgentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4314,6 +4461,11 @@ impl From<CredentialsError> for UpdateContainerInstancesStateError {
 impl From<HttpDispatchError> for UpdateContainerInstancesStateError {
     fn from(err: HttpDispatchError) -> UpdateContainerInstancesStateError {
         UpdateContainerInstancesStateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateContainerInstancesStateError {
+    fn from(err: io::Error) -> UpdateContainerInstancesStateError {
+        UpdateContainerInstancesStateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateContainerInstancesStateError {
@@ -4414,6 +4566,11 @@ impl From<CredentialsError> for UpdateServiceError {
 impl From<HttpDispatchError> for UpdateServiceError {
     fn from(err: HttpDispatchError) -> UpdateServiceError {
         UpdateServiceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateServiceError {
+    fn from(err: io::Error) -> UpdateServiceError {
+        UpdateServiceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateServiceError {
@@ -4670,14 +4827,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateClusterResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateClusterResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4697,14 +4860,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateServiceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateServiceResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateServiceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateServiceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4724,15 +4893,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteAttributesResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4752,14 +4926,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteClusterResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteClusterResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4779,14 +4959,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteServiceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteServiceResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteServiceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteServiceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4807,13 +4993,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeregisterContainerInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeregisterContainerInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeregisterContainerInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterContainerInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -4833,13 +5026,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeregisterTaskDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeregisterTaskDefinitionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeregisterTaskDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterTaskDefinitionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4858,15 +5058,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeClustersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeClustersResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeClustersError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClustersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4887,13 +5092,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeContainerInstancesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeContainerInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeContainerInstancesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeContainerInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -4912,15 +5124,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeServicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeServicesResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeServicesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeServicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4941,15 +5158,18 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTaskDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTaskDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeTaskDefinitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTaskDefinitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4969,14 +5189,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTasksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTasksResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTasksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4997,15 +5223,18 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DiscoverPollEndpointResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DiscoverPollEndpointResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DiscoverPollEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DiscoverPollEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5025,15 +5254,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAttributesResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5053,14 +5287,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListClustersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListClustersResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListClustersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListClustersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5081,15 +5321,18 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListContainerInstancesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListContainerInstancesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListContainerInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListContainerInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5109,14 +5352,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListServicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListServicesResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListServicesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListServicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5137,13 +5386,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTaskDefinitionFamiliesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListTaskDefinitionFamiliesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTaskDefinitionFamiliesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTaskDefinitionFamiliesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5162,15 +5418,18 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTaskDefinitionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTaskDefinitionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTaskDefinitionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTaskDefinitionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5188,13 +5447,21 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTasksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTasksResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTasksError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5213,14 +5480,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutAttributesResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5241,13 +5514,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterContainerInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RegisterContainerInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterContainerInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterContainerInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5267,15 +5547,18 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterTaskDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterTaskDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RegisterTaskDefinitionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterTaskDefinitionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5292,15 +5575,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<RunTaskResponse>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RunTaskResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(RunTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RunTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5317,13 +5605,21 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StartTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartTaskResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5340,13 +5636,21 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StopTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopTaskResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5366,13 +5670,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SubmitContainerStateChangeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(SubmitContainerStateChangeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SubmitContainerStateChangeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SubmitContainerStateChangeError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5392,15 +5703,18 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SubmitTaskStateChangeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SubmitTaskStateChangeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(SubmitTaskStateChangeError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SubmitTaskStateChangeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5421,15 +5735,18 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateContainerAgentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateContainerAgentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateContainerAgentError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateContainerAgentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5450,13 +5767,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateContainerInstancesStateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateContainerInstancesStateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateContainerInstancesStateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateContainerInstancesStateError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -5475,14 +5799,20 @@ impl<P, D> Ecs for EcsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateServiceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateServiceResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateServiceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateServiceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -7532,6 +7534,11 @@ impl From<HttpDispatchError> for AddTagsToResourceError {
         AddTagsToResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToResourceError {
+    fn from(err: io::Error) -> AddTagsToResourceError {
+        AddTagsToResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7613,6 +7620,11 @@ impl From<CredentialsError> for AuthorizeCacheSecurityGroupIngressError {
 impl From<HttpDispatchError> for AuthorizeCacheSecurityGroupIngressError {
     fn from(err: HttpDispatchError) -> AuthorizeCacheSecurityGroupIngressError {
         AuthorizeCacheSecurityGroupIngressError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AuthorizeCacheSecurityGroupIngressError {
+    fn from(err: io::Error) -> AuthorizeCacheSecurityGroupIngressError {
+        AuthorizeCacheSecurityGroupIngressError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AuthorizeCacheSecurityGroupIngressError {
@@ -7710,6 +7722,11 @@ impl From<CredentialsError> for CopySnapshotError {
 impl From<HttpDispatchError> for CopySnapshotError {
     fn from(err: HttpDispatchError) -> CopySnapshotError {
         CopySnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CopySnapshotError {
+    fn from(err: io::Error) -> CopySnapshotError {
+        CopySnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CopySnapshotError {
@@ -7822,6 +7839,11 @@ impl From<HttpDispatchError> for CreateCacheClusterError {
         CreateCacheClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateCacheClusterError {
+    fn from(err: io::Error) -> CreateCacheClusterError {
+        CreateCacheClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateCacheClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7915,6 +7937,11 @@ impl From<HttpDispatchError> for CreateCacheParameterGroupError {
         CreateCacheParameterGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateCacheParameterGroupError {
+    fn from(err: io::Error) -> CreateCacheParameterGroupError {
+        CreateCacheParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateCacheParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8002,6 +8029,11 @@ impl From<HttpDispatchError> for CreateCacheSecurityGroupError {
         CreateCacheSecurityGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateCacheSecurityGroupError {
+    fn from(err: io::Error) -> CreateCacheSecurityGroupError {
+        CreateCacheSecurityGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateCacheSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8080,6 +8112,11 @@ impl From<CredentialsError> for CreateCacheSubnetGroupError {
 impl From<HttpDispatchError> for CreateCacheSubnetGroupError {
     fn from(err: HttpDispatchError) -> CreateCacheSubnetGroupError {
         CreateCacheSubnetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateCacheSubnetGroupError {
+    fn from(err: io::Error) -> CreateCacheSubnetGroupError {
+        CreateCacheSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateCacheSubnetGroupError {
@@ -8195,6 +8232,11 @@ impl From<HttpDispatchError> for CreateReplicationGroupError {
         CreateReplicationGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReplicationGroupError {
+    fn from(err: io::Error) -> CreateReplicationGroupError {
+        CreateReplicationGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReplicationGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8301,6 +8343,11 @@ impl From<HttpDispatchError> for CreateSnapshotError {
         CreateSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateSnapshotError {
+    fn from(err: io::Error) -> CreateSnapshotError {
+        CreateSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8393,6 +8440,11 @@ impl From<HttpDispatchError> for DeleteCacheClusterError {
         DeleteCacheClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteCacheClusterError {
+    fn from(err: io::Error) -> DeleteCacheClusterError {
+        DeleteCacheClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteCacheClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8474,6 +8526,11 @@ impl From<CredentialsError> for DeleteCacheParameterGroupError {
 impl From<HttpDispatchError> for DeleteCacheParameterGroupError {
     fn from(err: HttpDispatchError) -> DeleteCacheParameterGroupError {
         DeleteCacheParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteCacheParameterGroupError {
+    fn from(err: io::Error) -> DeleteCacheParameterGroupError {
+        DeleteCacheParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteCacheParameterGroupError {
@@ -8558,6 +8615,11 @@ impl From<HttpDispatchError> for DeleteCacheSecurityGroupError {
         DeleteCacheSecurityGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteCacheSecurityGroupError {
+    fn from(err: io::Error) -> DeleteCacheSecurityGroupError {
+        DeleteCacheSecurityGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteCacheSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8630,6 +8692,11 @@ impl From<CredentialsError> for DeleteCacheSubnetGroupError {
 impl From<HttpDispatchError> for DeleteCacheSubnetGroupError {
     fn from(err: HttpDispatchError) -> DeleteCacheSubnetGroupError {
         DeleteCacheSubnetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteCacheSubnetGroupError {
+    fn from(err: io::Error) -> DeleteCacheSubnetGroupError {
+        DeleteCacheSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteCacheSubnetGroupError {
@@ -8719,6 +8786,11 @@ impl From<HttpDispatchError> for DeleteReplicationGroupError {
         DeleteReplicationGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteReplicationGroupError {
+    fn from(err: io::Error) -> DeleteReplicationGroupError {
+        DeleteReplicationGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteReplicationGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8802,6 +8874,11 @@ impl From<HttpDispatchError> for DeleteSnapshotError {
         DeleteSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteSnapshotError {
+    fn from(err: io::Error) -> DeleteSnapshotError {
+        DeleteSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8877,6 +8954,11 @@ impl From<HttpDispatchError> for DescribeCacheClustersError {
         DescribeCacheClustersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCacheClustersError {
+    fn from(err: io::Error) -> DescribeCacheClustersError {
+        DescribeCacheClustersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCacheClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8942,6 +9024,11 @@ impl From<CredentialsError> for DescribeCacheEngineVersionsError {
 impl From<HttpDispatchError> for DescribeCacheEngineVersionsError {
     fn from(err: HttpDispatchError) -> DescribeCacheEngineVersionsError {
         DescribeCacheEngineVersionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCacheEngineVersionsError {
+    fn from(err: io::Error) -> DescribeCacheEngineVersionsError {
+        DescribeCacheEngineVersionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCacheEngineVersionsError {
@@ -9015,6 +9102,11 @@ impl From<CredentialsError> for DescribeCacheParameterGroupsError {
 impl From<HttpDispatchError> for DescribeCacheParameterGroupsError {
     fn from(err: HttpDispatchError) -> DescribeCacheParameterGroupsError {
         DescribeCacheParameterGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCacheParameterGroupsError {
+    fn from(err: io::Error) -> DescribeCacheParameterGroupsError {
+        DescribeCacheParameterGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCacheParameterGroupsError {
@@ -9093,6 +9185,11 @@ impl From<HttpDispatchError> for DescribeCacheParametersError {
         DescribeCacheParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCacheParametersError {
+    fn from(err: io::Error) -> DescribeCacheParametersError {
+        DescribeCacheParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCacheParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9169,6 +9266,11 @@ impl From<HttpDispatchError> for DescribeCacheSecurityGroupsError {
         DescribeCacheSecurityGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCacheSecurityGroupsError {
+    fn from(err: io::Error) -> DescribeCacheSecurityGroupsError {
+        DescribeCacheSecurityGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCacheSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9237,6 +9339,11 @@ impl From<CredentialsError> for DescribeCacheSubnetGroupsError {
 impl From<HttpDispatchError> for DescribeCacheSubnetGroupsError {
     fn from(err: HttpDispatchError) -> DescribeCacheSubnetGroupsError {
         DescribeCacheSubnetGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCacheSubnetGroupsError {
+    fn from(err: io::Error) -> DescribeCacheSubnetGroupsError {
+        DescribeCacheSubnetGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCacheSubnetGroupsError {
@@ -9308,6 +9415,11 @@ impl From<CredentialsError> for DescribeEngineDefaultParametersError {
 impl From<HttpDispatchError> for DescribeEngineDefaultParametersError {
     fn from(err: HttpDispatchError) -> DescribeEngineDefaultParametersError {
         DescribeEngineDefaultParametersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEngineDefaultParametersError {
+    fn from(err: io::Error) -> DescribeEngineDefaultParametersError {
+        DescribeEngineDefaultParametersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEngineDefaultParametersError {
@@ -9382,6 +9494,11 @@ impl From<HttpDispatchError> for DescribeEventsError {
         DescribeEventsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEventsError {
+    fn from(err: io::Error) -> DescribeEventsError {
+        DescribeEventsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9453,6 +9570,11 @@ impl From<CredentialsError> for DescribeReplicationGroupsError {
 impl From<HttpDispatchError> for DescribeReplicationGroupsError {
     fn from(err: HttpDispatchError) -> DescribeReplicationGroupsError {
         DescribeReplicationGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeReplicationGroupsError {
+    fn from(err: io::Error) -> DescribeReplicationGroupsError {
+        DescribeReplicationGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeReplicationGroupsError {
@@ -9531,6 +9653,11 @@ impl From<HttpDispatchError> for DescribeReservedCacheNodesError {
         DescribeReservedCacheNodesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReservedCacheNodesError {
+    fn from(err: io::Error) -> DescribeReservedCacheNodesError {
+        DescribeReservedCacheNodesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReservedCacheNodesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9605,6 +9732,11 @@ impl From<CredentialsError> for DescribeReservedCacheNodesOfferingsError {
 impl From<HttpDispatchError> for DescribeReservedCacheNodesOfferingsError {
     fn from(err: HttpDispatchError) -> DescribeReservedCacheNodesOfferingsError {
         DescribeReservedCacheNodesOfferingsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeReservedCacheNodesOfferingsError {
+    fn from(err: io::Error) -> DescribeReservedCacheNodesOfferingsError {
+        DescribeReservedCacheNodesOfferingsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeReservedCacheNodesOfferingsError {
@@ -9688,6 +9820,11 @@ impl From<HttpDispatchError> for DescribeSnapshotsError {
         DescribeSnapshotsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSnapshotsError {
+    fn from(err: io::Error) -> DescribeSnapshotsError {
+        DescribeSnapshotsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9768,6 +9905,11 @@ impl From<HttpDispatchError> for ListAllowedNodeTypeModificationsError {
         ListAllowedNodeTypeModificationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListAllowedNodeTypeModificationsError {
+    fn from(err: io::Error) -> ListAllowedNodeTypeModificationsError {
+        ListAllowedNodeTypeModificationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListAllowedNodeTypeModificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9845,6 +9987,11 @@ impl From<CredentialsError> for ListTagsForResourceError {
 impl From<HttpDispatchError> for ListTagsForResourceError {
     fn from(err: HttpDispatchError) -> ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForResourceError {
@@ -9947,6 +10094,11 @@ impl From<HttpDispatchError> for ModifyCacheClusterError {
         ModifyCacheClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyCacheClusterError {
+    fn from(err: io::Error) -> ModifyCacheClusterError {
+        ModifyCacheClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyCacheClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10034,6 +10186,11 @@ impl From<HttpDispatchError> for ModifyCacheParameterGroupError {
         ModifyCacheParameterGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyCacheParameterGroupError {
+    fn from(err: io::Error) -> ModifyCacheParameterGroupError {
+        ModifyCacheParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyCacheParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10116,6 +10273,11 @@ impl From<CredentialsError> for ModifyCacheSubnetGroupError {
 impl From<HttpDispatchError> for ModifyCacheSubnetGroupError {
     fn from(err: HttpDispatchError) -> ModifyCacheSubnetGroupError {
         ModifyCacheSubnetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyCacheSubnetGroupError {
+    fn from(err: io::Error) -> ModifyCacheSubnetGroupError {
+        ModifyCacheSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyCacheSubnetGroupError {
@@ -10225,6 +10387,11 @@ impl From<HttpDispatchError> for ModifyReplicationGroupError {
         ModifyReplicationGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyReplicationGroupError {
+    fn from(err: io::Error) -> ModifyReplicationGroupError {
+        ModifyReplicationGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyReplicationGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10317,6 +10484,11 @@ impl From<HttpDispatchError> for PurchaseReservedCacheNodesOfferingError {
         PurchaseReservedCacheNodesOfferingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PurchaseReservedCacheNodesOfferingError {
+    fn from(err: io::Error) -> PurchaseReservedCacheNodesOfferingError {
+        PurchaseReservedCacheNodesOfferingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PurchaseReservedCacheNodesOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10392,6 +10564,11 @@ impl From<CredentialsError> for RebootCacheClusterError {
 impl From<HttpDispatchError> for RebootCacheClusterError {
     fn from(err: HttpDispatchError) -> RebootCacheClusterError {
         RebootCacheClusterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RebootCacheClusterError {
+    fn from(err: io::Error) -> RebootCacheClusterError {
+        RebootCacheClusterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RebootCacheClusterError {
@@ -10472,6 +10649,11 @@ impl From<HttpDispatchError> for RemoveTagsFromResourceError {
         RemoveTagsFromResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTagsFromResourceError {
+    fn from(err: io::Error) -> RemoveTagsFromResourceError {
+        RemoveTagsFromResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10550,6 +10732,11 @@ impl From<CredentialsError> for ResetCacheParameterGroupError {
 impl From<HttpDispatchError> for ResetCacheParameterGroupError {
     fn from(err: HttpDispatchError) -> ResetCacheParameterGroupError {
         ResetCacheParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResetCacheParameterGroupError {
+    fn from(err: io::Error) -> ResetCacheParameterGroupError {
+        ResetCacheParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResetCacheParameterGroupError {
@@ -10633,6 +10820,11 @@ impl From<CredentialsError> for RevokeCacheSecurityGroupIngressError {
 impl From<HttpDispatchError> for RevokeCacheSecurityGroupIngressError {
     fn from(err: HttpDispatchError) -> RevokeCacheSecurityGroupIngressError {
         RevokeCacheSecurityGroupIngressError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RevokeCacheSecurityGroupIngressError {
+    fn from(err: io::Error) -> RevokeCacheSecurityGroupIngressError {
+        RevokeCacheSecurityGroupIngressError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RevokeCacheSecurityGroupIngressError {
@@ -10730,6 +10922,11 @@ impl From<CredentialsError> for TestFailoverError {
 impl From<HttpDispatchError> for TestFailoverError {
     fn from(err: HttpDispatchError) -> TestFailoverError {
         TestFailoverError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TestFailoverError {
+    fn from(err: io::Error) -> TestFailoverError {
+        TestFailoverError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TestFailoverError {
@@ -11054,16 +11251,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TagListMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11078,8 +11277,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11100,16 +11300,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AuthorizeCacheSecurityGroupIngressResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11123,8 +11325,10 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AuthorizeCacheSecurityGroupIngressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AuthorizeCacheSecurityGroupIngressError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11142,16 +11346,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopySnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11166,7 +11372,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CopySnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopySnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11185,16 +11393,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateCacheClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11209,8 +11419,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateCacheClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCacheClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11230,16 +11441,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateCacheParameterGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11255,8 +11468,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateCacheParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCacheParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -11275,16 +11491,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateCacheSecurityGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11300,8 +11518,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateCacheSecurityGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCacheSecurityGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -11320,16 +11541,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateCacheSubnetGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11345,8 +11568,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateCacheSubnetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCacheSubnetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11366,16 +11590,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateReplicationGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11391,8 +11617,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateReplicationGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReplicationGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11411,16 +11638,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11435,8 +11664,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11455,16 +11685,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteCacheClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11479,8 +11711,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteCacheClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCacheClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11499,15 +11732,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteCacheParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCacheParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -11525,15 +11761,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteCacheSecurityGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCacheSecurityGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -11551,15 +11790,16 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteCacheSubnetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCacheSubnetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11579,16 +11819,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteReplicationGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11604,8 +11846,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteReplicationGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReplicationGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11624,16 +11867,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11648,8 +11893,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11668,16 +11914,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CacheClusterMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11692,8 +11940,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeCacheClustersError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCacheClustersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11713,16 +11962,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CacheEngineVersionMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11737,8 +11988,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeCacheEngineVersionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCacheEngineVersionsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -11757,16 +12011,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CacheParameterGroupsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11781,8 +12037,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeCacheParameterGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCacheParameterGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -11801,16 +12060,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CacheParameterGroupDetails::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11825,8 +12086,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeCacheParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCacheParametersError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -11845,16 +12109,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CacheSecurityGroupMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11869,8 +12135,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeCacheSecurityGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCacheSecurityGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -11889,16 +12158,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CacheSubnetGroupMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11913,8 +12184,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeCacheSubnetGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCacheSubnetGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -11933,16 +12207,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeEngineDefaultParametersResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11956,8 +12232,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEngineDefaultParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEngineDefaultParametersError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -11975,16 +12254,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EventsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11999,8 +12280,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12020,16 +12302,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReplicationGroupMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12044,8 +12328,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReplicationGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReplicationGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -12064,16 +12351,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReservedCacheNodeMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12088,8 +12377,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedCacheNodesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedCacheNodesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -12108,16 +12400,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReservedCacheNodesOfferingMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12131,8 +12425,10 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedCacheNodesOfferingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedCacheNodesOfferingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12150,16 +12446,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSnapshotsListMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12175,8 +12473,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeSnapshotsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSnapshotsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12196,16 +12495,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AllowedNodeTypeModificationsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12219,8 +12520,10 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListAllowedNodeTypeModificationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAllowedNodeTypeModificationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12238,16 +12541,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TagListMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12262,8 +12567,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12282,16 +12588,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyCacheClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12306,8 +12614,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ModifyCacheClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyCacheClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12327,16 +12636,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CacheParameterGroupNameMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12352,8 +12663,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ModifyCacheParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyCacheParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -12372,16 +12686,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyCacheSubnetGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12397,8 +12713,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ModifyCacheSubnetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyCacheSubnetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12418,16 +12735,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyReplicationGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12443,8 +12762,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ModifyReplicationGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyReplicationGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12465,16 +12785,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PurchaseReservedCacheNodesOfferingResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12488,8 +12810,10 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(PurchaseReservedCacheNodesOfferingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurchaseReservedCacheNodesOfferingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12507,16 +12831,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RebootCacheClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12531,8 +12857,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RebootCacheClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebootCacheClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12551,16 +12878,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TagListMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12575,8 +12904,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12596,16 +12926,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CacheParameterGroupNameMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12621,8 +12953,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ResetCacheParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetCacheParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -12641,16 +12976,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RevokeCacheSecurityGroupIngressResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12664,8 +13001,11 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(RevokeCacheSecurityGroupIngressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RevokeCacheSecurityGroupIngressError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -12683,16 +13023,18 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TestFailoverResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12707,7 +13049,9 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(TestFailoverError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestFailoverError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -9374,6 +9376,11 @@ impl From<HttpDispatchError> for AbortEnvironmentUpdateError {
         AbortEnvironmentUpdateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AbortEnvironmentUpdateError {
+    fn from(err: io::Error) -> AbortEnvironmentUpdateError {
+        AbortEnvironmentUpdateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AbortEnvironmentUpdateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9445,6 +9452,11 @@ impl From<HttpDispatchError> for ApplyEnvironmentManagedActionError {
         ApplyEnvironmentManagedActionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ApplyEnvironmentManagedActionError {
+    fn from(err: io::Error) -> ApplyEnvironmentManagedActionError {
+        ApplyEnvironmentManagedActionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ApplyEnvironmentManagedActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9509,6 +9521,11 @@ impl From<CredentialsError> for CheckDNSAvailabilityError {
 impl From<HttpDispatchError> for CheckDNSAvailabilityError {
     fn from(err: HttpDispatchError) -> CheckDNSAvailabilityError {
         CheckDNSAvailabilityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CheckDNSAvailabilityError {
+    fn from(err: io::Error) -> CheckDNSAvailabilityError {
+        CheckDNSAvailabilityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CheckDNSAvailabilityError {
@@ -9581,6 +9598,11 @@ impl From<HttpDispatchError> for ComposeEnvironmentsError {
         ComposeEnvironmentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ComposeEnvironmentsError {
+    fn from(err: io::Error) -> ComposeEnvironmentsError {
+        ComposeEnvironmentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ComposeEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9648,6 +9670,11 @@ impl From<CredentialsError> for CreateApplicationError {
 impl From<HttpDispatchError> for CreateApplicationError {
     fn from(err: HttpDispatchError) -> CreateApplicationError {
         CreateApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateApplicationError {
+    fn from(err: io::Error) -> CreateApplicationError {
+        CreateApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateApplicationError {
@@ -9730,6 +9757,11 @@ impl From<HttpDispatchError> for CreateApplicationVersionError {
         CreateApplicationVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateApplicationVersionError {
+    fn from(err: io::Error) -> CreateApplicationVersionError {
+        CreateApplicationVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateApplicationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9808,6 +9840,11 @@ impl From<HttpDispatchError> for CreateConfigurationTemplateError {
         CreateConfigurationTemplateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateConfigurationTemplateError {
+    fn from(err: io::Error) -> CreateConfigurationTemplateError {
+        CreateConfigurationTemplateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateConfigurationTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9879,6 +9916,11 @@ impl From<CredentialsError> for CreateEnvironmentError {
 impl From<HttpDispatchError> for CreateEnvironmentError {
     fn from(err: HttpDispatchError) -> CreateEnvironmentError {
         CreateEnvironmentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateEnvironmentError {
+    fn from(err: io::Error) -> CreateEnvironmentError {
+        CreateEnvironmentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateEnvironmentError {
@@ -9954,6 +9996,11 @@ impl From<CredentialsError> for CreatePlatformVersionError {
 impl From<HttpDispatchError> for CreatePlatformVersionError {
     fn from(err: HttpDispatchError) -> CreatePlatformVersionError {
         CreatePlatformVersionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePlatformVersionError {
+    fn from(err: io::Error) -> CreatePlatformVersionError {
+        CreatePlatformVersionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePlatformVersionError {
@@ -10032,6 +10079,11 @@ impl From<HttpDispatchError> for CreateStorageLocationError {
         CreateStorageLocationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateStorageLocationError {
+    fn from(err: io::Error) -> CreateStorageLocationError {
+        CreateStorageLocationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateStorageLocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10100,6 +10152,11 @@ impl From<CredentialsError> for DeleteApplicationError {
 impl From<HttpDispatchError> for DeleteApplicationError {
     fn from(err: HttpDispatchError) -> DeleteApplicationError {
         DeleteApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteApplicationError {
+    fn from(err: io::Error) -> DeleteApplicationError {
+        DeleteApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteApplicationError {
@@ -10179,6 +10236,11 @@ impl From<HttpDispatchError> for DeleteApplicationVersionError {
         DeleteApplicationVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteApplicationVersionError {
+    fn from(err: io::Error) -> DeleteApplicationVersionError {
+        DeleteApplicationVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteApplicationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10250,6 +10312,11 @@ impl From<HttpDispatchError> for DeleteConfigurationTemplateError {
         DeleteConfigurationTemplateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteConfigurationTemplateError {
+    fn from(err: io::Error) -> DeleteConfigurationTemplateError {
+        DeleteConfigurationTemplateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteConfigurationTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10313,6 +10380,11 @@ impl From<CredentialsError> for DeleteEnvironmentConfigurationError {
 impl From<HttpDispatchError> for DeleteEnvironmentConfigurationError {
     fn from(err: HttpDispatchError) -> DeleteEnvironmentConfigurationError {
         DeleteEnvironmentConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteEnvironmentConfigurationError {
+    fn from(err: io::Error) -> DeleteEnvironmentConfigurationError {
+        DeleteEnvironmentConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteEnvironmentConfigurationError {
@@ -10391,6 +10463,11 @@ impl From<HttpDispatchError> for DeletePlatformVersionError {
         DeletePlatformVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePlatformVersionError {
+    fn from(err: io::Error) -> DeletePlatformVersionError {
+        DeletePlatformVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePlatformVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10459,6 +10536,11 @@ impl From<HttpDispatchError> for DescribeApplicationVersionsError {
         DescribeApplicationVersionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeApplicationVersionsError {
+    fn from(err: io::Error) -> DescribeApplicationVersionsError {
+        DescribeApplicationVersionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeApplicationVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10521,6 +10603,11 @@ impl From<CredentialsError> for DescribeApplicationsError {
 impl From<HttpDispatchError> for DescribeApplicationsError {
     fn from(err: HttpDispatchError) -> DescribeApplicationsError {
         DescribeApplicationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeApplicationsError {
+    fn from(err: io::Error) -> DescribeApplicationsError {
+        DescribeApplicationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeApplicationsError {
@@ -10590,6 +10677,11 @@ impl From<HttpDispatchError> for DescribeConfigurationOptionsError {
         DescribeConfigurationOptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeConfigurationOptionsError {
+    fn from(err: io::Error) -> DescribeConfigurationOptionsError {
+        DescribeConfigurationOptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeConfigurationOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10656,6 +10748,11 @@ impl From<CredentialsError> for DescribeConfigurationSettingsError {
 impl From<HttpDispatchError> for DescribeConfigurationSettingsError {
     fn from(err: HttpDispatchError) -> DescribeConfigurationSettingsError {
         DescribeConfigurationSettingsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeConfigurationSettingsError {
+    fn from(err: io::Error) -> DescribeConfigurationSettingsError {
+        DescribeConfigurationSettingsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeConfigurationSettingsError {
@@ -10729,6 +10826,11 @@ impl From<HttpDispatchError> for DescribeEnvironmentHealthError {
         DescribeEnvironmentHealthError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEnvironmentHealthError {
+    fn from(err: io::Error) -> DescribeEnvironmentHealthError {
+        DescribeEnvironmentHealthError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEnvironmentHealthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10796,6 +10898,11 @@ impl From<CredentialsError> for DescribeEnvironmentManagedActionHistoryError {
 impl From<HttpDispatchError> for DescribeEnvironmentManagedActionHistoryError {
     fn from(err: HttpDispatchError) -> DescribeEnvironmentManagedActionHistoryError {
         DescribeEnvironmentManagedActionHistoryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEnvironmentManagedActionHistoryError {
+    fn from(err: io::Error) -> DescribeEnvironmentManagedActionHistoryError {
+        DescribeEnvironmentManagedActionHistoryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEnvironmentManagedActionHistoryError {
@@ -10868,6 +10975,11 @@ impl From<HttpDispatchError> for DescribeEnvironmentManagedActionsError {
         DescribeEnvironmentManagedActionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEnvironmentManagedActionsError {
+    fn from(err: io::Error) -> DescribeEnvironmentManagedActionsError {
+        DescribeEnvironmentManagedActionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEnvironmentManagedActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10936,6 +11048,11 @@ impl From<HttpDispatchError> for DescribeEnvironmentResourcesError {
         DescribeEnvironmentResourcesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEnvironmentResourcesError {
+    fn from(err: io::Error) -> DescribeEnvironmentResourcesError {
+        DescribeEnvironmentResourcesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEnvironmentResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11001,6 +11118,11 @@ impl From<HttpDispatchError> for DescribeEnvironmentsError {
         DescribeEnvironmentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEnvironmentsError {
+    fn from(err: io::Error) -> DescribeEnvironmentsError {
+        DescribeEnvironmentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11063,6 +11185,11 @@ impl From<CredentialsError> for DescribeEventsError {
 impl From<HttpDispatchError> for DescribeEventsError {
     fn from(err: HttpDispatchError) -> DescribeEventsError {
         DescribeEventsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventsError {
+    fn from(err: io::Error) -> DescribeEventsError {
+        DescribeEventsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventsError {
@@ -11131,6 +11258,11 @@ impl From<CredentialsError> for DescribeInstancesHealthError {
 impl From<HttpDispatchError> for DescribeInstancesHealthError {
     fn from(err: HttpDispatchError) -> DescribeInstancesHealthError {
         DescribeInstancesHealthError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeInstancesHealthError {
+    fn from(err: io::Error) -> DescribeInstancesHealthError {
+        DescribeInstancesHealthError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeInstancesHealthError {
@@ -11205,6 +11337,11 @@ impl From<HttpDispatchError> for DescribePlatformVersionError {
         DescribePlatformVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribePlatformVersionError {
+    fn from(err: io::Error) -> DescribePlatformVersionError {
+        DescribePlatformVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribePlatformVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11269,6 +11406,11 @@ impl From<CredentialsError> for ListAvailableSolutionStacksError {
 impl From<HttpDispatchError> for ListAvailableSolutionStacksError {
     fn from(err: HttpDispatchError) -> ListAvailableSolutionStacksError {
         ListAvailableSolutionStacksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAvailableSolutionStacksError {
+    fn from(err: io::Error) -> ListAvailableSolutionStacksError {
+        ListAvailableSolutionStacksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAvailableSolutionStacksError {
@@ -11341,6 +11483,11 @@ impl From<HttpDispatchError> for ListPlatformVersionsError {
         ListPlatformVersionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPlatformVersionsError {
+    fn from(err: io::Error) -> ListPlatformVersionsError {
+        ListPlatformVersionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPlatformVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11410,6 +11557,11 @@ impl From<HttpDispatchError> for RebuildEnvironmentError {
         RebuildEnvironmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RebuildEnvironmentError {
+    fn from(err: io::Error) -> RebuildEnvironmentError {
+        RebuildEnvironmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RebuildEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11473,6 +11625,11 @@ impl From<CredentialsError> for RequestEnvironmentInfoError {
 impl From<HttpDispatchError> for RequestEnvironmentInfoError {
     fn from(err: HttpDispatchError) -> RequestEnvironmentInfoError {
         RequestEnvironmentInfoError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RequestEnvironmentInfoError {
+    fn from(err: io::Error) -> RequestEnvironmentInfoError {
+        RequestEnvironmentInfoError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RequestEnvironmentInfoError {
@@ -11539,6 +11696,11 @@ impl From<HttpDispatchError> for RestartAppServerError {
         RestartAppServerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RestartAppServerError {
+    fn from(err: io::Error) -> RestartAppServerError {
+        RestartAppServerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RestartAppServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11599,6 +11761,11 @@ impl From<CredentialsError> for RetrieveEnvironmentInfoError {
 impl From<HttpDispatchError> for RetrieveEnvironmentInfoError {
     fn from(err: HttpDispatchError) -> RetrieveEnvironmentInfoError {
         RetrieveEnvironmentInfoError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RetrieveEnvironmentInfoError {
+    fn from(err: io::Error) -> RetrieveEnvironmentInfoError {
+        RetrieveEnvironmentInfoError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RetrieveEnvironmentInfoError {
@@ -11663,6 +11830,11 @@ impl From<CredentialsError> for SwapEnvironmentCNAMEsError {
 impl From<HttpDispatchError> for SwapEnvironmentCNAMEsError {
     fn from(err: HttpDispatchError) -> SwapEnvironmentCNAMEsError {
         SwapEnvironmentCNAMEsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SwapEnvironmentCNAMEsError {
+    fn from(err: io::Error) -> SwapEnvironmentCNAMEsError {
+        SwapEnvironmentCNAMEsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SwapEnvironmentCNAMEsError {
@@ -11732,6 +11904,11 @@ impl From<HttpDispatchError> for TerminateEnvironmentError {
         TerminateEnvironmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TerminateEnvironmentError {
+    fn from(err: io::Error) -> TerminateEnvironmentError {
+        TerminateEnvironmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TerminateEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11795,6 +11972,11 @@ impl From<CredentialsError> for UpdateApplicationError {
 impl From<HttpDispatchError> for UpdateApplicationError {
     fn from(err: HttpDispatchError) -> UpdateApplicationError {
         UpdateApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateApplicationError {
+    fn from(err: io::Error) -> UpdateApplicationError {
+        UpdateApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateApplicationError {
@@ -11864,6 +12046,11 @@ impl From<HttpDispatchError> for UpdateApplicationResourceLifecycleError {
         UpdateApplicationResourceLifecycleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateApplicationResourceLifecycleError {
+    fn from(err: io::Error) -> UpdateApplicationResourceLifecycleError {
+        UpdateApplicationResourceLifecycleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateApplicationResourceLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11927,6 +12114,11 @@ impl From<CredentialsError> for UpdateApplicationVersionError {
 impl From<HttpDispatchError> for UpdateApplicationVersionError {
     fn from(err: HttpDispatchError) -> UpdateApplicationVersionError {
         UpdateApplicationVersionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateApplicationVersionError {
+    fn from(err: io::Error) -> UpdateApplicationVersionError {
+        UpdateApplicationVersionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateApplicationVersionError {
@@ -11997,6 +12189,11 @@ impl From<CredentialsError> for UpdateConfigurationTemplateError {
 impl From<HttpDispatchError> for UpdateConfigurationTemplateError {
     fn from(err: HttpDispatchError) -> UpdateConfigurationTemplateError {
         UpdateConfigurationTemplateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateConfigurationTemplateError {
+    fn from(err: io::Error) -> UpdateConfigurationTemplateError {
+        UpdateConfigurationTemplateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateConfigurationTemplateError {
@@ -12073,6 +12270,11 @@ impl From<HttpDispatchError> for UpdateEnvironmentError {
         UpdateEnvironmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateEnvironmentError {
+    fn from(err: io::Error) -> UpdateEnvironmentError {
+        UpdateEnvironmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12143,6 +12345,11 @@ impl From<CredentialsError> for ValidateConfigurationSettingsError {
 impl From<HttpDispatchError> for ValidateConfigurationSettingsError {
     fn from(err: HttpDispatchError) -> ValidateConfigurationSettingsError {
         ValidateConfigurationSettingsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ValidateConfigurationSettingsError {
+    fn from(err: io::Error) -> ValidateConfigurationSettingsError {
+        ValidateConfigurationSettingsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ValidateConfigurationSettingsError {
@@ -12467,15 +12674,16 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AbortEnvironmentUpdateError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AbortEnvironmentUpdateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12495,16 +12703,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplyEnvironmentManagedActionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12518,8 +12728,11 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ApplyEnvironmentManagedActionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ApplyEnvironmentManagedActionError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -12538,16 +12751,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CheckDNSAvailabilityResultMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12561,8 +12776,9 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CheckDNSAvailabilityError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CheckDNSAvailabilityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12581,16 +12797,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnvironmentDescriptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12606,8 +12824,9 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ComposeEnvironmentsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ComposeEnvironmentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12626,16 +12845,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplicationDescriptionMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12651,8 +12872,9 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12672,16 +12894,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplicationVersionDescriptionMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12695,8 +12919,11 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateApplicationVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateApplicationVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -12715,16 +12942,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ConfigurationSettingsDescription::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12740,8 +12969,11 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateConfigurationTemplateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateConfigurationTemplateError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12759,16 +12991,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnvironmentDescription::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12783,8 +13017,9 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateEnvironmentError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateEnvironmentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12804,16 +13039,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreatePlatformVersionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12828,8 +13065,9 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreatePlatformVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePlatformVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12848,16 +13086,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateStorageLocationResultMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12871,8 +13111,9 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateStorageLocationError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStorageLocationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12891,15 +13132,16 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12918,15 +13160,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteApplicationVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteApplicationVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -12944,15 +13189,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteConfigurationTemplateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteConfigurationTemplateError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12970,15 +13218,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteEnvironmentConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEnvironmentConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -12997,16 +13248,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeletePlatformVersionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13021,8 +13274,9 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeletePlatformVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePlatformVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13042,16 +13296,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplicationVersionDescriptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13065,8 +13321,11 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeApplicationVersionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeApplicationVersionsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -13085,16 +13344,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplicationDescriptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13110,8 +13371,9 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeApplicationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeApplicationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13131,16 +13393,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ConfigurationOptionsDescription::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13156,8 +13420,11 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeConfigurationOptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConfigurationOptionsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -13176,16 +13443,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ConfigurationSettingsDescriptions::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13199,8 +13468,11 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeConfigurationSettingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConfigurationSettingsError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -13219,16 +13491,18 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeEnvironmentHealthResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13244,8 +13518,11 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEnvironmentHealthError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEnvironmentHealthError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -13263,16 +13540,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeEnvironmentManagedActionHistoryResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13286,8 +13565,10 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEnvironmentManagedActionHistoryError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEnvironmentManagedActionHistoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13306,16 +13587,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeEnvironmentManagedActionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13329,8 +13612,10 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEnvironmentManagedActionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEnvironmentManagedActionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13349,16 +13634,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnvironmentResourceDescriptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13372,8 +13659,11 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEnvironmentResourcesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEnvironmentResourcesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -13392,16 +13682,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnvironmentDescriptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13417,8 +13709,9 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                Err(DescribeEnvironmentsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEnvironmentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13437,16 +13730,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EventDescriptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13461,8 +13756,9 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13482,16 +13778,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeInstancesHealthResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13507,8 +13805,11 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                            Err(DescribeInstancesHealthError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstancesHealthError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -13527,16 +13828,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribePlatformVersionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13552,8 +13855,11 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                            Err(DescribePlatformVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePlatformVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -13571,16 +13877,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListAvailableSolutionStacksResultMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13594,8 +13902,11 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                            Err(ListAvailableSolutionStacksError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAvailableSolutionStacksError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -13613,16 +13924,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListPlatformVersionsResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13637,8 +13950,9 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                Err(ListPlatformVersionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPlatformVersionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13657,15 +13971,16 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(RebuildEnvironmentError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebuildEnvironmentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13684,15 +13999,16 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(RequestEnvironmentInfoError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RequestEnvironmentInfoError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13711,15 +14027,16 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(RestartAppServerError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestartAppServerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13739,16 +14056,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RetrieveEnvironmentInfoResultMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13762,8 +14081,11 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                            Err(RetrieveEnvironmentInfoError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RetrieveEnvironmentInfoError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -13781,15 +14103,16 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SwapEnvironmentCNAMEsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SwapEnvironmentCNAMEsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13808,16 +14131,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnvironmentDescription::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13832,8 +14157,9 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                Err(TerminateEnvironmentError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TerminateEnvironmentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13852,16 +14178,18 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplicationDescriptionMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13877,8 +14205,9 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
                 Ok(result)
             }
             _ => {
-                Err(UpdateApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13895,16 +14224,18 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplicationResourceLifecycleDescriptionMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13918,8 +14249,10 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
                 Ok(result)
             }
             _ => {
-                            Err(UpdateApplicationResourceLifecycleError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateApplicationResourceLifecycleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13938,16 +14271,18 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplicationVersionDescriptionMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13961,8 +14296,11 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
                 Ok(result)
             }
             _ => {
-                            Err(UpdateApplicationVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateApplicationVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -13981,16 +14319,18 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ConfigurationSettingsDescription::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14006,8 +14346,11 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
                 Ok(result)
             }
             _ => {
-                            Err(UpdateConfigurationTemplateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateConfigurationTemplateError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -14025,16 +14368,18 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnvironmentDescription::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14049,8 +14394,9 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
                 Ok(result)
             }
             _ => {
-                Err(UpdateEnvironmentError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateEnvironmentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14070,16 +14416,18 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ConfigurationSettingsValidationMessages::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14093,8 +14441,11 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
                 Ok(result)
             }
             _ => {
-                            Err(ValidateConfigurationSettingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ValidateConfigurationSettingsError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1464,6 +1466,11 @@ impl From<HttpDispatchError> for CancelJobError {
         CancelJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelJobError {
+    fn from(err: io::Error) -> CancelJobError {
+        CancelJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1558,6 +1565,11 @@ impl From<CredentialsError> for CreateJobError {
 impl From<HttpDispatchError> for CreateJobError {
     fn from(err: HttpDispatchError) -> CreateJobError {
         CreateJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateJobError {
+    fn from(err: io::Error) -> CreateJobError {
+        CreateJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateJobError {
@@ -1658,6 +1670,11 @@ impl From<HttpDispatchError> for CreatePipelineError {
         CreatePipelineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreatePipelineError {
+    fn from(err: io::Error) -> CreatePipelineError {
+        CreatePipelineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1749,6 +1766,11 @@ impl From<CredentialsError> for CreatePresetError {
 impl From<HttpDispatchError> for CreatePresetError {
     fn from(err: HttpDispatchError) -> CreatePresetError {
         CreatePresetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePresetError {
+    fn from(err: io::Error) -> CreatePresetError {
+        CreatePresetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePresetError {
@@ -1848,6 +1870,11 @@ impl From<HttpDispatchError> for DeletePipelineError {
         DeletePipelineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePipelineError {
+    fn from(err: io::Error) -> DeletePipelineError {
+        DeletePipelineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1941,6 +1968,11 @@ impl From<HttpDispatchError> for DeletePresetError {
         DeletePresetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePresetError {
+    fn from(err: io::Error) -> DeletePresetError {
+        DeletePresetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2031,6 +2063,11 @@ impl From<CredentialsError> for ListJobsByPipelineError {
 impl From<HttpDispatchError> for ListJobsByPipelineError {
     fn from(err: HttpDispatchError) -> ListJobsByPipelineError {
         ListJobsByPipelineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListJobsByPipelineError {
+    fn from(err: io::Error) -> ListJobsByPipelineError {
+        ListJobsByPipelineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListJobsByPipelineError {
@@ -2127,6 +2164,11 @@ impl From<HttpDispatchError> for ListJobsByStatusError {
         ListJobsByStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListJobsByStatusError {
+    fn from(err: io::Error) -> ListJobsByStatusError {
+        ListJobsByStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListJobsByStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2214,6 +2256,11 @@ impl From<HttpDispatchError> for ListPipelinesError {
         ListPipelinesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPipelinesError {
+    fn from(err: io::Error) -> ListPipelinesError {
+        ListPipelinesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPipelinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2298,6 +2345,11 @@ impl From<CredentialsError> for ListPresetsError {
 impl From<HttpDispatchError> for ListPresetsError {
     fn from(err: HttpDispatchError) -> ListPresetsError {
         ListPresetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPresetsError {
+    fn from(err: io::Error) -> ListPresetsError {
+        ListPresetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPresetsError {
@@ -2387,6 +2439,11 @@ impl From<CredentialsError> for ReadJobError {
 impl From<HttpDispatchError> for ReadJobError {
     fn from(err: HttpDispatchError) -> ReadJobError {
         ReadJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ReadJobError {
+    fn from(err: io::Error) -> ReadJobError {
+        ReadJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ReadJobError {
@@ -2481,6 +2538,11 @@ impl From<HttpDispatchError> for ReadPipelineError {
         ReadPipelineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReadPipelineError {
+    fn from(err: io::Error) -> ReadPipelineError {
+        ReadPipelineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReadPipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2571,6 +2633,11 @@ impl From<HttpDispatchError> for ReadPresetError {
         ReadPresetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReadPresetError {
+    fn from(err: io::Error) -> ReadPresetError {
+        ReadPresetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReadPresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2659,6 +2726,11 @@ impl From<CredentialsError> for TestRoleError {
 impl From<HttpDispatchError> for TestRoleError {
     fn from(err: HttpDispatchError) -> TestRoleError {
         TestRoleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TestRoleError {
+    fn from(err: io::Error) -> TestRoleError {
+        TestRoleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TestRoleError {
@@ -2758,6 +2830,11 @@ impl From<HttpDispatchError> for UpdatePipelineError {
         UpdatePipelineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdatePipelineError {
+    fn from(err: io::Error) -> UpdatePipelineError {
+        UpdatePipelineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2848,6 +2925,11 @@ impl From<CredentialsError> for UpdatePipelineNotificationsError {
 impl From<HttpDispatchError> for UpdatePipelineNotificationsError {
     fn from(err: HttpDispatchError) -> UpdatePipelineNotificationsError {
         UpdatePipelineNotificationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdatePipelineNotificationsError {
+    fn from(err: io::Error) -> UpdatePipelineNotificationsError {
+        UpdatePipelineNotificationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdatePipelineNotificationsError {
@@ -2948,6 +3030,11 @@ impl From<CredentialsError> for UpdatePipelineStatusError {
 impl From<HttpDispatchError> for UpdatePipelineStatusError {
     fn from(err: HttpDispatchError) -> UpdatePipelineStatusError {
         UpdatePipelineStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdatePipelineStatusError {
+    fn from(err: io::Error) -> UpdatePipelineStatusError {
+        UpdatePipelineStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdatePipelineStatusError {
@@ -3111,13 +3198,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3131,7 +3218,11 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CancelJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3151,13 +3242,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3171,7 +3262,11 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3193,13 +3288,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3214,8 +3309,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreatePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3238,13 +3334,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3259,7 +3355,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreatePresetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePresetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3282,13 +3380,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3303,8 +3401,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeletePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3327,13 +3426,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3348,7 +3447,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeletePresetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePresetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3378,13 +3479,13 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3399,8 +3500,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListJobsByPipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListJobsByPipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3429,13 +3531,13 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3450,8 +3552,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListJobsByStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListJobsByStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3480,13 +3583,13 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3501,7 +3604,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListPipelinesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPipelinesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3530,13 +3635,13 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3550,7 +3655,11 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListPresetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPresetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3569,13 +3678,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3589,7 +3698,11 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ReadJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReadJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3610,13 +3723,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3631,7 +3744,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ReadPipelineError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReadPipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3653,13 +3768,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3673,7 +3788,11 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ReadPresetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReadPresetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3693,13 +3812,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3713,7 +3832,11 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(TestRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestRoleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3734,13 +3857,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3755,8 +3878,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdatePipelineError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3780,13 +3904,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3801,7 +3925,12 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdatePipelineNotificationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdatePipelineNotificationsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -3824,13 +3953,13 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3845,8 +3974,9 @@ impl<P, D> Ets for EtsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdatePipelineStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdatePipelineStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -5507,6 +5509,11 @@ impl From<HttpDispatchError> for AddTagsError {
         AddTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsError {
+    fn from(err: io::Error) -> AddTagsError {
+        AddTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5579,6 +5586,11 @@ impl From<CredentialsError> for ApplySecurityGroupsToLoadBalancerError {
 impl From<HttpDispatchError> for ApplySecurityGroupsToLoadBalancerError {
     fn from(err: HttpDispatchError) -> ApplySecurityGroupsToLoadBalancerError {
         ApplySecurityGroupsToLoadBalancerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ApplySecurityGroupsToLoadBalancerError {
+    fn from(err: io::Error) -> ApplySecurityGroupsToLoadBalancerError {
+        ApplySecurityGroupsToLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ApplySecurityGroupsToLoadBalancerError {
@@ -5660,6 +5672,11 @@ impl From<HttpDispatchError> for AttachLoadBalancerToSubnetsError {
         AttachLoadBalancerToSubnetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachLoadBalancerToSubnetsError {
+    fn from(err: io::Error) -> AttachLoadBalancerToSubnetsError {
+        AttachLoadBalancerToSubnetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachLoadBalancerToSubnetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5729,6 +5746,11 @@ impl From<CredentialsError> for ConfigureHealthCheckError {
 impl From<HttpDispatchError> for ConfigureHealthCheckError {
     fn from(err: HttpDispatchError) -> ConfigureHealthCheckError {
         ConfigureHealthCheckError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ConfigureHealthCheckError {
+    fn from(err: io::Error) -> ConfigureHealthCheckError {
+        ConfigureHealthCheckError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ConfigureHealthCheckError {
@@ -5806,6 +5828,11 @@ impl From<CredentialsError> for CreateAppCookieStickinessPolicyError {
 impl From<HttpDispatchError> for CreateAppCookieStickinessPolicyError {
     fn from(err: HttpDispatchError) -> CreateAppCookieStickinessPolicyError {
         CreateAppCookieStickinessPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAppCookieStickinessPolicyError {
+    fn from(err: io::Error) -> CreateAppCookieStickinessPolicyError {
+        CreateAppCookieStickinessPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAppCookieStickinessPolicyError {
@@ -5886,6 +5913,11 @@ impl From<CredentialsError> for CreateLBCookieStickinessPolicyError {
 impl From<HttpDispatchError> for CreateLBCookieStickinessPolicyError {
     fn from(err: HttpDispatchError) -> CreateLBCookieStickinessPolicyError {
         CreateLBCookieStickinessPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateLBCookieStickinessPolicyError {
+    fn from(err: io::Error) -> CreateLBCookieStickinessPolicyError {
+        CreateLBCookieStickinessPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateLBCookieStickinessPolicyError {
@@ -5997,6 +6029,11 @@ impl From<HttpDispatchError> for CreateLoadBalancerError {
         CreateLoadBalancerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLoadBalancerError {
+    fn from(err: io::Error) -> CreateLoadBalancerError {
+        CreateLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6087,6 +6124,11 @@ impl From<HttpDispatchError> for CreateLoadBalancerListenersError {
         CreateLoadBalancerListenersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLoadBalancerListenersError {
+    fn from(err: io::Error) -> CreateLoadBalancerListenersError {
+        CreateLoadBalancerListenersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLoadBalancerListenersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6171,6 +6213,11 @@ impl From<HttpDispatchError> for CreateLoadBalancerPolicyError {
         CreateLoadBalancerPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLoadBalancerPolicyError {
+    fn from(err: io::Error) -> CreateLoadBalancerPolicyError {
+        CreateLoadBalancerPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLoadBalancerPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6240,6 +6287,11 @@ impl From<HttpDispatchError> for DeleteLoadBalancerError {
         DeleteLoadBalancerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteLoadBalancerError {
+    fn from(err: io::Error) -> DeleteLoadBalancerError {
+        DeleteLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6305,6 +6357,11 @@ impl From<CredentialsError> for DeleteLoadBalancerListenersError {
 impl From<HttpDispatchError> for DeleteLoadBalancerListenersError {
     fn from(err: HttpDispatchError) -> DeleteLoadBalancerListenersError {
         DeleteLoadBalancerListenersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteLoadBalancerListenersError {
+    fn from(err: io::Error) -> DeleteLoadBalancerListenersError {
+        DeleteLoadBalancerListenersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteLoadBalancerListenersError {
@@ -6376,6 +6433,11 @@ impl From<CredentialsError> for DeleteLoadBalancerPolicyError {
 impl From<HttpDispatchError> for DeleteLoadBalancerPolicyError {
     fn from(err: HttpDispatchError) -> DeleteLoadBalancerPolicyError {
         DeleteLoadBalancerPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteLoadBalancerPolicyError {
+    fn from(err: io::Error) -> DeleteLoadBalancerPolicyError {
+        DeleteLoadBalancerPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteLoadBalancerPolicyError {
@@ -6450,6 +6512,11 @@ impl From<HttpDispatchError> for DeregisterInstancesFromLoadBalancerError {
         DeregisterInstancesFromLoadBalancerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterInstancesFromLoadBalancerError {
+    fn from(err: io::Error) -> DeregisterInstancesFromLoadBalancerError {
+        DeregisterInstancesFromLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterInstancesFromLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6514,6 +6581,11 @@ impl From<CredentialsError> for DescribeAccountLimitsError {
 impl From<HttpDispatchError> for DescribeAccountLimitsError {
     fn from(err: HttpDispatchError) -> DescribeAccountLimitsError {
         DescribeAccountLimitsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAccountLimitsError {
+    fn from(err: io::Error) -> DescribeAccountLimitsError {
+        DescribeAccountLimitsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAccountLimitsError {
@@ -6584,6 +6656,11 @@ impl From<CredentialsError> for DescribeInstanceHealthError {
 impl From<HttpDispatchError> for DescribeInstanceHealthError {
     fn from(err: HttpDispatchError) -> DescribeInstanceHealthError {
         DescribeInstanceHealthError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeInstanceHealthError {
+    fn from(err: io::Error) -> DescribeInstanceHealthError {
+        DescribeInstanceHealthError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeInstanceHealthError {
@@ -6658,6 +6735,11 @@ impl From<HttpDispatchError> for DescribeLoadBalancerAttributesError {
         DescribeLoadBalancerAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLoadBalancerAttributesError {
+    fn from(err: io::Error) -> DescribeLoadBalancerAttributesError {
+        DescribeLoadBalancerAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLoadBalancerAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6730,6 +6812,11 @@ impl From<HttpDispatchError> for DescribeLoadBalancerPoliciesError {
         DescribeLoadBalancerPoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLoadBalancerPoliciesError {
+    fn from(err: io::Error) -> DescribeLoadBalancerPoliciesError {
+        DescribeLoadBalancerPoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLoadBalancerPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6797,6 +6884,11 @@ impl From<CredentialsError> for DescribeLoadBalancerPolicyTypesError {
 impl From<HttpDispatchError> for DescribeLoadBalancerPolicyTypesError {
     fn from(err: HttpDispatchError) -> DescribeLoadBalancerPolicyTypesError {
         DescribeLoadBalancerPolicyTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLoadBalancerPolicyTypesError {
+    fn from(err: io::Error) -> DescribeLoadBalancerPolicyTypesError {
+        DescribeLoadBalancerPolicyTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLoadBalancerPolicyTypesError {
@@ -6870,6 +6962,11 @@ impl From<HttpDispatchError> for DescribeLoadBalancersError {
         DescribeLoadBalancersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLoadBalancersError {
+    fn from(err: io::Error) -> DescribeLoadBalancersError {
+        DescribeLoadBalancersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6941,6 +7038,11 @@ impl From<HttpDispatchError> for DescribeTagsError {
         DescribeTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTagsError {
+    fn from(err: io::Error) -> DescribeTagsError {
+        DescribeTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7008,6 +7110,11 @@ impl From<CredentialsError> for DetachLoadBalancerFromSubnetsError {
 impl From<HttpDispatchError> for DetachLoadBalancerFromSubnetsError {
     fn from(err: HttpDispatchError) -> DetachLoadBalancerFromSubnetsError {
         DetachLoadBalancerFromSubnetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DetachLoadBalancerFromSubnetsError {
+    fn from(err: io::Error) -> DetachLoadBalancerFromSubnetsError {
+        DetachLoadBalancerFromSubnetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DetachLoadBalancerFromSubnetsError {
@@ -7082,6 +7189,11 @@ impl From<HttpDispatchError> for DisableAvailabilityZonesForLoadBalancerError {
         DisableAvailabilityZonesForLoadBalancerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisableAvailabilityZonesForLoadBalancerError {
+    fn from(err: io::Error) -> DisableAvailabilityZonesForLoadBalancerError {
+        DisableAvailabilityZonesForLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisableAvailabilityZonesForLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7149,6 +7261,11 @@ impl From<CredentialsError> for EnableAvailabilityZonesForLoadBalancerError {
 impl From<HttpDispatchError> for EnableAvailabilityZonesForLoadBalancerError {
     fn from(err: HttpDispatchError) -> EnableAvailabilityZonesForLoadBalancerError {
         EnableAvailabilityZonesForLoadBalancerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnableAvailabilityZonesForLoadBalancerError {
+    fn from(err: io::Error) -> EnableAvailabilityZonesForLoadBalancerError {
+        EnableAvailabilityZonesForLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnableAvailabilityZonesForLoadBalancerError {
@@ -7225,6 +7342,11 @@ impl From<HttpDispatchError> for ModifyLoadBalancerAttributesError {
         ModifyLoadBalancerAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyLoadBalancerAttributesError {
+    fn from(err: io::Error) -> ModifyLoadBalancerAttributesError {
+        ModifyLoadBalancerAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyLoadBalancerAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7298,6 +7420,11 @@ impl From<HttpDispatchError> for RegisterInstancesWithLoadBalancerError {
         RegisterInstancesWithLoadBalancerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterInstancesWithLoadBalancerError {
+    fn from(err: io::Error) -> RegisterInstancesWithLoadBalancerError {
+        RegisterInstancesWithLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterInstancesWithLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7367,6 +7494,11 @@ impl From<CredentialsError> for RemoveTagsError {
 impl From<HttpDispatchError> for RemoveTagsError {
     fn from(err: HttpDispatchError) -> RemoveTagsError {
         RemoveTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveTagsError {
+    fn from(err: io::Error) -> RemoveTagsError {
+        RemoveTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveTagsError {
@@ -7445,6 +7577,11 @@ impl From<CredentialsError> for SetLoadBalancerListenerSSLCertificateError {
 impl From<HttpDispatchError> for SetLoadBalancerListenerSSLCertificateError {
     fn from(err: HttpDispatchError) -> SetLoadBalancerListenerSSLCertificateError {
         SetLoadBalancerListenerSSLCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetLoadBalancerListenerSSLCertificateError {
+    fn from(err: io::Error) -> SetLoadBalancerListenerSSLCertificateError {
+        SetLoadBalancerListenerSSLCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetLoadBalancerListenerSSLCertificateError {
@@ -7527,6 +7664,11 @@ impl From<HttpDispatchError> for SetLoadBalancerPoliciesForBackendServerError {
         SetLoadBalancerPoliciesForBackendServerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetLoadBalancerPoliciesForBackendServerError {
+    fn from(err: io::Error) -> SetLoadBalancerPoliciesForBackendServerError {
+        SetLoadBalancerPoliciesForBackendServerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetLoadBalancerPoliciesForBackendServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7604,6 +7746,11 @@ impl From<CredentialsError> for SetLoadBalancerPoliciesOfListenerError {
 impl From<HttpDispatchError> for SetLoadBalancerPoliciesOfListenerError {
     fn from(err: HttpDispatchError) -> SetLoadBalancerPoliciesOfListenerError {
         SetLoadBalancerPoliciesOfListenerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetLoadBalancerPoliciesOfListenerError {
+    fn from(err: io::Error) -> SetLoadBalancerPoliciesOfListenerError {
+        SetLoadBalancerPoliciesOfListenerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetLoadBalancerPoliciesOfListenerError {
@@ -7853,16 +8000,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AddTagsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7876,7 +8025,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(AddTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7895,16 +8048,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplySecurityGroupsToLoadBalancerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7918,8 +8073,10 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ApplySecurityGroupsToLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ApplySecurityGroupsToLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7938,16 +8095,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AttachLoadBalancerToSubnetsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -7961,8 +8120,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AttachLoadBalancerToSubnetsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachLoadBalancerToSubnetsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -7980,16 +8142,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ConfigureHealthCheckOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8004,8 +8168,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ConfigureHealthCheckError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfigureHealthCheckError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8025,16 +8190,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateAppCookieStickinessPolicyOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8048,8 +8215,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateAppCookieStickinessPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAppCookieStickinessPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -8068,16 +8238,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateLBCookieStickinessPolicyOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8091,8 +8263,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateLBCookieStickinessPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLBCookieStickinessPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -8110,16 +8285,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateAccessPointOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8134,8 +8311,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateLoadBalancerError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8155,16 +8333,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateLoadBalancerListenerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8180,8 +8360,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateLoadBalancerListenersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLoadBalancerListenersError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -8200,16 +8383,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateLoadBalancerPolicyOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8225,8 +8410,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateLoadBalancerPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLoadBalancerPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8244,16 +8432,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteAccessPointOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8268,8 +8458,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteLoadBalancerError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8289,16 +8480,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteLoadBalancerListenerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8314,8 +8507,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DeleteLoadBalancerListenersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLoadBalancerListenersError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -8334,16 +8530,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteLoadBalancerPolicyOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8359,8 +8557,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DeleteLoadBalancerPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLoadBalancerPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8379,16 +8580,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeregisterEndPointsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8403,8 +8606,10 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DeregisterInstancesFromLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterInstancesFromLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8423,16 +8628,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAccountLimitsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8447,8 +8654,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeAccountLimitsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountLimitsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8468,16 +8676,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeEndPointStateOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8492,8 +8702,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeInstanceHealthError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstanceHealthError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8513,16 +8724,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLoadBalancerAttributesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8536,8 +8749,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeLoadBalancerAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBalancerAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -8556,16 +8772,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLoadBalancerPoliciesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8579,8 +8797,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeLoadBalancerPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBalancerPoliciesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -8599,16 +8820,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLoadBalancerPolicyTypesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8622,8 +8845,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeLoadBalancerPolicyTypesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBalancerPolicyTypesError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -8642,16 +8868,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAccessPointsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8666,8 +8894,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeLoadBalancersError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBalancersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8686,16 +8915,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeTagsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8710,7 +8941,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8730,16 +8963,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DetachLoadBalancerFromSubnetsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8753,8 +8988,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DetachLoadBalancerFromSubnetsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachLoadBalancerFromSubnetsError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -8773,16 +9011,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RemoveAvailabilityZonesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8798,8 +9038,10 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DisableAvailabilityZonesForLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableAvailabilityZonesForLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8818,16 +9060,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AddAvailabilityZonesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8842,8 +9086,10 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(EnableAvailabilityZonesForLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableAvailabilityZonesForLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8862,16 +9108,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyLoadBalancerAttributesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8885,8 +9133,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ModifyLoadBalancerAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyLoadBalancerAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -8905,16 +9156,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RegisterEndPointsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8929,8 +9182,10 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(RegisterInstancesWithLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterInstancesWithLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8946,16 +9201,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RemoveTagsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8969,7 +9226,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(RemoveTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8985,16 +9246,18 @@ fn set_load_balancer_listener_ssl_certificate(&self, input: &SetLoadBalancerList
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetLoadBalancerListenerSSLCertificateOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9008,8 +9271,10 @@ fn set_load_balancer_listener_ssl_certificate(&self, input: &SetLoadBalancerList
                 Ok(result)
             }
             _ => {
-                            Err(SetLoadBalancerListenerSSLCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetLoadBalancerListenerSSLCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9025,16 +9290,18 @@ fn set_load_balancer_policies_for_backend_server(&self, input: &SetLoadBalancerP
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetLoadBalancerPoliciesForBackendServerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9048,8 +9315,10 @@ fn set_load_balancer_policies_for_backend_server(&self, input: &SetLoadBalancerP
                 Ok(result)
             }
             _ => {
-                            Err(SetLoadBalancerPoliciesForBackendServerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetLoadBalancerPoliciesForBackendServerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9068,16 +9337,18 @@ fn set_load_balancer_policies_for_backend_server(&self, input: &SetLoadBalancerP
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetLoadBalancerPoliciesOfListenerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9091,8 +9362,10 @@ fn set_load_balancer_policies_for_backend_server(&self, input: &SetLoadBalancerP
                 Ok(result)
             }
             _ => {
-                            Err(SetLoadBalancerPoliciesOfListenerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetLoadBalancerPoliciesOfListenerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -5683,6 +5685,11 @@ impl From<HttpDispatchError> for AddTagsError {
         AddTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsError {
+    fn from(err: io::Error) -> AddTagsError {
+        AddTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5799,6 +5806,11 @@ impl From<HttpDispatchError> for CreateListenerError {
         CreateListenerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateListenerError {
+    fn from(err: io::Error) -> CreateListenerError {
+        CreateListenerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateListenerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5908,6 +5920,11 @@ impl From<HttpDispatchError> for CreateLoadBalancerError {
         CreateLoadBalancerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLoadBalancerError {
+    fn from(err: io::Error) -> CreateLoadBalancerError {
+        CreateLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6015,6 +6032,11 @@ impl From<HttpDispatchError> for CreateRuleError {
         CreateRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRuleError {
+    fn from(err: io::Error) -> CreateRuleError {
+        CreateRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6091,6 +6113,11 @@ impl From<HttpDispatchError> for CreateTargetGroupError {
         CreateTargetGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTargetGroupError {
+    fn from(err: io::Error) -> CreateTargetGroupError {
+        CreateTargetGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTargetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6162,6 +6189,11 @@ impl From<HttpDispatchError> for DeleteListenerError {
         DeleteListenerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteListenerError {
+    fn from(err: io::Error) -> DeleteListenerError {
+        DeleteListenerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteListenerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6229,6 +6261,11 @@ impl From<CredentialsError> for DeleteLoadBalancerError {
 impl From<HttpDispatchError> for DeleteLoadBalancerError {
     fn from(err: HttpDispatchError) -> DeleteLoadBalancerError {
         DeleteLoadBalancerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteLoadBalancerError {
+    fn from(err: io::Error) -> DeleteLoadBalancerError {
+        DeleteLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteLoadBalancerError {
@@ -6307,6 +6344,11 @@ impl From<HttpDispatchError> for DeleteRuleError {
         DeleteRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRuleError {
+    fn from(err: io::Error) -> DeleteRuleError {
+        DeleteRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6374,6 +6416,11 @@ impl From<CredentialsError> for DeleteTargetGroupError {
 impl From<HttpDispatchError> for DeleteTargetGroupError {
     fn from(err: HttpDispatchError) -> DeleteTargetGroupError {
         DeleteTargetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteTargetGroupError {
+    fn from(err: io::Error) -> DeleteTargetGroupError {
+        DeleteTargetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteTargetGroupError {
@@ -6449,6 +6496,11 @@ impl From<HttpDispatchError> for DeregisterTargetsError {
         DeregisterTargetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterTargetsError {
+    fn from(err: io::Error) -> DeregisterTargetsError {
+        DeregisterTargetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6513,6 +6565,11 @@ impl From<CredentialsError> for DescribeAccountLimitsError {
 impl From<HttpDispatchError> for DescribeAccountLimitsError {
     fn from(err: HttpDispatchError) -> DescribeAccountLimitsError {
         DescribeAccountLimitsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAccountLimitsError {
+    fn from(err: io::Error) -> DescribeAccountLimitsError {
+        DescribeAccountLimitsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAccountLimitsError {
@@ -6587,6 +6644,11 @@ impl From<HttpDispatchError> for DescribeListenersError {
         DescribeListenersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeListenersError {
+    fn from(err: io::Error) -> DescribeListenersError {
+        DescribeListenersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeListenersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6656,6 +6718,11 @@ impl From<HttpDispatchError> for DescribeLoadBalancerAttributesError {
         DescribeLoadBalancerAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLoadBalancerAttributesError {
+    fn from(err: io::Error) -> DescribeLoadBalancerAttributesError {
+        DescribeLoadBalancerAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLoadBalancerAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6722,6 +6789,11 @@ impl From<CredentialsError> for DescribeLoadBalancersError {
 impl From<HttpDispatchError> for DescribeLoadBalancersError {
     fn from(err: HttpDispatchError) -> DescribeLoadBalancersError {
         DescribeLoadBalancersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLoadBalancersError {
+    fn from(err: io::Error) -> DescribeLoadBalancersError {
+        DescribeLoadBalancersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLoadBalancersError {
@@ -6799,6 +6871,11 @@ impl From<HttpDispatchError> for DescribeRulesError {
         DescribeRulesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeRulesError {
+    fn from(err: io::Error) -> DescribeRulesError {
+        DescribeRulesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6864,6 +6941,11 @@ impl From<CredentialsError> for DescribeSSLPoliciesError {
 impl From<HttpDispatchError> for DescribeSSLPoliciesError {
     fn from(err: HttpDispatchError) -> DescribeSSLPoliciesError {
         DescribeSSLPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSSLPoliciesError {
+    fn from(err: io::Error) -> DescribeSSLPoliciesError {
+        DescribeSSLPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSSLPoliciesError {
@@ -6951,6 +7033,11 @@ impl From<HttpDispatchError> for DescribeTagsError {
         DescribeTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTagsError {
+    fn from(err: io::Error) -> DescribeTagsError {
+        DescribeTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7018,6 +7105,11 @@ impl From<CredentialsError> for DescribeTargetGroupAttributesError {
 impl From<HttpDispatchError> for DescribeTargetGroupAttributesError {
     fn from(err: HttpDispatchError) -> DescribeTargetGroupAttributesError {
         DescribeTargetGroupAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTargetGroupAttributesError {
+    fn from(err: io::Error) -> DescribeTargetGroupAttributesError {
+        DescribeTargetGroupAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTargetGroupAttributesError {
@@ -7089,6 +7181,11 @@ impl From<CredentialsError> for DescribeTargetGroupsError {
 impl From<HttpDispatchError> for DescribeTargetGroupsError {
     fn from(err: HttpDispatchError) -> DescribeTargetGroupsError {
         DescribeTargetGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTargetGroupsError {
+    fn from(err: io::Error) -> DescribeTargetGroupsError {
+        DescribeTargetGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTargetGroupsError {
@@ -7166,6 +7263,11 @@ impl From<CredentialsError> for DescribeTargetHealthError {
 impl From<HttpDispatchError> for DescribeTargetHealthError {
     fn from(err: HttpDispatchError) -> DescribeTargetHealthError {
         DescribeTargetHealthError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTargetHealthError {
+    fn from(err: io::Error) -> DescribeTargetHealthError {
+        DescribeTargetHealthError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTargetHealthError {
@@ -7287,6 +7389,11 @@ impl From<HttpDispatchError> for ModifyListenerError {
         ModifyListenerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyListenerError {
+    fn from(err: io::Error) -> ModifyListenerError {
+        ModifyListenerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyListenerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7365,6 +7472,11 @@ impl From<CredentialsError> for ModifyLoadBalancerAttributesError {
 impl From<HttpDispatchError> for ModifyLoadBalancerAttributesError {
     fn from(err: HttpDispatchError) -> ModifyLoadBalancerAttributesError {
         ModifyLoadBalancerAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyLoadBalancerAttributesError {
+    fn from(err: io::Error) -> ModifyLoadBalancerAttributesError {
+        ModifyLoadBalancerAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyLoadBalancerAttributesError {
@@ -7459,6 +7571,11 @@ impl From<HttpDispatchError> for ModifyRuleError {
         ModifyRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyRuleError {
+    fn from(err: io::Error) -> ModifyRuleError {
+        ModifyRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7530,6 +7647,11 @@ impl From<HttpDispatchError> for ModifyTargetGroupError {
         ModifyTargetGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyTargetGroupError {
+    fn from(err: io::Error) -> ModifyTargetGroupError {
+        ModifyTargetGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyTargetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7596,6 +7718,11 @@ impl From<CredentialsError> for ModifyTargetGroupAttributesError {
 impl From<HttpDispatchError> for ModifyTargetGroupAttributesError {
     fn from(err: HttpDispatchError) -> ModifyTargetGroupAttributesError {
         ModifyTargetGroupAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyTargetGroupAttributesError {
+    fn from(err: io::Error) -> ModifyTargetGroupAttributesError {
+        ModifyTargetGroupAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyTargetGroupAttributesError {
@@ -7677,6 +7804,11 @@ impl From<CredentialsError> for RegisterTargetsError {
 impl From<HttpDispatchError> for RegisterTargetsError {
     fn from(err: HttpDispatchError) -> RegisterTargetsError {
         RegisterTargetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterTargetsError {
+    fn from(err: io::Error) -> RegisterTargetsError {
+        RegisterTargetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterTargetsError {
@@ -7770,6 +7902,11 @@ impl From<HttpDispatchError> for RemoveTagsError {
         RemoveTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTagsError {
+    fn from(err: io::Error) -> RemoveTagsError {
+        RemoveTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7846,6 +7983,11 @@ impl From<CredentialsError> for SetIpAddressTypeError {
 impl From<HttpDispatchError> for SetIpAddressTypeError {
     fn from(err: HttpDispatchError) -> SetIpAddressTypeError {
         SetIpAddressTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetIpAddressTypeError {
+    fn from(err: io::Error) -> SetIpAddressTypeError {
+        SetIpAddressTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetIpAddressTypeError {
@@ -7926,6 +8068,11 @@ impl From<HttpDispatchError> for SetRulePrioritiesError {
         SetRulePrioritiesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetRulePrioritiesError {
+    fn from(err: io::Error) -> SetRulePrioritiesError {
+        SetRulePrioritiesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetRulePrioritiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8000,6 +8147,11 @@ impl From<CredentialsError> for SetSecurityGroupsError {
 impl From<HttpDispatchError> for SetSecurityGroupsError {
     fn from(err: HttpDispatchError) -> SetSecurityGroupsError {
         SetSecurityGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetSecurityGroupsError {
+    fn from(err: io::Error) -> SetSecurityGroupsError {
+        SetSecurityGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetSecurityGroupsError {
@@ -8085,6 +8237,11 @@ impl From<CredentialsError> for SetSubnetsError {
 impl From<HttpDispatchError> for SetSubnetsError {
     fn from(err: HttpDispatchError) -> SetSubnetsError {
         SetSubnetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetSubnetsError {
+    fn from(err: io::Error) -> SetSubnetsError {
+        SetSubnetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetSubnetsError {
@@ -8325,16 +8482,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AddTagsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8348,7 +8507,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(AddTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8366,16 +8529,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateListenerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8390,8 +8555,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateListenerError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateListenerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8410,16 +8576,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateLoadBalancerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8434,8 +8602,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateLoadBalancerError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8452,16 +8621,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateRuleOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8475,7 +8646,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8493,16 +8668,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateTargetGroupOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8517,8 +8694,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateTargetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTargetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8537,16 +8715,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteListenerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8561,8 +8741,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteListenerError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteListenerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8581,16 +8762,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteLoadBalancerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8605,8 +8788,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteLoadBalancerError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLoadBalancerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8623,16 +8807,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteRuleOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8646,7 +8832,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(DeleteRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8664,16 +8854,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteTargetGroupOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8688,8 +8880,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteTargetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTargetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8708,16 +8901,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeregisterTargetsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8732,8 +8927,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeregisterTargetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterTargetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8753,16 +8949,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeAccountLimitsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8777,8 +8975,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeAccountLimitsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountLimitsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8797,16 +8996,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeListenersOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8821,8 +9022,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeListenersError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeListenersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8842,16 +9044,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLoadBalancerAttributesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8865,8 +9069,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeLoadBalancerAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBalancerAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -8885,16 +9092,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeLoadBalancersOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8909,8 +9118,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeLoadBalancersError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBalancersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8929,16 +9139,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeRulesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8953,7 +9165,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeRulesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRulesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8972,16 +9186,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeSSLPoliciesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -8996,8 +9212,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeSSLPoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSSLPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9016,16 +9233,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeTagsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9040,7 +9259,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9060,16 +9281,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeTargetGroupAttributesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9083,8 +9306,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeTargetGroupAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTargetGroupAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -9102,16 +9328,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeTargetGroupsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9126,8 +9354,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeTargetGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTargetGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9146,16 +9375,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeTargetHealthOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9170,8 +9401,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeTargetHealthError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTargetHealthError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9190,16 +9422,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyListenerOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9214,8 +9448,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ModifyListenerError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyListenerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9235,16 +9470,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyLoadBalancerAttributesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9258,8 +9495,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ModifyLoadBalancerAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyLoadBalancerAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -9275,16 +9515,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyRuleOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9298,7 +9540,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ModifyRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9316,16 +9562,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyTargetGroupOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9340,8 +9588,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ModifyTargetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyTargetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9361,16 +9610,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyTargetGroupAttributesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9384,8 +9635,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ModifyTargetGroupAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyTargetGroupAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -9403,16 +9657,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RegisterTargetsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9427,8 +9683,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RegisterTargetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterTargetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9445,16 +9702,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RemoveTagsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9468,7 +9727,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(RemoveTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9486,16 +9749,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetIpAddressTypeOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9510,8 +9775,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetIpAddressTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetIpAddressTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9530,16 +9796,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetRulePrioritiesOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9554,8 +9822,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetRulePrioritiesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetRulePrioritiesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9574,16 +9843,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetSecurityGroupsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9598,8 +9869,9 @@ impl<P, D> Elb for ElbClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetSecurityGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetSecurityGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9616,16 +9888,18 @@ impl<P, D> Elb for ElbClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetSubnetsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -9639,7 +9913,11 @@ impl<P, D> Elb for ElbClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(SetSubnetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetSubnetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2314,6 +2316,11 @@ impl From<HttpDispatchError> for AddInstanceFleetError {
         AddInstanceFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddInstanceFleetError {
+    fn from(err: io::Error) -> AddInstanceFleetError {
+        AddInstanceFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddInstanceFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2387,6 +2394,11 @@ impl From<CredentialsError> for AddInstanceGroupsError {
 impl From<HttpDispatchError> for AddInstanceGroupsError {
     fn from(err: HttpDispatchError) -> AddInstanceGroupsError {
         AddInstanceGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddInstanceGroupsError {
+    fn from(err: io::Error) -> AddInstanceGroupsError {
+        AddInstanceGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddInstanceGroupsError {
@@ -2465,6 +2477,11 @@ impl From<HttpDispatchError> for AddJobFlowStepsError {
         AddJobFlowStepsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddJobFlowStepsError {
+    fn from(err: io::Error) -> AddJobFlowStepsError {
+        AddJobFlowStepsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddJobFlowStepsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2540,6 +2557,11 @@ impl From<CredentialsError> for AddTagsError {
 impl From<HttpDispatchError> for AddTagsError {
     fn from(err: HttpDispatchError) -> AddTagsError {
         AddTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddTagsError {
+    fn from(err: io::Error) -> AddTagsError {
+        AddTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddTagsError {
@@ -2622,6 +2644,11 @@ impl From<HttpDispatchError> for CancelStepsError {
         CancelStepsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelStepsError {
+    fn from(err: io::Error) -> CancelStepsError {
+        CancelStepsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelStepsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2696,6 +2723,11 @@ impl From<CredentialsError> for CreateSecurityConfigurationError {
 impl From<HttpDispatchError> for CreateSecurityConfigurationError {
     fn from(err: HttpDispatchError) -> CreateSecurityConfigurationError {
         CreateSecurityConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateSecurityConfigurationError {
+    fn from(err: io::Error) -> CreateSecurityConfigurationError {
+        CreateSecurityConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateSecurityConfigurationError {
@@ -2774,6 +2806,11 @@ impl From<CredentialsError> for DeleteSecurityConfigurationError {
 impl From<HttpDispatchError> for DeleteSecurityConfigurationError {
     fn from(err: HttpDispatchError) -> DeleteSecurityConfigurationError {
         DeleteSecurityConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSecurityConfigurationError {
+    fn from(err: io::Error) -> DeleteSecurityConfigurationError {
+        DeleteSecurityConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSecurityConfigurationError {
@@ -2858,6 +2895,11 @@ impl From<HttpDispatchError> for DescribeClusterError {
         DescribeClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeClusterError {
+    fn from(err: io::Error) -> DescribeClusterError {
+        DescribeClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2933,6 +2975,11 @@ impl From<HttpDispatchError> for DescribeJobFlowsError {
         DescribeJobFlowsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeJobFlowsError {
+    fn from(err: io::Error) -> DescribeJobFlowsError {
+        DescribeJobFlowsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeJobFlowsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3006,6 +3053,11 @@ impl From<CredentialsError> for DescribeSecurityConfigurationError {
 impl From<HttpDispatchError> for DescribeSecurityConfigurationError {
     fn from(err: HttpDispatchError) -> DescribeSecurityConfigurationError {
         DescribeSecurityConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSecurityConfigurationError {
+    fn from(err: io::Error) -> DescribeSecurityConfigurationError {
+        DescribeSecurityConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSecurityConfigurationError {
@@ -3090,6 +3142,11 @@ impl From<HttpDispatchError> for DescribeStepError {
         DescribeStepError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeStepError {
+    fn from(err: io::Error) -> DescribeStepError {
+        DescribeStepError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeStepError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3168,6 +3225,11 @@ impl From<CredentialsError> for ListBootstrapActionsError {
 impl From<HttpDispatchError> for ListBootstrapActionsError {
     fn from(err: HttpDispatchError) -> ListBootstrapActionsError {
         ListBootstrapActionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListBootstrapActionsError {
+    fn from(err: io::Error) -> ListBootstrapActionsError {
+        ListBootstrapActionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListBootstrapActionsError {
@@ -3252,6 +3314,11 @@ impl From<HttpDispatchError> for ListClustersError {
         ListClustersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListClustersError {
+    fn from(err: io::Error) -> ListClustersError {
+        ListClustersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3330,6 +3397,11 @@ impl From<CredentialsError> for ListInstanceFleetsError {
 impl From<HttpDispatchError> for ListInstanceFleetsError {
     fn from(err: HttpDispatchError) -> ListInstanceFleetsError {
         ListInstanceFleetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListInstanceFleetsError {
+    fn from(err: io::Error) -> ListInstanceFleetsError {
+        ListInstanceFleetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListInstanceFleetsError {
@@ -3414,6 +3486,11 @@ impl From<HttpDispatchError> for ListInstanceGroupsError {
         ListInstanceGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListInstanceGroupsError {
+    fn from(err: io::Error) -> ListInstanceGroupsError {
+        ListInstanceGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListInstanceGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3496,6 +3573,11 @@ impl From<HttpDispatchError> for ListInstancesError {
         ListInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListInstancesError {
+    fn from(err: io::Error) -> ListInstancesError {
+        ListInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3574,6 +3656,11 @@ impl From<CredentialsError> for ListSecurityConfigurationsError {
 impl From<HttpDispatchError> for ListSecurityConfigurationsError {
     fn from(err: HttpDispatchError) -> ListSecurityConfigurationsError {
         ListSecurityConfigurationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListSecurityConfigurationsError {
+    fn from(err: io::Error) -> ListSecurityConfigurationsError {
+        ListSecurityConfigurationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListSecurityConfigurationsError {
@@ -3656,6 +3743,11 @@ impl From<HttpDispatchError> for ListStepsError {
         ListStepsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListStepsError {
+    fn from(err: io::Error) -> ListStepsError {
+        ListStepsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListStepsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3736,6 +3828,11 @@ impl From<HttpDispatchError> for ModifyInstanceFleetError {
         ModifyInstanceFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyInstanceFleetError {
+    fn from(err: io::Error) -> ModifyInstanceFleetError {
+        ModifyInstanceFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyInstanceFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3813,6 +3910,11 @@ impl From<HttpDispatchError> for ModifyInstanceGroupsError {
         ModifyInstanceGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyInstanceGroupsError {
+    fn from(err: io::Error) -> ModifyInstanceGroupsError {
+        ModifyInstanceGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyInstanceGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3884,6 +3986,11 @@ impl From<HttpDispatchError> for PutAutoScalingPolicyError {
         PutAutoScalingPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutAutoScalingPolicyError {
+    fn from(err: io::Error) -> PutAutoScalingPolicyError {
+        PutAutoScalingPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutAutoScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3952,6 +4059,11 @@ impl From<CredentialsError> for RemoveAutoScalingPolicyError {
 impl From<HttpDispatchError> for RemoveAutoScalingPolicyError {
     fn from(err: HttpDispatchError) -> RemoveAutoScalingPolicyError {
         RemoveAutoScalingPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveAutoScalingPolicyError {
+    fn from(err: io::Error) -> RemoveAutoScalingPolicyError {
+        RemoveAutoScalingPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveAutoScalingPolicyError {
@@ -4032,6 +4144,11 @@ impl From<HttpDispatchError> for RemoveTagsError {
         RemoveTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTagsError {
+    fn from(err: io::Error) -> RemoveTagsError {
+        RemoveTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4105,6 +4222,11 @@ impl From<HttpDispatchError> for RunJobFlowError {
         RunJobFlowError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RunJobFlowError {
+    fn from(err: io::Error) -> RunJobFlowError {
+        RunJobFlowError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RunJobFlowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4175,6 +4297,11 @@ impl From<CredentialsError> for SetTerminationProtectionError {
 impl From<HttpDispatchError> for SetTerminationProtectionError {
     fn from(err: HttpDispatchError) -> SetTerminationProtectionError {
         SetTerminationProtectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetTerminationProtectionError {
+    fn from(err: io::Error) -> SetTerminationProtectionError {
+        SetTerminationProtectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetTerminationProtectionError {
@@ -4253,6 +4380,11 @@ impl From<HttpDispatchError> for SetVisibleToAllUsersError {
         SetVisibleToAllUsersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetVisibleToAllUsersError {
+    fn from(err: io::Error) -> SetVisibleToAllUsersError {
+        SetVisibleToAllUsersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetVisibleToAllUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4327,6 +4459,11 @@ impl From<CredentialsError> for TerminateJobFlowsError {
 impl From<HttpDispatchError> for TerminateJobFlowsError {
     fn from(err: HttpDispatchError) -> TerminateJobFlowsError {
         TerminateJobFlowsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TerminateJobFlowsError {
+    fn from(err: io::Error) -> TerminateJobFlowsError {
+        TerminateJobFlowsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TerminateJobFlowsError {
@@ -4547,15 +4684,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddInstanceFleetOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddInstanceFleetOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AddInstanceFleetError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddInstanceFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4574,15 +4716,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddInstanceGroupsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddInstanceGroupsOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AddInstanceGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddInstanceGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4601,15 +4748,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddJobFlowStepsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddJobFlowStepsOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AddJobFlowStepsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddJobFlowStepsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4626,15 +4778,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AddTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4652,13 +4809,21 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CancelStepsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CancelStepsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelStepsOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelStepsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4678,13 +4843,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateSecurityConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateSecurityConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateSecurityConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSecurityConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -4704,13 +4876,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteSecurityConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteSecurityConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteSecurityConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSecurityConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -4728,15 +4907,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeClusterOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeClusterOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4755,15 +4939,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeJobFlowsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeJobFlowsOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeJobFlowsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeJobFlowsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4784,13 +4973,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeSecurityConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeSecurityConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeSecurityConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSecurityConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -4808,14 +5004,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeStepOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeStepOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeStepError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStepError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4834,15 +5036,18 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListBootstrapActionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListBootstrapActionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListBootstrapActionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListBootstrapActionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4861,14 +5066,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListClustersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListClustersOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListClustersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListClustersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4887,15 +5098,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListInstanceFleetsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListInstanceFleetsOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListInstanceFleetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListInstanceFleetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4914,15 +5130,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListInstanceGroupsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListInstanceGroupsOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListInstanceGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListInstanceGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4941,14 +5162,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListInstancesOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4969,13 +5196,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListSecurityConfigurationsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListSecurityConfigurationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListSecurityConfigurationsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSecurityConfigurationsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -4991,15 +5225,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListStepsOutput>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListStepsOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ListStepsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListStepsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5017,13 +5256,14 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(ModifyInstanceFleetError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyInstanceFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5042,13 +5282,14 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(ModifyInstanceGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyInstanceGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5067,15 +5308,18 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutAutoScalingPolicyOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutAutoScalingPolicyOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(PutAutoScalingPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutAutoScalingPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5095,13 +5339,20 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveAutoScalingPolicyOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RemoveAutoScalingPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveAutoScalingPolicyOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveAutoScalingPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -5117,13 +5368,21 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTagsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RemoveTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTagsOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5139,13 +5398,21 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RunJobFlowOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RunJobFlowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RunJobFlowOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RunJobFlowError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5163,11 +5430,16 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(SetTerminationProtectionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetTerminationProtectionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -5185,13 +5457,14 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(SetVisibleToAllUsersError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetVisibleToAllUsersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5210,13 +5483,14 @@ impl<P, D> Emr for EmrClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(TerminateJobFlowsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TerminateJobFlowsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -542,6 +544,11 @@ impl From<HttpDispatchError> for DeleteRuleError {
         DeleteRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRuleError {
+    fn from(err: io::Error) -> DeleteRuleError {
+        DeleteRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -618,6 +625,11 @@ impl From<CredentialsError> for DescribeRuleError {
 impl From<HttpDispatchError> for DescribeRuleError {
     fn from(err: HttpDispatchError) -> DescribeRuleError {
         DescribeRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeRuleError {
+    fn from(err: io::Error) -> DescribeRuleError {
+        DescribeRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeRuleError {
@@ -703,6 +715,11 @@ impl From<HttpDispatchError> for DisableRuleError {
         DisableRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisableRuleError {
+    fn from(err: io::Error) -> DisableRuleError {
+        DisableRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisableRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -785,6 +802,11 @@ impl From<HttpDispatchError> for EnableRuleError {
         EnableRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableRuleError {
+    fn from(err: io::Error) -> EnableRuleError {
+        EnableRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -861,6 +883,11 @@ impl From<HttpDispatchError> for ListRuleNamesByTargetError {
         ListRuleNamesByTargetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListRuleNamesByTargetError {
+    fn from(err: io::Error) -> ListRuleNamesByTargetError {
+        ListRuleNamesByTargetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListRuleNamesByTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -931,6 +958,11 @@ impl From<CredentialsError> for ListRulesError {
 impl From<HttpDispatchError> for ListRulesError {
     fn from(err: HttpDispatchError) -> ListRulesError {
         ListRulesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRulesError {
+    fn from(err: io::Error) -> ListRulesError {
+        ListRulesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRulesError {
@@ -1012,6 +1044,11 @@ impl From<HttpDispatchError> for ListTargetsByRuleError {
         ListTargetsByRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTargetsByRuleError {
+    fn from(err: io::Error) -> ListTargetsByRuleError {
+        ListTargetsByRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTargetsByRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1083,6 +1120,11 @@ impl From<CredentialsError> for PutEventsError {
 impl From<HttpDispatchError> for PutEventsError {
     fn from(err: HttpDispatchError) -> PutEventsError {
         PutEventsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutEventsError {
+    fn from(err: io::Error) -> PutEventsError {
+        PutEventsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutEventsError {
@@ -1168,6 +1210,11 @@ impl From<CredentialsError> for PutRuleError {
 impl From<HttpDispatchError> for PutRuleError {
     fn from(err: HttpDispatchError) -> PutRuleError {
         PutRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutRuleError {
+    fn from(err: io::Error) -> PutRuleError {
+        PutRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutRuleError {
@@ -1258,6 +1305,11 @@ impl From<HttpDispatchError> for PutTargetsError {
         PutTargetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutTargetsError {
+    fn from(err: io::Error) -> PutTargetsError {
+        PutTargetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1345,6 +1397,11 @@ impl From<HttpDispatchError> for RemoveTargetsError {
         RemoveTargetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTargetsError {
+    fn from(err: io::Error) -> RemoveTargetsError {
+        RemoveTargetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1424,6 +1481,11 @@ impl From<CredentialsError> for TestEventPatternError {
 impl From<HttpDispatchError> for TestEventPatternError {
     fn from(err: HttpDispatchError) -> TestEventPatternError {
         TestEventPatternError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TestEventPatternError {
+    fn from(err: io::Error) -> TestEventPatternError {
+        TestEventPatternError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TestEventPatternError {
@@ -1543,11 +1605,15 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1565,14 +1631,20 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeRuleResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1589,11 +1661,15 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DisableRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1609,11 +1685,15 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(EnableRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1632,15 +1712,18 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRuleNamesByTargetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRuleNamesByTargetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListRuleNamesByTargetError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRuleNamesByTargetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1657,13 +1740,21 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListRulesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRulesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1681,15 +1772,18 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTargetsByRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTargetsByRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTargetsByRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTargetsByRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1706,13 +1800,21 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(PutEventsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutEventsResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1728,15 +1830,20 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<PutRuleResponse>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutRuleResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(PutRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1754,13 +1861,21 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutTargetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(PutTargetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutTargetsResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutTargetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1778,14 +1893,20 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTargetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTargetsResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RemoveTargetsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTargetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1804,15 +1925,20 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TestEventPatternResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<TestEventPatternResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(TestEventPatternError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestEventPatternError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -949,6 +951,11 @@ impl From<HttpDispatchError> for CreateDeliveryStreamError {
         CreateDeliveryStreamError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDeliveryStreamError {
+    fn from(err: io::Error) -> CreateDeliveryStreamError {
+        CreateDeliveryStreamError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1032,6 +1039,11 @@ impl From<HttpDispatchError> for DeleteDeliveryStreamError {
         DeleteDeliveryStreamError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDeliveryStreamError {
+    fn from(err: io::Error) -> DeleteDeliveryStreamError {
+        DeleteDeliveryStreamError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1109,6 +1121,11 @@ impl From<HttpDispatchError> for DescribeDeliveryStreamError {
         DescribeDeliveryStreamError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDeliveryStreamError {
+    fn from(err: io::Error) -> DescribeDeliveryStreamError {
+        DescribeDeliveryStreamError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1178,6 +1195,11 @@ impl From<CredentialsError> for ListDeliveryStreamsError {
 impl From<HttpDispatchError> for ListDeliveryStreamsError {
     fn from(err: HttpDispatchError) -> ListDeliveryStreamsError {
         ListDeliveryStreamsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListDeliveryStreamsError {
+    fn from(err: io::Error) -> ListDeliveryStreamsError {
+        ListDeliveryStreamsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListDeliveryStreamsError {
@@ -1261,6 +1283,11 @@ impl From<CredentialsError> for PutRecordError {
 impl From<HttpDispatchError> for PutRecordError {
     fn from(err: HttpDispatchError) -> PutRecordError {
         PutRecordError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutRecordError {
+    fn from(err: io::Error) -> PutRecordError {
+        PutRecordError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutRecordError {
@@ -1347,6 +1374,11 @@ impl From<CredentialsError> for PutRecordBatchError {
 impl From<HttpDispatchError> for PutRecordBatchError {
     fn from(err: HttpDispatchError) -> PutRecordBatchError {
         PutRecordBatchError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutRecordBatchError {
+    fn from(err: io::Error) -> PutRecordBatchError {
+        PutRecordBatchError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutRecordBatchError {
@@ -1438,6 +1470,11 @@ impl From<CredentialsError> for UpdateDestinationError {
 impl From<HttpDispatchError> for UpdateDestinationError {
     fn from(err: HttpDispatchError) -> UpdateDestinationError {
         UpdateDestinationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateDestinationError {
+    fn from(err: io::Error) -> UpdateDestinationError {
+        UpdateDestinationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateDestinationError {
@@ -1543,15 +1580,18 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDeliveryStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDeliveryStreamOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateDeliveryStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDeliveryStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1570,15 +1610,18 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteDeliveryStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteDeliveryStreamOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteDeliveryStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDeliveryStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1598,15 +1641,18 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDeliveryStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDeliveryStreamOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeDeliveryStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDeliveryStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1625,15 +1671,18 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDeliveryStreamsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDeliveryStreamsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListDeliveryStreamsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDeliveryStreamsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1650,15 +1699,20 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<PutRecordOutput>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutRecordOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(PutRecordError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRecordError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1676,15 +1730,20 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutRecordBatchOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutRecordBatchOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutRecordBatchError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRecordBatchError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1703,15 +1762,20 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDestinationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDestinationOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateDestinationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDestinationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2129,6 +2131,11 @@ impl From<HttpDispatchError> for CreateAliasError {
         CreateAliasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateAliasError {
+    fn from(err: io::Error) -> CreateAliasError {
+        CreateAliasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2218,6 +2225,11 @@ impl From<CredentialsError> for CreateBuildError {
 impl From<HttpDispatchError> for CreateBuildError {
     fn from(err: HttpDispatchError) -> CreateBuildError {
         CreateBuildError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateBuildError {
+    fn from(err: io::Error) -> CreateBuildError {
+        CreateBuildError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateBuildError {
@@ -2316,6 +2328,11 @@ impl From<CredentialsError> for CreateFleetError {
 impl From<HttpDispatchError> for CreateFleetError {
     fn from(err: HttpDispatchError) -> CreateFleetError {
         CreateFleetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateFleetError {
+    fn from(err: io::Error) -> CreateFleetError {
+        CreateFleetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateFleetError {
@@ -2440,6 +2457,11 @@ impl From<HttpDispatchError> for CreateGameSessionError {
         CreateGameSessionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateGameSessionError {
+    fn from(err: io::Error) -> CreateGameSessionError {
+        CreateGameSessionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateGameSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2538,6 +2560,11 @@ impl From<CredentialsError> for CreateGameSessionQueueError {
 impl From<HttpDispatchError> for CreateGameSessionQueueError {
     fn from(err: HttpDispatchError) -> CreateGameSessionQueueError {
         CreateGameSessionQueueError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateGameSessionQueueError {
+    fn from(err: io::Error) -> CreateGameSessionQueueError {
+        CreateGameSessionQueueError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateGameSessionQueueError {
@@ -2643,6 +2670,11 @@ impl From<CredentialsError> for CreatePlayerSessionError {
 impl From<HttpDispatchError> for CreatePlayerSessionError {
     fn from(err: HttpDispatchError) -> CreatePlayerSessionError {
         CreatePlayerSessionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePlayerSessionError {
+    fn from(err: io::Error) -> CreatePlayerSessionError {
+        CreatePlayerSessionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePlayerSessionError {
@@ -2753,6 +2785,11 @@ impl From<HttpDispatchError> for CreatePlayerSessionsError {
         CreatePlayerSessionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreatePlayerSessionsError {
+    fn from(err: io::Error) -> CreatePlayerSessionsError {
+        CreatePlayerSessionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreatePlayerSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2848,6 +2885,11 @@ impl From<HttpDispatchError> for DeleteAliasError {
         DeleteAliasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAliasError {
+    fn from(err: io::Error) -> DeleteAliasError {
+        DeleteAliasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2936,6 +2978,11 @@ impl From<CredentialsError> for DeleteBuildError {
 impl From<HttpDispatchError> for DeleteBuildError {
     fn from(err: HttpDispatchError) -> DeleteBuildError {
         DeleteBuildError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBuildError {
+    fn from(err: io::Error) -> DeleteBuildError {
+        DeleteBuildError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBuildError {
@@ -3033,6 +3080,11 @@ impl From<HttpDispatchError> for DeleteFleetError {
         DeleteFleetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteFleetError {
+    fn from(err: io::Error) -> DeleteFleetError {
+        DeleteFleetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3124,6 +3176,11 @@ impl From<CredentialsError> for DeleteGameSessionQueueError {
 impl From<HttpDispatchError> for DeleteGameSessionQueueError {
     fn from(err: HttpDispatchError) -> DeleteGameSessionQueueError {
         DeleteGameSessionQueueError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteGameSessionQueueError {
+    fn from(err: io::Error) -> DeleteGameSessionQueueError {
+        DeleteGameSessionQueueError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteGameSessionQueueError {
@@ -3220,6 +3277,11 @@ impl From<HttpDispatchError> for DeleteScalingPolicyError {
         DeleteScalingPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteScalingPolicyError {
+    fn from(err: io::Error) -> DeleteScalingPolicyError {
+        DeleteScalingPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3314,6 +3376,11 @@ impl From<HttpDispatchError> for DescribeAliasError {
         DescribeAliasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAliasError {
+    fn from(err: io::Error) -> DescribeAliasError {
+        DescribeAliasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3406,6 +3473,11 @@ impl From<HttpDispatchError> for DescribeBuildError {
         DescribeBuildError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeBuildError {
+    fn from(err: io::Error) -> DescribeBuildError {
+        DescribeBuildError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3491,6 +3563,11 @@ impl From<CredentialsError> for DescribeEC2InstanceLimitsError {
 impl From<HttpDispatchError> for DescribeEC2InstanceLimitsError {
     fn from(err: HttpDispatchError) -> DescribeEC2InstanceLimitsError {
         DescribeEC2InstanceLimitsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEC2InstanceLimitsError {
+    fn from(err: io::Error) -> DescribeEC2InstanceLimitsError {
+        DescribeEC2InstanceLimitsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEC2InstanceLimitsError {
@@ -3584,6 +3661,11 @@ impl From<CredentialsError> for DescribeFleetAttributesError {
 impl From<HttpDispatchError> for DescribeFleetAttributesError {
     fn from(err: HttpDispatchError) -> DescribeFleetAttributesError {
         DescribeFleetAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeFleetAttributesError {
+    fn from(err: io::Error) -> DescribeFleetAttributesError {
+        DescribeFleetAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeFleetAttributesError {
@@ -3680,6 +3762,11 @@ impl From<HttpDispatchError> for DescribeFleetCapacityError {
         DescribeFleetCapacityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeFleetCapacityError {
+    fn from(err: io::Error) -> DescribeFleetCapacityError {
+        DescribeFleetCapacityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeFleetCapacityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3772,6 +3859,11 @@ impl From<CredentialsError> for DescribeFleetEventsError {
 impl From<HttpDispatchError> for DescribeFleetEventsError {
     fn from(err: HttpDispatchError) -> DescribeFleetEventsError {
         DescribeFleetEventsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeFleetEventsError {
+    fn from(err: io::Error) -> DescribeFleetEventsError {
+        DescribeFleetEventsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeFleetEventsError {
@@ -3868,6 +3960,11 @@ impl From<HttpDispatchError> for DescribeFleetPortSettingsError {
         DescribeFleetPortSettingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeFleetPortSettingsError {
+    fn from(err: io::Error) -> DescribeFleetPortSettingsError {
+        DescribeFleetPortSettingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeFleetPortSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3960,6 +4057,11 @@ impl From<CredentialsError> for DescribeFleetUtilizationError {
 impl From<HttpDispatchError> for DescribeFleetUtilizationError {
     fn from(err: HttpDispatchError) -> DescribeFleetUtilizationError {
         DescribeFleetUtilizationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeFleetUtilizationError {
+    fn from(err: io::Error) -> DescribeFleetUtilizationError {
+        DescribeFleetUtilizationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeFleetUtilizationError {
@@ -4057,6 +4159,11 @@ impl From<HttpDispatchError> for DescribeGameSessionDetailsError {
         DescribeGameSessionDetailsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeGameSessionDetailsError {
+    fn from(err: io::Error) -> DescribeGameSessionDetailsError {
+        DescribeGameSessionDetailsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeGameSessionDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4146,6 +4253,11 @@ impl From<CredentialsError> for DescribeGameSessionPlacementError {
 impl From<HttpDispatchError> for DescribeGameSessionPlacementError {
     fn from(err: HttpDispatchError) -> DescribeGameSessionPlacementError {
         DescribeGameSessionPlacementError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeGameSessionPlacementError {
+    fn from(err: io::Error) -> DescribeGameSessionPlacementError {
+        DescribeGameSessionPlacementError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeGameSessionPlacementError {
@@ -4240,6 +4352,11 @@ impl From<CredentialsError> for DescribeGameSessionQueuesError {
 impl From<HttpDispatchError> for DescribeGameSessionQueuesError {
     fn from(err: HttpDispatchError) -> DescribeGameSessionQueuesError {
         DescribeGameSessionQueuesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeGameSessionQueuesError {
+    fn from(err: io::Error) -> DescribeGameSessionQueuesError {
+        DescribeGameSessionQueuesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeGameSessionQueuesError {
@@ -4339,6 +4456,11 @@ impl From<HttpDispatchError> for DescribeGameSessionsError {
         DescribeGameSessionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeGameSessionsError {
+    fn from(err: io::Error) -> DescribeGameSessionsError {
+        DescribeGameSessionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeGameSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4432,6 +4554,11 @@ impl From<CredentialsError> for DescribeInstancesError {
 impl From<HttpDispatchError> for DescribeInstancesError {
     fn from(err: HttpDispatchError) -> DescribeInstancesError {
         DescribeInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeInstancesError {
+    fn from(err: io::Error) -> DescribeInstancesError {
+        DescribeInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeInstancesError {
@@ -4528,6 +4655,11 @@ impl From<HttpDispatchError> for DescribePlayerSessionsError {
         DescribePlayerSessionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribePlayerSessionsError {
+    fn from(err: io::Error) -> DescribePlayerSessionsError {
+        DescribePlayerSessionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribePlayerSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4616,6 +4748,11 @@ impl From<CredentialsError> for DescribeRuntimeConfigurationError {
 impl From<HttpDispatchError> for DescribeRuntimeConfigurationError {
     fn from(err: HttpDispatchError) -> DescribeRuntimeConfigurationError {
         DescribeRuntimeConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeRuntimeConfigurationError {
+    fn from(err: io::Error) -> DescribeRuntimeConfigurationError {
+        DescribeRuntimeConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeRuntimeConfigurationError {
@@ -4712,6 +4849,11 @@ impl From<HttpDispatchError> for DescribeScalingPoliciesError {
         DescribeScalingPoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeScalingPoliciesError {
+    fn from(err: io::Error) -> DescribeScalingPoliciesError {
+        DescribeScalingPoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeScalingPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4804,6 +4946,11 @@ impl From<CredentialsError> for GetGameSessionLogUrlError {
 impl From<HttpDispatchError> for GetGameSessionLogUrlError {
     fn from(err: HttpDispatchError) -> GetGameSessionLogUrlError {
         GetGameSessionLogUrlError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetGameSessionLogUrlError {
+    fn from(err: io::Error) -> GetGameSessionLogUrlError {
+        GetGameSessionLogUrlError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetGameSessionLogUrlError {
@@ -4900,6 +5047,11 @@ impl From<HttpDispatchError> for GetInstanceAccessError {
         GetInstanceAccessError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInstanceAccessError {
+    fn from(err: io::Error) -> GetInstanceAccessError {
+        GetInstanceAccessError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInstanceAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4989,6 +5141,11 @@ impl From<HttpDispatchError> for ListAliasesError {
         ListAliasesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListAliasesError {
+    fn from(err: io::Error) -> ListAliasesError {
+        ListAliasesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListAliasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5071,6 +5228,11 @@ impl From<CredentialsError> for ListBuildsError {
 impl From<HttpDispatchError> for ListBuildsError {
     fn from(err: HttpDispatchError) -> ListBuildsError {
         ListBuildsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListBuildsError {
+    fn from(err: io::Error) -> ListBuildsError {
+        ListBuildsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListBuildsError {
@@ -5158,6 +5320,11 @@ impl From<CredentialsError> for ListFleetsError {
 impl From<HttpDispatchError> for ListFleetsError {
     fn from(err: HttpDispatchError) -> ListFleetsError {
         ListFleetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListFleetsError {
+    fn from(err: io::Error) -> ListFleetsError {
+        ListFleetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListFleetsError {
@@ -5252,6 +5419,11 @@ impl From<HttpDispatchError> for PutScalingPolicyError {
         PutScalingPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutScalingPolicyError {
+    fn from(err: io::Error) -> PutScalingPolicyError {
+        PutScalingPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5342,6 +5514,11 @@ impl From<CredentialsError> for RequestUploadCredentialsError {
 impl From<HttpDispatchError> for RequestUploadCredentialsError {
     fn from(err: HttpDispatchError) -> RequestUploadCredentialsError {
         RequestUploadCredentialsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RequestUploadCredentialsError {
+    fn from(err: io::Error) -> RequestUploadCredentialsError {
+        RequestUploadCredentialsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RequestUploadCredentialsError {
@@ -5441,6 +5618,11 @@ impl From<HttpDispatchError> for ResolveAliasError {
         ResolveAliasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ResolveAliasError {
+    fn from(err: io::Error) -> ResolveAliasError {
+        ResolveAliasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ResolveAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5535,6 +5717,11 @@ impl From<CredentialsError> for SearchGameSessionsError {
 impl From<HttpDispatchError> for SearchGameSessionsError {
     fn from(err: HttpDispatchError) -> SearchGameSessionsError {
         SearchGameSessionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SearchGameSessionsError {
+    fn from(err: io::Error) -> SearchGameSessionsError {
+        SearchGameSessionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SearchGameSessionsError {
@@ -5632,6 +5819,11 @@ impl From<HttpDispatchError> for StartGameSessionPlacementError {
         StartGameSessionPlacementError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartGameSessionPlacementError {
+    fn from(err: io::Error) -> StartGameSessionPlacementError {
+        StartGameSessionPlacementError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartGameSessionPlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5726,6 +5918,11 @@ impl From<HttpDispatchError> for StopGameSessionPlacementError {
         StopGameSessionPlacementError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StopGameSessionPlacementError {
+    fn from(err: io::Error) -> StopGameSessionPlacementError {
+        StopGameSessionPlacementError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StopGameSessionPlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5818,6 +6015,11 @@ impl From<HttpDispatchError> for UpdateAliasError {
         UpdateAliasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateAliasError {
+    fn from(err: io::Error) -> UpdateAliasError {
+        UpdateAliasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5906,6 +6108,11 @@ impl From<CredentialsError> for UpdateBuildError {
 impl From<HttpDispatchError> for UpdateBuildError {
     fn from(err: HttpDispatchError) -> UpdateBuildError {
         UpdateBuildError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateBuildError {
+    fn from(err: io::Error) -> UpdateBuildError {
+        UpdateBuildError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateBuildError {
@@ -6013,6 +6220,11 @@ impl From<CredentialsError> for UpdateFleetAttributesError {
 impl From<HttpDispatchError> for UpdateFleetAttributesError {
     fn from(err: HttpDispatchError) -> UpdateFleetAttributesError {
         UpdateFleetAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateFleetAttributesError {
+    fn from(err: io::Error) -> UpdateFleetAttributesError {
+        UpdateFleetAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateFleetAttributesError {
@@ -6127,6 +6339,11 @@ impl From<HttpDispatchError> for UpdateFleetCapacityError {
         UpdateFleetCapacityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateFleetCapacityError {
+    fn from(err: io::Error) -> UpdateFleetCapacityError {
+        UpdateFleetCapacityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateFleetCapacityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6237,6 +6454,11 @@ impl From<HttpDispatchError> for UpdateFleetPortSettingsError {
         UpdateFleetPortSettingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateFleetPortSettingsError {
+    fn from(err: io::Error) -> UpdateFleetPortSettingsError {
+        UpdateFleetPortSettingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateFleetPortSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6342,6 +6564,11 @@ impl From<HttpDispatchError> for UpdateGameSessionError {
         UpdateGameSessionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateGameSessionError {
+    fn from(err: io::Error) -> UpdateGameSessionError {
+        UpdateGameSessionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateGameSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6438,6 +6665,11 @@ impl From<HttpDispatchError> for UpdateGameSessionQueueError {
         UpdateGameSessionQueueError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateGameSessionQueueError {
+    fn from(err: io::Error) -> UpdateGameSessionQueueError {
+        UpdateGameSessionQueueError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateGameSessionQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6531,6 +6763,11 @@ impl From<CredentialsError> for UpdateRuntimeConfigurationError {
 impl From<HttpDispatchError> for UpdateRuntimeConfigurationError {
     fn from(err: HttpDispatchError) -> UpdateRuntimeConfigurationError {
         UpdateRuntimeConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateRuntimeConfigurationError {
+    fn from(err: io::Error) -> UpdateRuntimeConfigurationError {
+        UpdateRuntimeConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateRuntimeConfigurationError {
@@ -6889,13 +7126,21 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAliasOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAliasOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6913,13 +7158,21 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateBuildOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateBuildError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateBuildOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateBuildError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6937,13 +7190,21 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateFleetOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateFleetOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6961,15 +7222,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateGameSessionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateGameSessionOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateGameSessionError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateGameSessionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6989,15 +7255,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateGameSessionQueueOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateGameSessionQueueOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateGameSessionQueueError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateGameSessionQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7016,15 +7285,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePlayerSessionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreatePlayerSessionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreatePlayerSessionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePlayerSessionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7043,15 +7315,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePlayerSessionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreatePlayerSessionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreatePlayerSessionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePlayerSessionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7068,11 +7343,15 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7088,11 +7367,15 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteBuildError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBuildError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7108,11 +7391,15 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteFleetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7131,15 +7418,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteGameSessionQueueOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteGameSessionQueueOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteGameSessionQueueError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteGameSessionQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7158,13 +7448,14 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteScalingPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteScalingPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7183,14 +7474,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAliasOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAliasOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7209,14 +7506,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeBuildOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeBuildOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeBuildError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeBuildError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7236,13 +7539,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEC2InstanceLimitsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeEC2InstanceLimitsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEC2InstanceLimitsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEC2InstanceLimitsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -7261,13 +7571,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeFleetAttributesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeFleetAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeFleetAttributesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFleetAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -7286,15 +7603,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeFleetCapacityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeFleetCapacityOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeFleetCapacityError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFleetCapacityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7313,15 +7633,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeFleetEventsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeFleetEventsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeFleetEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFleetEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7341,13 +7664,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeFleetPortSettingsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeFleetPortSettingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeFleetPortSettingsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFleetPortSettingsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -7366,13 +7696,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeFleetUtilizationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeFleetUtilizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeFleetUtilizationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFleetUtilizationError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7391,13 +7728,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeGameSessionDetailsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeGameSessionDetailsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeGameSessionDetailsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeGameSessionDetailsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -7416,13 +7760,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeGameSessionPlacementOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeGameSessionPlacementError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeGameSessionPlacementOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeGameSessionPlacementError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -7441,13 +7792,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeGameSessionQueuesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeGameSessionQueuesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeGameSessionQueuesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeGameSessionQueuesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -7465,15 +7823,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeGameSessionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeGameSessionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeGameSessionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeGameSessionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7492,15 +7853,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeInstancesOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7520,15 +7886,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribePlayerSessionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribePlayerSessionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribePlayerSessionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePlayerSessionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7548,13 +7917,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeRuntimeConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeRuntimeConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeRuntimeConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRuntimeConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -7573,13 +7949,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeScalingPoliciesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeScalingPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeScalingPoliciesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeScalingPoliciesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -7598,15 +7981,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetGameSessionLogUrlOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetGameSessionLogUrlOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetGameSessionLogUrlError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetGameSessionLogUrlError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7625,15 +8011,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstanceAccessOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstanceAccessOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetInstanceAccessError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstanceAccessError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7652,13 +8043,21 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAliasesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListAliasesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAliasesOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAliasesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7674,13 +8073,21 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListBuildsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListBuildsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListBuildsOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListBuildsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7696,13 +8103,21 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListFleetsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListFleetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListFleetsOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListFleetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7720,15 +8135,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutScalingPolicyOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutScalingPolicyOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutScalingPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutScalingPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7748,13 +8168,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RequestUploadCredentialsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RequestUploadCredentialsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RequestUploadCredentialsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RequestUploadCredentialsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7772,14 +8199,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ResolveAliasOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ResolveAliasOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ResolveAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResolveAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7798,15 +8231,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SearchGameSessionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SearchGameSessionsOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(SearchGameSessionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SearchGameSessionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7826,13 +8264,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartGameSessionPlacementOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StartGameSessionPlacementError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartGameSessionPlacementOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartGameSessionPlacementError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -7851,13 +8296,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopGameSessionPlacementOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StopGameSessionPlacementError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopGameSessionPlacementOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopGameSessionPlacementError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7875,13 +8327,21 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateAliasOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateAliasOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7899,13 +8359,21 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateBuildOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateBuildError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateBuildOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateBuildError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7924,15 +8392,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateFleetAttributesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateFleetAttributesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateFleetAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateFleetAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7951,15 +8422,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateFleetCapacityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateFleetCapacityOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateFleetCapacityError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateFleetCapacityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7979,13 +8453,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateFleetPortSettingsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateFleetPortSettingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateFleetPortSettingsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateFleetPortSettingsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -8003,15 +8484,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateGameSessionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateGameSessionOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateGameSessionError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateGameSessionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8031,15 +8517,18 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateGameSessionQueueOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateGameSessionQueueOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateGameSessionQueueError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateGameSessionQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8059,13 +8548,20 @@ impl<P, D> GameLift for GameLiftClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateRuntimeConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateRuntimeConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateRuntimeConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRuntimeConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1117,6 +1119,11 @@ impl From<HttpDispatchError> for AbortMultipartUploadError {
         AbortMultipartUploadError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AbortMultipartUploadError {
+    fn from(err: io::Error) -> AbortMultipartUploadError {
+        AbortMultipartUploadError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AbortMultipartUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1209,6 +1216,11 @@ impl From<CredentialsError> for AbortVaultLockError {
 impl From<HttpDispatchError> for AbortVaultLockError {
     fn from(err: HttpDispatchError) -> AbortVaultLockError {
         AbortVaultLockError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AbortVaultLockError {
+    fn from(err: io::Error) -> AbortVaultLockError {
+        AbortVaultLockError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AbortVaultLockError {
@@ -1308,6 +1320,11 @@ impl From<HttpDispatchError> for AddTagsToVaultError {
         AddTagsToVaultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToVaultError {
+    fn from(err: io::Error) -> AddTagsToVaultError {
+        AddTagsToVaultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1393,6 +1410,11 @@ impl From<CredentialsError> for CompleteMultipartUploadError {
 impl From<HttpDispatchError> for CompleteMultipartUploadError {
     fn from(err: HttpDispatchError) -> CompleteMultipartUploadError {
         CompleteMultipartUploadError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CompleteMultipartUploadError {
+    fn from(err: io::Error) -> CompleteMultipartUploadError {
+        CompleteMultipartUploadError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CompleteMultipartUploadError {
@@ -1489,6 +1511,11 @@ impl From<HttpDispatchError> for CompleteVaultLockError {
         CompleteVaultLockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CompleteVaultLockError {
+    fn from(err: io::Error) -> CompleteVaultLockError {
+        CompleteVaultLockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CompleteVaultLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1583,6 +1610,11 @@ impl From<HttpDispatchError> for CreateVaultError {
         CreateVaultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateVaultError {
+    fn from(err: io::Error) -> CreateVaultError {
+        CreateVaultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1673,6 +1705,11 @@ impl From<CredentialsError> for DeleteArchiveError {
 impl From<HttpDispatchError> for DeleteArchiveError {
     fn from(err: HttpDispatchError) -> DeleteArchiveError {
         DeleteArchiveError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteArchiveError {
+    fn from(err: io::Error) -> DeleteArchiveError {
+        DeleteArchiveError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteArchiveError {
@@ -1767,6 +1804,11 @@ impl From<HttpDispatchError> for DeleteVaultError {
         DeleteVaultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteVaultError {
+    fn from(err: io::Error) -> DeleteVaultError {
+        DeleteVaultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1851,6 +1893,11 @@ impl From<CredentialsError> for DeleteVaultAccessPolicyError {
 impl From<HttpDispatchError> for DeleteVaultAccessPolicyError {
     fn from(err: HttpDispatchError) -> DeleteVaultAccessPolicyError {
         DeleteVaultAccessPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteVaultAccessPolicyError {
+    fn from(err: io::Error) -> DeleteVaultAccessPolicyError {
+        DeleteVaultAccessPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteVaultAccessPolicyError {
@@ -1939,6 +1986,11 @@ impl From<CredentialsError> for DeleteVaultNotificationsError {
 impl From<HttpDispatchError> for DeleteVaultNotificationsError {
     fn from(err: HttpDispatchError) -> DeleteVaultNotificationsError {
         DeleteVaultNotificationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteVaultNotificationsError {
+    fn from(err: io::Error) -> DeleteVaultNotificationsError {
+        DeleteVaultNotificationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteVaultNotificationsError {
@@ -2035,6 +2087,11 @@ impl From<HttpDispatchError> for DescribeJobError {
         DescribeJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeJobError {
+    fn from(err: io::Error) -> DescribeJobError {
+        DescribeJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2127,6 +2184,11 @@ impl From<HttpDispatchError> for DescribeVaultError {
         DescribeVaultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVaultError {
+    fn from(err: io::Error) -> DescribeVaultError {
+        DescribeVaultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2208,6 +2270,11 @@ impl From<CredentialsError> for GetDataRetrievalPolicyError {
 impl From<HttpDispatchError> for GetDataRetrievalPolicyError {
     fn from(err: HttpDispatchError) -> GetDataRetrievalPolicyError {
         GetDataRetrievalPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDataRetrievalPolicyError {
+    fn from(err: io::Error) -> GetDataRetrievalPolicyError {
+        GetDataRetrievalPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDataRetrievalPolicyError {
@@ -2303,6 +2370,11 @@ impl From<HttpDispatchError> for GetJobOutputError {
         GetJobOutputError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetJobOutputError {
+    fn from(err: io::Error) -> GetJobOutputError {
+        GetJobOutputError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetJobOutputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2389,6 +2461,11 @@ impl From<CredentialsError> for GetVaultAccessPolicyError {
 impl From<HttpDispatchError> for GetVaultAccessPolicyError {
     fn from(err: HttpDispatchError) -> GetVaultAccessPolicyError {
         GetVaultAccessPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetVaultAccessPolicyError {
+    fn from(err: io::Error) -> GetVaultAccessPolicyError {
+        GetVaultAccessPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetVaultAccessPolicyError {
@@ -2485,6 +2562,11 @@ impl From<HttpDispatchError> for GetVaultLockError {
         GetVaultLockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetVaultLockError {
+    fn from(err: io::Error) -> GetVaultLockError {
+        GetVaultLockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetVaultLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2571,6 +2653,11 @@ impl From<CredentialsError> for GetVaultNotificationsError {
 impl From<HttpDispatchError> for GetVaultNotificationsError {
     fn from(err: HttpDispatchError) -> GetVaultNotificationsError {
         GetVaultNotificationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetVaultNotificationsError {
+    fn from(err: io::Error) -> GetVaultNotificationsError {
+        GetVaultNotificationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetVaultNotificationsError {
@@ -2677,6 +2764,11 @@ impl From<HttpDispatchError> for InitiateJobError {
         InitiateJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for InitiateJobError {
+    fn from(err: io::Error) -> InitiateJobError {
+        InitiateJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for InitiateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2763,6 +2855,11 @@ impl From<CredentialsError> for InitiateMultipartUploadError {
 impl From<HttpDispatchError> for InitiateMultipartUploadError {
     fn from(err: HttpDispatchError) -> InitiateMultipartUploadError {
         InitiateMultipartUploadError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for InitiateMultipartUploadError {
+    fn from(err: io::Error) -> InitiateMultipartUploadError {
+        InitiateMultipartUploadError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for InitiateMultipartUploadError {
@@ -2859,6 +2956,11 @@ impl From<HttpDispatchError> for InitiateVaultLockError {
         InitiateVaultLockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for InitiateVaultLockError {
+    fn from(err: io::Error) -> InitiateVaultLockError {
+        InitiateVaultLockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for InitiateVaultLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2951,6 +3053,11 @@ impl From<HttpDispatchError> for ListJobsError {
         ListJobsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListJobsError {
+    fn from(err: io::Error) -> ListJobsError {
+        ListJobsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3037,6 +3144,11 @@ impl From<CredentialsError> for ListMultipartUploadsError {
 impl From<HttpDispatchError> for ListMultipartUploadsError {
     fn from(err: HttpDispatchError) -> ListMultipartUploadsError {
         ListMultipartUploadsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListMultipartUploadsError {
+    fn from(err: io::Error) -> ListMultipartUploadsError {
+        ListMultipartUploadsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListMultipartUploadsError {
@@ -3131,6 +3243,11 @@ impl From<HttpDispatchError> for ListPartsError {
         ListPartsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPartsError {
+    fn from(err: io::Error) -> ListPartsError {
+        ListPartsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPartsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3210,6 +3327,11 @@ impl From<CredentialsError> for ListProvisionedCapacityError {
 impl From<HttpDispatchError> for ListProvisionedCapacityError {
     fn from(err: HttpDispatchError) -> ListProvisionedCapacityError {
         ListProvisionedCapacityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListProvisionedCapacityError {
+    fn from(err: io::Error) -> ListProvisionedCapacityError {
+        ListProvisionedCapacityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListProvisionedCapacityError {
@@ -3305,6 +3427,11 @@ impl From<HttpDispatchError> for ListTagsForVaultError {
         ListTagsForVaultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTagsForVaultError {
+    fn from(err: io::Error) -> ListTagsForVaultError {
+        ListTagsForVaultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTagsForVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3395,6 +3522,11 @@ impl From<HttpDispatchError> for ListVaultsError {
         ListVaultsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListVaultsError {
+    fn from(err: io::Error) -> ListVaultsError {
+        ListVaultsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListVaultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3479,6 +3611,11 @@ impl From<CredentialsError> for PurchaseProvisionedCapacityError {
 impl From<HttpDispatchError> for PurchaseProvisionedCapacityError {
     fn from(err: HttpDispatchError) -> PurchaseProvisionedCapacityError {
         PurchaseProvisionedCapacityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PurchaseProvisionedCapacityError {
+    fn from(err: io::Error) -> PurchaseProvisionedCapacityError {
+        PurchaseProvisionedCapacityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PurchaseProvisionedCapacityError {
@@ -3575,6 +3712,11 @@ impl From<HttpDispatchError> for RemoveTagsFromVaultError {
         RemoveTagsFromVaultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTagsFromVaultError {
+    fn from(err: io::Error) -> RemoveTagsFromVaultError {
+        RemoveTagsFromVaultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTagsFromVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3658,6 +3800,11 @@ impl From<CredentialsError> for SetDataRetrievalPolicyError {
 impl From<HttpDispatchError> for SetDataRetrievalPolicyError {
     fn from(err: HttpDispatchError) -> SetDataRetrievalPolicyError {
         SetDataRetrievalPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetDataRetrievalPolicyError {
+    fn from(err: io::Error) -> SetDataRetrievalPolicyError {
+        SetDataRetrievalPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetDataRetrievalPolicyError {
@@ -3749,6 +3896,11 @@ impl From<HttpDispatchError> for SetVaultAccessPolicyError {
         SetVaultAccessPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetVaultAccessPolicyError {
+    fn from(err: io::Error) -> SetVaultAccessPolicyError {
+        SetVaultAccessPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetVaultAccessPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3837,6 +3989,11 @@ impl From<CredentialsError> for SetVaultNotificationsError {
 impl From<HttpDispatchError> for SetVaultNotificationsError {
     fn from(err: HttpDispatchError) -> SetVaultNotificationsError {
         SetVaultNotificationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetVaultNotificationsError {
+    fn from(err: io::Error) -> SetVaultNotificationsError {
+        SetVaultNotificationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetVaultNotificationsError {
@@ -3938,6 +4095,11 @@ impl From<HttpDispatchError> for UploadArchiveError {
         UploadArchiveError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UploadArchiveError {
+    fn from(err: io::Error) -> UploadArchiveError {
+        UploadArchiveError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UploadArchiveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4034,6 +4196,11 @@ impl From<CredentialsError> for UploadMultipartPartError {
 impl From<HttpDispatchError> for UploadMultipartPartError {
     fn from(err: HttpDispatchError) -> UploadMultipartPartError {
         UploadMultipartPartError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UploadMultipartPartError {
+    fn from(err: io::Error) -> UploadMultipartPartError {
+        UploadMultipartPartError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UploadMultipartPartError {
@@ -4294,8 +4461,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4305,8 +4471,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AbortMultipartUploadError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AbortMultipartUploadError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4328,8 +4495,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4339,8 +4505,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AbortVaultLockError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AbortVaultLockError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4362,8 +4529,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4373,8 +4539,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AddTagsToVaultError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToVaultError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4399,13 +4566,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4430,7 +4597,12 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CompleteMultipartUploadError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CompleteMultipartUploadError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4454,8 +4626,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4465,8 +4636,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CompleteVaultLockError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CompleteVaultLockError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4490,13 +4662,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4513,7 +4685,11 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateVaultError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVaultError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4535,8 +4711,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4546,7 +4721,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteArchiveError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteArchiveError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4568,8 +4745,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4578,7 +4754,11 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteVaultError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVaultError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4601,8 +4781,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4611,7 +4790,12 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteVaultAccessPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVaultAccessPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4634,8 +4818,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4644,7 +4827,12 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteVaultNotificationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVaultNotificationsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4668,13 +4856,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4688,7 +4876,11 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DescribeJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4711,13 +4903,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4732,7 +4924,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeVaultError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVaultError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4756,13 +4950,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4777,8 +4971,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetDataRetrievalPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDataRetrievalPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4803,14 +4998,17 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
                 let mut result = GetJobOutputOutput::default();
-                result.body = Some(response.body);
+
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+
+                result.body = Some(body);
 
                 if let Some(accept_ranges) = response.headers.get("Accept-Ranges") {
                     let value = accept_ranges.to_owned();
@@ -4837,7 +5035,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetJobOutputError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetJobOutputError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4861,13 +5061,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4882,8 +5082,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetVaultAccessPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetVaultAccessPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4907,13 +5108,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4928,7 +5129,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetVaultLockError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetVaultLockError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4953,13 +5156,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4974,8 +5177,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetVaultNotificationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetVaultNotificationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4999,13 +5203,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5026,7 +5230,11 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(InitiateJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InitiateJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5050,13 +5258,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5078,7 +5286,12 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(InitiateMultipartUploadError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InitiateMultipartUploadError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -5101,13 +5314,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5125,8 +5338,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(InitiateVaultLockError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InitiateVaultLockError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5161,13 +5375,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5181,7 +5395,11 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListJobsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5211,13 +5429,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5232,8 +5450,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListMultipartUploadsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListMultipartUploadsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5263,13 +5482,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5283,7 +5502,11 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListPartsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPartsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5306,13 +5529,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5327,7 +5550,12 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListProvisionedCapacityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListProvisionedCapacityError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -5350,13 +5578,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5371,8 +5599,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListTagsForVaultError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForVaultError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5399,13 +5628,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5419,7 +5648,11 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListVaultsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListVaultsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5442,13 +5675,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5466,7 +5699,12 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(PurchaseProvisionedCapacityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurchaseProvisionedCapacityError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -5489,8 +5727,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -5500,8 +5737,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RemoveTagsFromVaultError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromVaultError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5524,8 +5762,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -5535,8 +5772,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetDataRetrievalPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetDataRetrievalPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5560,8 +5798,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -5571,8 +5808,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetVaultAccessPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetVaultAccessPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5596,8 +5834,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -5607,8 +5844,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetVaultNotificationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetVaultNotificationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5632,13 +5870,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5664,7 +5902,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UploadArchiveError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UploadArchiveError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5689,13 +5929,13 @@ impl<P, D> Glacier for GlacierClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5714,8 +5954,9 @@ impl<P, D> Glacier for GlacierClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UploadMultipartPartError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UploadMultipartPartError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -503,6 +505,11 @@ impl From<HttpDispatchError> for DescribeAffectedEntitiesError {
         DescribeAffectedEntitiesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAffectedEntitiesError {
+    fn from(err: io::Error) -> DescribeAffectedEntitiesError {
+        DescribeAffectedEntitiesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAffectedEntitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -573,6 +580,11 @@ impl From<CredentialsError> for DescribeEntityAggregatesError {
 impl From<HttpDispatchError> for DescribeEntityAggregatesError {
     fn from(err: HttpDispatchError) -> DescribeEntityAggregatesError {
         DescribeEntityAggregatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEntityAggregatesError {
+    fn from(err: io::Error) -> DescribeEntityAggregatesError {
+        DescribeEntityAggregatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEntityAggregatesError {
@@ -646,6 +658,11 @@ impl From<CredentialsError> for DescribeEventAggregatesError {
 impl From<HttpDispatchError> for DescribeEventAggregatesError {
     fn from(err: HttpDispatchError) -> DescribeEventAggregatesError {
         DescribeEventAggregatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventAggregatesError {
+    fn from(err: io::Error) -> DescribeEventAggregatesError {
+        DescribeEventAggregatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventAggregatesError {
@@ -722,6 +739,11 @@ impl From<CredentialsError> for DescribeEventDetailsError {
 impl From<HttpDispatchError> for DescribeEventDetailsError {
     fn from(err: HttpDispatchError) -> DescribeEventDetailsError {
         DescribeEventDetailsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventDetailsError {
+    fn from(err: io::Error) -> DescribeEventDetailsError {
+        DescribeEventDetailsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventDetailsError {
@@ -805,6 +827,11 @@ impl From<HttpDispatchError> for DescribeEventTypesError {
         DescribeEventTypesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEventTypesError {
+    fn from(err: io::Error) -> DescribeEventTypesError {
+        DescribeEventTypesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEventTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -885,6 +912,11 @@ impl From<CredentialsError> for DescribeEventsError {
 impl From<HttpDispatchError> for DescribeEventsError {
     fn from(err: HttpDispatchError) -> DescribeEventsError {
         DescribeEventsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventsError {
+    fn from(err: io::Error) -> DescribeEventsError {
+        DescribeEventsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventsError {
@@ -987,13 +1019,20 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAffectedEntitiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeAffectedEntitiesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAffectedEntitiesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAffectedEntitiesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -1013,13 +1052,20 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEntityAggregatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeEntityAggregatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEntityAggregatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEntityAggregatesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -1038,13 +1084,20 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventAggregatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeEventAggregatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventAggregatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventAggregatesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -1063,15 +1116,18 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventDetailsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventDetailsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeEventDetailsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventDetailsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1090,15 +1146,18 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventTypesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventTypesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeEventTypesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1117,15 +1176,20 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -12125,6 +12127,11 @@ impl From<HttpDispatchError> for AddClientIDToOpenIDConnectProviderError {
         AddClientIDToOpenIDConnectProviderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddClientIDToOpenIDConnectProviderError {
+    fn from(err: io::Error) -> AddClientIDToOpenIDConnectProviderError {
+        AddClientIDToOpenIDConnectProviderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddClientIDToOpenIDConnectProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12206,6 +12213,11 @@ impl From<CredentialsError> for AddRoleToInstanceProfileError {
 impl From<HttpDispatchError> for AddRoleToInstanceProfileError {
     fn from(err: HttpDispatchError) -> AddRoleToInstanceProfileError {
         AddRoleToInstanceProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddRoleToInstanceProfileError {
+    fn from(err: io::Error) -> AddRoleToInstanceProfileError {
+        AddRoleToInstanceProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddRoleToInstanceProfileError {
@@ -12292,6 +12304,11 @@ impl From<HttpDispatchError> for AddUserToGroupError {
         AddUserToGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddUserToGroupError {
+    fn from(err: io::Error) -> AddUserToGroupError {
+        AddUserToGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddUserToGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12375,6 +12392,11 @@ impl From<CredentialsError> for AttachGroupPolicyError {
 impl From<HttpDispatchError> for AttachGroupPolicyError {
     fn from(err: HttpDispatchError) -> AttachGroupPolicyError {
         AttachGroupPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AttachGroupPolicyError {
+    fn from(err: io::Error) -> AttachGroupPolicyError {
+        AttachGroupPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AttachGroupPolicyError {
@@ -12468,6 +12490,11 @@ impl From<HttpDispatchError> for AttachRolePolicyError {
         AttachRolePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachRolePolicyError {
+    fn from(err: io::Error) -> AttachRolePolicyError {
+        AttachRolePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12553,6 +12580,11 @@ impl From<CredentialsError> for AttachUserPolicyError {
 impl From<HttpDispatchError> for AttachUserPolicyError {
     fn from(err: HttpDispatchError) -> AttachUserPolicyError {
         AttachUserPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AttachUserPolicyError {
+    fn from(err: io::Error) -> AttachUserPolicyError {
+        AttachUserPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AttachUserPolicyError {
@@ -12647,6 +12679,11 @@ impl From<HttpDispatchError> for ChangePasswordError {
         ChangePasswordError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ChangePasswordError {
+    fn from(err: io::Error) -> ChangePasswordError {
+        ChangePasswordError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ChangePasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12730,6 +12767,11 @@ impl From<HttpDispatchError> for CreateAccessKeyError {
         CreateAccessKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateAccessKeyError {
+    fn from(err: io::Error) -> CreateAccessKeyError {
+        CreateAccessKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateAccessKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12806,6 +12848,11 @@ impl From<CredentialsError> for CreateAccountAliasError {
 impl From<HttpDispatchError> for CreateAccountAliasError {
     fn from(err: HttpDispatchError) -> CreateAccountAliasError {
         CreateAccountAliasError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAccountAliasError {
+    fn from(err: io::Error) -> CreateAccountAliasError {
+        CreateAccountAliasError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAccountAliasError {
@@ -12895,6 +12942,11 @@ impl From<HttpDispatchError> for CreateGroupError {
         CreateGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateGroupError {
+    fn from(err: io::Error) -> CreateGroupError {
+        CreateGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12968,6 +13020,11 @@ impl From<CredentialsError> for CreateInstanceProfileError {
 impl From<HttpDispatchError> for CreateInstanceProfileError {
     fn from(err: HttpDispatchError) -> CreateInstanceProfileError {
         CreateInstanceProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateInstanceProfileError {
+    fn from(err: io::Error) -> CreateInstanceProfileError {
+        CreateInstanceProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateInstanceProfileError {
@@ -13058,6 +13115,11 @@ impl From<HttpDispatchError> for CreateLoginProfileError {
         CreateLoginProfileError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLoginProfileError {
+    fn from(err: io::Error) -> CreateLoginProfileError {
+        CreateLoginProfileError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLoginProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13137,6 +13199,11 @@ impl From<CredentialsError> for CreateOpenIDConnectProviderError {
 impl From<HttpDispatchError> for CreateOpenIDConnectProviderError {
     fn from(err: HttpDispatchError) -> CreateOpenIDConnectProviderError {
         CreateOpenIDConnectProviderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateOpenIDConnectProviderError {
+    fn from(err: io::Error) -> CreateOpenIDConnectProviderError {
+        CreateOpenIDConnectProviderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateOpenIDConnectProviderError {
@@ -13230,6 +13297,11 @@ impl From<HttpDispatchError> for CreatePolicyError {
         CreatePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreatePolicyError {
+    fn from(err: io::Error) -> CreatePolicyError {
+        CreatePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreatePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13318,6 +13390,11 @@ impl From<CredentialsError> for CreatePolicyVersionError {
 impl From<HttpDispatchError> for CreatePolicyVersionError {
     fn from(err: HttpDispatchError) -> CreatePolicyVersionError {
         CreatePolicyVersionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePolicyVersionError {
+    fn from(err: io::Error) -> CreatePolicyVersionError {
+        CreatePolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePolicyVersionError {
@@ -13414,6 +13491,11 @@ impl From<HttpDispatchError> for CreateRoleError {
         CreateRoleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRoleError {
+    fn from(err: io::Error) -> CreateRoleError {
+        CreateRoleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13499,6 +13581,11 @@ impl From<HttpDispatchError> for CreateSAMLProviderError {
         CreateSAMLProviderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateSAMLProviderError {
+    fn from(err: io::Error) -> CreateSAMLProviderError {
+        CreateSAMLProviderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateSAMLProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13579,6 +13666,11 @@ impl From<HttpDispatchError> for CreateServiceLinkedRoleError {
         CreateServiceLinkedRoleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateServiceLinkedRoleError {
+    fn from(err: io::Error) -> CreateServiceLinkedRoleError {
+        CreateServiceLinkedRoleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateServiceLinkedRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13654,6 +13746,11 @@ impl From<CredentialsError> for CreateServiceSpecificCredentialError {
 impl From<HttpDispatchError> for CreateServiceSpecificCredentialError {
     fn from(err: HttpDispatchError) -> CreateServiceSpecificCredentialError {
         CreateServiceSpecificCredentialError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateServiceSpecificCredentialError {
+    fn from(err: io::Error) -> CreateServiceSpecificCredentialError {
+        CreateServiceSpecificCredentialError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateServiceSpecificCredentialError {
@@ -13743,6 +13840,11 @@ impl From<HttpDispatchError> for CreateUserError {
         CreateUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateUserError {
+    fn from(err: io::Error) -> CreateUserError {
+        CreateUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13816,6 +13918,11 @@ impl From<CredentialsError> for CreateVirtualMFADeviceError {
 impl From<HttpDispatchError> for CreateVirtualMFADeviceError {
     fn from(err: HttpDispatchError) -> CreateVirtualMFADeviceError {
         CreateVirtualMFADeviceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateVirtualMFADeviceError {
+    fn from(err: io::Error) -> CreateVirtualMFADeviceError {
+        CreateVirtualMFADeviceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateVirtualMFADeviceError {
@@ -13903,6 +14010,11 @@ impl From<HttpDispatchError> for DeactivateMFADeviceError {
         DeactivateMFADeviceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeactivateMFADeviceError {
+    fn from(err: io::Error) -> DeactivateMFADeviceError {
+        DeactivateMFADeviceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeactivateMFADeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13986,6 +14098,11 @@ impl From<HttpDispatchError> for DeleteAccessKeyError {
         DeleteAccessKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAccessKeyError {
+    fn from(err: io::Error) -> DeleteAccessKeyError {
+        DeleteAccessKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAccessKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14066,6 +14183,11 @@ impl From<HttpDispatchError> for DeleteAccountAliasError {
         DeleteAccountAliasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAccountAliasError {
+    fn from(err: io::Error) -> DeleteAccountAliasError {
+        DeleteAccountAliasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAccountAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14140,6 +14262,11 @@ impl From<CredentialsError> for DeleteAccountPasswordPolicyError {
 impl From<HttpDispatchError> for DeleteAccountPasswordPolicyError {
     fn from(err: HttpDispatchError) -> DeleteAccountPasswordPolicyError {
         DeleteAccountPasswordPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteAccountPasswordPolicyError {
+    fn from(err: io::Error) -> DeleteAccountPasswordPolicyError {
+        DeleteAccountPasswordPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteAccountPasswordPolicyError {
@@ -14229,6 +14356,11 @@ impl From<HttpDispatchError> for DeleteGroupError {
         DeleteGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteGroupError {
+    fn from(err: io::Error) -> DeleteGroupError {
+        DeleteGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14310,6 +14442,11 @@ impl From<HttpDispatchError> for DeleteGroupPolicyError {
         DeleteGroupPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteGroupPolicyError {
+    fn from(err: io::Error) -> DeleteGroupPolicyError {
+        DeleteGroupPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteGroupPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14389,6 +14526,11 @@ impl From<CredentialsError> for DeleteInstanceProfileError {
 impl From<HttpDispatchError> for DeleteInstanceProfileError {
     fn from(err: HttpDispatchError) -> DeleteInstanceProfileError {
         DeleteInstanceProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteInstanceProfileError {
+    fn from(err: io::Error) -> DeleteInstanceProfileError {
+        DeleteInstanceProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteInstanceProfileError {
@@ -14477,6 +14619,11 @@ impl From<HttpDispatchError> for DeleteLoginProfileError {
         DeleteLoginProfileError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteLoginProfileError {
+    fn from(err: io::Error) -> DeleteLoginProfileError {
+        DeleteLoginProfileError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteLoginProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14552,6 +14699,11 @@ impl From<CredentialsError> for DeleteOpenIDConnectProviderError {
 impl From<HttpDispatchError> for DeleteOpenIDConnectProviderError {
     fn from(err: HttpDispatchError) -> DeleteOpenIDConnectProviderError {
         DeleteOpenIDConnectProviderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteOpenIDConnectProviderError {
+    fn from(err: io::Error) -> DeleteOpenIDConnectProviderError {
+        DeleteOpenIDConnectProviderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteOpenIDConnectProviderError {
@@ -14646,6 +14798,11 @@ impl From<HttpDispatchError> for DeletePolicyError {
         DeletePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePolicyError {
+    fn from(err: io::Error) -> DeletePolicyError {
+        DeletePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14736,6 +14893,11 @@ impl From<CredentialsError> for DeletePolicyVersionError {
 impl From<HttpDispatchError> for DeletePolicyVersionError {
     fn from(err: HttpDispatchError) -> DeletePolicyVersionError {
         DeletePolicyVersionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeletePolicyVersionError {
+    fn from(err: io::Error) -> DeletePolicyVersionError {
+        DeletePolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeletePolicyVersionError {
@@ -14832,6 +14994,11 @@ impl From<HttpDispatchError> for DeleteRoleError {
         DeleteRoleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRoleError {
+    fn from(err: io::Error) -> DeleteRoleError {
+        DeleteRoleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14915,6 +15082,11 @@ impl From<CredentialsError> for DeleteRolePolicyError {
 impl From<HttpDispatchError> for DeleteRolePolicyError {
     fn from(err: HttpDispatchError) -> DeleteRolePolicyError {
         DeleteRolePolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteRolePolicyError {
+    fn from(err: io::Error) -> DeleteRolePolicyError {
+        DeleteRolePolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteRolePolicyError {
@@ -15003,6 +15175,11 @@ impl From<HttpDispatchError> for DeleteSAMLProviderError {
         DeleteSAMLProviderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteSAMLProviderError {
+    fn from(err: io::Error) -> DeleteSAMLProviderError {
+        DeleteSAMLProviderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteSAMLProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15074,6 +15251,11 @@ impl From<CredentialsError> for DeleteSSHPublicKeyError {
 impl From<HttpDispatchError> for DeleteSSHPublicKeyError {
     fn from(err: HttpDispatchError) -> DeleteSSHPublicKeyError {
         DeleteSSHPublicKeyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSSHPublicKeyError {
+    fn from(err: io::Error) -> DeleteSSHPublicKeyError {
+        DeleteSSHPublicKeyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSSHPublicKeyError {
@@ -15153,6 +15335,11 @@ impl From<HttpDispatchError> for DeleteServerCertificateError {
         DeleteServerCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteServerCertificateError {
+    fn from(err: io::Error) -> DeleteServerCertificateError {
+        DeleteServerCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteServerCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15222,6 +15409,11 @@ impl From<CredentialsError> for DeleteServiceSpecificCredentialError {
 impl From<HttpDispatchError> for DeleteServiceSpecificCredentialError {
     fn from(err: HttpDispatchError) -> DeleteServiceSpecificCredentialError {
         DeleteServiceSpecificCredentialError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteServiceSpecificCredentialError {
+    fn from(err: io::Error) -> DeleteServiceSpecificCredentialError {
+        DeleteServiceSpecificCredentialError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteServiceSpecificCredentialError {
@@ -15296,6 +15488,11 @@ impl From<CredentialsError> for DeleteSigningCertificateError {
 impl From<HttpDispatchError> for DeleteSigningCertificateError {
     fn from(err: HttpDispatchError) -> DeleteSigningCertificateError {
         DeleteSigningCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSigningCertificateError {
+    fn from(err: io::Error) -> DeleteSigningCertificateError {
+        DeleteSigningCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSigningCertificateError {
@@ -15385,6 +15582,11 @@ impl From<HttpDispatchError> for DeleteUserError {
         DeleteUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteUserError {
+    fn from(err: io::Error) -> DeleteUserError {
+        DeleteUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15466,6 +15668,11 @@ impl From<HttpDispatchError> for DeleteUserPolicyError {
         DeleteUserPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteUserPolicyError {
+    fn from(err: io::Error) -> DeleteUserPolicyError {
+        DeleteUserPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteUserPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15541,6 +15748,11 @@ impl From<CredentialsError> for DeleteVirtualMFADeviceError {
 impl From<HttpDispatchError> for DeleteVirtualMFADeviceError {
     fn from(err: HttpDispatchError) -> DeleteVirtualMFADeviceError {
         DeleteVirtualMFADeviceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteVirtualMFADeviceError {
+    fn from(err: io::Error) -> DeleteVirtualMFADeviceError {
+        DeleteVirtualMFADeviceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteVirtualMFADeviceError {
@@ -15629,6 +15841,11 @@ impl From<CredentialsError> for DetachGroupPolicyError {
 impl From<HttpDispatchError> for DetachGroupPolicyError {
     fn from(err: HttpDispatchError) -> DetachGroupPolicyError {
         DetachGroupPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DetachGroupPolicyError {
+    fn from(err: io::Error) -> DetachGroupPolicyError {
+        DetachGroupPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DetachGroupPolicyError {
@@ -15722,6 +15939,11 @@ impl From<HttpDispatchError> for DetachRolePolicyError {
         DetachRolePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachRolePolicyError {
+    fn from(err: io::Error) -> DetachRolePolicyError {
+        DetachRolePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15807,6 +16029,11 @@ impl From<CredentialsError> for DetachUserPolicyError {
 impl From<HttpDispatchError> for DetachUserPolicyError {
     fn from(err: HttpDispatchError) -> DetachUserPolicyError {
         DetachUserPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DetachUserPolicyError {
+    fn from(err: io::Error) -> DetachUserPolicyError {
+        DetachUserPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DetachUserPolicyError {
@@ -15899,6 +16126,11 @@ impl From<HttpDispatchError> for EnableMFADeviceError {
         EnableMFADeviceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableMFADeviceError {
+    fn from(err: io::Error) -> EnableMFADeviceError {
+        EnableMFADeviceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableMFADeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15973,6 +16205,11 @@ impl From<HttpDispatchError> for GenerateCredentialReportError {
         GenerateCredentialReportError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GenerateCredentialReportError {
+    fn from(err: io::Error) -> GenerateCredentialReportError {
+        GenerateCredentialReportError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GenerateCredentialReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16044,6 +16281,11 @@ impl From<HttpDispatchError> for GetAccessKeyLastUsedError {
         GetAccessKeyLastUsedError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAccessKeyLastUsedError {
+    fn from(err: io::Error) -> GetAccessKeyLastUsedError {
+        GetAccessKeyLastUsedError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAccessKeyLastUsedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16110,6 +16352,11 @@ impl From<CredentialsError> for GetAccountAuthorizationDetailsError {
 impl From<HttpDispatchError> for GetAccountAuthorizationDetailsError {
     fn from(err: HttpDispatchError) -> GetAccountAuthorizationDetailsError {
         GetAccountAuthorizationDetailsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetAccountAuthorizationDetailsError {
+    fn from(err: io::Error) -> GetAccountAuthorizationDetailsError {
+        GetAccountAuthorizationDetailsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetAccountAuthorizationDetailsError {
@@ -16183,6 +16430,11 @@ impl From<HttpDispatchError> for GetAccountPasswordPolicyError {
         GetAccountPasswordPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAccountPasswordPolicyError {
+    fn from(err: io::Error) -> GetAccountPasswordPolicyError {
+        GetAccountPasswordPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAccountPasswordPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16254,6 +16506,11 @@ impl From<HttpDispatchError> for GetAccountSummaryError {
         GetAccountSummaryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAccountSummaryError {
+    fn from(err: io::Error) -> GetAccountSummaryError {
+        GetAccountSummaryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAccountSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16320,6 +16577,11 @@ impl From<CredentialsError> for GetContextKeysForCustomPolicyError {
 impl From<HttpDispatchError> for GetContextKeysForCustomPolicyError {
     fn from(err: HttpDispatchError) -> GetContextKeysForCustomPolicyError {
         GetContextKeysForCustomPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetContextKeysForCustomPolicyError {
+    fn from(err: io::Error) -> GetContextKeysForCustomPolicyError {
+        GetContextKeysForCustomPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetContextKeysForCustomPolicyError {
@@ -16391,6 +16653,11 @@ impl From<CredentialsError> for GetContextKeysForPrincipalPolicyError {
 impl From<HttpDispatchError> for GetContextKeysForPrincipalPolicyError {
     fn from(err: HttpDispatchError) -> GetContextKeysForPrincipalPolicyError {
         GetContextKeysForPrincipalPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetContextKeysForPrincipalPolicyError {
+    fn from(err: io::Error) -> GetContextKeysForPrincipalPolicyError {
+        GetContextKeysForPrincipalPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetContextKeysForPrincipalPolicyError {
@@ -16473,6 +16740,11 @@ impl From<HttpDispatchError> for GetCredentialReportError {
         GetCredentialReportError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetCredentialReportError {
+    fn from(err: io::Error) -> GetCredentialReportError {
+        GetCredentialReportError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetCredentialReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16551,6 +16823,11 @@ impl From<HttpDispatchError> for GetGroupError {
         GetGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetGroupError {
+    fn from(err: io::Error) -> GetGroupError {
+        GetGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16625,6 +16902,11 @@ impl From<HttpDispatchError> for GetGroupPolicyError {
         GetGroupPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetGroupPolicyError {
+    fn from(err: io::Error) -> GetGroupPolicyError {
+        GetGroupPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetGroupPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16697,6 +16979,11 @@ impl From<CredentialsError> for GetInstanceProfileError {
 impl From<HttpDispatchError> for GetInstanceProfileError {
     fn from(err: HttpDispatchError) -> GetInstanceProfileError {
         GetInstanceProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetInstanceProfileError {
+    fn from(err: io::Error) -> GetInstanceProfileError {
+        GetInstanceProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetInstanceProfileError {
@@ -16775,6 +17062,11 @@ impl From<HttpDispatchError> for GetLoginProfileError {
         GetLoginProfileError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetLoginProfileError {
+    fn from(err: io::Error) -> GetLoginProfileError {
+        GetLoginProfileError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetLoginProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16846,6 +17138,11 @@ impl From<CredentialsError> for GetOpenIDConnectProviderError {
 impl From<HttpDispatchError> for GetOpenIDConnectProviderError {
     fn from(err: HttpDispatchError) -> GetOpenIDConnectProviderError {
         GetOpenIDConnectProviderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetOpenIDConnectProviderError {
+    fn from(err: io::Error) -> GetOpenIDConnectProviderError {
+        GetOpenIDConnectProviderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetOpenIDConnectProviderError {
@@ -16930,6 +17227,11 @@ impl From<HttpDispatchError> for GetPolicyError {
         GetPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetPolicyError {
+    fn from(err: io::Error) -> GetPolicyError {
+        GetPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17010,6 +17312,11 @@ impl From<HttpDispatchError> for GetPolicyVersionError {
         GetPolicyVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetPolicyVersionError {
+    fn from(err: io::Error) -> GetPolicyVersionError {
+        GetPolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17085,6 +17392,11 @@ impl From<HttpDispatchError> for GetRoleError {
         GetRoleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRoleError {
+    fn from(err: io::Error) -> GetRoleError {
+        GetRoleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17157,6 +17469,11 @@ impl From<CredentialsError> for GetRolePolicyError {
 impl From<HttpDispatchError> for GetRolePolicyError {
     fn from(err: HttpDispatchError) -> GetRolePolicyError {
         GetRolePolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetRolePolicyError {
+    fn from(err: io::Error) -> GetRolePolicyError {
+        GetRolePolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetRolePolicyError {
@@ -17238,6 +17555,11 @@ impl From<HttpDispatchError> for GetSAMLProviderError {
         GetSAMLProviderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSAMLProviderError {
+    fn from(err: io::Error) -> GetSAMLProviderError {
+        GetSAMLProviderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSAMLProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17311,6 +17633,11 @@ impl From<HttpDispatchError> for GetSSHPublicKeyError {
         GetSSHPublicKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSSHPublicKeyError {
+    fn from(err: io::Error) -> GetSSHPublicKeyError {
+        GetSSHPublicKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSSHPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17381,6 +17708,11 @@ impl From<CredentialsError> for GetServerCertificateError {
 impl From<HttpDispatchError> for GetServerCertificateError {
     fn from(err: HttpDispatchError) -> GetServerCertificateError {
         GetServerCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetServerCertificateError {
+    fn from(err: io::Error) -> GetServerCertificateError {
+        GetServerCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetServerCertificateError {
@@ -17459,6 +17791,11 @@ impl From<HttpDispatchError> for GetUserError {
         GetUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetUserError {
+    fn from(err: io::Error) -> GetUserError {
+        GetUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17531,6 +17868,11 @@ impl From<CredentialsError> for GetUserPolicyError {
 impl From<HttpDispatchError> for GetUserPolicyError {
     fn from(err: HttpDispatchError) -> GetUserPolicyError {
         GetUserPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetUserPolicyError {
+    fn from(err: io::Error) -> GetUserPolicyError {
+        GetUserPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetUserPolicyError {
@@ -17607,6 +17949,11 @@ impl From<HttpDispatchError> for ListAccessKeysError {
         ListAccessKeysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListAccessKeysError {
+    fn from(err: io::Error) -> ListAccessKeysError {
+        ListAccessKeysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListAccessKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17674,6 +18021,11 @@ impl From<CredentialsError> for ListAccountAliasesError {
 impl From<HttpDispatchError> for ListAccountAliasesError {
     fn from(err: HttpDispatchError) -> ListAccountAliasesError {
         ListAccountAliasesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAccountAliasesError {
+    fn from(err: io::Error) -> ListAccountAliasesError {
+        ListAccountAliasesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAccountAliasesError {
@@ -17748,6 +18100,11 @@ impl From<CredentialsError> for ListAttachedGroupPoliciesError {
 impl From<HttpDispatchError> for ListAttachedGroupPoliciesError {
     fn from(err: HttpDispatchError) -> ListAttachedGroupPoliciesError {
         ListAttachedGroupPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAttachedGroupPoliciesError {
+    fn from(err: io::Error) -> ListAttachedGroupPoliciesError {
+        ListAttachedGroupPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAttachedGroupPoliciesError {
@@ -17826,6 +18183,11 @@ impl From<HttpDispatchError> for ListAttachedRolePoliciesError {
         ListAttachedRolePoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListAttachedRolePoliciesError {
+    fn from(err: io::Error) -> ListAttachedRolePoliciesError {
+        ListAttachedRolePoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListAttachedRolePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17900,6 +18262,11 @@ impl From<CredentialsError> for ListAttachedUserPoliciesError {
 impl From<HttpDispatchError> for ListAttachedUserPoliciesError {
     fn from(err: HttpDispatchError) -> ListAttachedUserPoliciesError {
         ListAttachedUserPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAttachedUserPoliciesError {
+    fn from(err: io::Error) -> ListAttachedUserPoliciesError {
+        ListAttachedUserPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAttachedUserPoliciesError {
@@ -17982,6 +18349,11 @@ impl From<HttpDispatchError> for ListEntitiesForPolicyError {
         ListEntitiesForPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListEntitiesForPolicyError {
+    fn from(err: io::Error) -> ListEntitiesForPolicyError {
+        ListEntitiesForPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListEntitiesForPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18059,6 +18431,11 @@ impl From<HttpDispatchError> for ListGroupPoliciesError {
         ListGroupPoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListGroupPoliciesError {
+    fn from(err: io::Error) -> ListGroupPoliciesError {
+        ListGroupPoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListGroupPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18128,6 +18505,11 @@ impl From<CredentialsError> for ListGroupsError {
 impl From<HttpDispatchError> for ListGroupsError {
     fn from(err: HttpDispatchError) -> ListGroupsError {
         ListGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListGroupsError {
+    fn from(err: io::Error) -> ListGroupsError {
+        ListGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListGroupsError {
@@ -18203,6 +18585,11 @@ impl From<HttpDispatchError> for ListGroupsForUserError {
         ListGroupsForUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListGroupsForUserError {
+    fn from(err: io::Error) -> ListGroupsForUserError {
+        ListGroupsForUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListGroupsForUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18270,6 +18657,11 @@ impl From<CredentialsError> for ListInstanceProfilesError {
 impl From<HttpDispatchError> for ListInstanceProfilesError {
     fn from(err: HttpDispatchError) -> ListInstanceProfilesError {
         ListInstanceProfilesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListInstanceProfilesError {
+    fn from(err: io::Error) -> ListInstanceProfilesError {
+        ListInstanceProfilesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListInstanceProfilesError {
@@ -18341,6 +18733,11 @@ impl From<CredentialsError> for ListInstanceProfilesForRoleError {
 impl From<HttpDispatchError> for ListInstanceProfilesForRoleError {
     fn from(err: HttpDispatchError) -> ListInstanceProfilesForRoleError {
         ListInstanceProfilesForRoleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListInstanceProfilesForRoleError {
+    fn from(err: io::Error) -> ListInstanceProfilesForRoleError {
+        ListInstanceProfilesForRoleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListInstanceProfilesForRoleError {
@@ -18419,6 +18816,11 @@ impl From<HttpDispatchError> for ListMFADevicesError {
         ListMFADevicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListMFADevicesError {
+    fn from(err: io::Error) -> ListMFADevicesError {
+        ListMFADevicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListMFADevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18484,6 +18886,11 @@ impl From<CredentialsError> for ListOpenIDConnectProvidersError {
 impl From<HttpDispatchError> for ListOpenIDConnectProvidersError {
     fn from(err: HttpDispatchError) -> ListOpenIDConnectProvidersError {
         ListOpenIDConnectProvidersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListOpenIDConnectProvidersError {
+    fn from(err: io::Error) -> ListOpenIDConnectProvidersError {
+        ListOpenIDConnectProvidersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListOpenIDConnectProvidersError {
@@ -18554,6 +18961,11 @@ impl From<CredentialsError> for ListPoliciesError {
 impl From<HttpDispatchError> for ListPoliciesError {
     fn from(err: HttpDispatchError) -> ListPoliciesError {
         ListPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPoliciesError {
+    fn from(err: io::Error) -> ListPoliciesError {
+        ListPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPoliciesError {
@@ -18634,6 +19046,11 @@ impl From<HttpDispatchError> for ListPolicyVersionsError {
         ListPolicyVersionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPolicyVersionsError {
+    fn from(err: io::Error) -> ListPolicyVersionsError {
+        ListPolicyVersionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPolicyVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18711,6 +19128,11 @@ impl From<HttpDispatchError> for ListRolePoliciesError {
         ListRolePoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListRolePoliciesError {
+    fn from(err: io::Error) -> ListRolePoliciesError {
+        ListRolePoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListRolePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18780,6 +19202,11 @@ impl From<HttpDispatchError> for ListRolesError {
         ListRolesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListRolesError {
+    fn from(err: io::Error) -> ListRolesError {
+        ListRolesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListRolesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18846,6 +19273,11 @@ impl From<CredentialsError> for ListSAMLProvidersError {
 impl From<HttpDispatchError> for ListSAMLProvidersError {
     fn from(err: HttpDispatchError) -> ListSAMLProvidersError {
         ListSAMLProvidersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListSAMLProvidersError {
+    fn from(err: io::Error) -> ListSAMLProvidersError {
+        ListSAMLProvidersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListSAMLProvidersError {
@@ -18918,6 +19350,11 @@ impl From<HttpDispatchError> for ListSSHPublicKeysError {
         ListSSHPublicKeysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListSSHPublicKeysError {
+    fn from(err: io::Error) -> ListSSHPublicKeysError {
+        ListSSHPublicKeysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListSSHPublicKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18984,6 +19421,11 @@ impl From<CredentialsError> for ListServerCertificatesError {
 impl From<HttpDispatchError> for ListServerCertificatesError {
     fn from(err: HttpDispatchError) -> ListServerCertificatesError {
         ListServerCertificatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListServerCertificatesError {
+    fn from(err: io::Error) -> ListServerCertificatesError {
+        ListServerCertificatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListServerCertificatesError {
@@ -19057,6 +19499,11 @@ impl From<HttpDispatchError> for ListServiceSpecificCredentialsError {
         ListServiceSpecificCredentialsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListServiceSpecificCredentialsError {
+    fn from(err: io::Error) -> ListServiceSpecificCredentialsError {
+        ListServiceSpecificCredentialsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListServiceSpecificCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19127,6 +19574,11 @@ impl From<CredentialsError> for ListSigningCertificatesError {
 impl From<HttpDispatchError> for ListSigningCertificatesError {
     fn from(err: HttpDispatchError) -> ListSigningCertificatesError {
         ListSigningCertificatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListSigningCertificatesError {
+    fn from(err: io::Error) -> ListSigningCertificatesError {
+        ListSigningCertificatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListSigningCertificatesError {
@@ -19205,6 +19657,11 @@ impl From<HttpDispatchError> for ListUserPoliciesError {
         ListUserPoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListUserPoliciesError {
+    fn from(err: io::Error) -> ListUserPoliciesError {
+        ListUserPoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListUserPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19274,6 +19731,11 @@ impl From<HttpDispatchError> for ListUsersError {
         ListUsersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListUsersError {
+    fn from(err: io::Error) -> ListUsersError {
+        ListUsersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19335,6 +19797,11 @@ impl From<CredentialsError> for ListVirtualMFADevicesError {
 impl From<HttpDispatchError> for ListVirtualMFADevicesError {
     fn from(err: HttpDispatchError) -> ListVirtualMFADevicesError {
         ListVirtualMFADevicesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListVirtualMFADevicesError {
+    fn from(err: io::Error) -> ListVirtualMFADevicesError {
+        ListVirtualMFADevicesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListVirtualMFADevicesError {
@@ -19417,6 +19884,11 @@ impl From<CredentialsError> for PutGroupPolicyError {
 impl From<HttpDispatchError> for PutGroupPolicyError {
     fn from(err: HttpDispatchError) -> PutGroupPolicyError {
         PutGroupPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutGroupPolicyError {
+    fn from(err: io::Error) -> PutGroupPolicyError {
+        PutGroupPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutGroupPolicyError {
@@ -19508,6 +19980,11 @@ impl From<HttpDispatchError> for PutRolePolicyError {
         PutRolePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutRolePolicyError {
+    fn from(err: io::Error) -> PutRolePolicyError {
+        PutRolePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19593,6 +20070,11 @@ impl From<HttpDispatchError> for PutUserPolicyError {
         PutUserPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutUserPolicyError {
+    fn from(err: io::Error) -> PutUserPolicyError {
+        PutUserPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutUserPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19666,6 +20148,11 @@ impl From<CredentialsError> for RemoveClientIDFromOpenIDConnectProviderError {
 impl From<HttpDispatchError> for RemoveClientIDFromOpenIDConnectProviderError {
     fn from(err: HttpDispatchError) -> RemoveClientIDFromOpenIDConnectProviderError {
         RemoveClientIDFromOpenIDConnectProviderError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveClientIDFromOpenIDConnectProviderError {
+    fn from(err: io::Error) -> RemoveClientIDFromOpenIDConnectProviderError {
+        RemoveClientIDFromOpenIDConnectProviderError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveClientIDFromOpenIDConnectProviderError {
@@ -19745,6 +20232,11 @@ impl From<CredentialsError> for RemoveRoleFromInstanceProfileError {
 impl From<HttpDispatchError> for RemoveRoleFromInstanceProfileError {
     fn from(err: HttpDispatchError) -> RemoveRoleFromInstanceProfileError {
         RemoveRoleFromInstanceProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveRoleFromInstanceProfileError {
+    fn from(err: io::Error) -> RemoveRoleFromInstanceProfileError {
+        RemoveRoleFromInstanceProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveRoleFromInstanceProfileError {
@@ -19830,6 +20322,11 @@ impl From<HttpDispatchError> for RemoveUserFromGroupError {
         RemoveUserFromGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveUserFromGroupError {
+    fn from(err: io::Error) -> RemoveUserFromGroupError {
+        RemoveUserFromGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveUserFromGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19898,6 +20395,11 @@ impl From<CredentialsError> for ResetServiceSpecificCredentialError {
 impl From<HttpDispatchError> for ResetServiceSpecificCredentialError {
     fn from(err: HttpDispatchError) -> ResetServiceSpecificCredentialError {
         ResetServiceSpecificCredentialError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResetServiceSpecificCredentialError {
+    fn from(err: io::Error) -> ResetServiceSpecificCredentialError {
+        ResetServiceSpecificCredentialError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResetServiceSpecificCredentialError {
@@ -19983,6 +20485,11 @@ impl From<HttpDispatchError> for ResyncMFADeviceError {
         ResyncMFADeviceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ResyncMFADeviceError {
+    fn from(err: io::Error) -> ResyncMFADeviceError {
+        ResyncMFADeviceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ResyncMFADeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20061,6 +20568,11 @@ impl From<HttpDispatchError> for SetDefaultPolicyVersionError {
         SetDefaultPolicyVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetDefaultPolicyVersionError {
+    fn from(err: io::Error) -> SetDefaultPolicyVersionError {
+        SetDefaultPolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetDefaultPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20137,6 +20649,11 @@ impl From<HttpDispatchError> for SimulateCustomPolicyError {
         SimulateCustomPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SimulateCustomPolicyError {
+    fn from(err: io::Error) -> SimulateCustomPolicyError {
+        SimulateCustomPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SimulateCustomPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20210,6 +20727,11 @@ impl From<CredentialsError> for SimulatePrincipalPolicyError {
 impl From<HttpDispatchError> for SimulatePrincipalPolicyError {
     fn from(err: HttpDispatchError) -> SimulatePrincipalPolicyError {
         SimulatePrincipalPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SimulatePrincipalPolicyError {
+    fn from(err: io::Error) -> SimulatePrincipalPolicyError {
+        SimulatePrincipalPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SimulatePrincipalPolicyError {
@@ -20294,6 +20816,11 @@ impl From<HttpDispatchError> for UpdateAccessKeyError {
         UpdateAccessKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateAccessKeyError {
+    fn from(err: io::Error) -> UpdateAccessKeyError {
+        UpdateAccessKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateAccessKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20369,6 +20896,11 @@ impl From<CredentialsError> for UpdateAccountPasswordPolicyError {
 impl From<HttpDispatchError> for UpdateAccountPasswordPolicyError {
     fn from(err: HttpDispatchError) -> UpdateAccountPasswordPolicyError {
         UpdateAccountPasswordPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAccountPasswordPolicyError {
+    fn from(err: io::Error) -> UpdateAccountPasswordPolicyError {
+        UpdateAccountPasswordPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAccountPasswordPolicyError {
@@ -20452,6 +20984,11 @@ impl From<CredentialsError> for UpdateAssumeRolePolicyError {
 impl From<HttpDispatchError> for UpdateAssumeRolePolicyError {
     fn from(err: HttpDispatchError) -> UpdateAssumeRolePolicyError {
         UpdateAssumeRolePolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAssumeRolePolicyError {
+    fn from(err: io::Error) -> UpdateAssumeRolePolicyError {
+        UpdateAssumeRolePolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAssumeRolePolicyError {
@@ -20543,6 +21080,11 @@ impl From<HttpDispatchError> for UpdateGroupError {
         UpdateGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateGroupError {
+    fn from(err: io::Error) -> UpdateGroupError {
+        UpdateGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20630,6 +21172,11 @@ impl From<HttpDispatchError> for UpdateLoginProfileError {
         UpdateLoginProfileError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateLoginProfileError {
+    fn from(err: io::Error) -> UpdateLoginProfileError {
+        UpdateLoginProfileError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateLoginProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20708,6 +21255,11 @@ impl From<HttpDispatchError> for UpdateOpenIDConnectProviderThumbprintError {
         UpdateOpenIDConnectProviderThumbprintError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateOpenIDConnectProviderThumbprintError {
+    fn from(err: io::Error) -> UpdateOpenIDConnectProviderThumbprintError {
+        UpdateOpenIDConnectProviderThumbprintError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateOpenIDConnectProviderThumbprintError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20784,6 +21336,11 @@ impl From<CredentialsError> for UpdateRoleDescriptionError {
 impl From<HttpDispatchError> for UpdateRoleDescriptionError {
     fn from(err: HttpDispatchError) -> UpdateRoleDescriptionError {
         UpdateRoleDescriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateRoleDescriptionError {
+    fn from(err: io::Error) -> UpdateRoleDescriptionError {
+        UpdateRoleDescriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateRoleDescriptionError {
@@ -20873,6 +21430,11 @@ impl From<HttpDispatchError> for UpdateSAMLProviderError {
         UpdateSAMLProviderError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateSAMLProviderError {
+    fn from(err: io::Error) -> UpdateSAMLProviderError {
+        UpdateSAMLProviderError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateSAMLProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20944,6 +21506,11 @@ impl From<CredentialsError> for UpdateSSHPublicKeyError {
 impl From<HttpDispatchError> for UpdateSSHPublicKeyError {
     fn from(err: HttpDispatchError) -> UpdateSSHPublicKeyError {
         UpdateSSHPublicKeyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateSSHPublicKeyError {
+    fn from(err: io::Error) -> UpdateSSHPublicKeyError {
+        UpdateSSHPublicKeyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateSSHPublicKeyError {
@@ -21023,6 +21590,11 @@ impl From<HttpDispatchError> for UpdateServerCertificateError {
         UpdateServerCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateServerCertificateError {
+    fn from(err: io::Error) -> UpdateServerCertificateError {
+        UpdateServerCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateServerCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21092,6 +21664,11 @@ impl From<CredentialsError> for UpdateServiceSpecificCredentialError {
 impl From<HttpDispatchError> for UpdateServiceSpecificCredentialError {
     fn from(err: HttpDispatchError) -> UpdateServiceSpecificCredentialError {
         UpdateServiceSpecificCredentialError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateServiceSpecificCredentialError {
+    fn from(err: io::Error) -> UpdateServiceSpecificCredentialError {
+        UpdateServiceSpecificCredentialError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateServiceSpecificCredentialError {
@@ -21166,6 +21743,11 @@ impl From<CredentialsError> for UpdateSigningCertificateError {
 impl From<HttpDispatchError> for UpdateSigningCertificateError {
     fn from(err: HttpDispatchError) -> UpdateSigningCertificateError {
         UpdateSigningCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateSigningCertificateError {
+    fn from(err: io::Error) -> UpdateSigningCertificateError {
+        UpdateSigningCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateSigningCertificateError {
@@ -21258,6 +21840,11 @@ impl From<HttpDispatchError> for UpdateUserError {
         UpdateUserError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateUserError {
+    fn from(err: io::Error) -> UpdateUserError {
+        UpdateUserError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21344,6 +21931,11 @@ impl From<HttpDispatchError> for UploadSSHPublicKeyError {
         UploadSSHPublicKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UploadSSHPublicKeyError {
+    fn from(err: io::Error) -> UploadSSHPublicKeyError {
+        UploadSSHPublicKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UploadSSHPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21426,6 +22018,11 @@ impl From<CredentialsError> for UploadServerCertificateError {
 impl From<HttpDispatchError> for UploadServerCertificateError {
     fn from(err: HttpDispatchError) -> UploadServerCertificateError {
         UploadServerCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UploadServerCertificateError {
+    fn from(err: io::Error) -> UploadServerCertificateError {
+        UploadServerCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UploadServerCertificateError {
@@ -21516,6 +22113,11 @@ impl From<CredentialsError> for UploadSigningCertificateError {
 impl From<HttpDispatchError> for UploadSigningCertificateError {
     fn from(err: HttpDispatchError) -> UploadSigningCertificateError {
         UploadSigningCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UploadSigningCertificateError {
+    fn from(err: io::Error) -> UploadSigningCertificateError {
+        UploadSigningCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UploadSigningCertificateError {
@@ -22295,15 +22897,17 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(AddClientIDToOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddClientIDToOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -22321,15 +22925,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(AddRoleToInstanceProfileError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddRoleToInstanceProfileError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -22345,15 +22952,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AddUserToGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddUserToGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22372,15 +22980,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AttachGroupPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachGroupPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22399,15 +23008,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AttachRolePolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachRolePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22426,15 +23036,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AttachUserPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachUserPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22451,15 +23062,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ChangePasswordError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ChangePasswordError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22478,16 +23090,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateAccessKeyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22502,8 +23116,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateAccessKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAccessKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22522,15 +23137,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(CreateAccountAliasError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAccountAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22549,16 +23165,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateGroupResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22572,7 +23190,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -22591,16 +23213,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateInstanceProfileResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22616,8 +23240,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateInstanceProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInstanceProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22636,16 +23261,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateLoginProfileResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22660,8 +23287,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateLoginProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLoginProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22681,16 +23309,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateOpenIDConnectProviderResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22704,8 +23334,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -22723,16 +23356,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreatePolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22747,7 +23382,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreatePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22766,16 +23403,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreatePolicyVersionResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22790,8 +23429,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreatePolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22810,16 +23450,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateRoleResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22833,7 +23475,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRoleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -22851,16 +23497,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateSAMLProviderResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22875,8 +23523,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateSAMLProviderError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSAMLProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -22896,16 +23545,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateServiceLinkedRoleResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22921,8 +23572,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateServiceLinkedRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateServiceLinkedRoleError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -22941,16 +23595,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateServiceSpecificCredentialResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -22964,8 +23620,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateServiceSpecificCredentialError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateServiceSpecificCredentialError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -22983,16 +23642,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateUserResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23006,7 +23667,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateUserError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -23025,16 +23690,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateVirtualMFADeviceResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23050,8 +23717,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateVirtualMFADeviceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVirtualMFADeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23070,15 +23738,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeactivateMFADeviceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeactivateMFADeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23097,15 +23766,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteAccessKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAccessKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23124,15 +23794,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteAccountAliasError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAccountAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23149,15 +23820,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteAccountPasswordPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAccountPasswordPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -23173,13 +23847,17 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -23197,15 +23875,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteGroupPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteGroupPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23224,15 +23903,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteInstanceProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteInstanceProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23251,15 +23931,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteLoginProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLoginProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23278,15 +23959,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -23302,14 +23986,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23328,15 +24014,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeletePolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23353,13 +24040,17 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRoleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -23377,15 +24068,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteRolePolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRolePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23404,15 +24096,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteSAMLProviderError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSAMLProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23431,15 +24124,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteSSHPublicKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSSHPublicKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23458,15 +24152,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteServerCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteServerCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -23484,15 +24181,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteServiceSpecificCredentialError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteServiceSpecificCredentialError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -23510,15 +24210,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteSigningCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSigningCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -23534,13 +24237,17 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteUserError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -23558,15 +24265,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteUserPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUserPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23585,15 +24293,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteVirtualMFADeviceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVirtualMFADeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23612,15 +24321,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DetachGroupPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachGroupPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23639,15 +24349,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DetachRolePolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachRolePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23666,15 +24377,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DetachUserPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachUserPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23693,15 +24405,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(EnableMFADeviceError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableMFADeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23720,16 +24433,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GenerateCredentialReportResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23745,8 +24460,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(GenerateCredentialReportError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GenerateCredentialReportError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -23765,16 +24483,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetAccessKeyLastUsedResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23790,8 +24510,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetAccessKeyLastUsedError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAccessKeyLastUsedError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23811,16 +24532,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetAccountAuthorizationDetailsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23834,8 +24557,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(GetAccountAuthorizationDetailsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAccountAuthorizationDetailsError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -23853,16 +24579,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetAccountPasswordPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23878,8 +24606,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(GetAccountPasswordPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAccountPasswordPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -23895,16 +24626,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetAccountSummaryResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23919,8 +24652,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetAccountSummaryError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAccountSummaryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23940,16 +24674,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetContextKeysForPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23965,8 +24701,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(GetContextKeysForCustomPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetContextKeysForCustomPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -23985,16 +24724,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetContextKeysForPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24010,8 +24751,10 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(GetContextKeysForPrincipalPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetContextKeysForPrincipalPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -24028,16 +24771,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetCredentialReportResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24052,8 +24797,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetCredentialReportError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCredentialReportError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24070,16 +24816,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetGroupResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24093,7 +24841,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(GetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -24111,16 +24863,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetGroupPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24135,8 +24889,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetGroupPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetGroupPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24155,16 +24910,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetInstanceProfileResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24179,8 +24936,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetInstanceProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstanceProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24199,16 +24957,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetLoginProfileResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24223,8 +24983,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetLoginProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetLoginProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24244,16 +25005,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetOpenIDConnectProviderResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24269,8 +25032,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(GetOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -24286,16 +25052,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24309,7 +25077,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(GetPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -24327,16 +25099,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetPolicyVersionResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24351,8 +25125,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetPolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24369,16 +25144,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetRoleResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24392,7 +25169,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(GetRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRoleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -24410,16 +25191,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetRolePolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24434,7 +25217,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetRolePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRolePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24453,16 +25238,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetSAMLProviderResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24477,8 +25264,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetSAMLProviderError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSAMLProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24497,16 +25285,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetSSHPublicKeyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24521,8 +25311,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetSSHPublicKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSSHPublicKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24542,16 +25333,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetServerCertificateResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24567,8 +25360,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetServerCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetServerCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24585,16 +25379,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetUserResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24608,7 +25404,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(GetUserError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -24626,16 +25426,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetUserPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24650,7 +25452,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetUserPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetUserPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24669,16 +25473,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListAccessKeysResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24693,8 +25499,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListAccessKeysError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAccessKeysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24713,16 +25520,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListAccountAliasesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24737,8 +25546,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListAccountAliasesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAccountAliasesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24758,16 +25568,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListAttachedGroupPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24781,8 +25593,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListAttachedGroupPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAttachedGroupPoliciesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -24801,16 +25616,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListAttachedRolePoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24826,8 +25643,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListAttachedRolePoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAttachedRolePoliciesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -24846,16 +25666,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListAttachedUserPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24871,8 +25693,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListAttachedUserPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAttachedUserPoliciesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -24891,16 +25716,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListEntitiesForPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24916,8 +25743,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListEntitiesForPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListEntitiesForPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24936,16 +25764,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListGroupPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24960,8 +25790,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListGroupPoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListGroupPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24980,16 +25811,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListGroupsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25003,7 +25836,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25021,16 +25858,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListGroupsForUserResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25045,8 +25884,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListGroupsForUserError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListGroupsForUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25066,16 +25906,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListInstanceProfilesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25091,8 +25933,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListInstanceProfilesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListInstanceProfilesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25112,16 +25955,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListInstanceProfilesForRoleResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25135,8 +25980,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListInstanceProfilesForRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListInstanceProfilesForRoleError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -25154,16 +26002,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListMFADevicesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25178,8 +26028,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListMFADevicesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListMFADevicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25199,16 +26050,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListOpenIDConnectProvidersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25222,8 +26075,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListOpenIDConnectProvidersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOpenIDConnectProvidersError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -25241,16 +26097,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25265,7 +26123,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25284,16 +26144,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListPolicyVersionsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25308,8 +26170,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListPolicyVersionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPolicyVersionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25328,16 +26191,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListRolePoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25352,8 +26217,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListRolePoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRolePoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25370,16 +26236,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListRolesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25393,7 +26261,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListRolesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRolesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25411,16 +26283,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListSAMLProvidersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25435,8 +26309,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListSAMLProvidersError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSAMLProvidersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25455,16 +26330,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListSSHPublicKeysResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25479,8 +26356,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListSSHPublicKeysError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSSHPublicKeysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25500,16 +26378,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListServerCertificatesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25525,8 +26405,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListServerCertificatesError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListServerCertificatesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25546,16 +26427,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListServiceSpecificCredentialsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25569,8 +26452,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListServiceSpecificCredentialsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListServiceSpecificCredentialsError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -25589,16 +26475,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListSigningCertificatesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25614,8 +26502,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListSigningCertificatesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSigningCertificatesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -25633,16 +26524,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListUserPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25657,8 +26550,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListUserPoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUserPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25675,16 +26569,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListUsersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25698,7 +26594,11 @@ impl<P, D> Iam for IamClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListUsersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListUsersError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25717,16 +26617,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListVirtualMFADevicesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25742,8 +26644,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListVirtualMFADevicesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListVirtualMFADevicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25760,15 +26663,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(PutGroupPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutGroupPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25785,14 +26689,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(PutRolePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRolePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25809,14 +26715,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(PutUserPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutUserPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25838,15 +26746,17 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(RemoveClientIDFromOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveClientIDFromOpenIDConnectProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25864,15 +26774,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(RemoveRoleFromInstanceProfileError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveRoleFromInstanceProfileError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -25890,15 +26803,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(RemoveUserFromGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveUserFromGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25918,16 +26832,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ResetServiceSpecificCredentialResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25941,8 +26857,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ResetServiceSpecificCredentialError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetServiceSpecificCredentialError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -25960,15 +26879,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(ResyncMFADeviceError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResyncMFADeviceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25987,15 +26907,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(SetDefaultPolicyVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetDefaultPolicyVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -26013,16 +26936,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SimulatePolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26037,8 +26962,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SimulateCustomPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SimulateCustomPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26058,16 +26984,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SimulatePolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26082,8 +27010,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(SimulatePrincipalPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SimulatePrincipalPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -26101,15 +27032,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(UpdateAccessKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAccessKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26128,15 +27060,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(UpdateAccountPasswordPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAccountPasswordPolicyError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -26154,15 +27089,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(UpdateAssumeRolePolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAssumeRolePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26179,13 +27115,17 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(UpdateGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -26203,15 +27143,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(UpdateLoginProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateLoginProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26231,15 +27172,17 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(UpdateOpenIDConnectProviderThumbprintError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateOpenIDConnectProviderThumbprintError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -26258,16 +27201,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateRoleDescriptionResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26283,8 +27228,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateRoleDescriptionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRoleDescriptionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26303,16 +27249,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateSAMLProviderResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26327,8 +27275,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateSAMLProviderError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateSAMLProviderError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26347,15 +27296,16 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(UpdateSSHPublicKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateSSHPublicKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26374,15 +27324,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(UpdateServerCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateServerCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -26400,15 +27353,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(UpdateServiceSpecificCredentialError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateServiceSpecificCredentialError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -26426,15 +27382,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(UpdateSigningCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateSigningCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -26450,13 +27409,17 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(UpdateUserError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateUserError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -26474,16 +27437,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UploadSSHPublicKeyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26498,8 +27463,9 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UploadSSHPublicKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UploadSSHPublicKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26519,16 +27485,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UploadServerCertificateResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26544,8 +27512,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(UploadServerCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UploadServerCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -26564,16 +27535,18 @@ impl<P, D> Iam for IamClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UploadSigningCertificateResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26589,8 +27562,11 @@ impl<P, D> Iam for IamClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(UploadSigningCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UploadSigningCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1266,6 +1268,11 @@ impl From<HttpDispatchError> for CancelJobError {
         CancelJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelJobError {
+    fn from(err: io::Error) -> CancelJobError {
+        CancelJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1414,6 +1421,11 @@ impl From<HttpDispatchError> for CreateJobError {
         CreateJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateJobError {
+    fn from(err: io::Error) -> CreateJobError {
+        CreateJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1525,6 +1537,11 @@ impl From<HttpDispatchError> for GetShippingLabelError {
         GetShippingLabelError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetShippingLabelError {
+    fn from(err: io::Error) -> GetShippingLabelError {
+        GetShippingLabelError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetShippingLabelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1619,6 +1636,11 @@ impl From<HttpDispatchError> for GetStatusError {
         GetStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetStatusError {
+    fn from(err: io::Error) -> GetStatusError {
+        GetStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1699,6 +1721,11 @@ impl From<CredentialsError> for ListJobsError {
 impl From<HttpDispatchError> for ListJobsError {
     fn from(err: HttpDispatchError) -> ListJobsError {
         ListJobsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListJobsError {
+    fn from(err: io::Error) -> ListJobsError {
+        ListJobsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListJobsError {
@@ -1856,6 +1883,11 @@ impl From<HttpDispatchError> for UpdateJobError {
         UpdateJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateJobError {
+    fn from(err: io::Error) -> UpdateJobError {
+        UpdateJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1955,16 +1987,18 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CancelJobOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -1978,7 +2012,11 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CancelJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1995,16 +2033,18 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateJobOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -2018,7 +2058,11 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2039,16 +2083,18 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetShippingLabelOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -2063,8 +2109,9 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetShippingLabelError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetShippingLabelError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2082,16 +2129,18 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetStatusOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -2105,7 +2154,11 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(GetStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2122,16 +2175,18 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListJobsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -2145,7 +2200,11 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListJobsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2162,16 +2221,18 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateJobOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -2185,7 +2246,11 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(UpdateJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1249,6 +1251,11 @@ impl From<HttpDispatchError> for AddAttributesToFindingsError {
         AddAttributesToFindingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddAttributesToFindingsError {
+    fn from(err: io::Error) -> AddAttributesToFindingsError {
+        AddAttributesToFindingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddAttributesToFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1346,6 +1353,11 @@ impl From<CredentialsError> for CreateAssessmentTargetError {
 impl From<HttpDispatchError> for CreateAssessmentTargetError {
     fn from(err: HttpDispatchError) -> CreateAssessmentTargetError {
         CreateAssessmentTargetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAssessmentTargetError {
+    fn from(err: io::Error) -> CreateAssessmentTargetError {
+        CreateAssessmentTargetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAssessmentTargetError {
@@ -1448,6 +1460,11 @@ impl From<HttpDispatchError> for CreateAssessmentTemplateError {
         CreateAssessmentTemplateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateAssessmentTemplateError {
+    fn from(err: io::Error) -> CreateAssessmentTemplateError {
+        CreateAssessmentTemplateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateAssessmentTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1541,6 +1558,11 @@ impl From<CredentialsError> for CreateResourceGroupError {
 impl From<HttpDispatchError> for CreateResourceGroupError {
     fn from(err: HttpDispatchError) -> CreateResourceGroupError {
         CreateResourceGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateResourceGroupError {
+    fn from(err: io::Error) -> CreateResourceGroupError {
+        CreateResourceGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateResourceGroupError {
@@ -1638,6 +1660,11 @@ impl From<CredentialsError> for DeleteAssessmentRunError {
 impl From<HttpDispatchError> for DeleteAssessmentRunError {
     fn from(err: HttpDispatchError) -> DeleteAssessmentRunError {
         DeleteAssessmentRunError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteAssessmentRunError {
+    fn from(err: io::Error) -> DeleteAssessmentRunError {
+        DeleteAssessmentRunError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteAssessmentRunError {
@@ -1738,6 +1765,11 @@ impl From<HttpDispatchError> for DeleteAssessmentTargetError {
         DeleteAssessmentTargetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAssessmentTargetError {
+    fn from(err: io::Error) -> DeleteAssessmentTargetError {
+        DeleteAssessmentTargetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAssessmentTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1836,6 +1868,11 @@ impl From<HttpDispatchError> for DeleteAssessmentTemplateError {
         DeleteAssessmentTemplateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAssessmentTemplateError {
+    fn from(err: io::Error) -> DeleteAssessmentTemplateError {
+        DeleteAssessmentTemplateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAssessmentTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1921,6 +1958,11 @@ impl From<HttpDispatchError> for DescribeAssessmentRunsError {
         DescribeAssessmentRunsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAssessmentRunsError {
+    fn from(err: io::Error) -> DescribeAssessmentRunsError {
+        DescribeAssessmentRunsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAssessmentRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2001,6 +2043,11 @@ impl From<CredentialsError> for DescribeAssessmentTargetsError {
 impl From<HttpDispatchError> for DescribeAssessmentTargetsError {
     fn from(err: HttpDispatchError) -> DescribeAssessmentTargetsError {
         DescribeAssessmentTargetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAssessmentTargetsError {
+    fn from(err: io::Error) -> DescribeAssessmentTargetsError {
+        DescribeAssessmentTargetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAssessmentTargetsError {
@@ -2085,6 +2132,11 @@ impl From<HttpDispatchError> for DescribeAssessmentTemplatesError {
         DescribeAssessmentTemplatesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAssessmentTemplatesError {
+    fn from(err: io::Error) -> DescribeAssessmentTemplatesError {
+        DescribeAssessmentTemplatesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAssessmentTemplatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2160,6 +2212,11 @@ impl From<CredentialsError> for DescribeCrossAccountAccessRoleError {
 impl From<HttpDispatchError> for DescribeCrossAccountAccessRoleError {
     fn from(err: HttpDispatchError) -> DescribeCrossAccountAccessRoleError {
         DescribeCrossAccountAccessRoleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCrossAccountAccessRoleError {
+    fn from(err: io::Error) -> DescribeCrossAccountAccessRoleError {
+        DescribeCrossAccountAccessRoleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCrossAccountAccessRoleError {
@@ -2243,6 +2300,11 @@ impl From<HttpDispatchError> for DescribeFindingsError {
         DescribeFindingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeFindingsError {
+    fn from(err: io::Error) -> DescribeFindingsError {
+        DescribeFindingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2321,6 +2383,11 @@ impl From<CredentialsError> for DescribeResourceGroupsError {
 impl From<HttpDispatchError> for DescribeResourceGroupsError {
     fn from(err: HttpDispatchError) -> DescribeResourceGroupsError {
         DescribeResourceGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeResourceGroupsError {
+    fn from(err: io::Error) -> DescribeResourceGroupsError {
+        DescribeResourceGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeResourceGroupsError {
@@ -2403,6 +2470,11 @@ impl From<CredentialsError> for DescribeRulesPackagesError {
 impl From<HttpDispatchError> for DescribeRulesPackagesError {
     fn from(err: HttpDispatchError) -> DescribeRulesPackagesError {
         DescribeRulesPackagesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeRulesPackagesError {
+    fn from(err: io::Error) -> DescribeRulesPackagesError {
+        DescribeRulesPackagesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeRulesPackagesError {
@@ -2505,6 +2577,11 @@ impl From<HttpDispatchError> for GetAssessmentReportError {
         GetAssessmentReportError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAssessmentReportError {
+    fn from(err: io::Error) -> GetAssessmentReportError {
+        GetAssessmentReportError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAssessmentReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2601,6 +2678,11 @@ impl From<HttpDispatchError> for GetTelemetryMetadataError {
         GetTelemetryMetadataError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetTelemetryMetadataError {
+    fn from(err: io::Error) -> GetTelemetryMetadataError {
+        GetTelemetryMetadataError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetTelemetryMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2693,6 +2775,11 @@ impl From<CredentialsError> for ListAssessmentRunAgentsError {
 impl From<HttpDispatchError> for ListAssessmentRunAgentsError {
     fn from(err: HttpDispatchError) -> ListAssessmentRunAgentsError {
         ListAssessmentRunAgentsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAssessmentRunAgentsError {
+    fn from(err: io::Error) -> ListAssessmentRunAgentsError {
+        ListAssessmentRunAgentsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAssessmentRunAgentsError {
@@ -2789,6 +2876,11 @@ impl From<HttpDispatchError> for ListAssessmentRunsError {
         ListAssessmentRunsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListAssessmentRunsError {
+    fn from(err: io::Error) -> ListAssessmentRunsError {
+        ListAssessmentRunsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListAssessmentRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2876,6 +2968,11 @@ impl From<CredentialsError> for ListAssessmentTargetsError {
 impl From<HttpDispatchError> for ListAssessmentTargetsError {
     fn from(err: HttpDispatchError) -> ListAssessmentTargetsError {
         ListAssessmentTargetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAssessmentTargetsError {
+    fn from(err: io::Error) -> ListAssessmentTargetsError {
+        ListAssessmentTargetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAssessmentTargetsError {
@@ -2969,6 +3066,11 @@ impl From<CredentialsError> for ListAssessmentTemplatesError {
 impl From<HttpDispatchError> for ListAssessmentTemplatesError {
     fn from(err: HttpDispatchError) -> ListAssessmentTemplatesError {
         ListAssessmentTemplatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAssessmentTemplatesError {
+    fn from(err: io::Error) -> ListAssessmentTemplatesError {
+        ListAssessmentTemplatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAssessmentTemplatesError {
@@ -3065,6 +3167,11 @@ impl From<HttpDispatchError> for ListEventSubscriptionsError {
         ListEventSubscriptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListEventSubscriptionsError {
+    fn from(err: io::Error) -> ListEventSubscriptionsError {
+        ListEventSubscriptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3157,6 +3264,11 @@ impl From<HttpDispatchError> for ListFindingsError {
         ListFindingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListFindingsError {
+    fn from(err: io::Error) -> ListFindingsError {
+        ListFindingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3242,6 +3354,11 @@ impl From<CredentialsError> for ListRulesPackagesError {
 impl From<HttpDispatchError> for ListRulesPackagesError {
     fn from(err: HttpDispatchError) -> ListRulesPackagesError {
         ListRulesPackagesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRulesPackagesError {
+    fn from(err: io::Error) -> ListRulesPackagesError {
+        ListRulesPackagesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRulesPackagesError {
@@ -3335,6 +3452,11 @@ impl From<CredentialsError> for ListTagsForResourceError {
 impl From<HttpDispatchError> for ListTagsForResourceError {
     fn from(err: HttpDispatchError) -> ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForResourceError {
@@ -3436,6 +3558,11 @@ impl From<HttpDispatchError> for PreviewAgentsError {
         PreviewAgentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PreviewAgentsError {
+    fn from(err: io::Error) -> PreviewAgentsError {
+        PreviewAgentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PreviewAgentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3521,6 +3648,11 @@ impl From<CredentialsError> for RegisterCrossAccountAccessRoleError {
 impl From<HttpDispatchError> for RegisterCrossAccountAccessRoleError {
     fn from(err: HttpDispatchError) -> RegisterCrossAccountAccessRoleError {
         RegisterCrossAccountAccessRoleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterCrossAccountAccessRoleError {
+    fn from(err: io::Error) -> RegisterCrossAccountAccessRoleError {
+        RegisterCrossAccountAccessRoleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterCrossAccountAccessRoleError {
@@ -3617,6 +3749,11 @@ impl From<HttpDispatchError> for RemoveAttributesFromFindingsError {
         RemoveAttributesFromFindingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveAttributesFromFindingsError {
+    fn from(err: io::Error) -> RemoveAttributesFromFindingsError {
+        RemoveAttributesFromFindingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveAttributesFromFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3709,6 +3846,11 @@ impl From<CredentialsError> for SetTagsForResourceError {
 impl From<HttpDispatchError> for SetTagsForResourceError {
     fn from(err: HttpDispatchError) -> SetTagsForResourceError {
         SetTagsForResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetTagsForResourceError {
+    fn from(err: io::Error) -> SetTagsForResourceError {
+        SetTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetTagsForResourceError {
@@ -3816,6 +3958,11 @@ impl From<HttpDispatchError> for StartAssessmentRunError {
         StartAssessmentRunError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartAssessmentRunError {
+    fn from(err: io::Error) -> StartAssessmentRunError {
+        StartAssessmentRunError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartAssessmentRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3911,6 +4058,11 @@ impl From<CredentialsError> for StopAssessmentRunError {
 impl From<HttpDispatchError> for StopAssessmentRunError {
     fn from(err: HttpDispatchError) -> StopAssessmentRunError {
         StopAssessmentRunError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopAssessmentRunError {
+    fn from(err: io::Error) -> StopAssessmentRunError {
+        StopAssessmentRunError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopAssessmentRunError {
@@ -4012,6 +4164,11 @@ impl From<HttpDispatchError> for SubscribeToEventError {
         SubscribeToEventError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SubscribeToEventError {
+    fn from(err: io::Error) -> SubscribeToEventError {
+        SubscribeToEventError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SubscribeToEventError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4103,6 +4260,11 @@ impl From<CredentialsError> for UnsubscribeFromEventError {
 impl From<HttpDispatchError> for UnsubscribeFromEventError {
     fn from(err: HttpDispatchError) -> UnsubscribeFromEventError {
         UnsubscribeFromEventError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UnsubscribeFromEventError {
+    fn from(err: io::Error) -> UnsubscribeFromEventError {
+        UnsubscribeFromEventError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UnsubscribeFromEventError {
@@ -4197,6 +4359,11 @@ impl From<CredentialsError> for UpdateAssessmentTargetError {
 impl From<HttpDispatchError> for UpdateAssessmentTargetError {
     fn from(err: HttpDispatchError) -> UpdateAssessmentTargetError {
         UpdateAssessmentTargetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAssessmentTargetError {
+    fn from(err: io::Error) -> UpdateAssessmentTargetError {
+        UpdateAssessmentTargetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAssessmentTargetError {
@@ -4474,13 +4641,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddAttributesToFindingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AddAttributesToFindingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddAttributesToFindingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddAttributesToFindingsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4499,15 +4673,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAssessmentTargetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAssessmentTargetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateAssessmentTargetError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAssessmentTargetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4527,13 +4704,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAssessmentTemplateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateAssessmentTemplateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAssessmentTemplateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAssessmentTemplateError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4551,15 +4735,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateResourceGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateResourceGroupResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateResourceGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateResourceGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4578,13 +4765,14 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteAssessmentRunError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAssessmentRunError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4603,13 +4791,14 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteAssessmentTargetError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAssessmentTargetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4628,11 +4817,16 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteAssessmentTemplateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAssessmentTemplateError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4651,15 +4845,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAssessmentRunsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAssessmentRunsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeAssessmentRunsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAssessmentRunsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4679,13 +4876,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAssessmentTargetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeAssessmentTargetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAssessmentTargetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAssessmentTargetsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -4705,13 +4909,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAssessmentTemplatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeAssessmentTemplatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAssessmentTemplatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAssessmentTemplatesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -4729,13 +4940,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCrossAccountAccessRoleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeCrossAccountAccessRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCrossAccountAccessRoleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCrossAccountAccessRoleError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -4753,15 +4971,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeFindingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeFindingsResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeFindingsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeFindingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4781,15 +5004,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeResourceGroupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeResourceGroupsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeResourceGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeResourceGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4809,15 +5035,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeRulesPackagesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeRulesPackagesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeRulesPackagesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRulesPackagesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4836,15 +5065,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetAssessmentReportResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetAssessmentReportResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetAssessmentReportError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAssessmentReportError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4864,15 +5096,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetTelemetryMetadataResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetTelemetryMetadataResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetTelemetryMetadataError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTelemetryMetadataError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4892,13 +5127,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAssessmentRunAgentsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListAssessmentRunAgentsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAssessmentRunAgentsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAssessmentRunAgentsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4916,15 +5158,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAssessmentRunsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAssessmentRunsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListAssessmentRunsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAssessmentRunsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4944,15 +5189,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAssessmentTargetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAssessmentTargetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListAssessmentTargetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAssessmentTargetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4972,13 +5220,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAssessmentTemplatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListAssessmentTemplatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAssessmentTemplatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAssessmentTemplatesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4997,15 +5252,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListEventSubscriptionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListEventSubscriptionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListEventSubscriptionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListEventSubscriptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5024,14 +5282,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListFindingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListFindingsResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListFindingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListFindingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5050,15 +5314,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRulesPackagesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRulesPackagesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListRulesPackagesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRulesPackagesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5077,15 +5344,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5104,14 +5374,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PreviewAgentsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PreviewAgentsResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PreviewAgentsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PreviewAgentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5131,11 +5407,16 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RegisterCrossAccountAccessRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterCrossAccountAccessRoleError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -5155,13 +5436,20 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveAttributesFromFindingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RemoveAttributesFromFindingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveAttributesFromFindingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveAttributesFromFindingsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -5179,13 +5467,14 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(SetTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5204,15 +5493,18 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartAssessmentRunResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartAssessmentRunResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(StartAssessmentRunError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartAssessmentRunError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5231,13 +5523,14 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(StopAssessmentRunError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopAssessmentRunError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5256,13 +5549,14 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(SubscribeToEventError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SubscribeToEventError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5281,13 +5575,14 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UnsubscribeFromEventError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnsubscribeFromEventError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5306,13 +5601,14 @@ impl<P, D> Inspector for InspectorClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateAssessmentTargetError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAssessmentTargetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1954,6 +1956,11 @@ impl From<HttpDispatchError> for AcceptCertificateTransferError {
         AcceptCertificateTransferError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AcceptCertificateTransferError {
+    fn from(err: io::Error) -> AcceptCertificateTransferError {
+        AcceptCertificateTransferError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AcceptCertificateTransferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2066,6 +2073,11 @@ impl From<HttpDispatchError> for AttachPrincipalPolicyError {
         AttachPrincipalPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachPrincipalPolicyError {
+    fn from(err: io::Error) -> AttachPrincipalPolicyError {
+        AttachPrincipalPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachPrincipalPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2173,6 +2185,11 @@ impl From<HttpDispatchError> for AttachThingPrincipalError {
         AttachThingPrincipalError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachThingPrincipalError {
+    fn from(err: io::Error) -> AttachThingPrincipalError {
+        AttachThingPrincipalError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachThingPrincipalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2278,6 +2295,11 @@ impl From<HttpDispatchError> for CancelCertificateTransferError {
         CancelCertificateTransferError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelCertificateTransferError {
+    fn from(err: io::Error) -> CancelCertificateTransferError {
+        CancelCertificateTransferError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelCertificateTransferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2378,6 +2400,11 @@ impl From<HttpDispatchError> for CreateCertificateFromCsrError {
         CreateCertificateFromCsrError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateCertificateFromCsrError {
+    fn from(err: io::Error) -> CreateCertificateFromCsrError {
+        CreateCertificateFromCsrError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateCertificateFromCsrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2474,6 +2501,11 @@ impl From<CredentialsError> for CreateKeysAndCertificateError {
 impl From<HttpDispatchError> for CreateKeysAndCertificateError {
     fn from(err: HttpDispatchError) -> CreateKeysAndCertificateError {
         CreateKeysAndCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateKeysAndCertificateError {
+    fn from(err: io::Error) -> CreateKeysAndCertificateError {
+        CreateKeysAndCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateKeysAndCertificateError {
@@ -2584,6 +2616,11 @@ impl From<CredentialsError> for CreatePolicyError {
 impl From<HttpDispatchError> for CreatePolicyError {
     fn from(err: HttpDispatchError) -> CreatePolicyError {
         CreatePolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePolicyError {
+    fn from(err: io::Error) -> CreatePolicyError {
+        CreatePolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePolicyError {
@@ -2701,6 +2738,11 @@ impl From<HttpDispatchError> for CreatePolicyVersionError {
         CreatePolicyVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreatePolicyVersionError {
+    fn from(err: io::Error) -> CreatePolicyVersionError {
+        CreatePolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreatePolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2814,6 +2856,11 @@ impl From<HttpDispatchError> for CreateThingError {
         CreateThingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateThingError {
+    fn from(err: io::Error) -> CreateThingError {
+        CreateThingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2919,6 +2966,11 @@ impl From<HttpDispatchError> for CreateThingTypeError {
         CreateThingTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateThingTypeError {
+    fn from(err: io::Error) -> CreateThingTypeError {
+        CreateThingTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateThingTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3016,6 +3068,11 @@ impl From<CredentialsError> for CreateTopicRuleError {
 impl From<HttpDispatchError> for CreateTopicRuleError {
     fn from(err: HttpDispatchError) -> CreateTopicRuleError {
         CreateTopicRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateTopicRuleError {
+    fn from(err: io::Error) -> CreateTopicRuleError {
+        CreateTopicRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateTopicRuleError {
@@ -3124,6 +3181,11 @@ impl From<CredentialsError> for DeleteCACertificateError {
 impl From<HttpDispatchError> for DeleteCACertificateError {
     fn from(err: HttpDispatchError) -> DeleteCACertificateError {
         DeleteCACertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteCACertificateError {
+    fn from(err: io::Error) -> DeleteCACertificateError {
+        DeleteCACertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteCACertificateError {
@@ -3243,6 +3305,11 @@ impl From<HttpDispatchError> for DeleteCertificateError {
         DeleteCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteCertificateError {
+    fn from(err: io::Error) -> DeleteCertificateError {
+        DeleteCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3356,6 +3423,11 @@ impl From<HttpDispatchError> for DeletePolicyError {
         DeletePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePolicyError {
+    fn from(err: io::Error) -> DeletePolicyError {
+        DeletePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3466,6 +3538,11 @@ impl From<HttpDispatchError> for DeletePolicyVersionError {
         DeletePolicyVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePolicyVersionError {
+    fn from(err: io::Error) -> DeletePolicyVersionError {
+        DeletePolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3566,6 +3643,11 @@ impl From<CredentialsError> for DeleteRegistrationCodeError {
 impl From<HttpDispatchError> for DeleteRegistrationCodeError {
     fn from(err: HttpDispatchError) -> DeleteRegistrationCodeError {
         DeleteRegistrationCodeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteRegistrationCodeError {
+    fn from(err: io::Error) -> DeleteRegistrationCodeError {
+        DeleteRegistrationCodeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteRegistrationCodeError {
@@ -3678,6 +3760,11 @@ impl From<HttpDispatchError> for DeleteThingError {
         DeleteThingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteThingError {
+    fn from(err: io::Error) -> DeleteThingError {
+        DeleteThingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3783,6 +3870,11 @@ impl From<HttpDispatchError> for DeleteThingTypeError {
         DeleteThingTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteThingTypeError {
+    fn from(err: io::Error) -> DeleteThingTypeError {
+        DeleteThingTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteThingTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3875,6 +3967,11 @@ impl From<CredentialsError> for DeleteTopicRuleError {
 impl From<HttpDispatchError> for DeleteTopicRuleError {
     fn from(err: HttpDispatchError) -> DeleteTopicRuleError {
         DeleteTopicRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteTopicRuleError {
+    fn from(err: io::Error) -> DeleteTopicRuleError {
+        DeleteTopicRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteTopicRuleError {
@@ -3977,6 +4074,11 @@ impl From<CredentialsError> for DeprecateThingTypeError {
 impl From<HttpDispatchError> for DeprecateThingTypeError {
     fn from(err: HttpDispatchError) -> DeprecateThingTypeError {
         DeprecateThingTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeprecateThingTypeError {
+    fn from(err: io::Error) -> DeprecateThingTypeError {
+        DeprecateThingTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeprecateThingTypeError {
@@ -4085,6 +4187,11 @@ impl From<HttpDispatchError> for DescribeCACertificateError {
         DescribeCACertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCACertificateError {
+    fn from(err: io::Error) -> DescribeCACertificateError {
+        DescribeCACertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCACertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4191,6 +4298,11 @@ impl From<HttpDispatchError> for DescribeCertificateError {
         DescribeCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCertificateError {
+    fn from(err: io::Error) -> DescribeCertificateError {
+        DescribeCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4280,6 +4392,11 @@ impl From<CredentialsError> for DescribeEndpointError {
 impl From<HttpDispatchError> for DescribeEndpointError {
     fn from(err: HttpDispatchError) -> DescribeEndpointError {
         DescribeEndpointError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEndpointError {
+    fn from(err: io::Error) -> DescribeEndpointError {
+        DescribeEndpointError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEndpointError {
@@ -4381,6 +4498,11 @@ impl From<CredentialsError> for DescribeThingError {
 impl From<HttpDispatchError> for DescribeThingError {
     fn from(err: HttpDispatchError) -> DescribeThingError {
         DescribeThingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeThingError {
+    fn from(err: io::Error) -> DescribeThingError {
+        DescribeThingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeThingError {
@@ -4485,6 +4607,11 @@ impl From<CredentialsError> for DescribeThingTypeError {
 impl From<HttpDispatchError> for DescribeThingTypeError {
     fn from(err: HttpDispatchError) -> DescribeThingTypeError {
         DescribeThingTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeThingTypeError {
+    fn from(err: io::Error) -> DescribeThingTypeError {
+        DescribeThingTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeThingTypeError {
@@ -4593,6 +4720,11 @@ impl From<HttpDispatchError> for DetachPrincipalPolicyError {
         DetachPrincipalPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachPrincipalPolicyError {
+    fn from(err: io::Error) -> DetachPrincipalPolicyError {
+        DetachPrincipalPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachPrincipalPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4699,6 +4831,11 @@ impl From<HttpDispatchError> for DetachThingPrincipalError {
         DetachThingPrincipalError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachThingPrincipalError {
+    fn from(err: io::Error) -> DetachThingPrincipalError {
+        DetachThingPrincipalError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachThingPrincipalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4795,6 +4932,11 @@ impl From<HttpDispatchError> for DisableTopicRuleError {
         DisableTopicRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisableTopicRuleError {
+    fn from(err: io::Error) -> DisableTopicRuleError {
+        DisableTopicRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisableTopicRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4887,6 +5029,11 @@ impl From<HttpDispatchError> for EnableTopicRuleError {
         EnableTopicRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableTopicRuleError {
+    fn from(err: io::Error) -> EnableTopicRuleError {
+        EnableTopicRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableTopicRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4972,6 +5119,11 @@ impl From<CredentialsError> for GetLoggingOptionsError {
 impl From<HttpDispatchError> for GetLoggingOptionsError {
     fn from(err: HttpDispatchError) -> GetLoggingOptionsError {
         GetLoggingOptionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetLoggingOptionsError {
+    fn from(err: io::Error) -> GetLoggingOptionsError {
+        GetLoggingOptionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetLoggingOptionsError {
@@ -5073,6 +5225,11 @@ impl From<CredentialsError> for GetPolicyError {
 impl From<HttpDispatchError> for GetPolicyError {
     fn from(err: HttpDispatchError) -> GetPolicyError {
         GetPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetPolicyError {
+    fn from(err: io::Error) -> GetPolicyError {
+        GetPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetPolicyError {
@@ -5179,6 +5336,11 @@ impl From<HttpDispatchError> for GetPolicyVersionError {
         GetPolicyVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetPolicyVersionError {
+    fn from(err: io::Error) -> GetPolicyVersionError {
+        GetPolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5278,6 +5440,11 @@ impl From<HttpDispatchError> for GetRegistrationCodeError {
         GetRegistrationCodeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRegistrationCodeError {
+    fn from(err: io::Error) -> GetRegistrationCodeError {
+        GetRegistrationCodeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRegistrationCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5369,6 +5536,11 @@ impl From<CredentialsError> for GetTopicRuleError {
 impl From<HttpDispatchError> for GetTopicRuleError {
     fn from(err: HttpDispatchError) -> GetTopicRuleError {
         GetTopicRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetTopicRuleError {
+    fn from(err: io::Error) -> GetTopicRuleError {
+        GetTopicRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetTopicRuleError {
@@ -5466,6 +5638,11 @@ impl From<CredentialsError> for ListCACertificatesError {
 impl From<HttpDispatchError> for ListCACertificatesError {
     fn from(err: HttpDispatchError) -> ListCACertificatesError {
         ListCACertificatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListCACertificatesError {
+    fn from(err: io::Error) -> ListCACertificatesError {
+        ListCACertificatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListCACertificatesError {
@@ -5568,6 +5745,11 @@ impl From<HttpDispatchError> for ListCertificatesError {
         ListCertificatesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListCertificatesError {
+    fn from(err: io::Error) -> ListCertificatesError {
+        ListCertificatesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5664,6 +5846,11 @@ impl From<CredentialsError> for ListCertificatesByCAError {
 impl From<HttpDispatchError> for ListCertificatesByCAError {
     fn from(err: HttpDispatchError) -> ListCertificatesByCAError {
         ListCertificatesByCAError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListCertificatesByCAError {
+    fn from(err: io::Error) -> ListCertificatesByCAError {
+        ListCertificatesByCAError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListCertificatesByCAError {
@@ -5764,6 +5951,11 @@ impl From<HttpDispatchError> for ListOutgoingCertificatesError {
         ListOutgoingCertificatesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListOutgoingCertificatesError {
+    fn from(err: io::Error) -> ListOutgoingCertificatesError {
+        ListOutgoingCertificatesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListOutgoingCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5862,6 +6054,11 @@ impl From<CredentialsError> for ListPoliciesError {
 impl From<HttpDispatchError> for ListPoliciesError {
     fn from(err: HttpDispatchError) -> ListPoliciesError {
         ListPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPoliciesError {
+    fn from(err: io::Error) -> ListPoliciesError {
+        ListPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPoliciesError {
@@ -5965,6 +6162,11 @@ impl From<CredentialsError> for ListPolicyPrincipalsError {
 impl From<HttpDispatchError> for ListPolicyPrincipalsError {
     fn from(err: HttpDispatchError) -> ListPolicyPrincipalsError {
         ListPolicyPrincipalsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPolicyPrincipalsError {
+    fn from(err: io::Error) -> ListPolicyPrincipalsError {
+        ListPolicyPrincipalsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPolicyPrincipalsError {
@@ -6073,6 +6275,11 @@ impl From<HttpDispatchError> for ListPolicyVersionsError {
         ListPolicyVersionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPolicyVersionsError {
+    fn from(err: io::Error) -> ListPolicyVersionsError {
+        ListPolicyVersionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPolicyVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6177,6 +6384,11 @@ impl From<CredentialsError> for ListPrincipalPoliciesError {
 impl From<HttpDispatchError> for ListPrincipalPoliciesError {
     fn from(err: HttpDispatchError) -> ListPrincipalPoliciesError {
         ListPrincipalPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPrincipalPoliciesError {
+    fn from(err: io::Error) -> ListPrincipalPoliciesError {
+        ListPrincipalPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPrincipalPoliciesError {
@@ -6285,6 +6497,11 @@ impl From<HttpDispatchError> for ListPrincipalThingsError {
         ListPrincipalThingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPrincipalThingsError {
+    fn from(err: io::Error) -> ListPrincipalThingsError {
+        ListPrincipalThingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPrincipalThingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6391,6 +6608,11 @@ impl From<HttpDispatchError> for ListThingPrincipalsError {
         ListThingPrincipalsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListThingPrincipalsError {
+    fn from(err: io::Error) -> ListThingPrincipalsError {
+        ListThingPrincipalsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListThingPrincipalsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6492,6 +6714,11 @@ impl From<HttpDispatchError> for ListThingTypesError {
         ListThingTypesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListThingTypesError {
+    fn from(err: io::Error) -> ListThingTypesError {
+        ListThingTypesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListThingTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6588,6 +6815,11 @@ impl From<HttpDispatchError> for ListThingsError {
         ListThingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListThingsError {
+    fn from(err: io::Error) -> ListThingsError {
+        ListThingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListThingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6674,6 +6906,11 @@ impl From<CredentialsError> for ListTopicRulesError {
 impl From<HttpDispatchError> for ListTopicRulesError {
     fn from(err: HttpDispatchError) -> ListTopicRulesError {
         ListTopicRulesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTopicRulesError {
+    fn from(err: io::Error) -> ListTopicRulesError {
+        ListTopicRulesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTopicRulesError {
@@ -6784,6 +7021,11 @@ impl From<CredentialsError> for RegisterCACertificateError {
 impl From<HttpDispatchError> for RegisterCACertificateError {
     fn from(err: HttpDispatchError) -> RegisterCACertificateError {
         RegisterCACertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterCACertificateError {
+    fn from(err: io::Error) -> RegisterCACertificateError {
+        RegisterCACertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterCACertificateError {
@@ -6910,6 +7152,11 @@ impl From<HttpDispatchError> for RegisterCertificateError {
         RegisterCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterCertificateError {
+    fn from(err: io::Error) -> RegisterCertificateError {
+        RegisterCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7018,6 +7265,11 @@ impl From<HttpDispatchError> for RejectCertificateTransferError {
         RejectCertificateTransferError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RejectCertificateTransferError {
+    fn from(err: io::Error) -> RejectCertificateTransferError {
+        RejectCertificateTransferError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RejectCertificateTransferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7118,6 +7370,11 @@ impl From<CredentialsError> for ReplaceTopicRuleError {
 impl From<HttpDispatchError> for ReplaceTopicRuleError {
     fn from(err: HttpDispatchError) -> ReplaceTopicRuleError {
         ReplaceTopicRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ReplaceTopicRuleError {
+    fn from(err: io::Error) -> ReplaceTopicRuleError {
+        ReplaceTopicRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ReplaceTopicRuleError {
@@ -7221,6 +7478,11 @@ impl From<HttpDispatchError> for SetDefaultPolicyVersionError {
         SetDefaultPolicyVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetDefaultPolicyVersionError {
+    fn from(err: io::Error) -> SetDefaultPolicyVersionError {
+        SetDefaultPolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetDefaultPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7310,6 +7572,11 @@ impl From<CredentialsError> for SetLoggingOptionsError {
 impl From<HttpDispatchError> for SetLoggingOptionsError {
     fn from(err: HttpDispatchError) -> SetLoggingOptionsError {
         SetLoggingOptionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetLoggingOptionsError {
+    fn from(err: io::Error) -> SetLoggingOptionsError {
+        SetLoggingOptionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetLoggingOptionsError {
@@ -7425,6 +7692,11 @@ impl From<HttpDispatchError> for TransferCertificateError {
         TransferCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TransferCertificateError {
+    fn from(err: io::Error) -> TransferCertificateError {
+        TransferCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TransferCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7531,6 +7803,11 @@ impl From<CredentialsError> for UpdateCACertificateError {
 impl From<HttpDispatchError> for UpdateCACertificateError {
     fn from(err: HttpDispatchError) -> UpdateCACertificateError {
         UpdateCACertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateCACertificateError {
+    fn from(err: io::Error) -> UpdateCACertificateError {
+        UpdateCACertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateCACertificateError {
@@ -7644,6 +7921,11 @@ impl From<HttpDispatchError> for UpdateCertificateError {
         UpdateCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateCertificateError {
+    fn from(err: io::Error) -> UpdateCertificateError {
+        UpdateCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7754,6 +8036,11 @@ impl From<CredentialsError> for UpdateThingError {
 impl From<HttpDispatchError> for UpdateThingError {
     fn from(err: HttpDispatchError) -> UpdateThingError {
         UpdateThingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateThingError {
+    fn from(err: io::Error) -> UpdateThingError {
+        UpdateThingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateThingError {
@@ -8170,8 +8457,7 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8180,7 +8466,12 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(AcceptCertificateTransferError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AcceptCertificateTransferError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -8202,8 +8493,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8213,8 +8503,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AttachPrincipalPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachPrincipalPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8238,13 +8529,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8259,8 +8550,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AttachThingPrincipalError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachThingPrincipalError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8283,8 +8575,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8293,7 +8584,12 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CancelCertificateTransferError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelCertificateTransferError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -8319,13 +8615,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8340,7 +8636,12 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateCertificateFromCsrError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCertificateFromCsrError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8366,13 +8667,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8387,7 +8688,12 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateKeysAndCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateKeysAndCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8408,13 +8714,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8429,7 +8735,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreatePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8456,13 +8764,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8477,8 +8785,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreatePolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8500,13 +8809,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8520,7 +8829,11 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateThingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateThingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8542,13 +8855,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8563,8 +8876,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateThingTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateThingTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8586,8 +8900,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8597,8 +8910,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8621,13 +8935,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8642,8 +8956,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteCACertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCACertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8666,8 +8981,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8677,8 +8991,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8698,8 +9013,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8709,7 +9023,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8733,8 +9049,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8744,8 +9059,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeletePolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8767,13 +9083,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8789,8 +9105,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteRegistrationCodeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRegistrationCodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8816,13 +9133,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8836,7 +9153,11 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteThingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteThingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8858,13 +9179,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8879,8 +9200,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteThingTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteThingTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8902,8 +9224,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8913,8 +9234,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8937,13 +9259,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -8958,8 +9280,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeprecateThingTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeprecateThingTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8983,13 +9306,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9005,8 +9328,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeCACertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCACertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9029,13 +9353,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9050,8 +9374,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9071,13 +9396,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9092,8 +9417,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9115,13 +9441,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9136,7 +9462,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeThingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeThingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9159,13 +9487,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9180,8 +9508,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeThingTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeThingTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9204,8 +9533,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9215,8 +9543,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DetachPrincipalPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachPrincipalPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9240,13 +9569,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9261,8 +9590,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DetachThingPrincipalError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachThingPrincipalError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9284,8 +9614,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9295,8 +9624,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DisableTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9318,8 +9648,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9329,8 +9658,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(EnableTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9350,13 +9680,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9371,8 +9701,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetLoggingOptionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetLoggingOptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9392,13 +9723,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9412,7 +9743,11 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9435,13 +9770,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9456,8 +9791,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetPolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9478,13 +9814,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9499,8 +9835,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetRegistrationCodeError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRegistrationCodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9522,13 +9859,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9543,7 +9880,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetTopicRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9575,13 +9914,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9596,8 +9935,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListCACertificatesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCACertificatesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9629,13 +9969,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9650,8 +9990,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListCertificatesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCertificatesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9685,13 +10026,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9706,8 +10047,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListCertificatesByCAError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCertificatesByCAError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9740,13 +10082,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9761,7 +10103,12 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListOutgoingCertificatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOutgoingCertificatesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -9792,13 +10139,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9813,7 +10160,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9846,13 +10195,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9867,8 +10216,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListPolicyPrincipalsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPolicyPrincipalsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9891,13 +10241,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9912,8 +10262,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListPolicyVersionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPolicyVersionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9946,13 +10297,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -9968,8 +10319,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListPrincipalPoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPrincipalPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9998,13 +10350,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10019,8 +10371,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListPrincipalThingsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPrincipalThingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10043,13 +10396,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10064,8 +10417,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListThingPrincipalsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListThingPrincipalsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10097,13 +10451,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10118,8 +10472,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListThingTypesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListThingTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10157,13 +10512,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10177,7 +10532,11 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListThingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListThingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10211,13 +10570,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10232,8 +10591,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListTopicRulesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTopicRulesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10263,13 +10623,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10285,8 +10645,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RegisterCACertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterCACertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10308,13 +10669,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10329,8 +10690,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RegisterCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10353,8 +10715,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10363,7 +10724,12 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(RejectCertificateTransferError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RejectCertificateTransferError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -10384,8 +10750,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10395,8 +10760,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ReplaceTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReplaceTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10420,8 +10786,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10430,7 +10795,12 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(SetDefaultPolicyVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetDefaultPolicyVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -10451,8 +10821,7 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10462,8 +10831,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetLoggingOptionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetLoggingOptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10488,13 +10858,13 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10509,8 +10879,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(TransferCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TransferCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10540,8 +10911,7 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10551,8 +10921,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateCACertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateCACertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10577,8 +10948,7 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10588,8 +10958,9 @@ impl<P, D> Iot for IotClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateCertificateError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateCertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10611,13 +10982,13 @@ impl<P, D> Iot for IotClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -10631,7 +11002,11 @@ impl<P, D> Iot for IotClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateThingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateThingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -625,6 +627,11 @@ impl From<HttpDispatchError> for AddTagsToStreamError {
         AddTagsToStreamError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToStreamError {
+    fn from(err: io::Error) -> AddTagsToStreamError {
+        AddTagsToStreamError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -712,6 +719,11 @@ impl From<HttpDispatchError> for CreateStreamError {
         CreateStreamError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateStreamError {
+    fn from(err: io::Error) -> CreateStreamError {
+        CreateStreamError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -790,6 +802,11 @@ impl From<CredentialsError> for DecreaseStreamRetentionPeriodError {
 impl From<HttpDispatchError> for DecreaseStreamRetentionPeriodError {
     fn from(err: HttpDispatchError) -> DecreaseStreamRetentionPeriodError {
         DecreaseStreamRetentionPeriodError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DecreaseStreamRetentionPeriodError {
+    fn from(err: io::Error) -> DecreaseStreamRetentionPeriodError {
+        DecreaseStreamRetentionPeriodError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DecreaseStreamRetentionPeriodError {
@@ -875,6 +892,11 @@ impl From<HttpDispatchError> for DeleteStreamError {
         DeleteStreamError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteStreamError {
+    fn from(err: io::Error) -> DeleteStreamError {
+        DeleteStreamError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -948,6 +970,11 @@ impl From<CredentialsError> for DescribeLimitsError {
 impl From<HttpDispatchError> for DescribeLimitsError {
     fn from(err: HttpDispatchError) -> DescribeLimitsError {
         DescribeLimitsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLimitsError {
+    fn from(err: io::Error) -> DescribeLimitsError {
+        DescribeLimitsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLimitsError {
@@ -1027,6 +1054,11 @@ impl From<CredentialsError> for DescribeStreamError {
 impl From<HttpDispatchError> for DescribeStreamError {
     fn from(err: HttpDispatchError) -> DescribeStreamError {
         DescribeStreamError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeStreamError {
+    fn from(err: io::Error) -> DescribeStreamError {
+        DescribeStreamError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeStreamError {
@@ -1115,6 +1147,11 @@ impl From<CredentialsError> for DisableEnhancedMonitoringError {
 impl From<HttpDispatchError> for DisableEnhancedMonitoringError {
     fn from(err: HttpDispatchError) -> DisableEnhancedMonitoringError {
         DisableEnhancedMonitoringError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableEnhancedMonitoringError {
+    fn from(err: io::Error) -> DisableEnhancedMonitoringError {
+        DisableEnhancedMonitoringError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableEnhancedMonitoringError {
@@ -1211,6 +1248,11 @@ impl From<HttpDispatchError> for EnableEnhancedMonitoringError {
         EnableEnhancedMonitoringError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableEnhancedMonitoringError {
+    fn from(err: io::Error) -> EnableEnhancedMonitoringError {
+        EnableEnhancedMonitoringError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableEnhancedMonitoringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1303,6 +1345,11 @@ impl From<HttpDispatchError> for GetRecordsError {
         GetRecordsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRecordsError {
+    fn from(err: io::Error) -> GetRecordsError {
+        GetRecordsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1388,6 +1435,11 @@ impl From<HttpDispatchError> for GetShardIteratorError {
         GetShardIteratorError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetShardIteratorError {
+    fn from(err: io::Error) -> GetShardIteratorError {
+        GetShardIteratorError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetShardIteratorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1468,6 +1520,11 @@ impl From<HttpDispatchError> for IncreaseStreamRetentionPeriodError {
         IncreaseStreamRetentionPeriodError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for IncreaseStreamRetentionPeriodError {
+    fn from(err: io::Error) -> IncreaseStreamRetentionPeriodError {
+        IncreaseStreamRetentionPeriodError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for IncreaseStreamRetentionPeriodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1544,6 +1601,11 @@ impl From<CredentialsError> for ListStreamsError {
 impl From<HttpDispatchError> for ListStreamsError {
     fn from(err: HttpDispatchError) -> ListStreamsError {
         ListStreamsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListStreamsError {
+    fn from(err: io::Error) -> ListStreamsError {
+        ListStreamsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListStreamsError {
@@ -1628,6 +1690,11 @@ impl From<CredentialsError> for ListTagsForStreamError {
 impl From<HttpDispatchError> for ListTagsForStreamError {
     fn from(err: HttpDispatchError) -> ListTagsForStreamError {
         ListTagsForStreamError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForStreamError {
+    fn from(err: io::Error) -> ListTagsForStreamError {
+        ListTagsForStreamError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForStreamError {
@@ -1723,6 +1790,11 @@ impl From<HttpDispatchError> for MergeShardsError {
         MergeShardsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for MergeShardsError {
+    fn from(err: io::Error) -> MergeShardsError {
+        MergeShardsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for MergeShardsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1808,6 +1880,11 @@ impl From<HttpDispatchError> for PutRecordError {
         PutRecordError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutRecordError {
+    fn from(err: io::Error) -> PutRecordError {
+        PutRecordError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutRecordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1890,6 +1967,11 @@ impl From<CredentialsError> for PutRecordsError {
 impl From<HttpDispatchError> for PutRecordsError {
     fn from(err: HttpDispatchError) -> PutRecordsError {
         PutRecordsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutRecordsError {
+    fn from(err: io::Error) -> PutRecordsError {
+        PutRecordsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutRecordsError {
@@ -1981,6 +2063,11 @@ impl From<CredentialsError> for RemoveTagsFromStreamError {
 impl From<HttpDispatchError> for RemoveTagsFromStreamError {
     fn from(err: HttpDispatchError) -> RemoveTagsFromStreamError {
         RemoveTagsFromStreamError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveTagsFromStreamError {
+    fn from(err: io::Error) -> RemoveTagsFromStreamError {
+        RemoveTagsFromStreamError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveTagsFromStreamError {
@@ -2075,6 +2162,11 @@ impl From<HttpDispatchError> for SplitShardError {
         SplitShardError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SplitShardError {
+    fn from(err: io::Error) -> SplitShardError {
+        SplitShardError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SplitShardError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2165,6 +2257,11 @@ impl From<CredentialsError> for UpdateShardCountError {
 impl From<HttpDispatchError> for UpdateShardCountError {
     fn from(err: HttpDispatchError) -> UpdateShardCountError {
         UpdateShardCountError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateShardCountError {
+    fn from(err: io::Error) -> UpdateShardCountError {
+        UpdateShardCountError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateShardCountError {
@@ -2323,13 +2420,14 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AddTagsToStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2346,12 +2444,14 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(CreateStreamError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2371,11 +2471,16 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DecreaseStreamRetentionPeriodError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DecreaseStreamRetentionPeriodError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -2391,12 +2496,14 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteStreamError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2412,15 +2519,20 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeLimitsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeLimitsOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeLimitsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLimitsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2439,15 +2551,20 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeStreamOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2467,13 +2584,22 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EnhancedMonitoringOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DisableEnhancedMonitoringError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EnhancedMonitoringOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableEnhancedMonitoringError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -2492,13 +2618,22 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EnhancedMonitoringOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(EnableEnhancedMonitoringError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EnhancedMonitoringOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableEnhancedMonitoringError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -2514,13 +2649,21 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRecordsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetRecordsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRecordsOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRecordsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2538,15 +2681,20 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetShardIteratorOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetShardIteratorOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetShardIteratorError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetShardIteratorError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2566,11 +2714,16 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(IncreaseStreamRetentionPeriodError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(IncreaseStreamRetentionPeriodError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -2588,13 +2741,21 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListStreamsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListStreamsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListStreamsOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListStreamsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2612,15 +2773,20 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForStreamOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListTagsForStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2637,11 +2803,15 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(MergeShardsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(MergeShardsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2657,15 +2827,20 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<PutRecordOutput>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutRecordOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(PutRecordError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRecordError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2681,13 +2856,21 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutRecordsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(PutRecordsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutRecordsOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRecordsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2705,13 +2888,14 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(RemoveTagsFromStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2728,11 +2912,15 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(SplitShardError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SplitShardError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2750,15 +2938,20 @@ impl<P, D> Kinesis for KinesisClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateShardCountOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateShardCountOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateShardCountError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateShardCountError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1040,6 +1042,11 @@ impl From<HttpDispatchError> for AddApplicationCloudWatchLoggingOptionError {
         AddApplicationCloudWatchLoggingOptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddApplicationCloudWatchLoggingOptionError {
+    fn from(err: io::Error) -> AddApplicationCloudWatchLoggingOptionError {
+        AddApplicationCloudWatchLoggingOptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddApplicationCloudWatchLoggingOptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1130,6 +1137,11 @@ impl From<CredentialsError> for AddApplicationInputError {
 impl From<HttpDispatchError> for AddApplicationInputError {
     fn from(err: HttpDispatchError) -> AddApplicationInputError {
         AddApplicationInputError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddApplicationInputError {
+    fn from(err: io::Error) -> AddApplicationInputError {
+        AddApplicationInputError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddApplicationInputError {
@@ -1224,6 +1236,11 @@ impl From<HttpDispatchError> for AddApplicationOutputError {
         AddApplicationOutputError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddApplicationOutputError {
+    fn from(err: io::Error) -> AddApplicationOutputError {
+        AddApplicationOutputError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddApplicationOutputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1309,6 +1326,11 @@ impl From<CredentialsError> for AddApplicationReferenceDataSourceError {
 impl From<HttpDispatchError> for AddApplicationReferenceDataSourceError {
     fn from(err: HttpDispatchError) -> AddApplicationReferenceDataSourceError {
         AddApplicationReferenceDataSourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddApplicationReferenceDataSourceError {
+    fn from(err: io::Error) -> AddApplicationReferenceDataSourceError {
+        AddApplicationReferenceDataSourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddApplicationReferenceDataSourceError {
@@ -1405,6 +1427,11 @@ impl From<HttpDispatchError> for CreateApplicationError {
         CreateApplicationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateApplicationError {
+    fn from(err: io::Error) -> CreateApplicationError {
+        CreateApplicationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1494,6 +1521,11 @@ impl From<HttpDispatchError> for DeleteApplicationError {
         DeleteApplicationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteApplicationError {
+    fn from(err: io::Error) -> DeleteApplicationError {
+        DeleteApplicationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1575,6 +1607,11 @@ impl From<CredentialsError> for DeleteApplicationCloudWatchLoggingOptionError {
 impl From<HttpDispatchError> for DeleteApplicationCloudWatchLoggingOptionError {
     fn from(err: HttpDispatchError) -> DeleteApplicationCloudWatchLoggingOptionError {
         DeleteApplicationCloudWatchLoggingOptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteApplicationCloudWatchLoggingOptionError {
+    fn from(err: io::Error) -> DeleteApplicationCloudWatchLoggingOptionError {
+        DeleteApplicationCloudWatchLoggingOptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteApplicationCloudWatchLoggingOptionError {
@@ -1673,6 +1710,11 @@ impl From<HttpDispatchError> for DeleteApplicationOutputError {
         DeleteApplicationOutputError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteApplicationOutputError {
+    fn from(err: io::Error) -> DeleteApplicationOutputError {
+        DeleteApplicationOutputError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteApplicationOutputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1760,6 +1802,11 @@ impl From<HttpDispatchError> for DeleteApplicationReferenceDataSourceError {
         DeleteApplicationReferenceDataSourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteApplicationReferenceDataSourceError {
+    fn from(err: io::Error) -> DeleteApplicationReferenceDataSourceError {
+        DeleteApplicationReferenceDataSourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteApplicationReferenceDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1837,6 +1884,11 @@ impl From<CredentialsError> for DescribeApplicationError {
 impl From<HttpDispatchError> for DescribeApplicationError {
     fn from(err: HttpDispatchError) -> DescribeApplicationError {
         DescribeApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeApplicationError {
+    fn from(err: io::Error) -> DescribeApplicationError {
+        DescribeApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeApplicationError {
@@ -1923,6 +1975,11 @@ impl From<HttpDispatchError> for DiscoverInputSchemaError {
         DiscoverInputSchemaError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DiscoverInputSchemaError {
+    fn from(err: io::Error) -> DiscoverInputSchemaError {
+        DiscoverInputSchemaError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DiscoverInputSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1994,6 +2051,11 @@ impl From<CredentialsError> for ListApplicationsError {
 impl From<HttpDispatchError> for ListApplicationsError {
     fn from(err: HttpDispatchError) -> ListApplicationsError {
         ListApplicationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListApplicationsError {
+    fn from(err: io::Error) -> ListApplicationsError {
+        ListApplicationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListApplicationsError {
@@ -2082,6 +2144,11 @@ impl From<HttpDispatchError> for StartApplicationError {
         StartApplicationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartApplicationError {
+    fn from(err: io::Error) -> StartApplicationError {
+        StartApplicationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2162,6 +2229,11 @@ impl From<CredentialsError> for StopApplicationError {
 impl From<HttpDispatchError> for StopApplicationError {
     fn from(err: HttpDispatchError) -> StopApplicationError {
         StopApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopApplicationError {
+    fn from(err: io::Error) -> StopApplicationError {
+        StopApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopApplicationError {
@@ -2257,6 +2329,11 @@ impl From<CredentialsError> for UpdateApplicationError {
 impl From<HttpDispatchError> for UpdateApplicationError {
     fn from(err: HttpDispatchError) -> UpdateApplicationError {
         UpdateApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateApplicationError {
+    fn from(err: io::Error) -> UpdateApplicationError {
+        UpdateApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateApplicationError {
@@ -2409,13 +2486,19 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddApplicationCloudWatchLoggingOptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AddApplicationCloudWatchLoggingOptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddApplicationCloudWatchLoggingOptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddApplicationCloudWatchLoggingOptionError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2434,15 +2517,18 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddApplicationInputResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddApplicationInputResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AddApplicationInputError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddApplicationInputError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2463,15 +2549,18 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddApplicationOutputResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddApplicationOutputResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AddApplicationOutputError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddApplicationOutputError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2493,13 +2582,19 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddApplicationReferenceDataSourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AddApplicationReferenceDataSourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddApplicationReferenceDataSourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddApplicationReferenceDataSourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2518,15 +2613,18 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2546,15 +2644,18 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2572,13 +2673,19 @@ fn delete_application_cloud_watch_logging_option(&self, input: &DeleteApplicatio
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteApplicationCloudWatchLoggingOptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteApplicationCloudWatchLoggingOptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteApplicationCloudWatchLoggingOptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteApplicationCloudWatchLoggingOptionError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2598,13 +2705,20 @@ fn delete_application_cloud_watch_logging_option(&self, input: &DeleteApplicatio
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteApplicationOutputResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteApplicationOutputError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteApplicationOutputResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteApplicationOutputError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -2621,13 +2735,19 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteApplicationReferenceDataSourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteApplicationReferenceDataSourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteApplicationReferenceDataSourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteApplicationReferenceDataSourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2646,15 +2766,18 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2674,15 +2797,18 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DiscoverInputSchemaResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DiscoverInputSchemaResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DiscoverInputSchemaError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DiscoverInputSchemaError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2701,15 +2827,20 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListApplicationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListApplicationsResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListApplicationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListApplicationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2728,15 +2859,20 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartApplicationResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StartApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2755,15 +2891,20 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopApplicationResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StopApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2783,15 +2924,18 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateApplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1021,6 +1023,11 @@ impl From<HttpDispatchError> for CancelKeyDeletionError {
         CancelKeyDeletionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelKeyDeletionError {
+    fn from(err: io::Error) -> CancelKeyDeletionError {
+        CancelKeyDeletionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelKeyDeletionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1127,6 +1134,11 @@ impl From<CredentialsError> for CreateAliasError {
 impl From<HttpDispatchError> for CreateAliasError {
     fn from(err: HttpDispatchError) -> CreateAliasError {
         CreateAliasError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAliasError {
+    fn from(err: io::Error) -> CreateAliasError {
+        CreateAliasError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAliasError {
@@ -1240,6 +1252,11 @@ impl From<HttpDispatchError> for CreateGrantError {
         CreateGrantError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateGrantError {
+    fn from(err: io::Error) -> CreateGrantError {
+        CreateGrantError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateGrantError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1345,6 +1362,11 @@ impl From<CredentialsError> for CreateKeyError {
 impl From<HttpDispatchError> for CreateKeyError {
     fn from(err: HttpDispatchError) -> CreateKeyError {
         CreateKeyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateKeyError {
+    fn from(err: io::Error) -> CreateKeyError {
+        CreateKeyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateKeyError {
@@ -1456,6 +1478,11 @@ impl From<HttpDispatchError> for DecryptError {
         DecryptError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DecryptError {
+    fn from(err: io::Error) -> DecryptError {
+        DecryptError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DecryptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1548,6 +1575,11 @@ impl From<CredentialsError> for DeleteAliasError {
 impl From<HttpDispatchError> for DeleteAliasError {
     fn from(err: HttpDispatchError) -> DeleteAliasError {
         DeleteAliasError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteAliasError {
+    fn from(err: io::Error) -> DeleteAliasError {
+        DeleteAliasError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteAliasError {
@@ -1648,6 +1680,11 @@ impl From<HttpDispatchError> for DeleteImportedKeyMaterialError {
         DeleteImportedKeyMaterialError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteImportedKeyMaterialError {
+    fn from(err: io::Error) -> DeleteImportedKeyMaterialError {
+        DeleteImportedKeyMaterialError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteImportedKeyMaterialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1742,6 +1779,11 @@ impl From<HttpDispatchError> for DescribeKeyError {
         DescribeKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeKeyError {
+    fn from(err: io::Error) -> DescribeKeyError {
+        DescribeKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1833,6 +1875,11 @@ impl From<CredentialsError> for DisableKeyError {
 impl From<HttpDispatchError> for DisableKeyError {
     fn from(err: HttpDispatchError) -> DisableKeyError {
         DisableKeyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableKeyError {
+    fn from(err: io::Error) -> DisableKeyError {
+        DisableKeyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableKeyError {
@@ -1943,6 +1990,11 @@ impl From<HttpDispatchError> for DisableKeyRotationError {
         DisableKeyRotationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisableKeyRotationError {
+    fn from(err: io::Error) -> DisableKeyRotationError {
+        DisableKeyRotationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisableKeyRotationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2044,6 +2096,11 @@ impl From<CredentialsError> for EnableKeyError {
 impl From<HttpDispatchError> for EnableKeyError {
     fn from(err: HttpDispatchError) -> EnableKeyError {
         EnableKeyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnableKeyError {
+    fn from(err: io::Error) -> EnableKeyError {
+        EnableKeyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnableKeyError {
@@ -2155,6 +2212,11 @@ impl From<HttpDispatchError> for EnableKeyRotationError {
         EnableKeyRotationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableKeyRotationError {
+    fn from(err: io::Error) -> EnableKeyRotationError {
+        EnableKeyRotationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableKeyRotationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2264,6 +2326,11 @@ impl From<CredentialsError> for EncryptError {
 impl From<HttpDispatchError> for EncryptError {
     fn from(err: HttpDispatchError) -> EncryptError {
         EncryptError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EncryptError {
+    fn from(err: io::Error) -> EncryptError {
+        EncryptError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EncryptError {
@@ -2382,6 +2449,11 @@ impl From<HttpDispatchError> for GenerateDataKeyError {
         GenerateDataKeyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GenerateDataKeyError {
+    fn from(err: io::Error) -> GenerateDataKeyError {
+        GenerateDataKeyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GenerateDataKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2486,6 +2558,11 @@ impl From<HttpDispatchError> for GenerateDataKeyWithoutPlaintextError {
         GenerateDataKeyWithoutPlaintextError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GenerateDataKeyWithoutPlaintextError {
+    fn from(err: io::Error) -> GenerateDataKeyWithoutPlaintextError {
+        GenerateDataKeyWithoutPlaintextError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GenerateDataKeyWithoutPlaintextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2572,6 +2649,11 @@ impl From<CredentialsError> for GenerateRandomError {
 impl From<HttpDispatchError> for GenerateRandomError {
     fn from(err: HttpDispatchError) -> GenerateRandomError {
         GenerateRandomError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GenerateRandomError {
+    fn from(err: io::Error) -> GenerateRandomError {
+        GenerateRandomError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GenerateRandomError {
@@ -2665,6 +2747,11 @@ impl From<CredentialsError> for GetKeyPolicyError {
 impl From<HttpDispatchError> for GetKeyPolicyError {
     fn from(err: HttpDispatchError) -> GetKeyPolicyError {
         GetKeyPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetKeyPolicyError {
+    fn from(err: io::Error) -> GetKeyPolicyError {
+        GetKeyPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetKeyPolicyError {
@@ -2770,6 +2857,11 @@ impl From<HttpDispatchError> for GetKeyRotationStatusError {
         GetKeyRotationStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetKeyRotationStatusError {
+    fn from(err: io::Error) -> GetKeyRotationStatusError {
+        GetKeyRotationStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetKeyRotationStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2872,6 +2964,11 @@ impl From<CredentialsError> for GetParametersForImportError {
 impl From<HttpDispatchError> for GetParametersForImportError {
     fn from(err: HttpDispatchError) -> GetParametersForImportError {
         GetParametersForImportError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetParametersForImportError {
+    fn from(err: io::Error) -> GetParametersForImportError {
+        GetParametersForImportError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetParametersForImportError {
@@ -3000,6 +3097,11 @@ impl From<HttpDispatchError> for ImportKeyMaterialError {
         ImportKeyMaterialError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportKeyMaterialError {
+    fn from(err: io::Error) -> ImportKeyMaterialError {
+        ImportKeyMaterialError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportKeyMaterialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3093,6 +3195,11 @@ impl From<CredentialsError> for ListAliasesError {
 impl From<HttpDispatchError> for ListAliasesError {
     fn from(err: HttpDispatchError) -> ListAliasesError {
         ListAliasesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAliasesError {
+    fn from(err: io::Error) -> ListAliasesError {
+        ListAliasesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAliasesError {
@@ -3190,6 +3297,11 @@ impl From<CredentialsError> for ListGrantsError {
 impl From<HttpDispatchError> for ListGrantsError {
     fn from(err: HttpDispatchError) -> ListGrantsError {
         ListGrantsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListGrantsError {
+    fn from(err: io::Error) -> ListGrantsError {
+        ListGrantsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListGrantsError {
@@ -3291,6 +3403,11 @@ impl From<HttpDispatchError> for ListKeyPoliciesError {
         ListKeyPoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListKeyPoliciesError {
+    fn from(err: io::Error) -> ListKeyPoliciesError {
+        ListKeyPoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListKeyPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3375,6 +3492,11 @@ impl From<CredentialsError> for ListKeysError {
 impl From<HttpDispatchError> for ListKeysError {
     fn from(err: HttpDispatchError) -> ListKeysError {
         ListKeysError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListKeysError {
+    fn from(err: io::Error) -> ListKeysError {
+        ListKeysError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListKeysError {
@@ -3466,6 +3588,11 @@ impl From<CredentialsError> for ListResourceTagsError {
 impl From<HttpDispatchError> for ListResourceTagsError {
     fn from(err: HttpDispatchError) -> ListResourceTagsError {
         ListResourceTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListResourceTagsError {
+    fn from(err: io::Error) -> ListResourceTagsError {
+        ListResourceTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListResourceTagsError {
@@ -3563,6 +3690,11 @@ impl From<CredentialsError> for ListRetirableGrantsError {
 impl From<HttpDispatchError> for ListRetirableGrantsError {
     fn from(err: HttpDispatchError) -> ListRetirableGrantsError {
         ListRetirableGrantsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRetirableGrantsError {
+    fn from(err: io::Error) -> ListRetirableGrantsError {
+        ListRetirableGrantsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRetirableGrantsError {
@@ -3676,6 +3808,11 @@ impl From<CredentialsError> for PutKeyPolicyError {
 impl From<HttpDispatchError> for PutKeyPolicyError {
     fn from(err: HttpDispatchError) -> PutKeyPolicyError {
         PutKeyPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutKeyPolicyError {
+    fn from(err: io::Error) -> PutKeyPolicyError {
+        PutKeyPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutKeyPolicyError {
@@ -3793,6 +3930,11 @@ impl From<HttpDispatchError> for ReEncryptError {
         ReEncryptError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReEncryptError {
+    fn from(err: io::Error) -> ReEncryptError {
+        ReEncryptError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReEncryptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3898,6 +4040,11 @@ impl From<HttpDispatchError> for RetireGrantError {
         RetireGrantError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RetireGrantError {
+    fn from(err: io::Error) -> RetireGrantError {
+        RetireGrantError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RetireGrantError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4000,6 +4147,11 @@ impl From<HttpDispatchError> for RevokeGrantError {
         RevokeGrantError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RevokeGrantError {
+    fn from(err: io::Error) -> RevokeGrantError {
+        RevokeGrantError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RevokeGrantError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4097,6 +4249,11 @@ impl From<CredentialsError> for ScheduleKeyDeletionError {
 impl From<HttpDispatchError> for ScheduleKeyDeletionError {
     fn from(err: HttpDispatchError) -> ScheduleKeyDeletionError {
         ScheduleKeyDeletionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ScheduleKeyDeletionError {
+    fn from(err: io::Error) -> ScheduleKeyDeletionError {
+        ScheduleKeyDeletionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ScheduleKeyDeletionError {
@@ -4200,6 +4357,11 @@ impl From<HttpDispatchError> for TagResourceError {
         TagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TagResourceError {
+    fn from(err: io::Error) -> TagResourceError {
+        TagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4297,6 +4459,11 @@ impl From<HttpDispatchError> for UntagResourceError {
         UntagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UntagResourceError {
+    fn from(err: io::Error) -> UntagResourceError {
+        UntagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4386,6 +4553,11 @@ impl From<CredentialsError> for UpdateAliasError {
 impl From<HttpDispatchError> for UpdateAliasError {
     fn from(err: HttpDispatchError) -> UpdateAliasError {
         UpdateAliasError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAliasError {
+    fn from(err: io::Error) -> UpdateAliasError {
+        UpdateAliasError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAliasError {
@@ -4483,6 +4655,11 @@ impl From<CredentialsError> for UpdateKeyDescriptionError {
 impl From<HttpDispatchError> for UpdateKeyDescriptionError {
     fn from(err: HttpDispatchError) -> UpdateKeyDescriptionError {
         UpdateKeyDescriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateKeyDescriptionError {
+    fn from(err: io::Error) -> UpdateKeyDescriptionError {
+        UpdateKeyDescriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateKeyDescriptionError {
@@ -4731,15 +4908,18 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CancelKeyDeletionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelKeyDeletionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CancelKeyDeletionError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelKeyDeletionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4756,11 +4936,15 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4778,13 +4962,21 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateGrantResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateGrantError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateGrantResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateGrantError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4800,13 +4992,21 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateKeyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateKeyResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4822,15 +5022,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DecryptResponse>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DecryptResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(DecryptError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DecryptError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4846,11 +5051,15 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4868,11 +5077,16 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteImportedKeyMaterialError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteImportedKeyMaterialError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -4890,13 +5104,21 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeKeyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeKeyResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4912,11 +5134,15 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DisableKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4934,13 +5160,14 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DisableKeyRotationError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableKeyRotationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4957,11 +5184,15 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(EnableKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4979,13 +5210,14 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(EnableKeyRotationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableKeyRotationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5002,15 +5234,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<EncryptResponse>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EncryptResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(EncryptError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EncryptError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5028,15 +5265,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GenerateDataKeyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GenerateDataKeyResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GenerateDataKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GenerateDataKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5057,13 +5299,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GenerateDataKeyWithoutPlaintextResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GenerateDataKeyWithoutPlaintextError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GenerateDataKeyWithoutPlaintextResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GenerateDataKeyWithoutPlaintextError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -5081,15 +5330,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GenerateRandomResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GenerateRandomResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GenerateRandomError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GenerateRandomError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5108,14 +5362,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetKeyPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetKeyPolicyResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetKeyPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetKeyPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5135,15 +5395,18 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetKeyRotationStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetKeyRotationStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetKeyRotationStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetKeyRotationStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5163,15 +5426,18 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetParametersForImportResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetParametersForImportResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetParametersForImportError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetParametersForImportError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5190,15 +5456,18 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ImportKeyMaterialResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ImportKeyMaterialResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ImportKeyMaterialError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportKeyMaterialError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5217,13 +5486,21 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAliasesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListAliasesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAliasesResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAliasesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5241,13 +5518,21 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListGrantsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListGrantsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListGrantsResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListGrantsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5265,15 +5550,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListKeyPoliciesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListKeyPoliciesResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListKeyPoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListKeyPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5290,13 +5580,21 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListKeysResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListKeysError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListKeysResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListKeysError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5314,15 +5612,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListResourceTagsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListResourceTagsResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListResourceTagsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListResourceTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5341,15 +5644,20 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListGrantsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListGrantsResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListRetirableGrantsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRetirableGrantsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5366,12 +5674,14 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutKeyPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutKeyPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5388,13 +5698,21 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ReEncryptResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ReEncryptError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ReEncryptResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReEncryptError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5410,11 +5728,15 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RetireGrantError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RetireGrantError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5430,11 +5752,15 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RevokeGrantError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RevokeGrantError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5452,15 +5778,18 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ScheduleKeyDeletionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ScheduleKeyDeletionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ScheduleKeyDeletionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ScheduleKeyDeletionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5477,11 +5806,15 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5497,12 +5830,14 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UntagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5519,11 +5854,15 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(UpdateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5541,13 +5880,14 @@ impl<P, D> Kms for KmsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateKeyDescriptionError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateKeyDescriptionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1047,6 +1049,11 @@ impl From<HttpDispatchError> for AddPermissionError {
         AddPermissionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddPermissionError {
+    fn from(err: io::Error) -> AddPermissionError {
+        AddPermissionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1144,6 +1151,11 @@ impl From<HttpDispatchError> for CreateAliasError {
         CreateAliasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateAliasError {
+    fn from(err: io::Error) -> CreateAliasError {
+        CreateAliasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1238,6 +1250,11 @@ impl From<CredentialsError> for CreateEventSourceMappingError {
 impl From<HttpDispatchError> for CreateEventSourceMappingError {
     fn from(err: HttpDispatchError) -> CreateEventSourceMappingError {
         CreateEventSourceMappingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateEventSourceMappingError {
+    fn from(err: io::Error) -> CreateEventSourceMappingError {
+        CreateEventSourceMappingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateEventSourceMappingError {
@@ -1343,6 +1360,11 @@ impl From<HttpDispatchError> for CreateFunctionError {
         CreateFunctionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateFunctionError {
+    fn from(err: io::Error) -> CreateFunctionError {
+        CreateFunctionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1428,6 +1450,11 @@ impl From<CredentialsError> for DeleteAliasError {
 impl From<HttpDispatchError> for DeleteAliasError {
     fn from(err: HttpDispatchError) -> DeleteAliasError {
         DeleteAliasError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteAliasError {
+    fn from(err: io::Error) -> DeleteAliasError {
+        DeleteAliasError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteAliasError {
@@ -1517,6 +1544,11 @@ impl From<CredentialsError> for DeleteEventSourceMappingError {
 impl From<HttpDispatchError> for DeleteEventSourceMappingError {
     fn from(err: HttpDispatchError) -> DeleteEventSourceMappingError {
         DeleteEventSourceMappingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteEventSourceMappingError {
+    fn from(err: io::Error) -> DeleteEventSourceMappingError {
+        DeleteEventSourceMappingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteEventSourceMappingError {
@@ -1616,6 +1648,11 @@ impl From<HttpDispatchError> for DeleteFunctionError {
         DeleteFunctionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteFunctionError {
+    fn from(err: io::Error) -> DeleteFunctionError {
+        DeleteFunctionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1697,6 +1734,11 @@ impl From<CredentialsError> for GetAccountSettingsError {
 impl From<HttpDispatchError> for GetAccountSettingsError {
     fn from(err: HttpDispatchError) -> GetAccountSettingsError {
         GetAccountSettingsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetAccountSettingsError {
+    fn from(err: io::Error) -> GetAccountSettingsError {
+        GetAccountSettingsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetAccountSettingsError {
@@ -1787,6 +1829,11 @@ impl From<HttpDispatchError> for GetAliasError {
         GetAliasError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAliasError {
+    fn from(err: io::Error) -> GetAliasError {
+        GetAliasError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1875,6 +1922,11 @@ impl From<CredentialsError> for GetEventSourceMappingError {
 impl From<HttpDispatchError> for GetEventSourceMappingError {
     fn from(err: HttpDispatchError) -> GetEventSourceMappingError {
         GetEventSourceMappingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetEventSourceMappingError {
+    fn from(err: io::Error) -> GetEventSourceMappingError {
+        GetEventSourceMappingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetEventSourceMappingError {
@@ -1969,6 +2021,11 @@ impl From<HttpDispatchError> for GetFunctionError {
         GetFunctionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetFunctionError {
+    fn from(err: io::Error) -> GetFunctionError {
+        GetFunctionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2059,6 +2116,11 @@ impl From<HttpDispatchError> for GetFunctionConfigurationError {
         GetFunctionConfigurationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetFunctionConfigurationError {
+    fn from(err: io::Error) -> GetFunctionConfigurationError {
+        GetFunctionConfigurationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetFunctionConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2147,6 +2209,11 @@ impl From<CredentialsError> for GetPolicyError {
 impl From<HttpDispatchError> for GetPolicyError {
     fn from(err: HttpDispatchError) -> GetPolicyError {
         GetPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetPolicyError {
+    fn from(err: io::Error) -> GetPolicyError {
+        GetPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetPolicyError {
@@ -2313,6 +2380,11 @@ impl From<HttpDispatchError> for InvokeError {
         InvokeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for InvokeError {
+    fn from(err: io::Error) -> InvokeError {
+        InvokeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for InvokeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2419,6 +2491,11 @@ impl From<HttpDispatchError> for InvokeAsyncError {
         InvokeAsyncError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for InvokeAsyncError {
+    fn from(err: io::Error) -> InvokeAsyncError {
+        InvokeAsyncError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for InvokeAsyncError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2507,6 +2584,11 @@ impl From<CredentialsError> for ListAliasesError {
 impl From<HttpDispatchError> for ListAliasesError {
     fn from(err: HttpDispatchError) -> ListAliasesError {
         ListAliasesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAliasesError {
+    fn from(err: io::Error) -> ListAliasesError {
+        ListAliasesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAliasesError {
@@ -2599,6 +2681,11 @@ impl From<HttpDispatchError> for ListEventSourceMappingsError {
         ListEventSourceMappingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListEventSourceMappingsError {
+    fn from(err: io::Error) -> ListEventSourceMappingsError {
+        ListEventSourceMappingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListEventSourceMappingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2679,6 +2766,11 @@ impl From<CredentialsError> for ListFunctionsError {
 impl From<HttpDispatchError> for ListFunctionsError {
     fn from(err: HttpDispatchError) -> ListFunctionsError {
         ListFunctionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListFunctionsError {
+    fn from(err: io::Error) -> ListFunctionsError {
+        ListFunctionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListFunctionsError {
@@ -2765,6 +2857,11 @@ impl From<CredentialsError> for ListTagsError {
 impl From<HttpDispatchError> for ListTagsError {
     fn from(err: HttpDispatchError) -> ListTagsError {
         ListTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsError {
+    fn from(err: io::Error) -> ListTagsError {
+        ListTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsError {
@@ -2855,6 +2952,11 @@ impl From<CredentialsError> for ListVersionsByFunctionError {
 impl From<HttpDispatchError> for ListVersionsByFunctionError {
     fn from(err: HttpDispatchError) -> ListVersionsByFunctionError {
         ListVersionsByFunctionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListVersionsByFunctionError {
+    fn from(err: io::Error) -> ListVersionsByFunctionError {
+        ListVersionsByFunctionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListVersionsByFunctionError {
@@ -2954,6 +3056,11 @@ impl From<HttpDispatchError> for PublishVersionError {
         PublishVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PublishVersionError {
+    fn from(err: io::Error) -> PublishVersionError {
+        PublishVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PublishVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3047,6 +3154,11 @@ impl From<HttpDispatchError> for RemovePermissionError {
         RemovePermissionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemovePermissionError {
+    fn from(err: io::Error) -> RemovePermissionError {
+        RemovePermissionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemovePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3135,6 +3247,11 @@ impl From<CredentialsError> for TagResourceError {
 impl From<HttpDispatchError> for TagResourceError {
     fn from(err: HttpDispatchError) -> TagResourceError {
         TagResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TagResourceError {
+    fn from(err: io::Error) -> TagResourceError {
+        TagResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TagResourceError {
@@ -3227,6 +3344,11 @@ impl From<HttpDispatchError> for UntagResourceError {
         UntagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UntagResourceError {
+    fn from(err: io::Error) -> UntagResourceError {
+        UntagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3315,6 +3437,11 @@ impl From<CredentialsError> for UpdateAliasError {
 impl From<HttpDispatchError> for UpdateAliasError {
     fn from(err: HttpDispatchError) -> UpdateAliasError {
         UpdateAliasError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAliasError {
+    fn from(err: io::Error) -> UpdateAliasError {
+        UpdateAliasError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAliasError {
@@ -3410,6 +3537,11 @@ impl From<CredentialsError> for UpdateEventSourceMappingError {
 impl From<HttpDispatchError> for UpdateEventSourceMappingError {
     fn from(err: HttpDispatchError) -> UpdateEventSourceMappingError {
         UpdateEventSourceMappingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateEventSourceMappingError {
+    fn from(err: io::Error) -> UpdateEventSourceMappingError {
+        UpdateEventSourceMappingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateEventSourceMappingError {
@@ -3512,6 +3644,11 @@ impl From<HttpDispatchError> for UpdateFunctionCodeError {
         UpdateFunctionCodeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateFunctionCodeError {
+    fn from(err: io::Error) -> UpdateFunctionCodeError {
+        UpdateFunctionCodeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateFunctionCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3602,6 +3739,11 @@ impl From<CredentialsError> for UpdateFunctionConfigurationError {
 impl From<HttpDispatchError> for UpdateFunctionConfigurationError {
     fn from(err: HttpDispatchError) -> UpdateFunctionConfigurationError {
         UpdateFunctionConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateFunctionConfigurationError {
+    fn from(err: io::Error) -> UpdateFunctionConfigurationError {
+        UpdateFunctionConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateFunctionConfigurationError {
@@ -3833,13 +3975,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3854,7 +3996,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AddPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddPermissionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3877,13 +4021,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3897,7 +4041,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3919,13 +4067,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3940,7 +4088,12 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateEventSourceMappingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateEventSourceMappingError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -3961,13 +4114,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -3982,8 +4135,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateFunctionError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateFunctionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4005,8 +4159,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4015,7 +4168,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4038,13 +4195,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4059,7 +4216,12 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteEventSourceMappingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEventSourceMappingError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4083,8 +4245,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4094,8 +4255,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteFunctionError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteFunctionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4115,13 +4277,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4136,8 +4298,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetAccountSettingsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAccountSettingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4159,13 +4322,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4179,7 +4342,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4202,13 +4369,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4224,8 +4391,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetEventSourceMappingError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetEventSourceMappingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4252,13 +4420,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4272,7 +4440,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetFunctionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetFunctionError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4299,13 +4471,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4319,7 +4491,12 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetFunctionConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetFunctionConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4343,13 +4520,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4363,7 +4540,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4387,14 +4568,17 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
                 let mut result = InvocationResponse::default();
-                result.payload = Some(response.body);
+
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+
+                result.payload = Some(body);
 
                 if let Some(function_error) = response.headers.get("X-Amz-Function-Error") {
                     let value = function_error.to_owned();
@@ -4407,7 +4591,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 result.status_code = Some(StatusCode::to_u16(&response.status) as i64);
                 Ok(result)
             }
-            _ => Err(InvokeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InvokeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4429,13 +4617,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4449,7 +4637,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 result.status = Some(StatusCode::to_u16(&response.status) as i64);
                 Ok(result)
             }
-            _ => Err(InvokeAsyncError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InvokeAsyncError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4481,13 +4673,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4501,7 +4693,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListAliasesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAliasesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4536,13 +4732,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4557,7 +4753,12 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListEventSourceMappingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListEventSourceMappingsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4585,13 +4786,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4606,7 +4807,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListFunctionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListFunctionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4626,13 +4829,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4646,7 +4849,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4676,13 +4883,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4698,8 +4905,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListVersionsByFunctionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListVersionsByFunctionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4722,13 +4930,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4743,8 +4951,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PublishVersionError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PublishVersionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4772,8 +4981,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4783,8 +4991,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RemovePermissionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemovePermissionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4804,8 +5013,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4814,7 +5022,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4837,8 +5049,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4848,7 +5059,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UntagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4872,13 +5085,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4892,7 +5105,11 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAliasError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4915,13 +5132,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4936,7 +5153,12 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateEventSourceMappingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateEventSourceMappingError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4958,13 +5180,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -4979,8 +5201,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UpdateFunctionCodeError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateFunctionCodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5004,13 +5227,13 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -5024,7 +5247,12 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(UpdateFunctionConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateFunctionConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1701,6 +1703,11 @@ impl From<HttpDispatchError> for AllocateStaticIpError {
         AllocateStaticIpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AllocateStaticIpError {
+    fn from(err: io::Error) -> AllocateStaticIpError {
+        AllocateStaticIpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AllocateStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1807,6 +1814,11 @@ impl From<CredentialsError> for AttachStaticIpError {
 impl From<HttpDispatchError> for AttachStaticIpError {
     fn from(err: HttpDispatchError) -> AttachStaticIpError {
         AttachStaticIpError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AttachStaticIpError {
+    fn from(err: io::Error) -> AttachStaticIpError {
+        AttachStaticIpError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AttachStaticIpError {
@@ -1917,6 +1929,11 @@ impl From<HttpDispatchError> for CloseInstancePublicPortsError {
         CloseInstancePublicPortsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CloseInstancePublicPortsError {
+    fn from(err: io::Error) -> CloseInstancePublicPortsError {
+        CloseInstancePublicPortsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CloseInstancePublicPortsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2023,6 +2040,11 @@ impl From<CredentialsError> for CreateDomainError {
 impl From<HttpDispatchError> for CreateDomainError {
     fn from(err: HttpDispatchError) -> CreateDomainError {
         CreateDomainError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDomainError {
+    fn from(err: io::Error) -> CreateDomainError {
+        CreateDomainError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDomainError {
@@ -2135,6 +2157,11 @@ impl From<HttpDispatchError> for CreateDomainEntryError {
         CreateDomainEntryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDomainEntryError {
+    fn from(err: io::Error) -> CreateDomainEntryError {
+        CreateDomainEntryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDomainEntryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2243,6 +2270,11 @@ impl From<CredentialsError> for CreateInstanceSnapshotError {
 impl From<HttpDispatchError> for CreateInstanceSnapshotError {
     fn from(err: HttpDispatchError) -> CreateInstanceSnapshotError {
         CreateInstanceSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateInstanceSnapshotError {
+    fn from(err: io::Error) -> CreateInstanceSnapshotError {
+        CreateInstanceSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateInstanceSnapshotError {
@@ -2357,6 +2389,11 @@ impl From<HttpDispatchError> for CreateInstancesError {
         CreateInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateInstancesError {
+    fn from(err: io::Error) -> CreateInstancesError {
+        CreateInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2459,6 +2496,11 @@ impl From<CredentialsError> for CreateInstancesFromSnapshotError {
 impl From<HttpDispatchError> for CreateInstancesFromSnapshotError {
     fn from(err: HttpDispatchError) -> CreateInstancesFromSnapshotError {
         CreateInstancesFromSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateInstancesFromSnapshotError {
+    fn from(err: io::Error) -> CreateInstancesFromSnapshotError {
+        CreateInstancesFromSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateInstancesFromSnapshotError {
@@ -2571,6 +2613,11 @@ impl From<HttpDispatchError> for CreateKeyPairError {
         CreateKeyPairError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateKeyPairError {
+    fn from(err: io::Error) -> CreateKeyPairError {
+        CreateKeyPairError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2675,6 +2722,11 @@ impl From<CredentialsError> for DeleteDomainError {
 impl From<HttpDispatchError> for DeleteDomainError {
     fn from(err: HttpDispatchError) -> DeleteDomainError {
         DeleteDomainError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDomainError {
+    fn from(err: io::Error) -> DeleteDomainError {
+        DeleteDomainError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDomainError {
@@ -2787,6 +2839,11 @@ impl From<HttpDispatchError> for DeleteDomainEntryError {
         DeleteDomainEntryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDomainEntryError {
+    fn from(err: io::Error) -> DeleteDomainEntryError {
+        DeleteDomainEntryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDomainEntryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2897,6 +2954,11 @@ impl From<HttpDispatchError> for DeleteInstanceError {
         DeleteInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteInstanceError {
+    fn from(err: io::Error) -> DeleteInstanceError {
+        DeleteInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3003,6 +3065,11 @@ impl From<CredentialsError> for DeleteInstanceSnapshotError {
 impl From<HttpDispatchError> for DeleteInstanceSnapshotError {
     fn from(err: HttpDispatchError) -> DeleteInstanceSnapshotError {
         DeleteInstanceSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteInstanceSnapshotError {
+    fn from(err: io::Error) -> DeleteInstanceSnapshotError {
+        DeleteInstanceSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteInstanceSnapshotError {
@@ -3115,6 +3182,11 @@ impl From<HttpDispatchError> for DeleteKeyPairError {
         DeleteKeyPairError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteKeyPairError {
+    fn from(err: io::Error) -> DeleteKeyPairError {
+        DeleteKeyPairError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3223,6 +3295,11 @@ impl From<HttpDispatchError> for DetachStaticIpError {
         DetachStaticIpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachStaticIpError {
+    fn from(err: io::Error) -> DetachStaticIpError {
+        DetachStaticIpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3329,6 +3406,11 @@ impl From<CredentialsError> for DownloadDefaultKeyPairError {
 impl From<HttpDispatchError> for DownloadDefaultKeyPairError {
     fn from(err: HttpDispatchError) -> DownloadDefaultKeyPairError {
         DownloadDefaultKeyPairError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DownloadDefaultKeyPairError {
+    fn from(err: io::Error) -> DownloadDefaultKeyPairError {
+        DownloadDefaultKeyPairError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DownloadDefaultKeyPairError {
@@ -3441,6 +3523,11 @@ impl From<HttpDispatchError> for GetActiveNamesError {
         GetActiveNamesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetActiveNamesError {
+    fn from(err: io::Error) -> GetActiveNamesError {
+        GetActiveNamesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetActiveNamesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3549,6 +3636,11 @@ impl From<HttpDispatchError> for GetBlueprintsError {
         GetBlueprintsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBlueprintsError {
+    fn from(err: io::Error) -> GetBlueprintsError {
+        GetBlueprintsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBlueprintsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3651,6 +3743,11 @@ impl From<CredentialsError> for GetBundlesError {
 impl From<HttpDispatchError> for GetBundlesError {
     fn from(err: HttpDispatchError) -> GetBundlesError {
         GetBundlesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBundlesError {
+    fn from(err: io::Error) -> GetBundlesError {
+        GetBundlesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBundlesError {
@@ -3757,6 +3854,11 @@ impl From<HttpDispatchError> for GetDomainError {
         GetDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDomainError {
+    fn from(err: io::Error) -> GetDomainError {
+        GetDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3859,6 +3961,11 @@ impl From<CredentialsError> for GetDomainsError {
 impl From<HttpDispatchError> for GetDomainsError {
     fn from(err: HttpDispatchError) -> GetDomainsError {
         GetDomainsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDomainsError {
+    fn from(err: io::Error) -> GetDomainsError {
+        GetDomainsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDomainsError {
@@ -3967,6 +4074,11 @@ impl From<HttpDispatchError> for GetInstanceError {
         GetInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInstanceError {
+    fn from(err: io::Error) -> GetInstanceError {
+        GetInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4073,6 +4185,11 @@ impl From<CredentialsError> for GetInstanceAccessDetailsError {
 impl From<HttpDispatchError> for GetInstanceAccessDetailsError {
     fn from(err: HttpDispatchError) -> GetInstanceAccessDetailsError {
         GetInstanceAccessDetailsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetInstanceAccessDetailsError {
+    fn from(err: io::Error) -> GetInstanceAccessDetailsError {
+        GetInstanceAccessDetailsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetInstanceAccessDetailsError {
@@ -4185,6 +4302,11 @@ impl From<HttpDispatchError> for GetInstanceMetricDataError {
         GetInstanceMetricDataError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInstanceMetricDataError {
+    fn from(err: io::Error) -> GetInstanceMetricDataError {
+        GetInstanceMetricDataError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInstanceMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4293,6 +4415,11 @@ impl From<CredentialsError> for GetInstancePortStatesError {
 impl From<HttpDispatchError> for GetInstancePortStatesError {
     fn from(err: HttpDispatchError) -> GetInstancePortStatesError {
         GetInstancePortStatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetInstancePortStatesError {
+    fn from(err: io::Error) -> GetInstancePortStatesError {
+        GetInstancePortStatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetInstancePortStatesError {
@@ -4405,6 +4532,11 @@ impl From<HttpDispatchError> for GetInstanceSnapshotError {
         GetInstanceSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInstanceSnapshotError {
+    fn from(err: io::Error) -> GetInstanceSnapshotError {
+        GetInstanceSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInstanceSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4513,6 +4645,11 @@ impl From<CredentialsError> for GetInstanceSnapshotsError {
 impl From<HttpDispatchError> for GetInstanceSnapshotsError {
     fn from(err: HttpDispatchError) -> GetInstanceSnapshotsError {
         GetInstanceSnapshotsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetInstanceSnapshotsError {
+    fn from(err: io::Error) -> GetInstanceSnapshotsError {
+        GetInstanceSnapshotsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetInstanceSnapshotsError {
@@ -4627,6 +4764,11 @@ impl From<HttpDispatchError> for GetInstanceStateError {
         GetInstanceStateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInstanceStateError {
+    fn from(err: io::Error) -> GetInstanceStateError {
+        GetInstanceStateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInstanceStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4733,6 +4875,11 @@ impl From<HttpDispatchError> for GetInstancesError {
         GetInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInstancesError {
+    fn from(err: io::Error) -> GetInstancesError {
+        GetInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4835,6 +4982,11 @@ impl From<CredentialsError> for GetKeyPairError {
 impl From<HttpDispatchError> for GetKeyPairError {
     fn from(err: HttpDispatchError) -> GetKeyPairError {
         GetKeyPairError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetKeyPairError {
+    fn from(err: io::Error) -> GetKeyPairError {
+        GetKeyPairError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetKeyPairError {
@@ -4943,6 +5095,11 @@ impl From<HttpDispatchError> for GetKeyPairsError {
         GetKeyPairsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetKeyPairsError {
+    fn from(err: io::Error) -> GetKeyPairsError {
+        GetKeyPairsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetKeyPairsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5047,6 +5204,11 @@ impl From<CredentialsError> for GetOperationError {
 impl From<HttpDispatchError> for GetOperationError {
     fn from(err: HttpDispatchError) -> GetOperationError {
         GetOperationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetOperationError {
+    fn from(err: io::Error) -> GetOperationError {
+        GetOperationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetOperationError {
@@ -5157,6 +5319,11 @@ impl From<HttpDispatchError> for GetOperationsError {
         GetOperationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetOperationsError {
+    fn from(err: io::Error) -> GetOperationsError {
+        GetOperationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetOperationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5265,6 +5432,11 @@ impl From<HttpDispatchError> for GetOperationsForResourceError {
         GetOperationsForResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetOperationsForResourceError {
+    fn from(err: io::Error) -> GetOperationsForResourceError {
+        GetOperationsForResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetOperationsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5369,6 +5541,11 @@ impl From<CredentialsError> for GetRegionsError {
 impl From<HttpDispatchError> for GetRegionsError {
     fn from(err: HttpDispatchError) -> GetRegionsError {
         GetRegionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetRegionsError {
+    fn from(err: io::Error) -> GetRegionsError {
+        GetRegionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetRegionsError {
@@ -5477,6 +5654,11 @@ impl From<HttpDispatchError> for GetStaticIpError {
         GetStaticIpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetStaticIpError {
+    fn from(err: io::Error) -> GetStaticIpError {
+        GetStaticIpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5581,6 +5763,11 @@ impl From<CredentialsError> for GetStaticIpsError {
 impl From<HttpDispatchError> for GetStaticIpsError {
     fn from(err: HttpDispatchError) -> GetStaticIpsError {
         GetStaticIpsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetStaticIpsError {
+    fn from(err: io::Error) -> GetStaticIpsError {
+        GetStaticIpsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetStaticIpsError {
@@ -5691,6 +5878,11 @@ impl From<HttpDispatchError> for ImportKeyPairError {
         ImportKeyPairError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportKeyPairError {
+    fn from(err: io::Error) -> ImportKeyPairError {
+        ImportKeyPairError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5795,6 +5987,11 @@ impl From<CredentialsError> for IsVpcPeeredError {
 impl From<HttpDispatchError> for IsVpcPeeredError {
     fn from(err: HttpDispatchError) -> IsVpcPeeredError {
         IsVpcPeeredError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for IsVpcPeeredError {
+    fn from(err: io::Error) -> IsVpcPeeredError {
+        IsVpcPeeredError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for IsVpcPeeredError {
@@ -5905,6 +6102,11 @@ impl From<HttpDispatchError> for OpenInstancePublicPortsError {
         OpenInstancePublicPortsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for OpenInstancePublicPortsError {
+    fn from(err: io::Error) -> OpenInstancePublicPortsError {
+        OpenInstancePublicPortsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for OpenInstancePublicPortsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6009,6 +6211,11 @@ impl From<CredentialsError> for PeerVpcError {
 impl From<HttpDispatchError> for PeerVpcError {
     fn from(err: HttpDispatchError) -> PeerVpcError {
         PeerVpcError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PeerVpcError {
+    fn from(err: io::Error) -> PeerVpcError {
+        PeerVpcError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PeerVpcError {
@@ -6117,6 +6324,11 @@ impl From<CredentialsError> for PutInstancePublicPortsError {
 impl From<HttpDispatchError> for PutInstancePublicPortsError {
     fn from(err: HttpDispatchError) -> PutInstancePublicPortsError {
         PutInstancePublicPortsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutInstancePublicPortsError {
+    fn from(err: io::Error) -> PutInstancePublicPortsError {
+        PutInstancePublicPortsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutInstancePublicPortsError {
@@ -6229,6 +6441,11 @@ impl From<HttpDispatchError> for RebootInstanceError {
         RebootInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RebootInstanceError {
+    fn from(err: io::Error) -> RebootInstanceError {
+        RebootInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RebootInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6339,6 +6556,11 @@ impl From<HttpDispatchError> for ReleaseStaticIpError {
         ReleaseStaticIpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReleaseStaticIpError {
+    fn from(err: io::Error) -> ReleaseStaticIpError {
+        ReleaseStaticIpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReleaseStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6447,6 +6669,11 @@ impl From<HttpDispatchError> for StartInstanceError {
         StartInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartInstanceError {
+    fn from(err: io::Error) -> StartInstanceError {
+        StartInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6553,6 +6780,11 @@ impl From<HttpDispatchError> for StopInstanceError {
         StopInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StopInstanceError {
+    fn from(err: io::Error) -> StopInstanceError {
+        StopInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StopInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6655,6 +6887,11 @@ impl From<CredentialsError> for UnpeerVpcError {
 impl From<HttpDispatchError> for UnpeerVpcError {
     fn from(err: HttpDispatchError) -> UnpeerVpcError {
         UnpeerVpcError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UnpeerVpcError {
+    fn from(err: io::Error) -> UnpeerVpcError {
+        UnpeerVpcError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UnpeerVpcError {
@@ -6765,6 +7002,11 @@ impl From<CredentialsError> for UpdateDomainEntryError {
 impl From<HttpDispatchError> for UpdateDomainEntryError {
     fn from(err: HttpDispatchError) -> UpdateDomainEntryError {
         UpdateDomainEntryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateDomainEntryError {
+    fn from(err: io::Error) -> UpdateDomainEntryError {
+        UpdateDomainEntryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateDomainEntryError {
@@ -7114,15 +7356,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AllocateStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AllocateStaticIpResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AllocateStaticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AllocateStaticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7141,15 +7388,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AttachStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AttachStaticIpResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AttachStaticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachStaticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7170,13 +7422,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CloseInstancePublicPortsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CloseInstancePublicPortsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CloseInstancePublicPortsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CloseInstancePublicPortsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7194,14 +7453,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDomainResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDomainResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateDomainError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7220,15 +7485,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDomainEntryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDomainEntryResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateDomainEntryError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDomainEntryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7248,15 +7518,18 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateInstanceSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateInstanceSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateInstanceSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInstanceSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7275,15 +7548,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateInstancesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateInstancesResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7304,13 +7582,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateInstancesFromSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateInstancesFromSnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateInstancesFromSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInstancesFromSnapshotError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -7328,14 +7613,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateKeyPairResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateKeyPairError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateKeyPairError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7354,14 +7645,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteDomainResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteDomainResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteDomainError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7380,15 +7677,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteDomainEntryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteDomainEntryResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteDomainEntryError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDomainEntryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7407,15 +7709,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteInstanceResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7435,15 +7742,18 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteInstanceSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteInstanceSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteInstanceSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteInstanceSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7462,14 +7772,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteKeyPairResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteKeyPairError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteKeyPairError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7488,15 +7804,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DetachStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DetachStaticIpResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DetachStaticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachStaticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7514,15 +7835,18 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DownloadDefaultKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DownloadDefaultKeyPairResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DownloadDefaultKeyPairError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DownloadDefaultKeyPairError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7541,15 +7865,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetActiveNamesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetActiveNamesResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetActiveNamesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetActiveNamesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7568,14 +7897,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetBlueprintsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetBlueprintsResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetBlueprintsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBlueprintsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7592,13 +7927,21 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetBundlesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetBundlesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetBundlesResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBundlesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7614,15 +7957,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetDomainResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDomainResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetDomainError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7638,13 +7986,21 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDomainsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetDomainsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDomainsResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDomainsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7662,13 +8018,21 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstanceResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7688,13 +8052,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstanceAccessDetailsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetInstanceAccessDetailsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstanceAccessDetailsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstanceAccessDetailsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7713,15 +8084,18 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstanceMetricDataResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstanceMetricDataResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetInstanceMetricDataError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstanceMetricDataError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7741,15 +8115,18 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstancePortStatesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstancePortStatesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetInstancePortStatesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstancePortStatesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7768,15 +8145,18 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstanceSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstanceSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetInstanceSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstanceSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7795,15 +8175,18 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstanceSnapshotsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstanceSnapshotsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetInstanceSnapshotsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstanceSnapshotsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7822,15 +8205,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstanceStateResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstanceStateResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetInstanceStateError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstanceStateError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7849,14 +8237,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInstancesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInstancesResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7873,13 +8267,21 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetKeyPairError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetKeyPairResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetKeyPairError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7897,13 +8299,21 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetKeyPairsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetKeyPairsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetKeyPairsResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetKeyPairsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7921,14 +8331,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetOperationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetOperationResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetOperationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOperationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7947,14 +8363,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetOperationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetOperationsResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetOperationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOperationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7975,13 +8397,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetOperationsForResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetOperationsForResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetOperationsForResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOperationsForResourceError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7997,13 +8426,21 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRegionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetRegionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRegionsResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRegionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8021,13 +8458,21 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetStaticIpError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetStaticIpResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetStaticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8045,14 +8490,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetStaticIpsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetStaticIpsResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetStaticIpsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetStaticIpsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8071,14 +8522,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ImportKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ImportKeyPairResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ImportKeyPairError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportKeyPairError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8094,13 +8551,21 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<IsVpcPeeredResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(IsVpcPeeredError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<IsVpcPeeredResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(IsVpcPeeredError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8119,13 +8584,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<OpenInstancePublicPortsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(OpenInstancePublicPortsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<OpenInstancePublicPortsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(OpenInstancePublicPortsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -8140,15 +8612,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<PeerVpcResult>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PeerVpcResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(PeerVpcError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PeerVpcError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8167,15 +8644,18 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutInstancePublicPortsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutInstancePublicPortsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(PutInstancePublicPortsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutInstancePublicPortsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8194,15 +8674,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RebootInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RebootInstanceResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RebootInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebootInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8221,15 +8706,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ReleaseStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ReleaseStaticIpResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ReleaseStaticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReleaseStaticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8248,14 +8738,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartInstanceResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StartInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8274,14 +8770,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopInstanceResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StopInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8297,15 +8799,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<UnpeerVpcResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UnpeerVpcResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(UnpeerVpcError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnpeerVpcError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8323,15 +8830,20 @@ impl<P, D> Lightsail for LightsailClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDomainEntryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDomainEntryResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateDomainEntryError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDomainEntryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -999,6 +1001,11 @@ impl From<HttpDispatchError> for CancelExportTaskError {
         CancelExportTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelExportTaskError {
+    fn from(err: io::Error) -> CancelExportTaskError {
+        CancelExportTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelExportTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1101,6 +1108,11 @@ impl From<HttpDispatchError> for CreateExportTaskError {
         CreateExportTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateExportTaskError {
+    fn from(err: io::Error) -> CreateExportTaskError {
+        CreateExportTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateExportTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1200,6 +1212,11 @@ impl From<HttpDispatchError> for CreateLogGroupError {
         CreateLogGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLogGroupError {
+    fn from(err: io::Error) -> CreateLogGroupError {
+        CreateLogGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLogGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1293,6 +1310,11 @@ impl From<HttpDispatchError> for CreateLogStreamError {
         CreateLogStreamError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLogStreamError {
+    fn from(err: io::Error) -> CreateLogStreamError {
+        CreateLogStreamError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLogStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1383,6 +1405,11 @@ impl From<CredentialsError> for DeleteDestinationError {
 impl From<HttpDispatchError> for DeleteDestinationError {
     fn from(err: HttpDispatchError) -> DeleteDestinationError {
         DeleteDestinationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDestinationError {
+    fn from(err: io::Error) -> DeleteDestinationError {
+        DeleteDestinationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDestinationError {
@@ -1479,6 +1506,11 @@ impl From<HttpDispatchError> for DeleteLogGroupError {
         DeleteLogGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteLogGroupError {
+    fn from(err: io::Error) -> DeleteLogGroupError {
+        DeleteLogGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteLogGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1571,6 +1603,11 @@ impl From<HttpDispatchError> for DeleteLogStreamError {
         DeleteLogStreamError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteLogStreamError {
+    fn from(err: io::Error) -> DeleteLogStreamError {
+        DeleteLogStreamError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteLogStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1661,6 +1698,11 @@ impl From<CredentialsError> for DeleteMetricFilterError {
 impl From<HttpDispatchError> for DeleteMetricFilterError {
     fn from(err: HttpDispatchError) -> DeleteMetricFilterError {
         DeleteMetricFilterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteMetricFilterError {
+    fn from(err: io::Error) -> DeleteMetricFilterError {
+        DeleteMetricFilterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteMetricFilterError {
@@ -1757,6 +1799,11 @@ impl From<HttpDispatchError> for DeleteRetentionPolicyError {
         DeleteRetentionPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRetentionPolicyError {
+    fn from(err: io::Error) -> DeleteRetentionPolicyError {
+        DeleteRetentionPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRetentionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1849,6 +1896,11 @@ impl From<HttpDispatchError> for DeleteSubscriptionFilterError {
         DeleteSubscriptionFilterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteSubscriptionFilterError {
+    fn from(err: io::Error) -> DeleteSubscriptionFilterError {
+        DeleteSubscriptionFilterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteSubscriptionFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1933,6 +1985,11 @@ impl From<HttpDispatchError> for DescribeDestinationsError {
         DescribeDestinationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDestinationsError {
+    fn from(err: io::Error) -> DescribeDestinationsError {
+        DescribeDestinationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDestinationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2015,6 +2072,11 @@ impl From<HttpDispatchError> for DescribeExportTasksError {
         DescribeExportTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeExportTasksError {
+    fn from(err: io::Error) -> DescribeExportTasksError {
+        DescribeExportTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeExportTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2095,6 +2157,11 @@ impl From<CredentialsError> for DescribeLogGroupsError {
 impl From<HttpDispatchError> for DescribeLogGroupsError {
     fn from(err: HttpDispatchError) -> DescribeLogGroupsError {
         DescribeLogGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLogGroupsError {
+    fn from(err: io::Error) -> DescribeLogGroupsError {
+        DescribeLogGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLogGroupsError {
@@ -2182,6 +2249,11 @@ impl From<CredentialsError> for DescribeLogStreamsError {
 impl From<HttpDispatchError> for DescribeLogStreamsError {
     fn from(err: HttpDispatchError) -> DescribeLogStreamsError {
         DescribeLogStreamsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeLogStreamsError {
+    fn from(err: io::Error) -> DescribeLogStreamsError {
+        DescribeLogStreamsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeLogStreamsError {
@@ -2272,6 +2344,11 @@ impl From<HttpDispatchError> for DescribeMetricFiltersError {
         DescribeMetricFiltersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeMetricFiltersError {
+    fn from(err: io::Error) -> DescribeMetricFiltersError {
+        DescribeMetricFiltersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeMetricFiltersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2352,6 +2429,11 @@ impl From<CredentialsError> for DescribeSubscriptionFiltersError {
 impl From<HttpDispatchError> for DescribeSubscriptionFiltersError {
     fn from(err: HttpDispatchError) -> DescribeSubscriptionFiltersError {
         DescribeSubscriptionFiltersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSubscriptionFiltersError {
+    fn from(err: io::Error) -> DescribeSubscriptionFiltersError {
+        DescribeSubscriptionFiltersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSubscriptionFiltersError {
@@ -2442,6 +2524,11 @@ impl From<HttpDispatchError> for FilterLogEventsError {
         FilterLogEventsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for FilterLogEventsError {
+    fn from(err: io::Error) -> FilterLogEventsError {
+        FilterLogEventsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for FilterLogEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2528,6 +2615,11 @@ impl From<HttpDispatchError> for GetLogEventsError {
         GetLogEventsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetLogEventsError {
+    fn from(err: io::Error) -> GetLogEventsError {
+        GetLogEventsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetLogEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2607,6 +2699,11 @@ impl From<CredentialsError> for ListTagsLogGroupError {
 impl From<HttpDispatchError> for ListTagsLogGroupError {
     fn from(err: HttpDispatchError) -> ListTagsLogGroupError {
         ListTagsLogGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsLogGroupError {
+    fn from(err: io::Error) -> ListTagsLogGroupError {
+        ListTagsLogGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsLogGroupError {
@@ -2694,6 +2791,11 @@ impl From<HttpDispatchError> for PutDestinationError {
         PutDestinationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutDestinationError {
+    fn from(err: io::Error) -> PutDestinationError {
+        PutDestinationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2778,6 +2880,11 @@ impl From<CredentialsError> for PutDestinationPolicyError {
 impl From<HttpDispatchError> for PutDestinationPolicyError {
     fn from(err: HttpDispatchError) -> PutDestinationPolicyError {
         PutDestinationPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutDestinationPolicyError {
+    fn from(err: io::Error) -> PutDestinationPolicyError {
+        PutDestinationPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutDestinationPolicyError {
@@ -2878,6 +2985,11 @@ impl From<HttpDispatchError> for PutLogEventsError {
         PutLogEventsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutLogEventsError {
+    fn from(err: io::Error) -> PutLogEventsError {
+        PutLogEventsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutLogEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2976,6 +3088,11 @@ impl From<HttpDispatchError> for PutMetricFilterError {
         PutMetricFilterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutMetricFilterError {
+    fn from(err: io::Error) -> PutMetricFilterError {
+        PutMetricFilterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutMetricFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3067,6 +3184,11 @@ impl From<CredentialsError> for PutRetentionPolicyError {
 impl From<HttpDispatchError> for PutRetentionPolicyError {
     fn from(err: HttpDispatchError) -> PutRetentionPolicyError {
         PutRetentionPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutRetentionPolicyError {
+    fn from(err: io::Error) -> PutRetentionPolicyError {
+        PutRetentionPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutRetentionPolicyError {
@@ -3168,6 +3290,11 @@ impl From<HttpDispatchError> for PutSubscriptionFilterError {
         PutSubscriptionFilterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutSubscriptionFilterError {
+    fn from(err: io::Error) -> PutSubscriptionFilterError {
+        PutSubscriptionFilterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutSubscriptionFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3253,6 +3380,11 @@ impl From<HttpDispatchError> for TagLogGroupError {
         TagLogGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TagLogGroupError {
+    fn from(err: io::Error) -> TagLogGroupError {
+        TagLogGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TagLogGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3333,6 +3465,11 @@ impl From<HttpDispatchError> for TestMetricFilterError {
         TestMetricFilterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TestMetricFilterError {
+    fn from(err: io::Error) -> TestMetricFilterError {
+        TestMetricFilterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TestMetricFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3406,6 +3543,11 @@ impl From<CredentialsError> for UntagLogGroupError {
 impl From<HttpDispatchError> for UntagLogGroupError {
     fn from(err: HttpDispatchError) -> UntagLogGroupError {
         UntagLogGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UntagLogGroupError {
+    fn from(err: io::Error) -> UntagLogGroupError {
+        UntagLogGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UntagLogGroupError {
@@ -3627,13 +3769,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(CancelExportTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelExportTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3652,15 +3795,20 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateExportTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateExportTaskResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateExportTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateExportTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3677,13 +3825,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(CreateLogGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLogGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3702,13 +3851,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(CreateLogStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLogStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3727,13 +3877,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteDestinationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDestinationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3750,13 +3901,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteLogGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLogGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3775,13 +3927,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteLogStreamError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLogStreamError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3800,13 +3953,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteMetricFilterError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteMetricFilterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3825,13 +3979,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteRetentionPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRetentionPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3850,11 +4005,16 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteSubscriptionFilterError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSubscriptionFilterError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -3872,15 +4032,18 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDestinationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDestinationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeDestinationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDestinationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3899,15 +4062,18 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeExportTasksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeExportTasksResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeExportTasksError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeExportTasksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3926,15 +4092,18 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeLogGroupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeLogGroupsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeLogGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLogGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3953,15 +4122,18 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeLogStreamsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeLogStreamsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeLogStreamsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLogStreamsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3981,15 +4153,18 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMetricFiltersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMetricFiltersResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeMetricFiltersError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMetricFiltersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4009,13 +4184,20 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeSubscriptionFiltersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeSubscriptionFiltersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeSubscriptionFiltersResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSubscriptionFiltersError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -4033,15 +4215,20 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<FilterLogEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<FilterLogEventsResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(FilterLogEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(FilterLogEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4060,14 +4247,20 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetLogEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetLogEventsResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetLogEventsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetLogEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4086,15 +4279,20 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsLogGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsLogGroupResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListTagsLogGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsLogGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4113,15 +4311,20 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutDestinationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutDestinationResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutDestinationError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutDestinationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4140,13 +4343,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutDestinationPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutDestinationPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4165,14 +4369,20 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutLogEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutLogEventsResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutLogEventsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutLogEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4191,13 +4401,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutMetricFilterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutMetricFilterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4216,13 +4427,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutRetentionPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutRetentionPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4241,13 +4453,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(PutSubscriptionFilterError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutSubscriptionFilterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4264,11 +4477,15 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(TagLogGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TagLogGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4286,15 +4503,20 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TestMetricFilterResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<TestMetricFilterResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(TestMetricFilterError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestMetricFilterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4311,12 +4533,14 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UntagLogGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UntagLogGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1650,6 +1652,11 @@ impl From<HttpDispatchError> for AddTagsError {
         AddTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsError {
+    fn from(err: io::Error) -> AddTagsError {
+        AddTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1734,6 +1741,11 @@ impl From<CredentialsError> for CreateBatchPredictionError {
 impl From<HttpDispatchError> for CreateBatchPredictionError {
     fn from(err: HttpDispatchError) -> CreateBatchPredictionError {
         CreateBatchPredictionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateBatchPredictionError {
+    fn from(err: io::Error) -> CreateBatchPredictionError {
+        CreateBatchPredictionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateBatchPredictionError {
@@ -1822,6 +1834,11 @@ impl From<HttpDispatchError> for CreateDataSourceFromRDSError {
         CreateDataSourceFromRDSError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDataSourceFromRDSError {
+    fn from(err: io::Error) -> CreateDataSourceFromRDSError {
+        CreateDataSourceFromRDSError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDataSourceFromRDSError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1904,6 +1921,11 @@ impl From<CredentialsError> for CreateDataSourceFromRedshiftError {
 impl From<HttpDispatchError> for CreateDataSourceFromRedshiftError {
     fn from(err: HttpDispatchError) -> CreateDataSourceFromRedshiftError {
         CreateDataSourceFromRedshiftError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDataSourceFromRedshiftError {
+    fn from(err: io::Error) -> CreateDataSourceFromRedshiftError {
+        CreateDataSourceFromRedshiftError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDataSourceFromRedshiftError {
@@ -1992,6 +2014,11 @@ impl From<HttpDispatchError> for CreateDataSourceFromS3Error {
         CreateDataSourceFromS3Error::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDataSourceFromS3Error {
+    fn from(err: io::Error) -> CreateDataSourceFromS3Error {
+        CreateDataSourceFromS3Error::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDataSourceFromS3Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2076,6 +2103,11 @@ impl From<CredentialsError> for CreateEvaluationError {
 impl From<HttpDispatchError> for CreateEvaluationError {
     fn from(err: HttpDispatchError) -> CreateEvaluationError {
         CreateEvaluationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateEvaluationError {
+    fn from(err: io::Error) -> CreateEvaluationError {
+        CreateEvaluationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateEvaluationError {
@@ -2164,6 +2196,11 @@ impl From<HttpDispatchError> for CreateMLModelError {
         CreateMLModelError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateMLModelError {
+    fn from(err: io::Error) -> CreateMLModelError {
+        CreateMLModelError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateMLModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2248,6 +2285,11 @@ impl From<CredentialsError> for CreateRealtimeEndpointError {
 impl From<HttpDispatchError> for CreateRealtimeEndpointError {
     fn from(err: HttpDispatchError) -> CreateRealtimeEndpointError {
         CreateRealtimeEndpointError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateRealtimeEndpointError {
+    fn from(err: io::Error) -> CreateRealtimeEndpointError {
+        CreateRealtimeEndpointError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateRealtimeEndpointError {
@@ -2338,6 +2380,11 @@ impl From<HttpDispatchError> for DeleteBatchPredictionError {
         DeleteBatchPredictionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteBatchPredictionError {
+    fn from(err: io::Error) -> DeleteBatchPredictionError {
+        DeleteBatchPredictionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteBatchPredictionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2426,6 +2473,11 @@ impl From<HttpDispatchError> for DeleteDataSourceError {
         DeleteDataSourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDataSourceError {
+    fn from(err: io::Error) -> DeleteDataSourceError {
+        DeleteDataSourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2510,6 +2562,11 @@ impl From<CredentialsError> for DeleteEvaluationError {
 impl From<HttpDispatchError> for DeleteEvaluationError {
     fn from(err: HttpDispatchError) -> DeleteEvaluationError {
         DeleteEvaluationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteEvaluationError {
+    fn from(err: io::Error) -> DeleteEvaluationError {
+        DeleteEvaluationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteEvaluationError {
@@ -2598,6 +2655,11 @@ impl From<HttpDispatchError> for DeleteMLModelError {
         DeleteMLModelError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteMLModelError {
+    fn from(err: io::Error) -> DeleteMLModelError {
+        DeleteMLModelError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteMLModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2682,6 +2744,11 @@ impl From<CredentialsError> for DeleteRealtimeEndpointError {
 impl From<HttpDispatchError> for DeleteRealtimeEndpointError {
     fn from(err: HttpDispatchError) -> DeleteRealtimeEndpointError {
         DeleteRealtimeEndpointError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteRealtimeEndpointError {
+    fn from(err: io::Error) -> DeleteRealtimeEndpointError {
+        DeleteRealtimeEndpointError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteRealtimeEndpointError {
@@ -2775,6 +2842,11 @@ impl From<HttpDispatchError> for DeleteTagsError {
         DeleteTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTagsError {
+    fn from(err: io::Error) -> DeleteTagsError {
+        DeleteTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2855,6 +2927,11 @@ impl From<CredentialsError> for DescribeBatchPredictionsError {
 impl From<HttpDispatchError> for DescribeBatchPredictionsError {
     fn from(err: HttpDispatchError) -> DescribeBatchPredictionsError {
         DescribeBatchPredictionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeBatchPredictionsError {
+    fn from(err: io::Error) -> DescribeBatchPredictionsError {
+        DescribeBatchPredictionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeBatchPredictionsError {
@@ -2939,6 +3016,11 @@ impl From<HttpDispatchError> for DescribeDataSourcesError {
         DescribeDataSourcesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDataSourcesError {
+    fn from(err: io::Error) -> DescribeDataSourcesError {
+        DescribeDataSourcesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDataSourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3021,6 +3103,11 @@ impl From<HttpDispatchError> for DescribeEvaluationsError {
         DescribeEvaluationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEvaluationsError {
+    fn from(err: io::Error) -> DescribeEvaluationsError {
+        DescribeEvaluationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEvaluationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3101,6 +3188,11 @@ impl From<CredentialsError> for DescribeMLModelsError {
 impl From<HttpDispatchError> for DescribeMLModelsError {
     fn from(err: HttpDispatchError) -> DescribeMLModelsError {
         DescribeMLModelsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeMLModelsError {
+    fn from(err: io::Error) -> DescribeMLModelsError {
+        DescribeMLModelsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeMLModelsError {
@@ -3188,6 +3280,11 @@ impl From<HttpDispatchError> for DescribeTagsError {
         DescribeTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTagsError {
+    fn from(err: io::Error) -> DescribeTagsError {
+        DescribeTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3272,6 +3369,11 @@ impl From<CredentialsError> for GetBatchPredictionError {
 impl From<HttpDispatchError> for GetBatchPredictionError {
     fn from(err: HttpDispatchError) -> GetBatchPredictionError {
         GetBatchPredictionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBatchPredictionError {
+    fn from(err: io::Error) -> GetBatchPredictionError {
+        GetBatchPredictionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBatchPredictionError {
@@ -3362,6 +3464,11 @@ impl From<HttpDispatchError> for GetDataSourceError {
         GetDataSourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDataSourceError {
+    fn from(err: io::Error) -> GetDataSourceError {
+        GetDataSourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3448,6 +3555,11 @@ impl From<HttpDispatchError> for GetEvaluationError {
         GetEvaluationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetEvaluationError {
+    fn from(err: io::Error) -> GetEvaluationError {
+        GetEvaluationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3530,6 +3642,11 @@ impl From<CredentialsError> for GetMLModelError {
 impl From<HttpDispatchError> for GetMLModelError {
     fn from(err: HttpDispatchError) -> GetMLModelError {
         GetMLModelError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetMLModelError {
+    fn from(err: io::Error) -> GetMLModelError {
+        GetMLModelError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetMLModelError {
@@ -3626,6 +3743,11 @@ impl From<HttpDispatchError> for PredictError {
         PredictError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PredictError {
+    fn from(err: io::Error) -> PredictError {
+        PredictError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PredictError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3712,6 +3834,11 @@ impl From<CredentialsError> for UpdateBatchPredictionError {
 impl From<HttpDispatchError> for UpdateBatchPredictionError {
     fn from(err: HttpDispatchError) -> UpdateBatchPredictionError {
         UpdateBatchPredictionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateBatchPredictionError {
+    fn from(err: io::Error) -> UpdateBatchPredictionError {
+        UpdateBatchPredictionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateBatchPredictionError {
@@ -3802,6 +3929,11 @@ impl From<HttpDispatchError> for UpdateDataSourceError {
         UpdateDataSourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDataSourceError {
+    fn from(err: io::Error) -> UpdateDataSourceError {
+        UpdateDataSourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3888,6 +4020,11 @@ impl From<HttpDispatchError> for UpdateEvaluationError {
         UpdateEvaluationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateEvaluationError {
+    fn from(err: io::Error) -> UpdateEvaluationError {
+        UpdateEvaluationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3972,6 +4109,11 @@ impl From<CredentialsError> for UpdateMLModelError {
 impl From<HttpDispatchError> for UpdateMLModelError {
     fn from(err: HttpDispatchError) -> UpdateMLModelError {
         UpdateMLModelError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateMLModelError {
+    fn from(err: io::Error) -> UpdateMLModelError {
+        UpdateMLModelError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateMLModelError {
@@ -4200,15 +4342,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AddTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4227,15 +4374,18 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateBatchPredictionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateBatchPredictionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateBatchPredictionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateBatchPredictionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4255,13 +4405,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDataSourceFromRDSOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateDataSourceFromRDSError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDataSourceFromRDSOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDataSourceFromRDSError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -4281,13 +4438,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDataSourceFromRedshiftOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateDataSourceFromRedshiftError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDataSourceFromRedshiftOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDataSourceFromRedshiftError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -4306,15 +4470,18 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDataSourceFromS3Output>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDataSourceFromS3Output>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateDataSourceFromS3Error::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDataSourceFromS3Error::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4333,15 +4500,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateEvaluationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateEvaluationOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateEvaluationError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateEvaluationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4360,14 +4532,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateMLModelOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateMLModelOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateMLModelError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateMLModelError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4387,15 +4565,18 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateRealtimeEndpointOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateRealtimeEndpointOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateRealtimeEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRealtimeEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4415,15 +4596,18 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteBatchPredictionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteBatchPredictionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteBatchPredictionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBatchPredictionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4442,15 +4626,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteDataSourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteDataSourceOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteDataSourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDataSourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4469,15 +4658,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteEvaluationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteEvaluationOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteEvaluationError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEvaluationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4496,14 +4690,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteMLModelOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteMLModelOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteMLModelError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteMLModelError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4523,15 +4723,18 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRealtimeEndpointOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRealtimeEndpointOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteRealtimeEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRealtimeEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4548,13 +4751,21 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteTagsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteTagsOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4573,13 +4784,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeBatchPredictionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeBatchPredictionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeBatchPredictionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeBatchPredictionsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -4597,15 +4815,18 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDataSourcesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDataSourcesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeDataSourcesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDataSourcesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4624,15 +4845,18 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEvaluationsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEvaluationsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeEvaluationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEvaluationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4651,15 +4875,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMLModelsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMLModelsOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeMLModelsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMLModelsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4678,14 +4907,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTagsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTagsOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4704,15 +4939,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetBatchPredictionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetBatchPredictionOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetBatchPredictionError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBatchPredictionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4731,14 +4971,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDataSourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDataSourceOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetDataSourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDataSourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4757,14 +5003,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetEvaluationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetEvaluationOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetEvaluationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetEvaluationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4781,13 +5033,21 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetMLModelOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetMLModelError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetMLModelOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetMLModelError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4803,15 +5063,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<PredictOutput>(String::from_utf8_lossy(&response.body)
-                                                             .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PredictOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(PredictError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PredictError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4830,15 +5095,18 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateBatchPredictionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateBatchPredictionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateBatchPredictionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateBatchPredictionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4857,15 +5125,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDataSourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDataSourceOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateDataSourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDataSourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4884,15 +5157,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateEvaluationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateEvaluationOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateEvaluationError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateEvaluationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4911,14 +5189,20 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateMLModelOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateMLModelOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateMLModelError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateMLModelError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -214,6 +216,11 @@ impl From<HttpDispatchError> for BatchMeterUsageError {
         BatchMeterUsageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for BatchMeterUsageError {
+    fn from(err: io::Error) -> BatchMeterUsageError {
+        BatchMeterUsageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for BatchMeterUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -321,6 +328,11 @@ impl From<HttpDispatchError> for MeterUsageError {
         MeterUsageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for MeterUsageError {
+    fn from(err: io::Error) -> MeterUsageError {
+        MeterUsageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for MeterUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -416,6 +428,11 @@ impl From<HttpDispatchError> for ResolveCustomerError {
         ResolveCustomerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ResolveCustomerError {
+    fn from(err: io::Error) -> ResolveCustomerError {
+        ResolveCustomerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ResolveCustomerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -492,15 +509,20 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<BatchMeterUsageResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<BatchMeterUsageResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(BatchMeterUsageError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(BatchMeterUsageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -517,13 +539,21 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<MeterUsageResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(MeterUsageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<MeterUsageResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(MeterUsageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -541,15 +571,20 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ResolveCustomerResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ResolveCustomerResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ResolveCustomerError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResolveCustomerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1557,6 +1559,11 @@ impl From<HttpDispatchError> for AcceptQualificationRequestError {
         AcceptQualificationRequestError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AcceptQualificationRequestError {
+    fn from(err: io::Error) -> AcceptQualificationRequestError {
+        AcceptQualificationRequestError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AcceptQualificationRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1639,6 +1646,11 @@ impl From<HttpDispatchError> for ApproveAssignmentError {
         ApproveAssignmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ApproveAssignmentError {
+    fn from(err: io::Error) -> ApproveAssignmentError {
+        ApproveAssignmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ApproveAssignmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1715,6 +1727,11 @@ impl From<CredentialsError> for AssociateQualificationWithWorkerError {
 impl From<HttpDispatchError> for AssociateQualificationWithWorkerError {
     fn from(err: HttpDispatchError) -> AssociateQualificationWithWorkerError {
         AssociateQualificationWithWorkerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AssociateQualificationWithWorkerError {
+    fn from(err: io::Error) -> AssociateQualificationWithWorkerError {
+        AssociateQualificationWithWorkerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AssociateQualificationWithWorkerError {
@@ -1796,6 +1813,11 @@ impl From<HttpDispatchError> for CreateAdditionalAssignmentsForHITError {
         CreateAdditionalAssignmentsForHITError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateAdditionalAssignmentsForHITError {
+    fn from(err: io::Error) -> CreateAdditionalAssignmentsForHITError {
+        CreateAdditionalAssignmentsForHITError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateAdditionalAssignmentsForHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1872,6 +1894,11 @@ impl From<HttpDispatchError> for CreateHITError {
         CreateHITError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateHITError {
+    fn from(err: io::Error) -> CreateHITError {
+        CreateHITError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1946,6 +1973,11 @@ impl From<CredentialsError> for CreateHITTypeError {
 impl From<HttpDispatchError> for CreateHITTypeError {
     fn from(err: HttpDispatchError) -> CreateHITTypeError {
         CreateHITTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateHITTypeError {
+    fn from(err: io::Error) -> CreateHITTypeError {
+        CreateHITTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateHITTypeError {
@@ -2026,6 +2058,11 @@ impl From<CredentialsError> for CreateHITWithHITTypeError {
 impl From<HttpDispatchError> for CreateHITWithHITTypeError {
     fn from(err: HttpDispatchError) -> CreateHITWithHITTypeError {
         CreateHITWithHITTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateHITWithHITTypeError {
+    fn from(err: io::Error) -> CreateHITWithHITTypeError {
+        CreateHITWithHITTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateHITWithHITTypeError {
@@ -2110,6 +2147,11 @@ impl From<HttpDispatchError> for CreateQualificationTypeError {
         CreateQualificationTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateQualificationTypeError {
+    fn from(err: io::Error) -> CreateQualificationTypeError {
+        CreateQualificationTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateQualificationTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2192,6 +2234,11 @@ impl From<HttpDispatchError> for CreateWorkerBlockError {
         CreateWorkerBlockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateWorkerBlockError {
+    fn from(err: io::Error) -> CreateWorkerBlockError {
+        CreateWorkerBlockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateWorkerBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2266,6 +2313,11 @@ impl From<CredentialsError> for DeleteHITError {
 impl From<HttpDispatchError> for DeleteHITError {
     fn from(err: HttpDispatchError) -> DeleteHITError {
         DeleteHITError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteHITError {
+    fn from(err: io::Error) -> DeleteHITError {
+        DeleteHITError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteHITError {
@@ -2346,6 +2398,11 @@ impl From<CredentialsError> for DeleteQualificationTypeError {
 impl From<HttpDispatchError> for DeleteQualificationTypeError {
     fn from(err: HttpDispatchError) -> DeleteQualificationTypeError {
         DeleteQualificationTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteQualificationTypeError {
+    fn from(err: io::Error) -> DeleteQualificationTypeError {
+        DeleteQualificationTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteQualificationTypeError {
@@ -2430,6 +2487,11 @@ impl From<HttpDispatchError> for DeleteWorkerBlockError {
         DeleteWorkerBlockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteWorkerBlockError {
+    fn from(err: io::Error) -> DeleteWorkerBlockError {
+        DeleteWorkerBlockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteWorkerBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2507,6 +2569,11 @@ impl From<CredentialsError> for DisassociateQualificationFromWorkerError {
 impl From<HttpDispatchError> for DisassociateQualificationFromWorkerError {
     fn from(err: HttpDispatchError) -> DisassociateQualificationFromWorkerError {
         DisassociateQualificationFromWorkerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisassociateQualificationFromWorkerError {
+    fn from(err: io::Error) -> DisassociateQualificationFromWorkerError {
+        DisassociateQualificationFromWorkerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisassociateQualificationFromWorkerError {
@@ -2591,6 +2658,11 @@ impl From<HttpDispatchError> for GetAccountBalanceError {
         GetAccountBalanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetAccountBalanceError {
+    fn from(err: io::Error) -> GetAccountBalanceError {
+        GetAccountBalanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetAccountBalanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2667,6 +2739,11 @@ impl From<CredentialsError> for GetAssignmentError {
 impl From<HttpDispatchError> for GetAssignmentError {
     fn from(err: HttpDispatchError) -> GetAssignmentError {
         GetAssignmentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetAssignmentError {
+    fn from(err: io::Error) -> GetAssignmentError {
+        GetAssignmentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetAssignmentError {
@@ -2749,6 +2826,11 @@ impl From<HttpDispatchError> for GetFileUploadURLError {
         GetFileUploadURLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetFileUploadURLError {
+    fn from(err: io::Error) -> GetFileUploadURLError {
+        GetFileUploadURLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetFileUploadURLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2821,6 +2903,11 @@ impl From<CredentialsError> for GetHITError {
 impl From<HttpDispatchError> for GetHITError {
     fn from(err: HttpDispatchError) -> GetHITError {
         GetHITError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetHITError {
+    fn from(err: io::Error) -> GetHITError {
+        GetHITError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetHITError {
@@ -2901,6 +2988,11 @@ impl From<CredentialsError> for GetQualificationScoreError {
 impl From<HttpDispatchError> for GetQualificationScoreError {
     fn from(err: HttpDispatchError) -> GetQualificationScoreError {
         GetQualificationScoreError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetQualificationScoreError {
+    fn from(err: io::Error) -> GetQualificationScoreError {
+        GetQualificationScoreError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetQualificationScoreError {
@@ -2985,6 +3077,11 @@ impl From<HttpDispatchError> for GetQualificationTypeError {
         GetQualificationTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetQualificationTypeError {
+    fn from(err: io::Error) -> GetQualificationTypeError {
+        GetQualificationTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetQualificationTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3065,6 +3162,11 @@ impl From<CredentialsError> for ListAssignmentsForHITError {
 impl From<HttpDispatchError> for ListAssignmentsForHITError {
     fn from(err: HttpDispatchError) -> ListAssignmentsForHITError {
         ListAssignmentsForHITError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAssignmentsForHITError {
+    fn from(err: io::Error) -> ListAssignmentsForHITError {
+        ListAssignmentsForHITError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAssignmentsForHITError {
@@ -3149,6 +3251,11 @@ impl From<HttpDispatchError> for ListBonusPaymentsError {
         ListBonusPaymentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListBonusPaymentsError {
+    fn from(err: io::Error) -> ListBonusPaymentsError {
+        ListBonusPaymentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListBonusPaymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3223,6 +3330,11 @@ impl From<CredentialsError> for ListHITsError {
 impl From<HttpDispatchError> for ListHITsError {
     fn from(err: HttpDispatchError) -> ListHITsError {
         ListHITsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListHITsError {
+    fn from(err: io::Error) -> ListHITsError {
+        ListHITsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListHITsError {
@@ -3303,6 +3415,11 @@ impl From<CredentialsError> for ListHITsForQualificationTypeError {
 impl From<HttpDispatchError> for ListHITsForQualificationTypeError {
     fn from(err: HttpDispatchError) -> ListHITsForQualificationTypeError {
         ListHITsForQualificationTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListHITsForQualificationTypeError {
+    fn from(err: io::Error) -> ListHITsForQualificationTypeError {
+        ListHITsForQualificationTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListHITsForQualificationTypeError {
@@ -3387,6 +3504,11 @@ impl From<HttpDispatchError> for ListQualificationRequestsError {
         ListQualificationRequestsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListQualificationRequestsError {
+    fn from(err: io::Error) -> ListQualificationRequestsError {
+        ListQualificationRequestsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListQualificationRequestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3469,6 +3591,11 @@ impl From<HttpDispatchError> for ListQualificationTypesError {
         ListQualificationTypesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListQualificationTypesError {
+    fn from(err: io::Error) -> ListQualificationTypesError {
+        ListQualificationTypesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListQualificationTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3545,6 +3672,11 @@ impl From<CredentialsError> for ListReviewPolicyResultsForHITError {
 impl From<HttpDispatchError> for ListReviewPolicyResultsForHITError {
     fn from(err: HttpDispatchError) -> ListReviewPolicyResultsForHITError {
         ListReviewPolicyResultsForHITError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListReviewPolicyResultsForHITError {
+    fn from(err: io::Error) -> ListReviewPolicyResultsForHITError {
+        ListReviewPolicyResultsForHITError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListReviewPolicyResultsForHITError {
@@ -3629,6 +3761,11 @@ impl From<HttpDispatchError> for ListReviewableHITsError {
         ListReviewableHITsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListReviewableHITsError {
+    fn from(err: io::Error) -> ListReviewableHITsError {
+        ListReviewableHITsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListReviewableHITsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3711,6 +3848,11 @@ impl From<HttpDispatchError> for ListWorkerBlocksError {
         ListWorkerBlocksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListWorkerBlocksError {
+    fn from(err: io::Error) -> ListWorkerBlocksError {
+        ListWorkerBlocksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListWorkerBlocksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3785,6 +3927,11 @@ impl From<CredentialsError> for ListWorkersWithQualificationTypeError {
 impl From<HttpDispatchError> for ListWorkersWithQualificationTypeError {
     fn from(err: HttpDispatchError) -> ListWorkersWithQualificationTypeError {
         ListWorkersWithQualificationTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListWorkersWithQualificationTypeError {
+    fn from(err: io::Error) -> ListWorkersWithQualificationTypeError {
+        ListWorkersWithQualificationTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListWorkersWithQualificationTypeError {
@@ -3863,6 +4010,11 @@ impl From<CredentialsError> for NotifyWorkersError {
 impl From<HttpDispatchError> for NotifyWorkersError {
     fn from(err: HttpDispatchError) -> NotifyWorkersError {
         NotifyWorkersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for NotifyWorkersError {
+    fn from(err: io::Error) -> NotifyWorkersError {
+        NotifyWorkersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for NotifyWorkersError {
@@ -3945,6 +4097,11 @@ impl From<HttpDispatchError> for RejectAssignmentError {
         RejectAssignmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RejectAssignmentError {
+    fn from(err: io::Error) -> RejectAssignmentError {
+        RejectAssignmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RejectAssignmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4025,6 +4182,11 @@ impl From<HttpDispatchError> for RejectQualificationRequestError {
         RejectQualificationRequestError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RejectQualificationRequestError {
+    fn from(err: io::Error) -> RejectQualificationRequestError {
+        RejectQualificationRequestError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RejectQualificationRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4099,6 +4261,11 @@ impl From<CredentialsError> for SendBonusError {
 impl From<HttpDispatchError> for SendBonusError {
     fn from(err: HttpDispatchError) -> SendBonusError {
         SendBonusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SendBonusError {
+    fn from(err: io::Error) -> SendBonusError {
+        SendBonusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SendBonusError {
@@ -4179,6 +4346,11 @@ impl From<CredentialsError> for SendTestEventNotificationError {
 impl From<HttpDispatchError> for SendTestEventNotificationError {
     fn from(err: HttpDispatchError) -> SendTestEventNotificationError {
         SendTestEventNotificationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SendTestEventNotificationError {
+    fn from(err: io::Error) -> SendTestEventNotificationError {
+        SendTestEventNotificationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SendTestEventNotificationError {
@@ -4263,6 +4435,11 @@ impl From<HttpDispatchError> for UpdateExpirationForHITError {
         UpdateExpirationForHITError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateExpirationForHITError {
+    fn from(err: io::Error) -> UpdateExpirationForHITError {
+        UpdateExpirationForHITError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateExpirationForHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4343,6 +4520,11 @@ impl From<CredentialsError> for UpdateHITReviewStatusError {
 impl From<HttpDispatchError> for UpdateHITReviewStatusError {
     fn from(err: HttpDispatchError) -> UpdateHITReviewStatusError {
         UpdateHITReviewStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateHITReviewStatusError {
+    fn from(err: io::Error) -> UpdateHITReviewStatusError {
+        UpdateHITReviewStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateHITReviewStatusError {
@@ -4427,6 +4609,11 @@ impl From<HttpDispatchError> for UpdateHITTypeOfHITError {
         UpdateHITTypeOfHITError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateHITTypeOfHITError {
+    fn from(err: io::Error) -> UpdateHITTypeOfHITError {
+        UpdateHITTypeOfHITError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateHITTypeOfHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4509,6 +4696,11 @@ impl From<HttpDispatchError> for UpdateNotificationSettingsError {
         UpdateNotificationSettingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateNotificationSettingsError {
+    fn from(err: io::Error) -> UpdateNotificationSettingsError {
+        UpdateNotificationSettingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateNotificationSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4589,6 +4781,11 @@ impl From<CredentialsError> for UpdateQualificationTypeError {
 impl From<HttpDispatchError> for UpdateQualificationTypeError {
     fn from(err: HttpDispatchError) -> UpdateQualificationTypeError {
         UpdateQualificationTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateQualificationTypeError {
+    fn from(err: io::Error) -> UpdateQualificationTypeError {
+        UpdateQualificationTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateQualificationTypeError {
@@ -4898,13 +5095,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AcceptQualificationRequestResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AcceptQualificationRequestError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AcceptQualificationRequestResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AcceptQualificationRequestError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -4923,15 +5127,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ApproveAssignmentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ApproveAssignmentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ApproveAssignmentError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ApproveAssignmentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4952,13 +5159,19 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AssociateQualificationWithWorkerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AssociateQualificationWithWorkerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AssociateQualificationWithWorkerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateQualificationWithWorkerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4979,13 +5192,19 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAdditionalAssignmentsForHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateAdditionalAssignmentsForHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAdditionalAssignmentsForHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAdditionalAssignmentsForHITError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5001,13 +5220,21 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateHITResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHITError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5026,14 +5253,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateHITTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateHITTypeResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateHITTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHITTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5054,15 +5287,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateHITWithHITTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateHITWithHITTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateHITWithHITTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHITWithHITTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5083,13 +5319,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateQualificationTypeError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -5108,15 +5351,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateWorkerBlockResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateWorkerBlockResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateWorkerBlockError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateWorkerBlockError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5133,13 +5379,21 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteHITResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteHITError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5159,13 +5413,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteQualificationTypeError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -5184,15 +5445,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteWorkerBlockResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteWorkerBlockResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteWorkerBlockError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteWorkerBlockError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5214,13 +5478,19 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisassociateQualificationFromWorkerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DisassociateQualificationFromWorkerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisassociateQualificationFromWorkerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateQualificationFromWorkerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5236,15 +5506,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetAccountBalanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetAccountBalanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetAccountBalanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAccountBalanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5264,14 +5537,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetAssignmentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetAssignmentResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetAssignmentError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAssignmentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5291,15 +5570,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetFileUploadURLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetFileUploadURLResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetFileUploadURLError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetFileUploadURLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5316,15 +5600,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetHITResponse>(String::from_utf8_lossy(&response.body)
-                                                              .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetHITResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHITError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5344,15 +5633,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetQualificationScoreResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetQualificationScoreResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetQualificationScoreError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetQualificationScoreError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5373,15 +5665,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetQualificationTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetQualificationTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5402,15 +5697,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAssignmentsForHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAssignmentsForHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListAssignmentsForHITError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAssignmentsForHITError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5430,15 +5728,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListBonusPaymentsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListBonusPaymentsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListBonusPaymentsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListBonusPaymentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5455,13 +5756,21 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListHITsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListHITsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListHITsResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHITsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5481,13 +5790,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListHITsForQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListHITsForQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListHITsForQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHITsForQualificationTypeError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -5507,13 +5823,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListQualificationRequestsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListQualificationRequestsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListQualificationRequestsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListQualificationRequestsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5533,15 +5856,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListQualificationTypesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListQualificationTypesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListQualificationTypesError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListQualificationTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5562,13 +5888,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListReviewPolicyResultsForHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListReviewPolicyResultsForHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListReviewPolicyResultsForHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListReviewPolicyResultsForHITError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -5587,15 +5920,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListReviewableHITsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListReviewableHITsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListReviewableHITsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListReviewableHITsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5615,15 +5951,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListWorkerBlocksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListWorkerBlocksResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListWorkerBlocksError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListWorkerBlocksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5644,13 +5985,19 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListWorkersWithQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListWorkersWithQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListWorkersWithQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListWorkersWithQualificationTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5669,14 +6016,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<NotifyWorkersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<NotifyWorkersResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(NotifyWorkersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(NotifyWorkersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5696,15 +6049,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RejectAssignmentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RejectAssignmentResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RejectAssignmentError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RejectAssignmentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5725,13 +6083,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RejectQualificationRequestResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RejectQualificationRequestError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RejectQualificationRequestResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RejectQualificationRequestError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5747,13 +6112,21 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SendBonusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(SendBonusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SendBonusResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendBonusError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5773,13 +6146,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SendTestEventNotificationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(SendTestEventNotificationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SendTestEventNotificationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendTestEventNotificationError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5799,15 +6179,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateExpirationForHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateExpirationForHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateExpirationForHITError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateExpirationForHITError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5828,15 +6211,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateHITReviewStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateHITReviewStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateHITReviewStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateHITReviewStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5856,15 +6242,18 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateHITTypeOfHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateHITTypeOfHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateHITTypeOfHITError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateHITTypeOfHITError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5885,13 +6274,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateNotificationSettingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateNotificationSettingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateNotificationSettingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateNotificationSettingsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5911,13 +6307,20 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateQualificationTypeError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -3177,6 +3179,11 @@ impl From<HttpDispatchError> for AssignInstanceError {
         AssignInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssignInstanceError {
+    fn from(err: io::Error) -> AssignInstanceError {
+        AssignInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssignInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3249,6 +3256,11 @@ impl From<CredentialsError> for AssignVolumeError {
 impl From<HttpDispatchError> for AssignVolumeError {
     fn from(err: HttpDispatchError) -> AssignVolumeError {
         AssignVolumeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AssignVolumeError {
+    fn from(err: io::Error) -> AssignVolumeError {
+        AssignVolumeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AssignVolumeError {
@@ -3325,6 +3337,11 @@ impl From<HttpDispatchError> for AssociateElasticIpError {
         AssociateElasticIpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateElasticIpError {
+    fn from(err: io::Error) -> AssociateElasticIpError {
+        AssociateElasticIpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3397,6 +3414,11 @@ impl From<CredentialsError> for AttachElasticLoadBalancerError {
 impl From<HttpDispatchError> for AttachElasticLoadBalancerError {
     fn from(err: HttpDispatchError) -> AttachElasticLoadBalancerError {
         AttachElasticLoadBalancerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AttachElasticLoadBalancerError {
+    fn from(err: io::Error) -> AttachElasticLoadBalancerError {
+        AttachElasticLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AttachElasticLoadBalancerError {
@@ -3473,6 +3495,11 @@ impl From<HttpDispatchError> for CloneStackError {
         CloneStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CloneStackError {
+    fn from(err: io::Error) -> CloneStackError {
+        CloneStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CloneStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3543,6 +3570,11 @@ impl From<CredentialsError> for CreateAppError {
 impl From<HttpDispatchError> for CreateAppError {
     fn from(err: HttpDispatchError) -> CreateAppError {
         CreateAppError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAppError {
+    fn from(err: io::Error) -> CreateAppError {
+        CreateAppError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAppError {
@@ -3619,6 +3651,11 @@ impl From<HttpDispatchError> for CreateDeploymentError {
         CreateDeploymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDeploymentError {
+    fn from(err: io::Error) -> CreateDeploymentError {
+        CreateDeploymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3691,6 +3728,11 @@ impl From<CredentialsError> for CreateInstanceError {
 impl From<HttpDispatchError> for CreateInstanceError {
     fn from(err: HttpDispatchError) -> CreateInstanceError {
         CreateInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateInstanceError {
+    fn from(err: io::Error) -> CreateInstanceError {
+        CreateInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateInstanceError {
@@ -3767,6 +3809,11 @@ impl From<HttpDispatchError> for CreateLayerError {
         CreateLayerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateLayerError {
+    fn from(err: io::Error) -> CreateLayerError {
+        CreateLayerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateLayerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3836,6 +3883,11 @@ impl From<HttpDispatchError> for CreateStackError {
         CreateStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateStackError {
+    fn from(err: io::Error) -> CreateStackError {
+        CreateStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3902,6 +3954,11 @@ impl From<CredentialsError> for CreateUserProfileError {
 impl From<HttpDispatchError> for CreateUserProfileError {
     fn from(err: HttpDispatchError) -> CreateUserProfileError {
         CreateUserProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateUserProfileError {
+    fn from(err: io::Error) -> CreateUserProfileError {
+        CreateUserProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateUserProfileError {
@@ -3975,6 +4032,11 @@ impl From<CredentialsError> for DeleteAppError {
 impl From<HttpDispatchError> for DeleteAppError {
     fn from(err: HttpDispatchError) -> DeleteAppError {
         DeleteAppError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteAppError {
+    fn from(err: io::Error) -> DeleteAppError {
+        DeleteAppError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteAppError {
@@ -4051,6 +4113,11 @@ impl From<HttpDispatchError> for DeleteInstanceError {
         DeleteInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteInstanceError {
+    fn from(err: io::Error) -> DeleteInstanceError {
+        DeleteInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4123,6 +4190,11 @@ impl From<CredentialsError> for DeleteLayerError {
 impl From<HttpDispatchError> for DeleteLayerError {
     fn from(err: HttpDispatchError) -> DeleteLayerError {
         DeleteLayerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteLayerError {
+    fn from(err: io::Error) -> DeleteLayerError {
+        DeleteLayerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteLayerError {
@@ -4199,6 +4271,11 @@ impl From<HttpDispatchError> for DeleteStackError {
         DeleteStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteStackError {
+    fn from(err: io::Error) -> DeleteStackError {
+        DeleteStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4271,6 +4348,11 @@ impl From<CredentialsError> for DeleteUserProfileError {
 impl From<HttpDispatchError> for DeleteUserProfileError {
     fn from(err: HttpDispatchError) -> DeleteUserProfileError {
         DeleteUserProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteUserProfileError {
+    fn from(err: io::Error) -> DeleteUserProfileError {
+        DeleteUserProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteUserProfileError {
@@ -4349,6 +4431,11 @@ impl From<HttpDispatchError> for DeregisterEcsClusterError {
         DeregisterEcsClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterEcsClusterError {
+    fn from(err: io::Error) -> DeregisterEcsClusterError {
+        DeregisterEcsClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterEcsClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4423,6 +4510,11 @@ impl From<CredentialsError> for DeregisterElasticIpError {
 impl From<HttpDispatchError> for DeregisterElasticIpError {
     fn from(err: HttpDispatchError) -> DeregisterElasticIpError {
         DeregisterElasticIpError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeregisterElasticIpError {
+    fn from(err: io::Error) -> DeregisterElasticIpError {
+        DeregisterElasticIpError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeregisterElasticIpError {
@@ -4501,6 +4593,11 @@ impl From<HttpDispatchError> for DeregisterInstanceError {
         DeregisterInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterInstanceError {
+    fn from(err: io::Error) -> DeregisterInstanceError {
+        DeregisterInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4575,6 +4672,11 @@ impl From<CredentialsError> for DeregisterRdsDbInstanceError {
 impl From<HttpDispatchError> for DeregisterRdsDbInstanceError {
     fn from(err: HttpDispatchError) -> DeregisterRdsDbInstanceError {
         DeregisterRdsDbInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeregisterRdsDbInstanceError {
+    fn from(err: io::Error) -> DeregisterRdsDbInstanceError {
+        DeregisterRdsDbInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeregisterRdsDbInstanceError {
@@ -4653,6 +4755,11 @@ impl From<HttpDispatchError> for DeregisterVolumeError {
         DeregisterVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterVolumeError {
+    fn from(err: io::Error) -> DeregisterVolumeError {
+        DeregisterVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4725,6 +4832,11 @@ impl From<CredentialsError> for DescribeAgentVersionsError {
 impl From<HttpDispatchError> for DescribeAgentVersionsError {
     fn from(err: HttpDispatchError) -> DescribeAgentVersionsError {
         DescribeAgentVersionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAgentVersionsError {
+    fn from(err: io::Error) -> DescribeAgentVersionsError {
+        DescribeAgentVersionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAgentVersionsError {
@@ -4803,6 +4915,11 @@ impl From<HttpDispatchError> for DescribeAppsError {
         DescribeAppsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAppsError {
+    fn from(err: io::Error) -> DescribeAppsError {
+        DescribeAppsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAppsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4877,6 +4994,11 @@ impl From<HttpDispatchError> for DescribeCommandsError {
         DescribeCommandsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCommandsError {
+    fn from(err: io::Error) -> DescribeCommandsError {
+        DescribeCommandsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCommandsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4949,6 +5071,11 @@ impl From<CredentialsError> for DescribeDeploymentsError {
 impl From<HttpDispatchError> for DescribeDeploymentsError {
     fn from(err: HttpDispatchError) -> DescribeDeploymentsError {
         DescribeDeploymentsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDeploymentsError {
+    fn from(err: io::Error) -> DescribeDeploymentsError {
+        DescribeDeploymentsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDeploymentsError {
@@ -5027,6 +5154,11 @@ impl From<HttpDispatchError> for DescribeEcsClustersError {
         DescribeEcsClustersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEcsClustersError {
+    fn from(err: io::Error) -> DescribeEcsClustersError {
+        DescribeEcsClustersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEcsClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5103,6 +5235,11 @@ impl From<HttpDispatchError> for DescribeElasticIpsError {
         DescribeElasticIpsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeElasticIpsError {
+    fn from(err: io::Error) -> DescribeElasticIpsError {
+        DescribeElasticIpsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeElasticIpsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5175,6 +5312,11 @@ impl From<CredentialsError> for DescribeElasticLoadBalancersError {
 impl From<HttpDispatchError> for DescribeElasticLoadBalancersError {
     fn from(err: HttpDispatchError) -> DescribeElasticLoadBalancersError {
         DescribeElasticLoadBalancersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeElasticLoadBalancersError {
+    fn from(err: io::Error) -> DescribeElasticLoadBalancersError {
+        DescribeElasticLoadBalancersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeElasticLoadBalancersError {
@@ -5253,6 +5395,11 @@ impl From<HttpDispatchError> for DescribeInstancesError {
         DescribeInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeInstancesError {
+    fn from(err: io::Error) -> DescribeInstancesError {
+        DescribeInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5329,6 +5476,11 @@ impl From<HttpDispatchError> for DescribeLayersError {
         DescribeLayersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLayersError {
+    fn from(err: io::Error) -> DescribeLayersError {
+        DescribeLayersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLayersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5401,6 +5553,11 @@ impl From<HttpDispatchError> for DescribeLoadBasedAutoScalingError {
         DescribeLoadBasedAutoScalingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLoadBasedAutoScalingError {
+    fn from(err: io::Error) -> DescribeLoadBasedAutoScalingError {
+        DescribeLoadBasedAutoScalingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLoadBasedAutoScalingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5470,6 +5627,11 @@ impl From<CredentialsError> for DescribeMyUserProfileError {
 impl From<HttpDispatchError> for DescribeMyUserProfileError {
     fn from(err: HttpDispatchError) -> DescribeMyUserProfileError {
         DescribeMyUserProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeMyUserProfileError {
+    fn from(err: io::Error) -> DescribeMyUserProfileError {
+        DescribeMyUserProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeMyUserProfileError {
@@ -5545,6 +5707,11 @@ impl From<CredentialsError> for DescribePermissionsError {
 impl From<HttpDispatchError> for DescribePermissionsError {
     fn from(err: HttpDispatchError) -> DescribePermissionsError {
         DescribePermissionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribePermissionsError {
+    fn from(err: io::Error) -> DescribePermissionsError {
+        DescribePermissionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribePermissionsError {
@@ -5623,6 +5790,11 @@ impl From<HttpDispatchError> for DescribeRaidArraysError {
         DescribeRaidArraysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeRaidArraysError {
+    fn from(err: io::Error) -> DescribeRaidArraysError {
+        DescribeRaidArraysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeRaidArraysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5697,6 +5869,11 @@ impl From<CredentialsError> for DescribeRdsDbInstancesError {
 impl From<HttpDispatchError> for DescribeRdsDbInstancesError {
     fn from(err: HttpDispatchError) -> DescribeRdsDbInstancesError {
         DescribeRdsDbInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeRdsDbInstancesError {
+    fn from(err: io::Error) -> DescribeRdsDbInstancesError {
+        DescribeRdsDbInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeRdsDbInstancesError {
@@ -5775,6 +5952,11 @@ impl From<HttpDispatchError> for DescribeServiceErrorsError {
         DescribeServiceErrorsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeServiceErrorsError {
+    fn from(err: io::Error) -> DescribeServiceErrorsError {
+        DescribeServiceErrorsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeServiceErrorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5848,6 +6030,11 @@ impl From<CredentialsError> for DescribeStackProvisioningParametersError {
 impl From<HttpDispatchError> for DescribeStackProvisioningParametersError {
     fn from(err: HttpDispatchError) -> DescribeStackProvisioningParametersError {
         DescribeStackProvisioningParametersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeStackProvisioningParametersError {
+    fn from(err: io::Error) -> DescribeStackProvisioningParametersError {
+        DescribeStackProvisioningParametersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeStackProvisioningParametersError {
@@ -5926,6 +6113,11 @@ impl From<HttpDispatchError> for DescribeStackSummaryError {
         DescribeStackSummaryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeStackSummaryError {
+    fn from(err: io::Error) -> DescribeStackSummaryError {
+        DescribeStackSummaryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeStackSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6002,6 +6194,11 @@ impl From<HttpDispatchError> for DescribeStacksError {
         DescribeStacksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeStacksError {
+    fn from(err: io::Error) -> DescribeStacksError {
+        DescribeStacksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6072,6 +6269,11 @@ impl From<CredentialsError> for DescribeTimeBasedAutoScalingError {
 impl From<HttpDispatchError> for DescribeTimeBasedAutoScalingError {
     fn from(err: HttpDispatchError) -> DescribeTimeBasedAutoScalingError {
         DescribeTimeBasedAutoScalingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTimeBasedAutoScalingError {
+    fn from(err: io::Error) -> DescribeTimeBasedAutoScalingError {
+        DescribeTimeBasedAutoScalingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTimeBasedAutoScalingError {
@@ -6150,6 +6352,11 @@ impl From<HttpDispatchError> for DescribeUserProfilesError {
         DescribeUserProfilesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeUserProfilesError {
+    fn from(err: io::Error) -> DescribeUserProfilesError {
+        DescribeUserProfilesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeUserProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6226,6 +6433,11 @@ impl From<HttpDispatchError> for DescribeVolumesError {
         DescribeVolumesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVolumesError {
+    fn from(err: io::Error) -> DescribeVolumesError {
+        DescribeVolumesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVolumesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6296,6 +6508,11 @@ impl From<CredentialsError> for DetachElasticLoadBalancerError {
 impl From<HttpDispatchError> for DetachElasticLoadBalancerError {
     fn from(err: HttpDispatchError) -> DetachElasticLoadBalancerError {
         DetachElasticLoadBalancerError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DetachElasticLoadBalancerError {
+    fn from(err: io::Error) -> DetachElasticLoadBalancerError {
+        DetachElasticLoadBalancerError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DetachElasticLoadBalancerError {
@@ -6374,6 +6591,11 @@ impl From<HttpDispatchError> for DisassociateElasticIpError {
         DisassociateElasticIpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateElasticIpError {
+    fn from(err: io::Error) -> DisassociateElasticIpError {
+        DisassociateElasticIpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6448,6 +6670,11 @@ impl From<CredentialsError> for GetHostnameSuggestionError {
 impl From<HttpDispatchError> for GetHostnameSuggestionError {
     fn from(err: HttpDispatchError) -> GetHostnameSuggestionError {
         GetHostnameSuggestionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetHostnameSuggestionError {
+    fn from(err: io::Error) -> GetHostnameSuggestionError {
+        GetHostnameSuggestionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetHostnameSuggestionError {
@@ -6526,6 +6753,11 @@ impl From<HttpDispatchError> for GrantAccessError {
         GrantAccessError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GrantAccessError {
+    fn from(err: io::Error) -> GrantAccessError {
+        GrantAccessError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GrantAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6596,6 +6828,11 @@ impl From<CredentialsError> for ListTagsError {
 impl From<HttpDispatchError> for ListTagsError {
     fn from(err: HttpDispatchError) -> ListTagsError {
         ListTagsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsError {
+    fn from(err: io::Error) -> ListTagsError {
+        ListTagsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsError {
@@ -6672,6 +6909,11 @@ impl From<HttpDispatchError> for RebootInstanceError {
         RebootInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RebootInstanceError {
+    fn from(err: io::Error) -> RebootInstanceError {
+        RebootInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RebootInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6744,6 +6986,11 @@ impl From<CredentialsError> for RegisterEcsClusterError {
 impl From<HttpDispatchError> for RegisterEcsClusterError {
     fn from(err: HttpDispatchError) -> RegisterEcsClusterError {
         RegisterEcsClusterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterEcsClusterError {
+    fn from(err: io::Error) -> RegisterEcsClusterError {
+        RegisterEcsClusterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterEcsClusterError {
@@ -6822,6 +7069,11 @@ impl From<HttpDispatchError> for RegisterElasticIpError {
         RegisterElasticIpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterElasticIpError {
+    fn from(err: io::Error) -> RegisterElasticIpError {
+        RegisterElasticIpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6898,6 +7150,11 @@ impl From<HttpDispatchError> for RegisterInstanceError {
         RegisterInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterInstanceError {
+    fn from(err: io::Error) -> RegisterInstanceError {
+        RegisterInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6970,6 +7227,11 @@ impl From<CredentialsError> for RegisterRdsDbInstanceError {
 impl From<HttpDispatchError> for RegisterRdsDbInstanceError {
     fn from(err: HttpDispatchError) -> RegisterRdsDbInstanceError {
         RegisterRdsDbInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterRdsDbInstanceError {
+    fn from(err: io::Error) -> RegisterRdsDbInstanceError {
+        RegisterRdsDbInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterRdsDbInstanceError {
@@ -7048,6 +7310,11 @@ impl From<HttpDispatchError> for RegisterVolumeError {
         RegisterVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterVolumeError {
+    fn from(err: io::Error) -> RegisterVolumeError {
+        RegisterVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7120,6 +7387,11 @@ impl From<CredentialsError> for SetLoadBasedAutoScalingError {
 impl From<HttpDispatchError> for SetLoadBasedAutoScalingError {
     fn from(err: HttpDispatchError) -> SetLoadBasedAutoScalingError {
         SetLoadBasedAutoScalingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetLoadBasedAutoScalingError {
+    fn from(err: io::Error) -> SetLoadBasedAutoScalingError {
+        SetLoadBasedAutoScalingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetLoadBasedAutoScalingError {
@@ -7198,6 +7470,11 @@ impl From<HttpDispatchError> for SetPermissionError {
         SetPermissionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetPermissionError {
+    fn from(err: io::Error) -> SetPermissionError {
+        SetPermissionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7270,6 +7547,11 @@ impl From<CredentialsError> for SetTimeBasedAutoScalingError {
 impl From<HttpDispatchError> for SetTimeBasedAutoScalingError {
     fn from(err: HttpDispatchError) -> SetTimeBasedAutoScalingError {
         SetTimeBasedAutoScalingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetTimeBasedAutoScalingError {
+    fn from(err: io::Error) -> SetTimeBasedAutoScalingError {
+        SetTimeBasedAutoScalingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetTimeBasedAutoScalingError {
@@ -7348,6 +7630,11 @@ impl From<HttpDispatchError> for StartInstanceError {
         StartInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartInstanceError {
+    fn from(err: io::Error) -> StartInstanceError {
+        StartInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7418,6 +7705,11 @@ impl From<CredentialsError> for StartStackError {
 impl From<HttpDispatchError> for StartStackError {
     fn from(err: HttpDispatchError) -> StartStackError {
         StartStackError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StartStackError {
+    fn from(err: io::Error) -> StartStackError {
+        StartStackError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StartStackError {
@@ -7494,6 +7786,11 @@ impl From<HttpDispatchError> for StopInstanceError {
         StopInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StopInstanceError {
+    fn from(err: io::Error) -> StopInstanceError {
+        StopInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StopInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7564,6 +7861,11 @@ impl From<CredentialsError> for StopStackError {
 impl From<HttpDispatchError> for StopStackError {
     fn from(err: HttpDispatchError) -> StopStackError {
         StopStackError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopStackError {
+    fn from(err: io::Error) -> StopStackError {
+        StopStackError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopStackError {
@@ -7640,6 +7942,11 @@ impl From<HttpDispatchError> for TagResourceError {
         TagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TagResourceError {
+    fn from(err: io::Error) -> TagResourceError {
+        TagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7712,6 +8019,11 @@ impl From<CredentialsError> for UnassignInstanceError {
 impl From<HttpDispatchError> for UnassignInstanceError {
     fn from(err: HttpDispatchError) -> UnassignInstanceError {
         UnassignInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UnassignInstanceError {
+    fn from(err: io::Error) -> UnassignInstanceError {
+        UnassignInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UnassignInstanceError {
@@ -7788,6 +8100,11 @@ impl From<HttpDispatchError> for UnassignVolumeError {
         UnassignVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UnassignVolumeError {
+    fn from(err: io::Error) -> UnassignVolumeError {
+        UnassignVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UnassignVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7862,6 +8179,11 @@ impl From<HttpDispatchError> for UntagResourceError {
         UntagResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UntagResourceError {
+    fn from(err: io::Error) -> UntagResourceError {
+        UntagResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7932,6 +8254,11 @@ impl From<CredentialsError> for UpdateAppError {
 impl From<HttpDispatchError> for UpdateAppError {
     fn from(err: HttpDispatchError) -> UpdateAppError {
         UpdateAppError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAppError {
+    fn from(err: io::Error) -> UpdateAppError {
+        UpdateAppError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAppError {
@@ -8008,6 +8335,11 @@ impl From<HttpDispatchError> for UpdateElasticIpError {
         UpdateElasticIpError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateElasticIpError {
+    fn from(err: io::Error) -> UpdateElasticIpError {
+        UpdateElasticIpError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8080,6 +8412,11 @@ impl From<CredentialsError> for UpdateInstanceError {
 impl From<HttpDispatchError> for UpdateInstanceError {
     fn from(err: HttpDispatchError) -> UpdateInstanceError {
         UpdateInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateInstanceError {
+    fn from(err: io::Error) -> UpdateInstanceError {
+        UpdateInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateInstanceError {
@@ -8156,6 +8493,11 @@ impl From<HttpDispatchError> for UpdateLayerError {
         UpdateLayerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateLayerError {
+    fn from(err: io::Error) -> UpdateLayerError {
+        UpdateLayerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateLayerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8223,6 +8565,11 @@ impl From<CredentialsError> for UpdateMyUserProfileError {
 impl From<HttpDispatchError> for UpdateMyUserProfileError {
     fn from(err: HttpDispatchError) -> UpdateMyUserProfileError {
         UpdateMyUserProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateMyUserProfileError {
+    fn from(err: io::Error) -> UpdateMyUserProfileError {
+        UpdateMyUserProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateMyUserProfileError {
@@ -8298,6 +8645,11 @@ impl From<CredentialsError> for UpdateRdsDbInstanceError {
 impl From<HttpDispatchError> for UpdateRdsDbInstanceError {
     fn from(err: HttpDispatchError) -> UpdateRdsDbInstanceError {
         UpdateRdsDbInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateRdsDbInstanceError {
+    fn from(err: io::Error) -> UpdateRdsDbInstanceError {
+        UpdateRdsDbInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateRdsDbInstanceError {
@@ -8376,6 +8728,11 @@ impl From<HttpDispatchError> for UpdateStackError {
         UpdateStackError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateStackError {
+    fn from(err: io::Error) -> UpdateStackError {
+        UpdateStackError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8448,6 +8805,11 @@ impl From<CredentialsError> for UpdateUserProfileError {
 impl From<HttpDispatchError> for UpdateUserProfileError {
     fn from(err: HttpDispatchError) -> UpdateUserProfileError {
         UpdateUserProfileError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateUserProfileError {
+    fn from(err: io::Error) -> UpdateUserProfileError {
+        UpdateUserProfileError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateUserProfileError {
@@ -8524,6 +8886,11 @@ impl From<CredentialsError> for UpdateVolumeError {
 impl From<HttpDispatchError> for UpdateVolumeError {
     fn from(err: HttpDispatchError) -> UpdateVolumeError {
         UpdateVolumeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateVolumeError {
+    fn from(err: io::Error) -> UpdateVolumeError {
+        UpdateVolumeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateVolumeError {
@@ -8982,13 +9349,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AssignInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssignInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9005,12 +9373,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AssignVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssignVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9029,13 +9399,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AssociateElasticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateElasticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9055,11 +9426,16 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(AttachElasticLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachElasticLoadBalancerError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -9075,13 +9451,21 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CloneStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CloneStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CloneStackResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CloneStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9097,15 +9481,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<CreateAppResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAppResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(CreateAppError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAppError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9123,15 +9512,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDeploymentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDeploymentResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateDeploymentError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDeploymentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9150,15 +9544,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateInstanceResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9177,13 +9576,21 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateLayerResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateLayerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateLayerResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateLayerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9201,13 +9608,21 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateStackResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9225,15 +9640,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateUserProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateUserProfileResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateUserProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateUserProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9250,11 +9670,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteAppError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAppError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9270,13 +9694,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9293,11 +9718,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteLayerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLayerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9313,11 +9742,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9335,13 +9768,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteUserProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteUserProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9360,13 +9794,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeregisterEcsClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterEcsClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9385,13 +9820,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeregisterElasticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterElasticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9410,13 +9846,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeregisterInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9435,11 +9872,16 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeregisterRdsDbInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterRdsDbInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -9457,13 +9899,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeregisterVolumeError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9483,15 +9926,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAgentVersionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAgentVersionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeAgentVersionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAgentVersionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9510,14 +9956,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAppsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAppsResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeAppsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAppsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9536,15 +9988,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCommandsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCommandsResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeCommandsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCommandsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9563,15 +10020,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDeploymentsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDeploymentsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeDeploymentsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDeploymentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9590,15 +10050,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEcsClustersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEcsClustersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeEcsClustersError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEcsClustersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9617,15 +10080,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeElasticIpsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeElasticIpsResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeElasticIpsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeElasticIpsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9646,13 +10114,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeElasticLoadBalancersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeElasticLoadBalancersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeElasticLoadBalancersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeElasticLoadBalancersError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -9670,15 +10145,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeInstancesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeInstancesResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9697,15 +10177,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeLayersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeLayersResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeLayersError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLayersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9726,13 +10211,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeLoadBasedAutoScalingResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeLoadBasedAutoScalingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeLoadBasedAutoScalingResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoadBasedAutoScalingError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -9749,15 +10241,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMyUserProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMyUserProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeMyUserProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMyUserProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9776,15 +10271,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribePermissionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribePermissionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribePermissionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePermissionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9803,15 +10301,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeRaidArraysResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeRaidArraysResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeRaidArraysError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRaidArraysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9831,15 +10334,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeRdsDbInstancesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeRdsDbInstancesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeRdsDbInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRdsDbInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9859,15 +10365,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeServiceErrorsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeServiceErrorsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeServiceErrorsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeServiceErrorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9889,13 +10398,19 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeStackProvisioningParametersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeStackProvisioningParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeStackProvisioningParametersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStackProvisioningParametersError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -9913,15 +10428,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeStackSummaryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeStackSummaryResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeStackSummaryError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStackSummaryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9940,15 +10458,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeStacksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeStacksResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeStacksError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStacksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -9969,13 +10492,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTimeBasedAutoScalingResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeTimeBasedAutoScalingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTimeBasedAutoScalingResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTimeBasedAutoScalingError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -9993,15 +10523,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeUserProfilesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeUserProfilesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeUserProfilesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeUserProfilesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10020,15 +10553,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeVolumesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeVolumesResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeVolumesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVolumesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10048,11 +10586,16 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DetachElasticLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachElasticLoadBalancerError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -10070,13 +10613,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DisassociateElasticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateElasticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10096,15 +10640,18 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetHostnameSuggestionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetHostnameSuggestionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetHostnameSuggestionError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHostnameSuggestionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10123,13 +10670,21 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GrantAccessResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GrantAccessError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GrantAccessResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GrantAccessError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10145,15 +10700,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListTagsResult>(String::from_utf8_lossy(&response.body)
-                                                              .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ListTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10169,13 +10729,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(RebootInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebootInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10194,15 +10755,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterEcsClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterEcsClusterResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RegisterEcsClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterEcsClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10221,15 +10787,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterElasticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterElasticIpResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RegisterElasticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterElasticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10248,15 +10819,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterInstanceResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RegisterInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10275,13 +10851,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(RegisterRdsDbInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterRdsDbInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10300,15 +10877,20 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterVolumeResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterVolumeResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RegisterVolumeError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10327,11 +10909,16 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(SetLoadBasedAutoScalingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetLoadBasedAutoScalingError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -10347,12 +10934,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(SetPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetPermissionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10371,11 +10960,16 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(SetTimeBasedAutoScalingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetTimeBasedAutoScalingError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -10391,12 +10985,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(StartInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10413,11 +11009,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(StartStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10433,12 +11033,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(StopInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10455,11 +11057,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(StopStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10475,11 +11081,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10497,13 +11107,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UnassignInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnassignInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10520,13 +11131,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UnassignVolumeError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnassignVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10543,12 +11155,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UntagResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10565,11 +11179,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(UpdateAppError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAppError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10587,13 +11205,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateElasticIpError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateElasticIpError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10610,13 +11229,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10633,11 +11253,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(UpdateLayerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateLayerError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10655,13 +11279,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateMyUserProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateMyUserProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10680,13 +11305,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateRdsDbInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRdsDbInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10703,11 +11329,15 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(UpdateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateStackError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10725,13 +11355,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateUserProfileError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateUserProfileError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10748,12 +11379,14 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(UpdateVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -690,6 +692,11 @@ impl From<HttpDispatchError> for AssociateNodeError {
         AssociateNodeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateNodeError {
+    fn from(err: io::Error) -> AssociateNodeError {
+        AssociateNodeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateNodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -773,6 +780,11 @@ impl From<CredentialsError> for CreateBackupError {
 impl From<HttpDispatchError> for CreateBackupError {
     fn from(err: HttpDispatchError) -> CreateBackupError {
         CreateBackupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateBackupError {
+    fn from(err: io::Error) -> CreateBackupError {
+        CreateBackupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateBackupError {
@@ -861,6 +873,11 @@ impl From<HttpDispatchError> for CreateServerError {
         CreateServerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateServerError {
+    fn from(err: io::Error) -> CreateServerError {
+        CreateServerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -940,6 +957,11 @@ impl From<CredentialsError> for DeleteBackupError {
 impl From<HttpDispatchError> for DeleteBackupError {
     fn from(err: HttpDispatchError) -> DeleteBackupError {
         DeleteBackupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBackupError {
+    fn from(err: io::Error) -> DeleteBackupError {
+        DeleteBackupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBackupError {
@@ -1022,6 +1044,11 @@ impl From<HttpDispatchError> for DeleteServerError {
         DeleteServerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteServerError {
+    fn from(err: io::Error) -> DeleteServerError {
+        DeleteServerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1090,6 +1117,11 @@ impl From<CredentialsError> for DescribeAccountAttributesError {
 impl From<HttpDispatchError> for DescribeAccountAttributesError {
     fn from(err: HttpDispatchError) -> DescribeAccountAttributesError {
         DescribeAccountAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAccountAttributesError {
+    fn from(err: io::Error) -> DescribeAccountAttributesError {
+        DescribeAccountAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAccountAttributesError {
@@ -1172,6 +1204,11 @@ impl From<HttpDispatchError> for DescribeBackupsError {
         DescribeBackupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeBackupsError {
+    fn from(err: io::Error) -> DescribeBackupsError {
+        DescribeBackupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeBackupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1252,6 +1289,11 @@ impl From<HttpDispatchError> for DescribeEventsError {
         DescribeEventsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEventsError {
+    fn from(err: io::Error) -> DescribeEventsError {
+        DescribeEventsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1323,6 +1365,11 @@ impl From<CredentialsError> for DescribeNodeAssociationStatusError {
 impl From<HttpDispatchError> for DescribeNodeAssociationStatusError {
     fn from(err: HttpDispatchError) -> DescribeNodeAssociationStatusError {
         DescribeNodeAssociationStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeNodeAssociationStatusError {
+    fn from(err: io::Error) -> DescribeNodeAssociationStatusError {
+        DescribeNodeAssociationStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeNodeAssociationStatusError {
@@ -1406,6 +1453,11 @@ impl From<HttpDispatchError> for DescribeServersError {
         DescribeServersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeServersError {
+    fn from(err: io::Error) -> DescribeServersError {
+        DescribeServersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeServersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1484,6 +1536,11 @@ impl From<CredentialsError> for DisassociateNodeError {
 impl From<HttpDispatchError> for DisassociateNodeError {
     fn from(err: HttpDispatchError) -> DisassociateNodeError {
         DisassociateNodeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisassociateNodeError {
+    fn from(err: io::Error) -> DisassociateNodeError {
+        DisassociateNodeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisassociateNodeError {
@@ -1566,6 +1623,11 @@ impl From<HttpDispatchError> for RestoreServerError {
         RestoreServerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RestoreServerError {
+    fn from(err: io::Error) -> RestoreServerError {
+        RestoreServerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RestoreServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1644,6 +1706,11 @@ impl From<CredentialsError> for StartMaintenanceError {
 impl From<HttpDispatchError> for StartMaintenanceError {
     fn from(err: HttpDispatchError) -> StartMaintenanceError {
         StartMaintenanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StartMaintenanceError {
+    fn from(err: io::Error) -> StartMaintenanceError {
+        StartMaintenanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StartMaintenanceError {
@@ -1726,6 +1793,11 @@ impl From<HttpDispatchError> for UpdateServerError {
         UpdateServerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateServerError {
+    fn from(err: io::Error) -> UpdateServerError {
+        UpdateServerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1802,6 +1874,11 @@ impl From<CredentialsError> for UpdateServerEngineAttributesError {
 impl From<HttpDispatchError> for UpdateServerEngineAttributesError {
     fn from(err: HttpDispatchError) -> UpdateServerEngineAttributesError {
         UpdateServerEngineAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateServerEngineAttributesError {
+    fn from(err: io::Error) -> UpdateServerEngineAttributesError {
+        UpdateServerEngineAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateServerEngineAttributesError {
@@ -1956,14 +2033,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AssociateNodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AssociateNodeResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AssociateNodeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateNodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1982,14 +2065,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateBackupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateBackupResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateBackupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateBackupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2008,14 +2097,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateServerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateServerResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateServerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateServerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2034,14 +2129,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteBackupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteBackupResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteBackupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBackupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2060,14 +2161,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteServerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteServerResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteServerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteServerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2086,13 +2193,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAccountAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAccountAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -2110,15 +2224,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeBackupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeBackupsResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeBackupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeBackupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2137,15 +2256,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2166,13 +2290,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeNodeAssociationStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeNodeAssociationStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeNodeAssociationStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeNodeAssociationStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -2190,15 +2321,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeServersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeServersResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeServersError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeServersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2217,15 +2353,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisassociateNodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisassociateNodeResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DisassociateNodeError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateNodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2244,14 +2385,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RestoreServerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RestoreServerResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RestoreServerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreServerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2270,15 +2417,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartMaintenanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartMaintenanceResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StartMaintenanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartMaintenanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2297,14 +2449,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateServerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateServerResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateServerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateServerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2325,13 +2483,20 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateServerEngineAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateServerEngineAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateServerEngineAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateServerEngineAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1149,6 +1151,11 @@ impl From<HttpDispatchError> for AcceptHandshakeError {
         AcceptHandshakeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AcceptHandshakeError {
+    fn from(err: io::Error) -> AcceptHandshakeError {
+        AcceptHandshakeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AcceptHandshakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1280,6 +1287,11 @@ impl From<HttpDispatchError> for AttachPolicyError {
         AttachPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AttachPolicyError {
+    fn from(err: io::Error) -> AttachPolicyError {
+        AttachPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AttachPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1397,6 +1409,11 @@ impl From<HttpDispatchError> for CancelHandshakeError {
         CancelHandshakeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelHandshakeError {
+    fn from(err: io::Error) -> CancelHandshakeError {
+        CancelHandshakeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelHandshakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1511,6 +1528,11 @@ impl From<HttpDispatchError> for CreateAccountError {
         CreateAccountError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateAccountError {
+    fn from(err: io::Error) -> CreateAccountError {
+        CreateAccountError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1620,6 +1642,11 @@ impl From<CredentialsError> for CreateOrganizationError {
 impl From<HttpDispatchError> for CreateOrganizationError {
     fn from(err: HttpDispatchError) -> CreateOrganizationError {
         CreateOrganizationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateOrganizationError {
+    fn from(err: io::Error) -> CreateOrganizationError {
+        CreateOrganizationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateOrganizationError {
@@ -1734,6 +1761,11 @@ impl From<CredentialsError> for CreateOrganizationalUnitError {
 impl From<HttpDispatchError> for CreateOrganizationalUnitError {
     fn from(err: HttpDispatchError) -> CreateOrganizationalUnitError {
         CreateOrganizationalUnitError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateOrganizationalUnitError {
+    fn from(err: io::Error) -> CreateOrganizationalUnitError {
+        CreateOrganizationalUnitError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateOrganizationalUnitError {
@@ -1861,6 +1893,11 @@ impl From<HttpDispatchError> for CreatePolicyError {
         CreatePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreatePolicyError {
+    fn from(err: io::Error) -> CreatePolicyError {
+        CreatePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreatePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1977,6 +2014,11 @@ impl From<HttpDispatchError> for DeclineHandshakeError {
         DeclineHandshakeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeclineHandshakeError {
+    fn from(err: io::Error) -> DeclineHandshakeError {
+        DeclineHandshakeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeclineHandshakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2086,6 +2128,11 @@ impl From<HttpDispatchError> for DeleteOrganizationError {
         DeleteOrganizationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteOrganizationError {
+    fn from(err: io::Error) -> DeleteOrganizationError {
+        DeleteOrganizationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2193,6 +2240,11 @@ impl From<CredentialsError> for DeleteOrganizationalUnitError {
 impl From<HttpDispatchError> for DeleteOrganizationalUnitError {
     fn from(err: HttpDispatchError) -> DeleteOrganizationalUnitError {
         DeleteOrganizationalUnitError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteOrganizationalUnitError {
+    fn from(err: io::Error) -> DeleteOrganizationalUnitError {
+        DeleteOrganizationalUnitError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteOrganizationalUnitError {
@@ -2311,6 +2363,11 @@ impl From<HttpDispatchError> for DeletePolicyError {
         DeletePolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePolicyError {
+    fn from(err: io::Error) -> DeletePolicyError {
+        DeletePolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2417,6 +2474,11 @@ impl From<HttpDispatchError> for DescribeAccountError {
         DescribeAccountError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAccountError {
+    fn from(err: io::Error) -> DescribeAccountError {
+        DescribeAccountError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2513,6 +2575,11 @@ impl From<CredentialsError> for DescribeCreateAccountStatusError {
 impl From<HttpDispatchError> for DescribeCreateAccountStatusError {
     fn from(err: HttpDispatchError) -> DescribeCreateAccountStatusError {
         DescribeCreateAccountStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCreateAccountStatusError {
+    fn from(err: io::Error) -> DescribeCreateAccountStatusError {
+        DescribeCreateAccountStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCreateAccountStatusError {
@@ -2621,6 +2688,11 @@ impl From<HttpDispatchError> for DescribeHandshakeError {
         DescribeHandshakeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeHandshakeError {
+    fn from(err: io::Error) -> DescribeHandshakeError {
+        DescribeHandshakeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeHandshakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2716,6 +2788,11 @@ impl From<CredentialsError> for DescribeOrganizationError {
 impl From<HttpDispatchError> for DescribeOrganizationError {
     fn from(err: HttpDispatchError) -> DescribeOrganizationError {
         DescribeOrganizationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeOrganizationError {
+    fn from(err: io::Error) -> DescribeOrganizationError {
+        DescribeOrganizationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeOrganizationError {
@@ -2815,6 +2892,11 @@ impl From<CredentialsError> for DescribeOrganizationalUnitError {
 impl From<HttpDispatchError> for DescribeOrganizationalUnitError {
     fn from(err: HttpDispatchError) -> DescribeOrganizationalUnitError {
         DescribeOrganizationalUnitError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeOrganizationalUnitError {
+    fn from(err: io::Error) -> DescribeOrganizationalUnitError {
+        DescribeOrganizationalUnitError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeOrganizationalUnitError {
@@ -2919,6 +3001,11 @@ impl From<CredentialsError> for DescribePolicyError {
 impl From<HttpDispatchError> for DescribePolicyError {
     fn from(err: HttpDispatchError) -> DescribePolicyError {
         DescribePolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribePolicyError {
+    fn from(err: io::Error) -> DescribePolicyError {
+        DescribePolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribePolicyError {
@@ -3043,6 +3130,11 @@ impl From<HttpDispatchError> for DetachPolicyError {
         DetachPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetachPolicyError {
+    fn from(err: io::Error) -> DetachPolicyError {
+        DetachPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetachPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3164,6 +3256,11 @@ impl From<HttpDispatchError> for DisablePolicyTypeError {
         DisablePolicyTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisablePolicyTypeError {
+    fn from(err: io::Error) -> DisablePolicyTypeError {
+        DisablePolicyTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisablePolicyTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3272,6 +3369,11 @@ impl From<CredentialsError> for EnableAllFeaturesError {
 impl From<HttpDispatchError> for EnableAllFeaturesError {
     fn from(err: HttpDispatchError) -> EnableAllFeaturesError {
         EnableAllFeaturesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnableAllFeaturesError {
+    fn from(err: io::Error) -> EnableAllFeaturesError {
+        EnableAllFeaturesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnableAllFeaturesError {
@@ -3399,6 +3501,11 @@ impl From<HttpDispatchError> for EnablePolicyTypeError {
         EnablePolicyTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnablePolicyTypeError {
+    fn from(err: io::Error) -> EnablePolicyTypeError {
+        EnablePolicyTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnablePolicyTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3508,6 +3615,11 @@ impl From<CredentialsError> for InviteAccountToOrganizationError {
 impl From<HttpDispatchError> for InviteAccountToOrganizationError {
     fn from(err: HttpDispatchError) -> InviteAccountToOrganizationError {
         InviteAccountToOrganizationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for InviteAccountToOrganizationError {
+    fn from(err: io::Error) -> InviteAccountToOrganizationError {
+        InviteAccountToOrganizationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for InviteAccountToOrganizationError {
@@ -3630,6 +3742,11 @@ impl From<HttpDispatchError> for LeaveOrganizationError {
         LeaveOrganizationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for LeaveOrganizationError {
+    fn from(err: io::Error) -> LeaveOrganizationError {
+        LeaveOrganizationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for LeaveOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3732,6 +3849,11 @@ impl From<HttpDispatchError> for ListAccountsError {
         ListAccountsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListAccountsError {
+    fn from(err: io::Error) -> ListAccountsError {
+        ListAccountsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListAccountsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3831,6 +3953,11 @@ impl From<CredentialsError> for ListAccountsForParentError {
 impl From<HttpDispatchError> for ListAccountsForParentError {
     fn from(err: HttpDispatchError) -> ListAccountsForParentError {
         ListAccountsForParentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAccountsForParentError {
+    fn from(err: io::Error) -> ListAccountsForParentError {
+        ListAccountsForParentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAccountsForParentError {
@@ -3937,6 +4064,11 @@ impl From<HttpDispatchError> for ListChildrenError {
         ListChildrenError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListChildrenError {
+    fn from(err: io::Error) -> ListChildrenError {
+        ListChildrenError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListChildrenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4032,6 +4164,11 @@ impl From<CredentialsError> for ListCreateAccountStatusError {
 impl From<HttpDispatchError> for ListCreateAccountStatusError {
     fn from(err: HttpDispatchError) -> ListCreateAccountStatusError {
         ListCreateAccountStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListCreateAccountStatusError {
+    fn from(err: io::Error) -> ListCreateAccountStatusError {
+        ListCreateAccountStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListCreateAccountStatusError {
@@ -4132,6 +4269,11 @@ impl From<HttpDispatchError> for ListHandshakesForAccountError {
         ListHandshakesForAccountError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListHandshakesForAccountError {
+    fn from(err: io::Error) -> ListHandshakesForAccountError {
+        ListHandshakesForAccountError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListHandshakesForAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4225,6 +4367,11 @@ impl From<CredentialsError> for ListHandshakesForOrganizationError {
 impl From<HttpDispatchError> for ListHandshakesForOrganizationError {
     fn from(err: HttpDispatchError) -> ListHandshakesForOrganizationError {
         ListHandshakesForOrganizationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListHandshakesForOrganizationError {
+    fn from(err: io::Error) -> ListHandshakesForOrganizationError {
+        ListHandshakesForOrganizationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListHandshakesForOrganizationError {
@@ -4321,6 +4468,11 @@ impl From<CredentialsError> for ListOrganizationalUnitsForParentError {
 impl From<HttpDispatchError> for ListOrganizationalUnitsForParentError {
     fn from(err: HttpDispatchError) -> ListOrganizationalUnitsForParentError {
         ListOrganizationalUnitsForParentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListOrganizationalUnitsForParentError {
+    fn from(err: io::Error) -> ListOrganizationalUnitsForParentError {
+        ListOrganizationalUnitsForParentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListOrganizationalUnitsForParentError {
@@ -4427,6 +4579,11 @@ impl From<HttpDispatchError> for ListParentsError {
         ListParentsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListParentsError {
+    fn from(err: io::Error) -> ListParentsError {
+        ListParentsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListParentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4522,6 +4679,11 @@ impl From<CredentialsError> for ListPoliciesError {
 impl From<HttpDispatchError> for ListPoliciesError {
     fn from(err: HttpDispatchError) -> ListPoliciesError {
         ListPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPoliciesError {
+    fn from(err: io::Error) -> ListPoliciesError {
+        ListPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPoliciesError {
@@ -4625,6 +4787,11 @@ impl From<HttpDispatchError> for ListPoliciesForTargetError {
         ListPoliciesForTargetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPoliciesForTargetError {
+    fn from(err: io::Error) -> ListPoliciesForTargetError {
+        ListPoliciesForTargetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPoliciesForTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4720,6 +4887,11 @@ impl From<CredentialsError> for ListRootsError {
 impl From<HttpDispatchError> for ListRootsError {
     fn from(err: HttpDispatchError) -> ListRootsError {
         ListRootsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRootsError {
+    fn from(err: io::Error) -> ListRootsError {
+        ListRootsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRootsError {
@@ -4821,6 +4993,11 @@ impl From<CredentialsError> for ListTargetsForPolicyError {
 impl From<HttpDispatchError> for ListTargetsForPolicyError {
     fn from(err: HttpDispatchError) -> ListTargetsForPolicyError {
         ListTargetsForPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTargetsForPolicyError {
+    fn from(err: io::Error) -> ListTargetsForPolicyError {
+        ListTargetsForPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTargetsForPolicyError {
@@ -4947,6 +5124,11 @@ impl From<HttpDispatchError> for MoveAccountError {
         MoveAccountError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for MoveAccountError {
+    fn from(err: io::Error) -> MoveAccountError {
+        MoveAccountError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for MoveAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5052,6 +5234,11 @@ impl From<CredentialsError> for RemoveAccountFromOrganizationError {
 impl From<HttpDispatchError> for RemoveAccountFromOrganizationError {
     fn from(err: HttpDispatchError) -> RemoveAccountFromOrganizationError {
         RemoveAccountFromOrganizationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveAccountFromOrganizationError {
+    fn from(err: io::Error) -> RemoveAccountFromOrganizationError {
+        RemoveAccountFromOrganizationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveAccountFromOrganizationError {
@@ -5163,6 +5350,11 @@ impl From<CredentialsError> for UpdateOrganizationalUnitError {
 impl From<HttpDispatchError> for UpdateOrganizationalUnitError {
     fn from(err: HttpDispatchError) -> UpdateOrganizationalUnitError {
         UpdateOrganizationalUnitError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateOrganizationalUnitError {
+    fn from(err: io::Error) -> UpdateOrganizationalUnitError {
+        UpdateOrganizationalUnitError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateOrganizationalUnitError {
@@ -5289,6 +5481,11 @@ impl From<CredentialsError> for UpdatePolicyError {
 impl From<HttpDispatchError> for UpdatePolicyError {
     fn from(err: HttpDispatchError) -> UpdatePolicyError {
         UpdatePolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdatePolicyError {
+    fn from(err: io::Error) -> UpdatePolicyError {
+        UpdatePolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdatePolicyError {
@@ -5586,15 +5783,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AcceptHandshakeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AcceptHandshakeResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AcceptHandshakeError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AcceptHandshakeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5611,12 +5813,14 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(AttachPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AttachPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5635,15 +5839,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CancelHandshakeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelHandshakeResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CancelHandshakeError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelHandshakeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5662,14 +5871,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAccountResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAccountResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateAccountError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAccountError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5689,15 +5904,18 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateOrganizationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateOrganizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateOrganizationError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateOrganizationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5718,13 +5936,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateOrganizationalUnitResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateOrganizationalUnitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateOrganizationalUnitResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateOrganizationalUnitError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -5742,14 +5967,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreatePolicyResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreatePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5768,15 +5999,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeclineHandshakeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeclineHandshakeResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeclineHandshakeError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeclineHandshakeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5793,13 +6029,14 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeleteOrganizationError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteOrganizationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5819,11 +6056,16 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(DeleteOrganizationalUnitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteOrganizationalUnitError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -5839,12 +6081,14 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5863,15 +6107,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAccountResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAccountResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeAccountError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5892,13 +6141,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCreateAccountStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeCreateAccountStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCreateAccountStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCreateAccountStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -5917,15 +6173,18 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeHandshakeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeHandshakeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeHandshakeError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHandshakeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5943,15 +6202,18 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeOrganizationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeOrganizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeOrganizationError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeOrganizationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5972,13 +6234,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeOrganizationalUnitResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeOrganizationalUnitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeOrganizationalUnitResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeOrganizationalUnitError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5996,15 +6265,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribePolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribePolicyResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribePolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6021,12 +6295,14 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DetachPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetachPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6046,15 +6322,18 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisablePolicyTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisablePolicyTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DisablePolicyTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisablePolicyTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6071,15 +6350,18 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EnableAllFeaturesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EnableAllFeaturesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(EnableAllFeaturesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableAllFeaturesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6098,15 +6380,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EnablePolicyTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EnablePolicyTypeResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(EnablePolicyTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnablePolicyTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6127,13 +6414,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<InviteAccountToOrganizationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(InviteAccountToOrganizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<InviteAccountToOrganizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(InviteAccountToOrganizationError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -6149,13 +6443,14 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(LeaveOrganizationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(LeaveOrganizationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6174,14 +6469,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAccountsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAccountsResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListAccountsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAccountsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6202,15 +6503,18 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAccountsForParentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAccountsForParentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListAccountsForParentError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAccountsForParentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6229,14 +6533,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListChildrenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListChildrenResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListChildrenError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListChildrenError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6257,13 +6567,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListCreateAccountStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListCreateAccountStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListCreateAccountStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCreateAccountStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6283,13 +6600,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListHandshakesForAccountResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListHandshakesForAccountError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListHandshakesForAccountResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHandshakesForAccountError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -6309,13 +6633,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListHandshakesForOrganizationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListHandshakesForOrganizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListHandshakesForOrganizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHandshakesForOrganizationError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -6335,13 +6666,19 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListOrganizationalUnitsForParentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListOrganizationalUnitsForParentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListOrganizationalUnitsForParentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOrganizationalUnitsForParentError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6359,13 +6696,21 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListParentsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListParentsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListParentsResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListParentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6383,14 +6728,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPoliciesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPoliciesResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6411,15 +6762,18 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPoliciesForTargetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPoliciesForTargetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListPoliciesForTargetError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPoliciesForTargetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6436,13 +6790,21 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRootsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListRootsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRootsResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRootsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6462,15 +6824,18 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTargetsForPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTargetsForPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTargetsForPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTargetsForPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6487,11 +6852,15 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(MoveAccountError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(MoveAccountError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6510,11 +6879,16 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RemoveAccountFromOrganizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveAccountFromOrganizationError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -6534,13 +6908,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateOrganizationalUnitResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateOrganizationalUnitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateOrganizationalUnitResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateOrganizationalUnitError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -6558,14 +6939,20 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdatePolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdatePolicyResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdatePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdatePolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -295,6 +297,11 @@ impl From<HttpDispatchError> for DeleteLexiconError {
         DeleteLexiconError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteLexiconError {
+    fn from(err: io::Error) -> DeleteLexiconError {
+        DeleteLexiconError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteLexiconError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -375,6 +382,11 @@ impl From<HttpDispatchError> for DescribeVoicesError {
         DescribeVoicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVoicesError {
+    fn from(err: io::Error) -> DescribeVoicesError {
+        DescribeVoicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVoicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -451,6 +463,11 @@ impl From<CredentialsError> for GetLexiconError {
 impl From<HttpDispatchError> for GetLexiconError {
     fn from(err: HttpDispatchError) -> GetLexiconError {
         GetLexiconError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetLexiconError {
+    fn from(err: io::Error) -> GetLexiconError {
+        GetLexiconError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetLexiconError {
@@ -531,6 +548,11 @@ impl From<CredentialsError> for ListLexiconsError {
 impl From<HttpDispatchError> for ListLexiconsError {
     fn from(err: HttpDispatchError) -> ListLexiconsError {
         ListLexiconsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListLexiconsError {
+    fn from(err: io::Error) -> ListLexiconsError {
+        ListLexiconsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListLexiconsError {
@@ -634,6 +656,11 @@ impl From<CredentialsError> for PutLexiconError {
 impl From<HttpDispatchError> for PutLexiconError {
     fn from(err: HttpDispatchError) -> PutLexiconError {
         PutLexiconError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutLexiconError {
+    fn from(err: io::Error) -> PutLexiconError {
+        PutLexiconError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutLexiconError {
@@ -742,6 +769,11 @@ impl From<HttpDispatchError> for SynthesizeSpeechError {
         SynthesizeSpeechError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SynthesizeSpeechError {
+    fn from(err: io::Error) -> SynthesizeSpeechError {
+        SynthesizeSpeechError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SynthesizeSpeechError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -840,13 +872,13 @@ impl<P, D> Polly for PollyClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -861,7 +893,9 @@ impl<P, D> Polly for PollyClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteLexiconError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteLexiconError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -890,13 +924,13 @@ impl<P, D> Polly for PollyClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -911,8 +945,9 @@ impl<P, D> Polly for PollyClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeVoicesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVoicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -932,13 +967,13 @@ impl<P, D> Polly for PollyClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -952,7 +987,11 @@ impl<P, D> Polly for PollyClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetLexiconError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetLexiconError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -977,13 +1016,13 @@ impl<P, D> Polly for PollyClient<P, D>
         request.set_params(params);
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -998,7 +1037,9 @@ impl<P, D> Polly for PollyClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListLexiconsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListLexiconsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1018,13 +1059,13 @@ impl<P, D> Polly for PollyClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
-                let mut body = response.body;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
                 if body == b"{}" {
                     body = b"null".to_vec();
@@ -1038,7 +1079,11 @@ impl<P, D> Polly for PollyClient<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutLexiconError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutLexiconError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1059,14 +1104,17 @@ impl<P, D> Polly for PollyClient<P, D>
 
 
         request.sign(&self.credentials_provider.credentials()?);
-
-        let response = self.dispatcher.dispatch(&request)?;
+        let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
 
                 let mut result = SynthesizeSpeechOutput::default();
-                result.audio_stream = Some(response.body);
+
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+
+                result.audio_stream = Some(body);
 
                 if let Some(content_type) = response.headers.get("Content-Type") {
                     let value = content_type.to_owned();
@@ -1081,8 +1129,9 @@ impl<P, D> Polly for PollyClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SynthesizeSpeechError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SynthesizeSpeechError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -15909,6 +15911,11 @@ impl From<HttpDispatchError> for AddRoleToDBClusterError {
         AddRoleToDBClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddRoleToDBClusterError {
+    fn from(err: io::Error) -> AddRoleToDBClusterError {
+        AddRoleToDBClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddRoleToDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15981,6 +15988,11 @@ impl From<CredentialsError> for AddSourceIdentifierToSubscriptionError {
 impl From<HttpDispatchError> for AddSourceIdentifierToSubscriptionError {
     fn from(err: HttpDispatchError) -> AddSourceIdentifierToSubscriptionError {
         AddSourceIdentifierToSubscriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddSourceIdentifierToSubscriptionError {
+    fn from(err: io::Error) -> AddSourceIdentifierToSubscriptionError {
+        AddSourceIdentifierToSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddSourceIdentifierToSubscriptionError {
@@ -16058,6 +16070,11 @@ impl From<HttpDispatchError> for AddTagsToResourceError {
         AddTagsToResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToResourceError {
+    fn from(err: io::Error) -> AddTagsToResourceError {
+        AddTagsToResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16126,6 +16143,11 @@ impl From<CredentialsError> for ApplyPendingMaintenanceActionError {
 impl From<HttpDispatchError> for ApplyPendingMaintenanceActionError {
     fn from(err: HttpDispatchError) -> ApplyPendingMaintenanceActionError {
         ApplyPendingMaintenanceActionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ApplyPendingMaintenanceActionError {
+    fn from(err: io::Error) -> ApplyPendingMaintenanceActionError {
+        ApplyPendingMaintenanceActionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ApplyPendingMaintenanceActionError {
@@ -16203,6 +16225,11 @@ impl From<CredentialsError> for AuthorizeDBSecurityGroupIngressError {
 impl From<HttpDispatchError> for AuthorizeDBSecurityGroupIngressError {
     fn from(err: HttpDispatchError) -> AuthorizeDBSecurityGroupIngressError {
         AuthorizeDBSecurityGroupIngressError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AuthorizeDBSecurityGroupIngressError {
+    fn from(err: io::Error) -> AuthorizeDBSecurityGroupIngressError {
+        AuthorizeDBSecurityGroupIngressError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AuthorizeDBSecurityGroupIngressError {
@@ -16286,6 +16313,11 @@ impl From<CredentialsError> for CopyDBClusterParameterGroupError {
 impl From<HttpDispatchError> for CopyDBClusterParameterGroupError {
     fn from(err: HttpDispatchError) -> CopyDBClusterParameterGroupError {
         CopyDBClusterParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CopyDBClusterParameterGroupError {
+    fn from(err: io::Error) -> CopyDBClusterParameterGroupError {
+        CopyDBClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CopyDBClusterParameterGroupError {
@@ -16377,6 +16409,11 @@ impl From<HttpDispatchError> for CopyDBClusterSnapshotError {
         CopyDBClusterSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CopyDBClusterSnapshotError {
+    fn from(err: io::Error) -> CopyDBClusterSnapshotError {
+        CopyDBClusterSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CopyDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16454,6 +16491,11 @@ impl From<CredentialsError> for CopyDBParameterGroupError {
 impl From<HttpDispatchError> for CopyDBParameterGroupError {
     fn from(err: HttpDispatchError) -> CopyDBParameterGroupError {
         CopyDBParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CopyDBParameterGroupError {
+    fn from(err: io::Error) -> CopyDBParameterGroupError {
+        CopyDBParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CopyDBParameterGroupError {
@@ -16538,6 +16580,11 @@ impl From<HttpDispatchError> for CopyDBSnapshotError {
         CopyDBSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CopyDBSnapshotError {
+    fn from(err: io::Error) -> CopyDBSnapshotError {
+        CopyDBSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CopyDBSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16612,6 +16659,11 @@ impl From<CredentialsError> for CopyOptionGroupError {
 impl From<HttpDispatchError> for CopyOptionGroupError {
     fn from(err: HttpDispatchError) -> CopyOptionGroupError {
         CopyOptionGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CopyOptionGroupError {
+    fn from(err: io::Error) -> CopyOptionGroupError {
+        CopyOptionGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CopyOptionGroupError {
@@ -16726,6 +16778,11 @@ impl From<HttpDispatchError> for CreateDBClusterError {
         CreateDBClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDBClusterError {
+    fn from(err: io::Error) -> CreateDBClusterError {
+        CreateDBClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16807,6 +16864,11 @@ impl From<CredentialsError> for CreateDBClusterParameterGroupError {
 impl From<HttpDispatchError> for CreateDBClusterParameterGroupError {
     fn from(err: HttpDispatchError) -> CreateDBClusterParameterGroupError {
         CreateDBClusterParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDBClusterParameterGroupError {
+    fn from(err: io::Error) -> CreateDBClusterParameterGroupError {
+        CreateDBClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDBClusterParameterGroupError {
@@ -16892,6 +16954,11 @@ impl From<CredentialsError> for CreateDBClusterSnapshotError {
 impl From<HttpDispatchError> for CreateDBClusterSnapshotError {
     fn from(err: HttpDispatchError) -> CreateDBClusterSnapshotError {
         CreateDBClusterSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDBClusterSnapshotError {
+    fn from(err: io::Error) -> CreateDBClusterSnapshotError {
+        CreateDBClusterSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDBClusterSnapshotError {
@@ -17017,6 +17084,11 @@ impl From<CredentialsError> for CreateDBInstanceError {
 impl From<HttpDispatchError> for CreateDBInstanceError {
     fn from(err: HttpDispatchError) -> CreateDBInstanceError {
         CreateDBInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDBInstanceError {
+    fn from(err: io::Error) -> CreateDBInstanceError {
+        CreateDBInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDBInstanceError {
@@ -17153,6 +17225,11 @@ impl From<HttpDispatchError> for CreateDBInstanceReadReplicaError {
         CreateDBInstanceReadReplicaError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDBInstanceReadReplicaError {
+    fn from(err: io::Error) -> CreateDBInstanceReadReplicaError {
+        CreateDBInstanceReadReplicaError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDBInstanceReadReplicaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17247,6 +17324,11 @@ impl From<HttpDispatchError> for CreateDBParameterGroupError {
         CreateDBParameterGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDBParameterGroupError {
+    fn from(err: io::Error) -> CreateDBParameterGroupError {
+        CreateDBParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17320,6 +17402,11 @@ impl From<CredentialsError> for CreateDBSecurityGroupError {
 impl From<HttpDispatchError> for CreateDBSecurityGroupError {
     fn from(err: HttpDispatchError) -> CreateDBSecurityGroupError {
         CreateDBSecurityGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDBSecurityGroupError {
+    fn from(err: io::Error) -> CreateDBSecurityGroupError {
+        CreateDBSecurityGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDBSecurityGroupError {
@@ -17399,6 +17486,11 @@ impl From<CredentialsError> for CreateDBSnapshotError {
 impl From<HttpDispatchError> for CreateDBSnapshotError {
     fn from(err: HttpDispatchError) -> CreateDBSnapshotError {
         CreateDBSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDBSnapshotError {
+    fn from(err: io::Error) -> CreateDBSnapshotError {
+        CreateDBSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDBSnapshotError {
@@ -17482,6 +17574,11 @@ impl From<CredentialsError> for CreateDBSubnetGroupError {
 impl From<HttpDispatchError> for CreateDBSubnetGroupError {
     fn from(err: HttpDispatchError) -> CreateDBSubnetGroupError {
         CreateDBSubnetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateDBSubnetGroupError {
+    fn from(err: io::Error) -> CreateDBSubnetGroupError {
+        CreateDBSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateDBSubnetGroupError {
@@ -17574,6 +17671,11 @@ impl From<HttpDispatchError> for CreateEventSubscriptionError {
         CreateEventSubscriptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateEventSubscriptionError {
+    fn from(err: io::Error) -> CreateEventSubscriptionError {
+        CreateEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17649,6 +17751,11 @@ impl From<CredentialsError> for CreateOptionGroupError {
 impl From<HttpDispatchError> for CreateOptionGroupError {
     fn from(err: HttpDispatchError) -> CreateOptionGroupError {
         CreateOptionGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateOptionGroupError {
+    fn from(err: io::Error) -> CreateOptionGroupError {
+        CreateOptionGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateOptionGroupError {
@@ -17732,6 +17839,11 @@ impl From<HttpDispatchError> for DeleteDBClusterError {
         DeleteDBClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDBClusterError {
+    fn from(err: io::Error) -> DeleteDBClusterError {
+        DeleteDBClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -17803,6 +17915,11 @@ impl From<CredentialsError> for DeleteDBClusterParameterGroupError {
 impl From<HttpDispatchError> for DeleteDBClusterParameterGroupError {
     fn from(err: HttpDispatchError) -> DeleteDBClusterParameterGroupError {
         DeleteDBClusterParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDBClusterParameterGroupError {
+    fn from(err: io::Error) -> DeleteDBClusterParameterGroupError {
+        DeleteDBClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDBClusterParameterGroupError {
@@ -17877,6 +17994,11 @@ impl From<CredentialsError> for DeleteDBClusterSnapshotError {
 impl From<HttpDispatchError> for DeleteDBClusterSnapshotError {
     fn from(err: HttpDispatchError) -> DeleteDBClusterSnapshotError {
         DeleteDBClusterSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDBClusterSnapshotError {
+    fn from(err: io::Error) -> DeleteDBClusterSnapshotError {
+        DeleteDBClusterSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDBClusterSnapshotError {
@@ -17960,6 +18082,11 @@ impl From<HttpDispatchError> for DeleteDBInstanceError {
         DeleteDBInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDBInstanceError {
+    fn from(err: io::Error) -> DeleteDBInstanceError {
+        DeleteDBInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18031,6 +18158,11 @@ impl From<CredentialsError> for DeleteDBParameterGroupError {
 impl From<HttpDispatchError> for DeleteDBParameterGroupError {
     fn from(err: HttpDispatchError) -> DeleteDBParameterGroupError {
         DeleteDBParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDBParameterGroupError {
+    fn from(err: io::Error) -> DeleteDBParameterGroupError {
+        DeleteDBParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDBParameterGroupError {
@@ -18105,6 +18237,11 @@ impl From<HttpDispatchError> for DeleteDBSecurityGroupError {
         DeleteDBSecurityGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDBSecurityGroupError {
+    fn from(err: io::Error) -> DeleteDBSecurityGroupError {
+        DeleteDBSecurityGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDBSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18175,6 +18312,11 @@ impl From<CredentialsError> for DeleteDBSnapshotError {
 impl From<HttpDispatchError> for DeleteDBSnapshotError {
     fn from(err: HttpDispatchError) -> DeleteDBSnapshotError {
         DeleteDBSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteDBSnapshotError {
+    fn from(err: io::Error) -> DeleteDBSnapshotError {
+        DeleteDBSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteDBSnapshotError {
@@ -18250,6 +18392,11 @@ impl From<HttpDispatchError> for DeleteDBSubnetGroupError {
         DeleteDBSubnetGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDBSubnetGroupError {
+    fn from(err: io::Error) -> DeleteDBSubnetGroupError {
+        DeleteDBSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18321,6 +18468,11 @@ impl From<CredentialsError> for DeleteEventSubscriptionError {
 impl From<HttpDispatchError> for DeleteEventSubscriptionError {
     fn from(err: HttpDispatchError) -> DeleteEventSubscriptionError {
         DeleteEventSubscriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteEventSubscriptionError {
+    fn from(err: io::Error) -> DeleteEventSubscriptionError {
+        DeleteEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteEventSubscriptionError {
@@ -18395,6 +18547,11 @@ impl From<HttpDispatchError> for DeleteOptionGroupError {
         DeleteOptionGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteOptionGroupError {
+    fn from(err: io::Error) -> DeleteOptionGroupError {
+        DeleteOptionGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteOptionGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18459,6 +18616,11 @@ impl From<CredentialsError> for DescribeAccountAttributesError {
 impl From<HttpDispatchError> for DescribeAccountAttributesError {
     fn from(err: HttpDispatchError) -> DescribeAccountAttributesError {
         DescribeAccountAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAccountAttributesError {
+    fn from(err: io::Error) -> DescribeAccountAttributesError {
+        DescribeAccountAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAccountAttributesError {
@@ -18528,6 +18690,11 @@ impl From<HttpDispatchError> for DescribeCertificatesError {
         DescribeCertificatesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCertificatesError {
+    fn from(err: io::Error) -> DescribeCertificatesError {
+        DescribeCertificatesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18594,6 +18761,11 @@ impl From<CredentialsError> for DescribeDBClusterParameterGroupsError {
 impl From<HttpDispatchError> for DescribeDBClusterParameterGroupsError {
     fn from(err: HttpDispatchError) -> DescribeDBClusterParameterGroupsError {
         DescribeDBClusterParameterGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDBClusterParameterGroupsError {
+    fn from(err: io::Error) -> DescribeDBClusterParameterGroupsError {
+        DescribeDBClusterParameterGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDBClusterParameterGroupsError {
@@ -18666,6 +18838,11 @@ impl From<HttpDispatchError> for DescribeDBClusterParametersError {
         DescribeDBClusterParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDBClusterParametersError {
+    fn from(err: io::Error) -> DescribeDBClusterParametersError {
+        DescribeDBClusterParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDBClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18732,6 +18909,11 @@ impl From<CredentialsError> for DescribeDBClusterSnapshotAttributesError {
 impl From<HttpDispatchError> for DescribeDBClusterSnapshotAttributesError {
     fn from(err: HttpDispatchError) -> DescribeDBClusterSnapshotAttributesError {
         DescribeDBClusterSnapshotAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDBClusterSnapshotAttributesError {
+    fn from(err: io::Error) -> DescribeDBClusterSnapshotAttributesError {
+        DescribeDBClusterSnapshotAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDBClusterSnapshotAttributesError {
@@ -18804,6 +18986,11 @@ impl From<HttpDispatchError> for DescribeDBClusterSnapshotsError {
         DescribeDBClusterSnapshotsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDBClusterSnapshotsError {
+    fn from(err: io::Error) -> DescribeDBClusterSnapshotsError {
+        DescribeDBClusterSnapshotsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDBClusterSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18872,6 +19059,11 @@ impl From<HttpDispatchError> for DescribeDBClustersError {
         DescribeDBClustersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDBClustersError {
+    fn from(err: io::Error) -> DescribeDBClustersError {
+        DescribeDBClustersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDBClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -18935,6 +19127,11 @@ impl From<CredentialsError> for DescribeDBEngineVersionsError {
 impl From<HttpDispatchError> for DescribeDBEngineVersionsError {
     fn from(err: HttpDispatchError) -> DescribeDBEngineVersionsError {
         DescribeDBEngineVersionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDBEngineVersionsError {
+    fn from(err: io::Error) -> DescribeDBEngineVersionsError {
+        DescribeDBEngineVersionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDBEngineVersionsError {
@@ -19002,6 +19199,11 @@ impl From<CredentialsError> for DescribeDBInstancesError {
 impl From<HttpDispatchError> for DescribeDBInstancesError {
     fn from(err: HttpDispatchError) -> DescribeDBInstancesError {
         DescribeDBInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDBInstancesError {
+    fn from(err: io::Error) -> DescribeDBInstancesError {
+        DescribeDBInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDBInstancesError {
@@ -19072,6 +19274,11 @@ impl From<HttpDispatchError> for DescribeDBLogFilesError {
         DescribeDBLogFilesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDBLogFilesError {
+    fn from(err: io::Error) -> DescribeDBLogFilesError {
+        DescribeDBLogFilesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDBLogFilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19138,6 +19345,11 @@ impl From<CredentialsError> for DescribeDBParameterGroupsError {
 impl From<HttpDispatchError> for DescribeDBParameterGroupsError {
     fn from(err: HttpDispatchError) -> DescribeDBParameterGroupsError {
         DescribeDBParameterGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDBParameterGroupsError {
+    fn from(err: io::Error) -> DescribeDBParameterGroupsError {
+        DescribeDBParameterGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDBParameterGroupsError {
@@ -19208,6 +19420,11 @@ impl From<HttpDispatchError> for DescribeDBParametersError {
         DescribeDBParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDBParametersError {
+    fn from(err: io::Error) -> DescribeDBParametersError {
+        DescribeDBParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDBParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19274,6 +19491,11 @@ impl From<CredentialsError> for DescribeDBSecurityGroupsError {
 impl From<HttpDispatchError> for DescribeDBSecurityGroupsError {
     fn from(err: HttpDispatchError) -> DescribeDBSecurityGroupsError {
         DescribeDBSecurityGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDBSecurityGroupsError {
+    fn from(err: io::Error) -> DescribeDBSecurityGroupsError {
+        DescribeDBSecurityGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDBSecurityGroupsError {
@@ -19344,6 +19566,11 @@ impl From<HttpDispatchError> for DescribeDBSnapshotAttributesError {
         DescribeDBSnapshotAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDBSnapshotAttributesError {
+    fn from(err: io::Error) -> DescribeDBSnapshotAttributesError {
+        DescribeDBSnapshotAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDBSnapshotAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19410,6 +19637,11 @@ impl From<CredentialsError> for DescribeDBSnapshotsError {
 impl From<HttpDispatchError> for DescribeDBSnapshotsError {
     fn from(err: HttpDispatchError) -> DescribeDBSnapshotsError {
         DescribeDBSnapshotsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDBSnapshotsError {
+    fn from(err: io::Error) -> DescribeDBSnapshotsError {
+        DescribeDBSnapshotsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDBSnapshotsError {
@@ -19480,6 +19712,11 @@ impl From<HttpDispatchError> for DescribeDBSubnetGroupsError {
         DescribeDBSubnetGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDBSubnetGroupsError {
+    fn from(err: io::Error) -> DescribeDBSubnetGroupsError {
+        DescribeDBSubnetGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDBSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19543,6 +19780,11 @@ impl From<CredentialsError> for DescribeEngineDefaultClusterParametersError {
 impl From<HttpDispatchError> for DescribeEngineDefaultClusterParametersError {
     fn from(err: HttpDispatchError) -> DescribeEngineDefaultClusterParametersError {
         DescribeEngineDefaultClusterParametersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEngineDefaultClusterParametersError {
+    fn from(err: io::Error) -> DescribeEngineDefaultClusterParametersError {
+        DescribeEngineDefaultClusterParametersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEngineDefaultClusterParametersError {
@@ -19609,6 +19851,11 @@ impl From<HttpDispatchError> for DescribeEngineDefaultParametersError {
         DescribeEngineDefaultParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEngineDefaultParametersError {
+    fn from(err: io::Error) -> DescribeEngineDefaultParametersError {
+        DescribeEngineDefaultParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEngineDefaultParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19671,6 +19918,11 @@ impl From<CredentialsError> for DescribeEventCategoriesError {
 impl From<HttpDispatchError> for DescribeEventCategoriesError {
     fn from(err: HttpDispatchError) -> DescribeEventCategoriesError {
         DescribeEventCategoriesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventCategoriesError {
+    fn from(err: io::Error) -> DescribeEventCategoriesError {
+        DescribeEventCategoriesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventCategoriesError {
@@ -19740,6 +19992,11 @@ impl From<HttpDispatchError> for DescribeEventSubscriptionsError {
         DescribeEventSubscriptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEventSubscriptionsError {
+    fn from(err: io::Error) -> DescribeEventSubscriptionsError {
+        DescribeEventSubscriptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19805,6 +20062,11 @@ impl From<HttpDispatchError> for DescribeEventsError {
         DescribeEventsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEventsError {
+    fn from(err: io::Error) -> DescribeEventsError {
+        DescribeEventsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19865,6 +20127,11 @@ impl From<CredentialsError> for DescribeOptionGroupOptionsError {
 impl From<HttpDispatchError> for DescribeOptionGroupOptionsError {
     fn from(err: HttpDispatchError) -> DescribeOptionGroupOptionsError {
         DescribeOptionGroupOptionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeOptionGroupOptionsError {
+    fn from(err: io::Error) -> DescribeOptionGroupOptionsError {
+        DescribeOptionGroupOptionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeOptionGroupOptionsError {
@@ -19934,6 +20201,11 @@ impl From<HttpDispatchError> for DescribeOptionGroupsError {
         DescribeOptionGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeOptionGroupsError {
+    fn from(err: io::Error) -> DescribeOptionGroupsError {
+        DescribeOptionGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeOptionGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -19997,6 +20269,11 @@ impl From<CredentialsError> for DescribeOrderableDBInstanceOptionsError {
 impl From<HttpDispatchError> for DescribeOrderableDBInstanceOptionsError {
     fn from(err: HttpDispatchError) -> DescribeOrderableDBInstanceOptionsError {
         DescribeOrderableDBInstanceOptionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeOrderableDBInstanceOptionsError {
+    fn from(err: io::Error) -> DescribeOrderableDBInstanceOptionsError {
+        DescribeOrderableDBInstanceOptionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeOrderableDBInstanceOptionsError {
@@ -20064,6 +20341,11 @@ impl From<CredentialsError> for DescribePendingMaintenanceActionsError {
 impl From<HttpDispatchError> for DescribePendingMaintenanceActionsError {
     fn from(err: HttpDispatchError) -> DescribePendingMaintenanceActionsError {
         DescribePendingMaintenanceActionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribePendingMaintenanceActionsError {
+    fn from(err: io::Error) -> DescribePendingMaintenanceActionsError {
+        DescribePendingMaintenanceActionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribePendingMaintenanceActionsError {
@@ -20134,6 +20416,11 @@ impl From<HttpDispatchError> for DescribeReservedDBInstancesError {
         DescribeReservedDBInstancesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReservedDBInstancesError {
+    fn from(err: io::Error) -> DescribeReservedDBInstancesError {
+        DescribeReservedDBInstancesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReservedDBInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20202,6 +20489,11 @@ impl From<HttpDispatchError> for DescribeReservedDBInstancesOfferingsError {
         DescribeReservedDBInstancesOfferingsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReservedDBInstancesOfferingsError {
+    fn from(err: io::Error) -> DescribeReservedDBInstancesOfferingsError {
+        DescribeReservedDBInstancesOfferingsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReservedDBInstancesOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20265,6 +20557,11 @@ impl From<CredentialsError> for DescribeSourceRegionsError {
 impl From<HttpDispatchError> for DescribeSourceRegionsError {
     fn from(err: HttpDispatchError) -> DescribeSourceRegionsError {
         DescribeSourceRegionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSourceRegionsError {
+    fn from(err: io::Error) -> DescribeSourceRegionsError {
+        DescribeSourceRegionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSourceRegionsError {
@@ -20335,6 +20632,11 @@ impl From<CredentialsError> for DownloadDBLogFilePortionError {
 impl From<HttpDispatchError> for DownloadDBLogFilePortionError {
     fn from(err: HttpDispatchError) -> DownloadDBLogFilePortionError {
         DownloadDBLogFilePortionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DownloadDBLogFilePortionError {
+    fn from(err: io::Error) -> DownloadDBLogFilePortionError {
+        DownloadDBLogFilePortionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DownloadDBLogFilePortionError {
@@ -20412,6 +20714,11 @@ impl From<HttpDispatchError> for FailoverDBClusterError {
         FailoverDBClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for FailoverDBClusterError {
+    fn from(err: io::Error) -> FailoverDBClusterError {
+        FailoverDBClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for FailoverDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20486,6 +20793,11 @@ impl From<CredentialsError> for ListTagsForResourceError {
 impl From<HttpDispatchError> for ListTagsForResourceError {
     fn from(err: HttpDispatchError) -> ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForResourceError {
@@ -20590,6 +20902,11 @@ impl From<HttpDispatchError> for ModifyDBClusterError {
         ModifyDBClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyDBClusterError {
+    fn from(err: io::Error) -> ModifyDBClusterError {
+        ModifyDBClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20669,6 +20986,11 @@ impl From<HttpDispatchError> for ModifyDBClusterParameterGroupError {
         ModifyDBClusterParameterGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyDBClusterParameterGroupError {
+    fn from(err: io::Error) -> ModifyDBClusterParameterGroupError {
+        ModifyDBClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20744,6 +21066,11 @@ impl From<CredentialsError> for ModifyDBClusterSnapshotAttributeError {
 impl From<HttpDispatchError> for ModifyDBClusterSnapshotAttributeError {
     fn from(err: HttpDispatchError) -> ModifyDBClusterSnapshotAttributeError {
         ModifyDBClusterSnapshotAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyDBClusterSnapshotAttributeError {
+    fn from(err: io::Error) -> ModifyDBClusterSnapshotAttributeError {
+        ModifyDBClusterSnapshotAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyDBClusterSnapshotAttributeError {
@@ -20865,6 +21192,11 @@ impl From<HttpDispatchError> for ModifyDBInstanceError {
         ModifyDBInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyDBInstanceError {
+    fn from(err: io::Error) -> ModifyDBInstanceError {
+        ModifyDBInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -20949,6 +21281,11 @@ impl From<HttpDispatchError> for ModifyDBParameterGroupError {
         ModifyDBParameterGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyDBParameterGroupError {
+    fn from(err: io::Error) -> ModifyDBParameterGroupError {
+        ModifyDBParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21016,6 +21353,11 @@ impl From<CredentialsError> for ModifyDBSnapshotError {
 impl From<HttpDispatchError> for ModifyDBSnapshotError {
     fn from(err: HttpDispatchError) -> ModifyDBSnapshotError {
         ModifyDBSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyDBSnapshotError {
+    fn from(err: io::Error) -> ModifyDBSnapshotError {
+        ModifyDBSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyDBSnapshotError {
@@ -21088,6 +21430,11 @@ impl From<CredentialsError> for ModifyDBSnapshotAttributeError {
 impl From<HttpDispatchError> for ModifyDBSnapshotAttributeError {
     fn from(err: HttpDispatchError) -> ModifyDBSnapshotAttributeError {
         ModifyDBSnapshotAttributeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyDBSnapshotAttributeError {
+    fn from(err: io::Error) -> ModifyDBSnapshotAttributeError {
+        ModifyDBSnapshotAttributeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyDBSnapshotAttributeError {
@@ -21172,6 +21519,11 @@ impl From<CredentialsError> for ModifyDBSubnetGroupError {
 impl From<HttpDispatchError> for ModifyDBSubnetGroupError {
     fn from(err: HttpDispatchError) -> ModifyDBSubnetGroupError {
         ModifyDBSubnetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyDBSubnetGroupError {
+    fn from(err: io::Error) -> ModifyDBSubnetGroupError {
+        ModifyDBSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyDBSubnetGroupError {
@@ -21261,6 +21613,11 @@ impl From<HttpDispatchError> for ModifyEventSubscriptionError {
         ModifyEventSubscriptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyEventSubscriptionError {
+    fn from(err: io::Error) -> ModifyEventSubscriptionError {
+        ModifyEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21337,6 +21694,11 @@ impl From<HttpDispatchError> for ModifyOptionGroupError {
         ModifyOptionGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyOptionGroupError {
+    fn from(err: io::Error) -> ModifyOptionGroupError {
+        ModifyOptionGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyOptionGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21409,6 +21771,11 @@ impl From<HttpDispatchError> for PromoteReadReplicaError {
         PromoteReadReplicaError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PromoteReadReplicaError {
+    fn from(err: io::Error) -> PromoteReadReplicaError {
+        PromoteReadReplicaError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PromoteReadReplicaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21479,6 +21846,11 @@ impl From<CredentialsError> for PromoteReadReplicaDBClusterError {
 impl From<HttpDispatchError> for PromoteReadReplicaDBClusterError {
     fn from(err: HttpDispatchError) -> PromoteReadReplicaDBClusterError {
         PromoteReadReplicaDBClusterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PromoteReadReplicaDBClusterError {
+    fn from(err: io::Error) -> PromoteReadReplicaDBClusterError {
+        PromoteReadReplicaDBClusterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PromoteReadReplicaDBClusterError {
@@ -21556,6 +21928,11 @@ impl From<HttpDispatchError> for PurchaseReservedDBInstancesOfferingError {
         PurchaseReservedDBInstancesOfferingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PurchaseReservedDBInstancesOfferingError {
+    fn from(err: io::Error) -> PurchaseReservedDBInstancesOfferingError {
+        PurchaseReservedDBInstancesOfferingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PurchaseReservedDBInstancesOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21627,6 +22004,11 @@ impl From<CredentialsError> for RebootDBInstanceError {
 impl From<HttpDispatchError> for RebootDBInstanceError {
     fn from(err: HttpDispatchError) -> RebootDBInstanceError {
         RebootDBInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RebootDBInstanceError {
+    fn from(err: io::Error) -> RebootDBInstanceError {
+        RebootDBInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RebootDBInstanceError {
@@ -21702,6 +22084,11 @@ impl From<HttpDispatchError> for RemoveRoleFromDBClusterError {
         RemoveRoleFromDBClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveRoleFromDBClusterError {
+    fn from(err: io::Error) -> RemoveRoleFromDBClusterError {
+        RemoveRoleFromDBClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveRoleFromDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21773,6 +22160,11 @@ impl From<CredentialsError> for RemoveSourceIdentifierFromSubscriptionError {
 impl From<HttpDispatchError> for RemoveSourceIdentifierFromSubscriptionError {
     fn from(err: HttpDispatchError) -> RemoveSourceIdentifierFromSubscriptionError {
         RemoveSourceIdentifierFromSubscriptionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveSourceIdentifierFromSubscriptionError {
+    fn from(err: io::Error) -> RemoveSourceIdentifierFromSubscriptionError {
+        RemoveSourceIdentifierFromSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveSourceIdentifierFromSubscriptionError {
@@ -21852,6 +22244,11 @@ impl From<HttpDispatchError> for RemoveTagsFromResourceError {
         RemoveTagsFromResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemoveTagsFromResourceError {
+    fn from(err: io::Error) -> RemoveTagsFromResourceError {
+        RemoveTagsFromResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -21923,6 +22320,11 @@ impl From<CredentialsError> for ResetDBClusterParameterGroupError {
 impl From<HttpDispatchError> for ResetDBClusterParameterGroupError {
     fn from(err: HttpDispatchError) -> ResetDBClusterParameterGroupError {
         ResetDBClusterParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResetDBClusterParameterGroupError {
+    fn from(err: io::Error) -> ResetDBClusterParameterGroupError {
+        ResetDBClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResetDBClusterParameterGroupError {
@@ -21997,6 +22399,11 @@ impl From<CredentialsError> for ResetDBParameterGroupError {
 impl From<HttpDispatchError> for ResetDBParameterGroupError {
     fn from(err: HttpDispatchError) -> ResetDBParameterGroupError {
         ResetDBParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResetDBParameterGroupError {
+    fn from(err: io::Error) -> ResetDBParameterGroupError {
+        ResetDBParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResetDBParameterGroupError {
@@ -22102,6 +22509,11 @@ impl From<CredentialsError> for RestoreDBClusterFromS3Error {
 impl From<HttpDispatchError> for RestoreDBClusterFromS3Error {
     fn from(err: HttpDispatchError) -> RestoreDBClusterFromS3Error {
         RestoreDBClusterFromS3Error::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RestoreDBClusterFromS3Error {
+    fn from(err: io::Error) -> RestoreDBClusterFromS3Error {
+        RestoreDBClusterFromS3Error::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RestoreDBClusterFromS3Error {
@@ -22226,6 +22638,11 @@ impl From<CredentialsError> for RestoreDBClusterFromSnapshotError {
 impl From<HttpDispatchError> for RestoreDBClusterFromSnapshotError {
     fn from(err: HttpDispatchError) -> RestoreDBClusterFromSnapshotError {
         RestoreDBClusterFromSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RestoreDBClusterFromSnapshotError {
+    fn from(err: io::Error) -> RestoreDBClusterFromSnapshotError {
+        RestoreDBClusterFromSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RestoreDBClusterFromSnapshotError {
@@ -22357,6 +22774,11 @@ impl From<CredentialsError> for RestoreDBClusterToPointInTimeError {
 impl From<HttpDispatchError> for RestoreDBClusterToPointInTimeError {
     fn from(err: HttpDispatchError) -> RestoreDBClusterToPointInTimeError {
         RestoreDBClusterToPointInTimeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RestoreDBClusterToPointInTimeError {
+    fn from(err: io::Error) -> RestoreDBClusterToPointInTimeError {
+        RestoreDBClusterToPointInTimeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RestoreDBClusterToPointInTimeError {
@@ -22495,6 +22917,11 @@ impl From<CredentialsError> for RestoreDBInstanceFromDBSnapshotError {
 impl From<HttpDispatchError> for RestoreDBInstanceFromDBSnapshotError {
     fn from(err: HttpDispatchError) -> RestoreDBInstanceFromDBSnapshotError {
         RestoreDBInstanceFromDBSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RestoreDBInstanceFromDBSnapshotError {
+    fn from(err: io::Error) -> RestoreDBInstanceFromDBSnapshotError {
+        RestoreDBInstanceFromDBSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RestoreDBInstanceFromDBSnapshotError {
@@ -22638,6 +23065,11 @@ impl From<HttpDispatchError> for RestoreDBInstanceToPointInTimeError {
         RestoreDBInstanceToPointInTimeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RestoreDBInstanceToPointInTimeError {
+    fn from(err: io::Error) -> RestoreDBInstanceToPointInTimeError {
+        RestoreDBInstanceToPointInTimeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RestoreDBInstanceToPointInTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -22734,6 +23166,11 @@ impl From<CredentialsError> for RevokeDBSecurityGroupIngressError {
 impl From<HttpDispatchError> for RevokeDBSecurityGroupIngressError {
     fn from(err: HttpDispatchError) -> RevokeDBSecurityGroupIngressError {
         RevokeDBSecurityGroupIngressError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RevokeDBSecurityGroupIngressError {
+    fn from(err: io::Error) -> RevokeDBSecurityGroupIngressError {
+        RevokeDBSecurityGroupIngressError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RevokeDBSecurityGroupIngressError {
@@ -22838,6 +23275,11 @@ impl From<HttpDispatchError> for StartDBInstanceError {
         StartDBInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartDBInstanceError {
+    fn from(err: io::Error) -> StartDBInstanceError {
+        StartDBInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -22924,6 +23366,11 @@ impl From<CredentialsError> for StopDBInstanceError {
 impl From<HttpDispatchError> for StopDBInstanceError {
     fn from(err: HttpDispatchError) -> StopDBInstanceError {
         StopDBInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopDBInstanceError {
+    fn from(err: io::Error) -> StopDBInstanceError {
+        StopDBInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopDBInstanceError {
@@ -23565,15 +24012,16 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AddRoleToDBClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddRoleToDBClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23593,16 +24041,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AddSourceIdentifierToSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23616,8 +24066,10 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AddSourceIdentifierToSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddSourceIdentifierToSubscriptionError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -23635,15 +24087,16 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23663,16 +24116,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ApplyPendingMaintenanceActionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23686,8 +24141,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ApplyPendingMaintenanceActionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ApplyPendingMaintenanceActionError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -23706,16 +24164,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AuthorizeDBSecurityGroupIngressResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23729,8 +24189,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AuthorizeDBSecurityGroupIngressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AuthorizeDBSecurityGroupIngressError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -23749,16 +24212,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopyDBClusterParameterGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23772,8 +24237,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CopyDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopyDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -23792,16 +24260,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopyDBClusterSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23816,8 +24286,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CopyDBClusterSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopyDBClusterSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23836,16 +24307,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopyDBParameterGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23860,8 +24333,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CopyDBParameterGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopyDBParameterGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23880,16 +24354,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopyDBSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23904,8 +24380,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CopyDBSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopyDBSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23924,16 +24401,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopyOptionGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23948,8 +24427,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CopyOptionGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopyOptionGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -23968,16 +24448,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -23992,8 +24474,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDBClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24013,16 +24496,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBClusterParameterGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24036,8 +24521,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -24056,16 +24544,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBClusterSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24081,8 +24571,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateDBClusterSnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBClusterSnapshotError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -24100,16 +24593,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24124,8 +24619,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDBInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24145,16 +24641,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBInstanceReadReplicaResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24168,8 +24666,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateDBInstanceReadReplicaError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBInstanceReadReplicaError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -24188,16 +24689,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBParameterGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24213,8 +24716,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDBParameterGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBParameterGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24234,16 +24738,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBSecurityGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24258,8 +24764,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDBSecurityGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBSecurityGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24278,16 +24785,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24302,8 +24811,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDBSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24322,16 +24832,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateDBSubnetGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24346,8 +24858,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateDBSubnetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDBSubnetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24367,16 +24880,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateEventSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24392,8 +24907,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -24411,16 +24929,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateOptionGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24435,8 +24955,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateOptionGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateOptionGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24455,16 +24976,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteDBClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24479,8 +25002,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteDBClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDBClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24499,15 +25023,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -24526,16 +25053,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteDBClusterSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24551,8 +25080,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DeleteDBClusterSnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDBClusterSnapshotError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -24570,16 +25102,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteDBInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24594,8 +25128,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteDBInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDBInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24614,15 +25149,16 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteDBParameterGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDBParameterGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24641,15 +25177,16 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteDBSecurityGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDBSecurityGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24668,16 +25205,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteDBSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24692,8 +25231,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteDBSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDBSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24712,15 +25252,16 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteDBSubnetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDBSubnetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24740,16 +25281,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteEventSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24765,8 +25308,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DeleteEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -24784,15 +25330,16 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteOptionGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteOptionGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24812,16 +25359,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AccountAttributesMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24836,8 +25385,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -24855,16 +25407,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CertificateMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24879,8 +25433,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeCertificatesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCertificatesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -24900,16 +25455,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBClusterParameterGroupsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24925,8 +25482,10 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDBClusterParameterGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBClusterParameterGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -24945,16 +25504,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBClusterParameterGroupDetails::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -24970,8 +25531,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDBClusterParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBClusterParametersError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -24991,16 +25555,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeDBClusterSnapshotAttributesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25014,8 +25580,10 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDBClusterSnapshotAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBClusterSnapshotAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25034,16 +25602,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBClusterSnapshotMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25058,8 +25628,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDBClusterSnapshotsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBClusterSnapshotsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -25077,16 +25650,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBClusterMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25101,8 +25676,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeDBClustersError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBClustersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25122,16 +25698,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBEngineVersionMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25146,8 +25724,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDBEngineVersionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBEngineVersionsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -25165,16 +25746,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBInstanceMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25189,8 +25772,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeDBInstancesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBInstancesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25209,16 +25793,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeDBLogFilesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25233,8 +25819,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeDBLogFilesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBLogFilesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25254,16 +25841,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBParameterGroupsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25278,8 +25867,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDBParameterGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBParameterGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -25297,16 +25889,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBParameterGroupDetails::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25321,8 +25915,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeDBParametersError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBParametersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25342,16 +25937,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBSecurityGroupMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25366,8 +25963,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDBSecurityGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBSecurityGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -25386,16 +25986,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeDBSnapshotAttributesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25409,8 +26011,11 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDBSnapshotAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBSnapshotAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -25428,16 +26033,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBSnapshotMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25452,8 +26059,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeDBSnapshotsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBSnapshotsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25472,16 +26080,18 @@ impl<P, D> Rds for RdsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBSubnetGroupMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25496,8 +26106,9 @@ impl<P, D> Rds for RdsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeDBSubnetGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDBSubnetGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25514,16 +26125,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeEngineDefaultClusterParametersResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25537,8 +26150,10 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEngineDefaultClusterParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEngineDefaultClusterParametersError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25557,16 +26172,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeEngineDefaultParametersResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25580,8 +26197,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEngineDefaultParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEngineDefaultParametersError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -25600,16 +26220,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EventCategoriesMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25624,8 +26246,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEventCategoriesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventCategoriesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -25644,16 +26269,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EventSubscriptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25668,8 +26295,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEventSubscriptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventSubscriptionsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -25687,16 +26317,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EventsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25711,8 +26343,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25732,16 +26365,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = OptionGroupOptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25756,8 +26391,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribeOptionGroupOptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeOptionGroupOptionsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -25775,16 +26413,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = OptionGroups::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25799,8 +26439,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(DescribeOptionGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeOptionGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -25820,16 +26461,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = OrderableDBInstanceOptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25843,8 +26486,10 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribeOrderableDBInstanceOptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeOrderableDBInstanceOptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25863,16 +26508,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PendingMaintenanceActionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25888,8 +26535,10 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribePendingMaintenanceActionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePendingMaintenanceActionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25908,16 +26557,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReservedDBInstanceMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25932,8 +26583,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedDBInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedDBInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -25952,16 +26606,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReservedDBInstancesOfferingMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -25975,8 +26631,10 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedDBInstancesOfferingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedDBInstancesOfferingsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -25994,16 +26652,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SourceRegionMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26018,8 +26678,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(DescribeSourceRegionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSourceRegionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26039,16 +26700,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DownloadDBLogFilePortionDetails::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26064,8 +26727,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(DownloadDBLogFilePortionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DownloadDBLogFilePortionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -26083,16 +26749,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = FailoverDBClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26107,8 +26775,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(FailoverDBClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(FailoverDBClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26127,16 +26796,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TagListMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26151,8 +26822,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26171,16 +26843,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyDBClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26195,8 +26869,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(ModifyDBClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDBClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26216,16 +26891,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBClusterParameterGroupNameMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26239,8 +26916,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(ModifyDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -26259,16 +26939,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyDBClusterSnapshotAttributeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26282,8 +26964,10 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(ModifyDBClusterSnapshotAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDBClusterSnapshotAttributeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -26301,16 +26985,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyDBInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26325,8 +27011,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(ModifyDBInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDBInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26346,16 +27033,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBParameterGroupNameMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26370,8 +27059,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(ModifyDBParameterGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDBParameterGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26390,16 +27080,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyDBSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26414,8 +27106,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(ModifyDBSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDBSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26435,16 +27128,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyDBSnapshotAttributeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26460,8 +27155,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(ModifyDBSnapshotAttributeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDBSnapshotAttributeError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -26479,16 +27177,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyDBSubnetGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26503,8 +27203,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(ModifyDBSubnetGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDBSubnetGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26524,16 +27225,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyEventSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26549,8 +27252,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(ModifyEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -26568,16 +27274,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyOptionGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26592,8 +27300,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(ModifyOptionGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyOptionGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26612,16 +27321,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PromoteReadReplicaResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26636,8 +27347,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(PromoteReadReplicaError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PromoteReadReplicaError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26657,16 +27369,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PromoteReadReplicaDBClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26680,8 +27394,11 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(PromoteReadReplicaDBClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PromoteReadReplicaDBClusterError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -26701,16 +27418,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PurchaseReservedDBInstancesOfferingResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26724,8 +27443,10 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                            Err(PurchaseReservedDBInstancesOfferingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurchaseReservedDBInstancesOfferingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -26743,16 +27464,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RebootDBInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26767,8 +27490,9 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
                 Ok(result)
             }
             _ => {
-                Err(RebootDBInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebootDBInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26787,15 +27511,18 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(RemoveRoleFromDBClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveRoleFromDBClusterError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -26811,16 +27538,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RemoveSourceIdentifierFromSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26834,8 +27563,10 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                            Err(RemoveSourceIdentifierFromSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveSourceIdentifierFromSubscriptionError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -26853,15 +27584,16 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26881,16 +27613,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBClusterParameterGroupNameMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26904,8 +27638,11 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                            Err(ResetDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetDBClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -26924,16 +27661,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DBParameterGroupNameMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26948,8 +27687,9 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                Err(ResetDBParameterGroupError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetDBParameterGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -26969,16 +27709,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreDBClusterFromS3Result::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -26994,8 +27736,9 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                Err(RestoreDBClusterFromS3Error::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreDBClusterFromS3Error::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -27015,16 +27758,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreDBClusterFromSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -27038,8 +27783,11 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                            Err(RestoreDBClusterFromSnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreDBClusterFromSnapshotError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -27058,16 +27806,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreDBClusterToPointInTimeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -27081,8 +27831,11 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                            Err(RestoreDBClusterToPointInTimeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreDBClusterToPointInTimeError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -27101,16 +27854,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreDBInstanceFromDBSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -27124,8 +27879,11 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                            Err(RestoreDBInstanceFromDBSnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreDBInstanceFromDBSnapshotError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -27144,16 +27902,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreDBInstanceToPointInTimeResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -27167,8 +27927,11 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                            Err(RestoreDBInstanceToPointInTimeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreDBInstanceToPointInTimeError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -27187,16 +27950,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RevokeDBSecurityGroupIngressResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -27210,8 +27975,11 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                            Err(RevokeDBSecurityGroupIngressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RevokeDBSecurityGroupIngressError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -27229,16 +27997,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = StartDBInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -27253,8 +28023,9 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                Err(StartDBInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartDBInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -27273,16 +28044,18 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = StopDBInstanceResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -27297,8 +28070,9 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
                 Ok(result)
             }
             _ => {
-                Err(StopDBInstanceError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopDBInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -10498,6 +10500,11 @@ impl From<HttpDispatchError> for AuthorizeClusterSecurityGroupIngressError {
         AuthorizeClusterSecurityGroupIngressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AuthorizeClusterSecurityGroupIngressError {
+    fn from(err: io::Error) -> AuthorizeClusterSecurityGroupIngressError {
+        AuthorizeClusterSecurityGroupIngressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AuthorizeClusterSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10584,6 +10591,11 @@ impl From<HttpDispatchError> for AuthorizeSnapshotAccessError {
         AuthorizeSnapshotAccessError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AuthorizeSnapshotAccessError {
+    fn from(err: io::Error) -> AuthorizeSnapshotAccessError {
+        AuthorizeSnapshotAccessError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AuthorizeSnapshotAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10666,6 +10678,11 @@ impl From<CredentialsError> for CopyClusterSnapshotError {
 impl From<HttpDispatchError> for CopyClusterSnapshotError {
     fn from(err: HttpDispatchError) -> CopyClusterSnapshotError {
         CopyClusterSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CopyClusterSnapshotError {
+    fn from(err: io::Error) -> CopyClusterSnapshotError {
+        CopyClusterSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CopyClusterSnapshotError {
@@ -10799,6 +10816,11 @@ impl From<HttpDispatchError> for CreateClusterError {
         CreateClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateClusterError {
+    fn from(err: io::Error) -> CreateClusterError {
+        CreateClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10892,6 +10914,11 @@ impl From<HttpDispatchError> for CreateClusterParameterGroupError {
         CreateClusterParameterGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateClusterParameterGroupError {
+    fn from(err: io::Error) -> CreateClusterParameterGroupError {
+        CreateClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10970,6 +10997,11 @@ impl From<CredentialsError> for CreateClusterSecurityGroupError {
 impl From<HttpDispatchError> for CreateClusterSecurityGroupError {
     fn from(err: HttpDispatchError) -> CreateClusterSecurityGroupError {
         CreateClusterSecurityGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateClusterSecurityGroupError {
+    fn from(err: io::Error) -> CreateClusterSecurityGroupError {
+        CreateClusterSecurityGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateClusterSecurityGroupError {
@@ -11060,6 +11092,11 @@ impl From<CredentialsError> for CreateClusterSnapshotError {
 impl From<HttpDispatchError> for CreateClusterSnapshotError {
     fn from(err: HttpDispatchError) -> CreateClusterSnapshotError {
         CreateClusterSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateClusterSnapshotError {
+    fn from(err: io::Error) -> CreateClusterSnapshotError {
+        CreateClusterSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateClusterSnapshotError {
@@ -11154,6 +11191,11 @@ impl From<CredentialsError> for CreateClusterSubnetGroupError {
 impl From<HttpDispatchError> for CreateClusterSubnetGroupError {
     fn from(err: HttpDispatchError) -> CreateClusterSubnetGroupError {
         CreateClusterSubnetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateClusterSubnetGroupError {
+    fn from(err: io::Error) -> CreateClusterSubnetGroupError {
+        CreateClusterSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateClusterSubnetGroupError {
@@ -11263,6 +11305,11 @@ impl From<HttpDispatchError> for CreateEventSubscriptionError {
         CreateEventSubscriptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateEventSubscriptionError {
+    fn from(err: io::Error) -> CreateEventSubscriptionError {
+        CreateEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11350,6 +11397,11 @@ impl From<HttpDispatchError> for CreateHsmClientCertificateError {
         CreateHsmClientCertificateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateHsmClientCertificateError {
+    fn from(err: io::Error) -> CreateHsmClientCertificateError {
+        CreateHsmClientCertificateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateHsmClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11432,6 +11484,11 @@ impl From<CredentialsError> for CreateHsmConfigurationError {
 impl From<HttpDispatchError> for CreateHsmConfigurationError {
     fn from(err: HttpDispatchError) -> CreateHsmConfigurationError {
         CreateHsmConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateHsmConfigurationError {
+    fn from(err: io::Error) -> CreateHsmConfigurationError {
+        CreateHsmConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateHsmConfigurationError {
@@ -11518,6 +11575,11 @@ impl From<CredentialsError> for CreateSnapshotCopyGrantError {
 impl From<HttpDispatchError> for CreateSnapshotCopyGrantError {
     fn from(err: HttpDispatchError) -> CreateSnapshotCopyGrantError {
         CreateSnapshotCopyGrantError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateSnapshotCopyGrantError {
+    fn from(err: io::Error) -> CreateSnapshotCopyGrantError {
+        CreateSnapshotCopyGrantError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateSnapshotCopyGrantError {
@@ -11607,6 +11669,11 @@ impl From<HttpDispatchError> for CreateTagsError {
         CreateTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTagsError {
+    fn from(err: io::Error) -> CreateTagsError {
+        CreateTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11686,6 +11753,11 @@ impl From<HttpDispatchError> for DeleteClusterError {
         DeleteClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteClusterError {
+    fn from(err: io::Error) -> DeleteClusterError {
+        DeleteClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11756,6 +11828,11 @@ impl From<CredentialsError> for DeleteClusterParameterGroupError {
 impl From<HttpDispatchError> for DeleteClusterParameterGroupError {
     fn from(err: HttpDispatchError) -> DeleteClusterParameterGroupError {
         DeleteClusterParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteClusterParameterGroupError {
+    fn from(err: io::Error) -> DeleteClusterParameterGroupError {
+        DeleteClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteClusterParameterGroupError {
@@ -11834,6 +11911,11 @@ impl From<HttpDispatchError> for DeleteClusterSecurityGroupError {
         DeleteClusterSecurityGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteClusterSecurityGroupError {
+    fn from(err: io::Error) -> DeleteClusterSecurityGroupError {
+        DeleteClusterSecurityGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteClusterSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11906,6 +11988,11 @@ impl From<CredentialsError> for DeleteClusterSnapshotError {
 impl From<HttpDispatchError> for DeleteClusterSnapshotError {
     fn from(err: HttpDispatchError) -> DeleteClusterSnapshotError {
         DeleteClusterSnapshotError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteClusterSnapshotError {
+    fn from(err: io::Error) -> DeleteClusterSnapshotError {
+        DeleteClusterSnapshotError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteClusterSnapshotError {
@@ -11983,6 +12070,11 @@ impl From<HttpDispatchError> for DeleteClusterSubnetGroupError {
         DeleteClusterSubnetGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteClusterSubnetGroupError {
+    fn from(err: io::Error) -> DeleteClusterSubnetGroupError {
+        DeleteClusterSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteClusterSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12056,6 +12148,11 @@ impl From<HttpDispatchError> for DeleteEventSubscriptionError {
         DeleteEventSubscriptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteEventSubscriptionError {
+    fn from(err: io::Error) -> DeleteEventSubscriptionError {
+        DeleteEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12126,6 +12223,11 @@ impl From<CredentialsError> for DeleteHsmClientCertificateError {
 impl From<HttpDispatchError> for DeleteHsmClientCertificateError {
     fn from(err: HttpDispatchError) -> DeleteHsmClientCertificateError {
         DeleteHsmClientCertificateError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteHsmClientCertificateError {
+    fn from(err: io::Error) -> DeleteHsmClientCertificateError {
+        DeleteHsmClientCertificateError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteHsmClientCertificateError {
@@ -12202,6 +12304,11 @@ impl From<HttpDispatchError> for DeleteHsmConfigurationError {
         DeleteHsmConfigurationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteHsmConfigurationError {
+    fn from(err: io::Error) -> DeleteHsmConfigurationError {
+        DeleteHsmConfigurationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteHsmConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12272,6 +12379,11 @@ impl From<CredentialsError> for DeleteSnapshotCopyGrantError {
 impl From<HttpDispatchError> for DeleteSnapshotCopyGrantError {
     fn from(err: HttpDispatchError) -> DeleteSnapshotCopyGrantError {
         DeleteSnapshotCopyGrantError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSnapshotCopyGrantError {
+    fn from(err: io::Error) -> DeleteSnapshotCopyGrantError {
+        DeleteSnapshotCopyGrantError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSnapshotCopyGrantError {
@@ -12350,6 +12462,11 @@ impl From<HttpDispatchError> for DeleteTagsError {
         DeleteTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTagsError {
+    fn from(err: io::Error) -> DeleteTagsError {
+        DeleteTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12418,6 +12535,11 @@ impl From<CredentialsError> for DescribeClusterParameterGroupsError {
 impl From<HttpDispatchError> for DescribeClusterParameterGroupsError {
     fn from(err: HttpDispatchError) -> DescribeClusterParameterGroupsError {
         DescribeClusterParameterGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeClusterParameterGroupsError {
+    fn from(err: io::Error) -> DescribeClusterParameterGroupsError {
+        DescribeClusterParameterGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeClusterParameterGroupsError {
@@ -12491,6 +12613,11 @@ impl From<HttpDispatchError> for DescribeClusterParametersError {
         DescribeClusterParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeClusterParametersError {
+    fn from(err: io::Error) -> DescribeClusterParametersError {
+        DescribeClusterParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12560,6 +12687,11 @@ impl From<CredentialsError> for DescribeClusterSecurityGroupsError {
 impl From<HttpDispatchError> for DescribeClusterSecurityGroupsError {
     fn from(err: HttpDispatchError) -> DescribeClusterSecurityGroupsError {
         DescribeClusterSecurityGroupsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeClusterSecurityGroupsError {
+    fn from(err: io::Error) -> DescribeClusterSecurityGroupsError {
+        DescribeClusterSecurityGroupsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeClusterSecurityGroupsError {
@@ -12636,6 +12768,11 @@ impl From<HttpDispatchError> for DescribeClusterSnapshotsError {
         DescribeClusterSnapshotsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeClusterSnapshotsError {
+    fn from(err: io::Error) -> DescribeClusterSnapshotsError {
+        DescribeClusterSnapshotsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeClusterSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12708,6 +12845,11 @@ impl From<HttpDispatchError> for DescribeClusterSubnetGroupsError {
         DescribeClusterSubnetGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeClusterSubnetGroupsError {
+    fn from(err: io::Error) -> DescribeClusterSubnetGroupsError {
+        DescribeClusterSubnetGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeClusterSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12772,6 +12914,11 @@ impl From<CredentialsError> for DescribeClusterVersionsError {
 impl From<HttpDispatchError> for DescribeClusterVersionsError {
     fn from(err: HttpDispatchError) -> DescribeClusterVersionsError {
         DescribeClusterVersionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeClusterVersionsError {
+    fn from(err: io::Error) -> DescribeClusterVersionsError {
+        DescribeClusterVersionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeClusterVersionsError {
@@ -12846,6 +12993,11 @@ impl From<HttpDispatchError> for DescribeClustersError {
         DescribeClustersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeClustersError {
+    fn from(err: io::Error) -> DescribeClustersError {
+        DescribeClustersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12910,6 +13062,11 @@ impl From<HttpDispatchError> for DescribeDefaultClusterParametersError {
         DescribeDefaultClusterParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDefaultClusterParametersError {
+    fn from(err: io::Error) -> DescribeDefaultClusterParametersError {
+        DescribeDefaultClusterParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDefaultClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12972,6 +13129,11 @@ impl From<CredentialsError> for DescribeEventCategoriesError {
 impl From<HttpDispatchError> for DescribeEventCategoriesError {
     fn from(err: HttpDispatchError) -> DescribeEventCategoriesError {
         DescribeEventCategoriesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventCategoriesError {
+    fn from(err: io::Error) -> DescribeEventCategoriesError {
+        DescribeEventCategoriesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventCategoriesError {
@@ -13041,6 +13203,11 @@ impl From<HttpDispatchError> for DescribeEventSubscriptionsError {
         DescribeEventSubscriptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEventSubscriptionsError {
+    fn from(err: io::Error) -> DescribeEventSubscriptionsError {
+        DescribeEventSubscriptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13104,6 +13271,11 @@ impl From<CredentialsError> for DescribeEventsError {
 impl From<HttpDispatchError> for DescribeEventsError {
     fn from(err: HttpDispatchError) -> DescribeEventsError {
         DescribeEventsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEventsError {
+    fn from(err: io::Error) -> DescribeEventsError {
+        DescribeEventsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEventsError {
@@ -13172,6 +13344,11 @@ impl From<CredentialsError> for DescribeHsmClientCertificatesError {
 impl From<HttpDispatchError> for DescribeHsmClientCertificatesError {
     fn from(err: HttpDispatchError) -> DescribeHsmClientCertificatesError {
         DescribeHsmClientCertificatesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeHsmClientCertificatesError {
+    fn from(err: io::Error) -> DescribeHsmClientCertificatesError {
+        DescribeHsmClientCertificatesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeHsmClientCertificatesError {
@@ -13248,6 +13425,11 @@ impl From<HttpDispatchError> for DescribeHsmConfigurationsError {
         DescribeHsmConfigurationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeHsmConfigurationsError {
+    fn from(err: io::Error) -> DescribeHsmConfigurationsError {
+        DescribeHsmConfigurationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeHsmConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13317,6 +13499,11 @@ impl From<HttpDispatchError> for DescribeLoggingStatusError {
         DescribeLoggingStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeLoggingStatusError {
+    fn from(err: io::Error) -> DescribeLoggingStatusError {
+        DescribeLoggingStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeLoggingStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13380,6 +13567,11 @@ impl From<CredentialsError> for DescribeOrderableClusterOptionsError {
 impl From<HttpDispatchError> for DescribeOrderableClusterOptionsError {
     fn from(err: HttpDispatchError) -> DescribeOrderableClusterOptionsError {
         DescribeOrderableClusterOptionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeOrderableClusterOptionsError {
+    fn from(err: io::Error) -> DescribeOrderableClusterOptionsError {
+        DescribeOrderableClusterOptionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeOrderableClusterOptionsError {
@@ -13453,6 +13645,11 @@ impl From<CredentialsError> for DescribeReservedNodeOfferingsError {
 impl From<HttpDispatchError> for DescribeReservedNodeOfferingsError {
     fn from(err: HttpDispatchError) -> DescribeReservedNodeOfferingsError {
         DescribeReservedNodeOfferingsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeReservedNodeOfferingsError {
+    fn from(err: io::Error) -> DescribeReservedNodeOfferingsError {
+        DescribeReservedNodeOfferingsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeReservedNodeOfferingsError {
@@ -13532,6 +13729,11 @@ impl From<HttpDispatchError> for DescribeReservedNodesError {
         DescribeReservedNodesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReservedNodesError {
+    fn from(err: io::Error) -> DescribeReservedNodesError {
+        DescribeReservedNodesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReservedNodesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13606,6 +13808,11 @@ impl From<HttpDispatchError> for DescribeResizeError {
         DescribeResizeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeResizeError {
+    fn from(err: io::Error) -> DescribeResizeError {
+        DescribeResizeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeResizeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13674,6 +13881,11 @@ impl From<CredentialsError> for DescribeSnapshotCopyGrantsError {
 impl From<HttpDispatchError> for DescribeSnapshotCopyGrantsError {
     fn from(err: HttpDispatchError) -> DescribeSnapshotCopyGrantsError {
         DescribeSnapshotCopyGrantsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSnapshotCopyGrantsError {
+    fn from(err: io::Error) -> DescribeSnapshotCopyGrantsError {
+        DescribeSnapshotCopyGrantsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSnapshotCopyGrantsError {
@@ -13746,6 +13958,11 @@ impl From<CredentialsError> for DescribeTableRestoreStatusError {
 impl From<HttpDispatchError> for DescribeTableRestoreStatusError {
     fn from(err: HttpDispatchError) -> DescribeTableRestoreStatusError {
         DescribeTableRestoreStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTableRestoreStatusError {
+    fn from(err: io::Error) -> DescribeTableRestoreStatusError {
+        DescribeTableRestoreStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTableRestoreStatusError {
@@ -13824,6 +14041,11 @@ impl From<HttpDispatchError> for DescribeTagsError {
         DescribeTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTagsError {
+    fn from(err: io::Error) -> DescribeTagsError {
+        DescribeTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13889,6 +14111,11 @@ impl From<CredentialsError> for DisableLoggingError {
 impl From<HttpDispatchError> for DisableLoggingError {
     fn from(err: HttpDispatchError) -> DisableLoggingError {
         DisableLoggingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableLoggingError {
+    fn from(err: io::Error) -> DisableLoggingError {
+        DisableLoggingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableLoggingError {
@@ -13964,6 +14191,11 @@ impl From<CredentialsError> for DisableSnapshotCopyError {
 impl From<HttpDispatchError> for DisableSnapshotCopyError {
     fn from(err: HttpDispatchError) -> DisableSnapshotCopyError {
         DisableSnapshotCopyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableSnapshotCopyError {
+    fn from(err: io::Error) -> DisableSnapshotCopyError {
+        DisableSnapshotCopyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableSnapshotCopyError {
@@ -14051,6 +14283,11 @@ impl From<CredentialsError> for EnableLoggingError {
 impl From<HttpDispatchError> for EnableLoggingError {
     fn from(err: HttpDispatchError) -> EnableLoggingError {
         EnableLoggingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnableLoggingError {
+    fn from(err: io::Error) -> EnableLoggingError {
+        EnableLoggingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnableLoggingError {
@@ -14150,6 +14387,11 @@ impl From<HttpDispatchError> for EnableSnapshotCopyError {
         EnableSnapshotCopyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableSnapshotCopyError {
+    fn from(err: io::Error) -> EnableSnapshotCopyError {
+        EnableSnapshotCopyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableSnapshotCopyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14228,6 +14470,11 @@ impl From<CredentialsError> for GetClusterCredentialsError {
 impl From<HttpDispatchError> for GetClusterCredentialsError {
     fn from(err: HttpDispatchError) -> GetClusterCredentialsError {
         GetClusterCredentialsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetClusterCredentialsError {
+    fn from(err: io::Error) -> GetClusterCredentialsError {
+        GetClusterCredentialsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetClusterCredentialsError {
@@ -14348,6 +14595,11 @@ impl From<HttpDispatchError> for ModifyClusterError {
         ModifyClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyClusterError {
+    fn from(err: io::Error) -> ModifyClusterError {
+        ModifyClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14432,6 +14684,11 @@ impl From<HttpDispatchError> for ModifyClusterIamRolesError {
         ModifyClusterIamRolesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyClusterIamRolesError {
+    fn from(err: io::Error) -> ModifyClusterIamRolesError {
+        ModifyClusterIamRolesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyClusterIamRolesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14502,6 +14759,11 @@ impl From<CredentialsError> for ModifyClusterParameterGroupError {
 impl From<HttpDispatchError> for ModifyClusterParameterGroupError {
     fn from(err: HttpDispatchError) -> ModifyClusterParameterGroupError {
         ModifyClusterParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyClusterParameterGroupError {
+    fn from(err: io::Error) -> ModifyClusterParameterGroupError {
+        ModifyClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyClusterParameterGroupError {
@@ -14590,6 +14852,11 @@ impl From<CredentialsError> for ModifyClusterSubnetGroupError {
 impl From<HttpDispatchError> for ModifyClusterSubnetGroupError {
     fn from(err: HttpDispatchError) -> ModifyClusterSubnetGroupError {
         ModifyClusterSubnetGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyClusterSubnetGroupError {
+    fn from(err: io::Error) -> ModifyClusterSubnetGroupError {
+        ModifyClusterSubnetGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyClusterSubnetGroupError {
@@ -14691,6 +14958,11 @@ impl From<HttpDispatchError> for ModifyEventSubscriptionError {
         ModifyEventSubscriptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyEventSubscriptionError {
+    fn from(err: io::Error) -> ModifyEventSubscriptionError {
+        ModifyEventSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14776,6 +15048,11 @@ impl From<HttpDispatchError> for ModifySnapshotCopyRetentionPeriodError {
         ModifySnapshotCopyRetentionPeriodError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifySnapshotCopyRetentionPeriodError {
+    fn from(err: io::Error) -> ModifySnapshotCopyRetentionPeriodError {
+        ModifySnapshotCopyRetentionPeriodError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifySnapshotCopyRetentionPeriodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14856,6 +15133,11 @@ impl From<HttpDispatchError> for PurchaseReservedNodeOfferingError {
         PurchaseReservedNodeOfferingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PurchaseReservedNodeOfferingError {
+    fn from(err: io::Error) -> PurchaseReservedNodeOfferingError {
+        PurchaseReservedNodeOfferingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PurchaseReservedNodeOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14934,6 +15216,11 @@ impl From<HttpDispatchError> for RebootClusterError {
         RebootClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RebootClusterError {
+    fn from(err: io::Error) -> RebootClusterError {
+        RebootClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RebootClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15002,6 +15289,11 @@ impl From<CredentialsError> for ResetClusterParameterGroupError {
 impl From<HttpDispatchError> for ResetClusterParameterGroupError {
     fn from(err: HttpDispatchError) -> ResetClusterParameterGroupError {
         ResetClusterParameterGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResetClusterParameterGroupError {
+    fn from(err: io::Error) -> ResetClusterParameterGroupError {
+        ResetClusterParameterGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResetClusterParameterGroupError {
@@ -15135,6 +15427,11 @@ impl From<HttpDispatchError> for RestoreFromClusterSnapshotError {
         RestoreFromClusterSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RestoreFromClusterSnapshotError {
+    fn from(err: io::Error) -> RestoreFromClusterSnapshotError {
+        RestoreFromClusterSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RestoreFromClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15245,6 +15542,11 @@ impl From<HttpDispatchError> for RestoreTableFromClusterSnapshotError {
         RestoreTableFromClusterSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RestoreTableFromClusterSnapshotError {
+    fn from(err: io::Error) -> RestoreTableFromClusterSnapshotError {
+        RestoreTableFromClusterSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RestoreTableFromClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15329,6 +15631,11 @@ impl From<HttpDispatchError> for RevokeClusterSecurityGroupIngressError {
         RevokeClusterSecurityGroupIngressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RevokeClusterSecurityGroupIngressError {
+    fn from(err: io::Error) -> RevokeClusterSecurityGroupIngressError {
+        RevokeClusterSecurityGroupIngressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RevokeClusterSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15405,6 +15712,11 @@ impl From<HttpDispatchError> for RevokeSnapshotAccessError {
         RevokeSnapshotAccessError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RevokeSnapshotAccessError {
+    fn from(err: io::Error) -> RevokeSnapshotAccessError {
+        RevokeSnapshotAccessError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RevokeSnapshotAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15479,6 +15791,11 @@ impl From<CredentialsError> for RotateEncryptionKeyError {
 impl From<HttpDispatchError> for RotateEncryptionKeyError {
     fn from(err: HttpDispatchError) -> RotateEncryptionKeyError {
         RotateEncryptionKeyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RotateEncryptionKeyError {
+    fn from(err: io::Error) -> RotateEncryptionKeyError {
+        RotateEncryptionKeyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RotateEncryptionKeyError {
@@ -15954,16 +16271,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AuthorizeClusterSecurityGroupIngressResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -15977,8 +16296,10 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AuthorizeClusterSecurityGroupIngressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AuthorizeClusterSecurityGroupIngressError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -15997,16 +16318,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AuthorizeSnapshotAccessResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16022,8 +16345,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(AuthorizeSnapshotAccessError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AuthorizeSnapshotAccessError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -16041,16 +16367,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopyClusterSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16065,8 +16393,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CopyClusterSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopyClusterSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16085,16 +16414,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16109,7 +16440,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16129,16 +16462,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateClusterParameterGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16152,8 +16487,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -16172,16 +16510,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateClusterSecurityGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16197,8 +16537,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateClusterSecurityGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateClusterSecurityGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -16217,16 +16560,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateClusterSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16241,8 +16586,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateClusterSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateClusterSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16262,16 +16608,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateClusterSubnetGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16287,8 +16635,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateClusterSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateClusterSubnetGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -16307,16 +16658,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateEventSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16332,8 +16685,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -16352,16 +16708,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateHsmClientCertificateResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16377,8 +16735,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateHsmClientCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHsmClientCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -16397,16 +16758,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateHsmConfigurationResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16422,8 +16785,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateHsmConfigurationError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHsmConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16443,16 +16807,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateSnapshotCopyGrantResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16468,8 +16834,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreateSnapshotCopyGrantError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSnapshotCopyGrantError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -16485,13 +16854,17 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(CreateTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16509,16 +16882,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16533,7 +16908,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16552,15 +16929,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -16578,15 +16958,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteClusterSecurityGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteClusterSecurityGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -16605,16 +16988,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteClusterSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16629,8 +17014,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteClusterSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteClusterSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16649,15 +17035,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteClusterSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteClusterSubnetGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -16675,15 +17064,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -16701,15 +17093,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteHsmClientCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteHsmClientCertificateError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -16727,15 +17122,16 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteHsmConfigurationError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteHsmConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -16754,15 +17150,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteSnapshotCopyGrantError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSnapshotCopyGrantError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -16778,13 +17177,17 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -16803,16 +17206,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClusterParameterGroupsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16828,8 +17233,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeClusterParameterGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClusterParameterGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -16848,16 +17256,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClusterParameterGroupDetails::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16873,8 +17283,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeClusterParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClusterParametersError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -16893,16 +17306,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClusterSecurityGroupMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16917,8 +17332,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeClusterSecurityGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClusterSecurityGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -16936,16 +17354,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SnapshotMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16960,8 +17380,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeClusterSnapshotsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClusterSnapshotsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -16980,16 +17403,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClusterSubnetGroupMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17004,8 +17429,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeClusterSubnetGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClusterSubnetGroupsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -17024,16 +17452,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClusterVersionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17048,8 +17478,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeClusterVersionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClusterVersionsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -17067,16 +17500,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClustersMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17091,8 +17526,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeClustersError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClustersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17112,16 +17548,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeDefaultClusterParametersResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17135,8 +17573,10 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeDefaultClusterParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDefaultClusterParametersError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -17155,16 +17595,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EventCategoriesMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17179,8 +17621,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEventCategoriesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventCategoriesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -17199,16 +17644,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EventSubscriptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17223,8 +17670,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeEventSubscriptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventSubscriptionsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -17242,16 +17692,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EventsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17266,8 +17718,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEventsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17287,16 +17740,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = HsmClientCertificateMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17311,8 +17766,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeHsmClientCertificatesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHsmClientCertificatesError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -17331,16 +17789,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = HsmConfigurationMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17355,8 +17815,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeHsmConfigurationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeHsmConfigurationsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -17374,16 +17837,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = LoggingStatus::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17398,8 +17863,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeLoggingStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeLoggingStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17419,16 +17885,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = OrderableClusterOptionsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17444,8 +17912,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeOrderableClusterOptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeOrderableClusterOptionsError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -17464,16 +17935,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReservedNodeOfferingsMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17489,8 +17962,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeReservedNodeOfferingsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedNodeOfferingsError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -17508,16 +17984,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReservedNodesMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17532,8 +18010,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeReservedNodesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReservedNodesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17552,16 +18031,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ResizeProgressMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17576,8 +18057,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeResizeError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeResizeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17597,16 +18079,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SnapshotCopyGrantMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17621,8 +18105,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeSnapshotCopyGrantsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSnapshotCopyGrantsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -17641,16 +18128,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TableRestoreStatusMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17665,8 +18154,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(DescribeTableRestoreStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTableRestoreStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -17684,16 +18176,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TaggedResourceListMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17708,7 +18202,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17727,16 +18223,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = LoggingStatus::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17751,8 +18249,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DisableLoggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableLoggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17771,16 +18270,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DisableSnapshotCopyResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17795,8 +18296,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DisableSnapshotCopyError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableSnapshotCopyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17815,16 +18317,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = LoggingStatus::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17839,7 +18343,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(EnableLoggingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableLoggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17858,16 +18364,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = EnableSnapshotCopyResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17882,8 +18390,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(EnableSnapshotCopyError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableSnapshotCopyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17902,16 +18411,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClusterCredentials::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17926,8 +18437,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetClusterCredentialsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetClusterCredentialsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17946,16 +18458,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17970,7 +18484,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ModifyClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17990,16 +18506,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyClusterIamRolesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18014,8 +18532,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ModifyClusterIamRolesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyClusterIamRolesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18035,16 +18554,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClusterParameterGroupNameMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18060,8 +18581,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ModifyClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -18080,16 +18604,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyClusterSubnetGroupResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18105,8 +18631,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ModifyClusterSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyClusterSubnetGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -18125,16 +18654,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifyEventSubscriptionResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18150,8 +18681,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ModifyEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyEventSubscriptionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -18170,16 +18704,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ModifySnapshotCopyRetentionPeriodResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18193,8 +18729,10 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ModifySnapshotCopyRetentionPeriodError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifySnapshotCopyRetentionPeriodError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -18213,16 +18751,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PurchaseReservedNodeOfferingResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18236,8 +18776,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(PurchaseReservedNodeOfferingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurchaseReservedNodeOfferingError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -18255,16 +18798,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RebootClusterResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18279,7 +18824,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RebootClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebootClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18299,16 +18846,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ClusterParameterGroupNameMessage::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18324,8 +18873,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ResetClusterParameterGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetClusterParameterGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -18344,16 +18896,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreFromClusterSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18369,8 +18923,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(RestoreFromClusterSnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreFromClusterSnapshotError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -18389,16 +18946,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreTableFromClusterSnapshotResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18412,8 +18971,11 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(RestoreTableFromClusterSnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreTableFromClusterSnapshotError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -18432,16 +18994,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RevokeClusterSecurityGroupIngressResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18455,8 +19019,10 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(RevokeClusterSecurityGroupIngressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RevokeClusterSecurityGroupIngressError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -18474,16 +19040,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RevokeSnapshotAccessResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18498,8 +19066,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RevokeSnapshotAccessError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RevokeSnapshotAccessError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18518,16 +19087,18 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RotateEncryptionKeyResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18542,8 +19113,9 @@ impl<P, D> Redshift for RedshiftClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RotateEncryptionKeyError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RotateEncryptionKeyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -917,6 +919,11 @@ impl From<HttpDispatchError> for CompareFacesError {
         CompareFacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CompareFacesError {
+    fn from(err: io::Error) -> CompareFacesError {
+        CompareFacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CompareFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1021,6 +1028,11 @@ impl From<HttpDispatchError> for CreateCollectionError {
         CreateCollectionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateCollectionError {
+    fn from(err: io::Error) -> CreateCollectionError {
+        CreateCollectionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateCollectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1121,6 +1133,11 @@ impl From<CredentialsError> for DeleteCollectionError {
 impl From<HttpDispatchError> for DeleteCollectionError {
     fn from(err: HttpDispatchError) -> DeleteCollectionError {
         DeleteCollectionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteCollectionError {
+    fn from(err: io::Error) -> DeleteCollectionError {
+        DeleteCollectionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteCollectionError {
@@ -1225,6 +1242,11 @@ impl From<CredentialsError> for DeleteFacesError {
 impl From<HttpDispatchError> for DeleteFacesError {
     fn from(err: HttpDispatchError) -> DeleteFacesError {
         DeleteFacesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteFacesError {
+    fn from(err: io::Error) -> DeleteFacesError {
+        DeleteFacesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteFacesError {
@@ -1341,6 +1363,11 @@ impl From<HttpDispatchError> for DetectFacesError {
         DetectFacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetectFacesError {
+    fn from(err: io::Error) -> DetectFacesError {
+        DetectFacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetectFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1455,6 +1482,11 @@ impl From<HttpDispatchError> for DetectLabelsError {
         DetectLabelsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetectLabelsError {
+    fn from(err: io::Error) -> DetectLabelsError {
+        DetectLabelsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetectLabelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1567,6 +1599,11 @@ impl From<HttpDispatchError> for DetectModerationLabelsError {
         DetectModerationLabelsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DetectModerationLabelsError {
+    fn from(err: io::Error) -> DetectModerationLabelsError {
+        DetectModerationLabelsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DetectModerationLabelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1671,6 +1708,11 @@ impl From<CredentialsError> for GetCelebrityInfoError {
 impl From<HttpDispatchError> for GetCelebrityInfoError {
     fn from(err: HttpDispatchError) -> GetCelebrityInfoError {
         GetCelebrityInfoError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetCelebrityInfoError {
+    fn from(err: io::Error) -> GetCelebrityInfoError {
+        GetCelebrityInfoError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetCelebrityInfoError {
@@ -1790,6 +1832,11 @@ impl From<HttpDispatchError> for IndexFacesError {
         IndexFacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for IndexFacesError {
+    fn from(err: io::Error) -> IndexFacesError {
+        IndexFacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for IndexFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1900,6 +1947,11 @@ impl From<HttpDispatchError> for ListCollectionsError {
         ListCollectionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListCollectionsError {
+    fn from(err: io::Error) -> ListCollectionsError {
+        ListCollectionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListCollectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2006,6 +2058,11 @@ impl From<CredentialsError> for ListFacesError {
 impl From<HttpDispatchError> for ListFacesError {
     fn from(err: HttpDispatchError) -> ListFacesError {
         ListFacesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListFacesError {
+    fn from(err: io::Error) -> ListFacesError {
+        ListFacesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListFacesError {
@@ -2121,6 +2178,11 @@ impl From<HttpDispatchError> for RecognizeCelebritiesError {
         RecognizeCelebritiesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RecognizeCelebritiesError {
+    fn from(err: io::Error) -> RecognizeCelebritiesError {
+        RecognizeCelebritiesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RecognizeCelebritiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2227,6 +2289,11 @@ impl From<CredentialsError> for SearchFacesError {
 impl From<HttpDispatchError> for SearchFacesError {
     fn from(err: HttpDispatchError) -> SearchFacesError {
         SearchFacesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SearchFacesError {
+    fn from(err: io::Error) -> SearchFacesError {
+        SearchFacesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SearchFacesError {
@@ -2344,6 +2411,11 @@ impl From<CredentialsError> for SearchFacesByImageError {
 impl From<HttpDispatchError> for SearchFacesByImageError {
     fn from(err: HttpDispatchError) -> SearchFacesByImageError {
         SearchFacesByImageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SearchFacesByImageError {
+    fn from(err: io::Error) -> SearchFacesByImageError {
+        SearchFacesByImageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SearchFacesByImageError {
@@ -2496,14 +2568,20 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CompareFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CompareFacesResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CompareFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CompareFacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2522,15 +2600,20 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateCollectionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateCollectionResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateCollectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCollectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2549,15 +2632,20 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteCollectionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteCollectionResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteCollectionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteCollectionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2576,13 +2664,21 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteFacesResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteFacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2600,13 +2696,21 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DetectFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DetectFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DetectFacesResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetectFacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2624,14 +2728,20 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DetectLabelsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DetectLabelsResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DetectLabelsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetectLabelsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2651,15 +2761,18 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DetectModerationLabelsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DetectModerationLabelsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DetectModerationLabelsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DetectModerationLabelsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2678,15 +2791,20 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetCelebrityInfoResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetCelebrityInfoResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetCelebrityInfoError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCelebrityInfoError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2705,13 +2823,21 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<IndexFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(IndexFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<IndexFacesResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(IndexFacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2729,15 +2855,20 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListCollectionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListCollectionsResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListCollectionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCollectionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2754,13 +2885,21 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListFacesResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListFacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2778,15 +2917,18 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RecognizeCelebritiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RecognizeCelebritiesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RecognizeCelebritiesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RecognizeCelebritiesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2805,13 +2947,21 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SearchFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(SearchFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SearchFacesResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SearchFacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2829,15 +2979,18 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SearchFacesByImageResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SearchFacesByImageResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(SearchFacesByImageError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SearchFacesByImageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -38,7 +40,7 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AlarmIdentifier {
     #[doc="<p>The name of the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>"]
     pub name: String,
@@ -155,7 +157,7 @@ impl AliasHealthEnabledSerializer {
 }
 
 #[doc="<p> <i>Alias resource record sets only:</i> Information about the CloudFront distribution, Elastic Beanstalk environment, ELB load balancer, Amazon S3 bucket, or Amazon Route 53 resource record set that you're redirecting queries to. An Elastic Beanstalk environment must have a regionalized subdomain.</p> <p>When creating resource record sets for a private hosted zone, note the following:</p> <ul> <li> <p>Resource record sets can't be created for CloudFront distributions in a private hosted zone.</p> </li> <li> <p>Creating geolocation alias resource record sets or latency alias resource record sets in a private hosted zone is unsupported.</p> </li> <li> <p>For information about creating failover resource record sets in a private hosted zone, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a>.</p> </li> </ul>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AliasTarget {
     #[doc="<p> <i>Alias resource record sets only:</i> The value that you specify depends on where you want to route queries:</p> <dl> <dt>CloudFront distribution</dt> <dd> <p>Specify the domain name that CloudFront assigned when you created your distribution.</p> <p>Your CloudFront distribution must include an alternate domain name that matches the name of the resource record set. For example, if the name of the resource record set is <i>acme.example.com</i>, your CloudFront distribution must include <i>acme.example.com</i> as one of the alternate domain names. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html\">Using Alternate Domain Names (CNAMEs)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p> </dd> <dt>Elastic Beanstalk environment</dt> <dd> <p>Specify the <code>CNAME</code> attribute for the environment. (The environment must have a regionalized domain name.) You can use the following methods to get the value of the CNAME attribute:</p> <ul> <li> <p> <i>AWS Management Console</i>: For information about how to get the value by using the console, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html\">Using Custom Domains with AWS Elastic Beanstalk</a> in the <i>AWS Elastic Beanstalk Developer Guide</i>.</p> </li> <li> <p> <i>Elastic Beanstalk API</i>: Use the <code>DescribeEnvironments</code> action to get the value of the <code>CNAME</code> attribute. For more information, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_DescribeEnvironments.html\">DescribeEnvironments</a> in the <i>AWS Elastic Beanstalk API Reference</i>.</p> </li> <li> <p> <i>AWS CLI</i>: Use the <code>describe-environments</code> command to get the value of the <code>CNAME</code> attribute. For more information, see <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/describe-environments.html\">describe-environments</a> in the <i>AWS Command Line Interface Reference</i>.</p> </li> </ul> </dd> <dt>ELB load balancer</dt> <dd> <p>Specify the DNS name that is associated with the load balancer. Get the DNS name by using the AWS Management Console, the ELB API, or the AWS CLI. </p> <ul> <li> <p> <b>AWS Management Console</b>: Go to the EC2 page, choose <b>Load Balancers</b> in the navigation pane, choose the load balancer, choose the <b>Description</b> tab, and get the value of the <b>DNS name</b> field. (If you're routing traffic to a Classic Load Balancer, get the value that begins with <b>dualstack</b>.) </p> </li> <li> <p> <b>Elastic Load Balancing API</b>: Use <code>DescribeLoadBalancers</code> to get the value of <code>DNSName</code>. For more information, see the applicable guide:</p> <ul> <li> <p>Classic Load Balancer: <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> </p> </li> <li> <p>Application Load Balancer: <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> </p> </li> </ul> </li> <li> <p> <b>AWS CLI</b>: Use <code> <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancers.html\">describe-load-balancers</a> </code> to get the value of <code>DNSName</code>.</p> </li> </ul> </dd> <dt>Amazon S3 bucket that is configured as a static website</dt> <dd> <p>Specify the domain name of the Amazon S3 website endpoint in which you created the bucket, for example, <code>s3-website-us-east-2.amazonaws.com</code>. For more information about valid values, see the table <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region\">Amazon Simple Storage Service (S3) Website Endpoints</a> in the <i>Amazon Web Services General Reference</i>. For more information about using S3 buckets for websites, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/getting-started.html\">Getting Started with Amazon Route 53</a> in the <i>Amazon Route 53 Developer Guide.</i> </p> </dd> <dt>Another Amazon Route 53 resource record set</dt> <dd> <p>Specify the value of the <code>Name</code> element for a resource record set in the current hosted zone.</p> </dd> </dl>"]
     pub dns_name: String,
@@ -243,7 +245,7 @@ impl AssociateVPCCommentSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the request to associate a VPC with a private hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AssociateVPCWithHostedZoneRequest {
     #[doc="<p> <i>Optional:</i> A comment about the association request.</p>"]
     pub comment: Option<String>,
@@ -254,7 +256,7 @@ pub struct AssociateVPCWithHostedZoneRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the <code>AssociateVPCWithHostedZone</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AssociateVPCWithHostedZoneResponse {
     #[doc="<p>A complex type that describes the changes made to your hosted zone.</p>"]
     pub change_info: ChangeInfo,
@@ -304,7 +306,7 @@ impl AssociateVPCWithHostedZoneResponseDeserializer {
     }
 }
 #[doc="<p>The information for each resource record set that you want to change.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Change {
     #[doc="<p>The action to perform:</p> <ul> <li> <p> <code>CREATE</code>: Creates a resource record set that has the specified values.</p> </li> <li> <p> <code>DELETE</code>: Deletes a existing resource record set.</p> <important> <p>To delete the resource record set that is associated with a traffic policy instance, use <code> <a>DeleteTrafficPolicyInstance</a> </code>. Amazon Route 53 will delete the resource record set automatically. If you delete the resource record set by using <code>ChangeResourceRecordSets</code>, Amazon Route 53 doesn't automatically delete the traffic policy instance, and you'll continue to be charged for it even though it's no longer in use. </p> </important> </li> <li> <p> <code>UPSERT</code>: If a resource record set doesn't already exist, Amazon Route 53 creates it. If a resource record set does exist, Amazon Route 53 updates it with the values in the request.</p> </li> </ul> <p>The values that you need to include in the request depend on the type of resource record set that you're creating, deleting, or updating:</p> <p> <b>Basic resource record sets (excluding alias, failover, geolocation, latency, and weighted resource record sets)</b> </p> <ul> <li> <p> <code>Name</code> </p> </li> <li> <p> <code>Type</code> </p> </li> <li> <p> <code>TTL</code> </p> </li> </ul> <p> <b>Failover, geolocation, latency, or weighted resource record sets (excluding alias resource record sets)</b> </p> <ul> <li> <p> <code>Name</code> </p> </li> <li> <p> <code>Type</code> </p> </li> <li> <p> <code>TTL</code> </p> </li> <li> <p> <code>SetIdentifier</code> </p> </li> </ul> <p> <b>Alias resource record sets (including failover alias, geolocation alias, latency alias, and weighted alias resource record sets)</b> </p> <ul> <li> <p> <code>Name</code> </p> </li> <li> <p> <code>Type</code> </p> </li> <li> <p> <code>AliasTarget</code> (includes <code>DNSName</code>, <code>EvaluateTargetHealth</code>, and <code>HostedZoneId</code>)</p> </li> <li> <p> <code>SetIdentifier</code> (for failover, geolocation, latency, and weighted resource record sets)</p> </li> </ul>"]
     pub action: String,
@@ -338,7 +340,7 @@ impl ChangeActionSerializer {
 }
 
 #[doc="<p>The information for a change request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ChangeBatch {
     #[doc="<p>Information about the changes to make to the record sets.</p>"]
     pub changes: Vec<Change>,
@@ -362,7 +364,7 @@ impl ChangeBatchSerializer {
 }
 
 #[doc="<p>A complex type that describes change information about changes made to your hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ChangeInfo {
     #[doc="<p>A complex type that describes change information about changes made to your hosted zone.</p> <p>This element contains an ID that you use when performing a <a>GetChange</a> action to get detailed information about the change.</p>"]
     pub comment: Option<String>,
@@ -429,7 +431,7 @@ impl ChangeInfoDeserializer {
     }
 }
 #[doc="<p>A complex type that contains change information for the resource record set.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ChangeResourceRecordSetsRequest {
     #[doc="<p>A complex type that contains an optional comment and the <code>Changes</code> element.</p>"]
     pub change_batch: ChangeBatch,
@@ -438,7 +440,7 @@ pub struct ChangeResourceRecordSetsRequest {
 }
 
 #[doc="<p>A complex type containing the response for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ChangeResourceRecordSetsResponse {
     #[doc="<p>A complex type that contains information about changes made to your hosted zone.</p> <p>This element contains an ID that you use when performing a <a>GetChange</a> action to get detailed information about the change.</p>"]
     pub change_info: ChangeInfo,
@@ -502,7 +504,7 @@ impl ChangeStatusDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the tags that you want to add, edit, or delete.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ChangeTagsForResourceRequest {
     #[doc="<p>A complex type that contains a list of the tags that you want to add to the specified health check or hosted zone and/or the tags that you want to edit <code>Value</code> for.</p> <p>You can add a maximum of 10 tags to a health check or a hosted zone.</p>"]
     pub add_tags: Option<Vec<Tag>>,
@@ -515,7 +517,7 @@ pub struct ChangeTagsForResourceRequest {
 }
 
 #[doc="<p>Empty response for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ChangeTagsForResourceResponse;
 
 struct ChangeTagsForResourceResponseDeserializer;
@@ -648,7 +650,7 @@ impl ChildHealthCheckListSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the CloudWatch alarm that Amazon Route 53 is monitoring for this health check.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CloudWatchAlarmConfiguration {
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the arithmetic operation that is used for the comparison.</p>"]
     pub comparison_operator: String,
@@ -780,7 +782,7 @@ impl ComparisonOperatorDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the health check request information.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateHealthCheckRequest {
     #[doc="<p>A unique string that identifies the request and that allows you to retry a failed <code>CreateHealthCheck</code> request without the risk of creating two identical health checks:</p> <ul> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> and settings as a previous request, and if the health check doesn't exist, Amazon Route 53 creates the health check. If the health check does exist, Amazon Route 53 returns the settings for the existing health check.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> as a deleted health check, regardless of the settings, Amazon Route 53 returns a <code>HealthCheckAlreadyExists</code> error.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> as an existing health check but with different settings, Amazon Route 53 returns a <code>HealthCheckAlreadyExists</code> error.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with a unique <code>CallerReference</code> but settings identical to an existing health check, Amazon Route 53 creates the health check.</p> </li> </ul>"]
     pub caller_reference: String,
@@ -789,7 +791,7 @@ pub struct CreateHealthCheckRequest {
 }
 
 #[doc="<p>A complex type containing the response information for the new health check.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateHealthCheckResponse {
     #[doc="<p>A complex type that contains identifying information about the health check.</p>"]
     pub health_check: HealthCheck,
@@ -840,7 +842,7 @@ impl CreateHealthCheckResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the request to create a hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateHostedZoneRequest {
     #[doc="<p>A unique string that identifies the request and that allows failed <code>CreateHostedZone</code> requests to be retried without the risk of executing the operation twice. You must use a unique <code>CallerReference</code> string every time you submit a <code>CreateHostedZone</code> request. <code>CallerReference</code> can be any unique string, for example, a date/time stamp.</p>"]
     pub caller_reference: String,
@@ -855,7 +857,7 @@ pub struct CreateHostedZoneRequest {
 }
 
 #[doc="<p>A complex type containing the response information for the hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateHostedZoneResponse {
     #[doc="<p>A complex type that contains information about the <code>CreateHostedZone</code> request.</p>"]
     pub change_info: ChangeInfo,
@@ -923,7 +925,7 @@ impl CreateHostedZoneResponseDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateReusableDelegationSetRequest {
     #[doc="<p>A unique string that identifies the request, and that allows you to retry failed <code>CreateReusableDelegationSet</code> requests without the risk of executing the operation twice. You must use a unique <code>CallerReference</code> string every time you submit a <code>CreateReusableDelegationSet</code> request. <code>CallerReference</code> can be any unique string, for example a date/time stamp.</p>"]
     pub caller_reference: String,
@@ -931,7 +933,7 @@ pub struct CreateReusableDelegationSetRequest {
     pub hosted_zone_id: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateReusableDelegationSetResponse {
     #[doc="<p>A complex type that contains name server information.</p>"]
     pub delegation_set: DelegationSet,
@@ -984,7 +986,7 @@ impl CreateReusableDelegationSetResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the resource record sets that you want to create based on a specified traffic policy.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateTrafficPolicyInstanceRequest {
     #[doc="<p>The ID of the hosted zone in which you want Amazon Route 53 to create resource record sets by using the configuration in a traffic policy.</p>"]
     pub hosted_zone_id: String,
@@ -999,7 +1001,7 @@ pub struct CreateTrafficPolicyInstanceRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicyInstance</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateTrafficPolicyInstanceResponse {
     #[doc="<p>A unique URL that represents a new traffic policy instance.</p>"]
     pub location: String,
@@ -1052,7 +1054,7 @@ impl CreateTrafficPolicyInstanceResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the traffic policy that you want to create.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateTrafficPolicyRequest {
     #[doc="<p>(Optional) Any comments that you want to include about the traffic policy.</p>"]
     pub comment: Option<String>,
@@ -1063,7 +1065,7 @@ pub struct CreateTrafficPolicyRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicy</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateTrafficPolicyResponse {
     #[doc="<p>A unique URL that represents a new traffic policy.</p>"]
     pub location: String,
@@ -1115,7 +1117,7 @@ impl CreateTrafficPolicyResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the traffic policy that you want to create a new version for.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateTrafficPolicyVersionRequest {
     #[doc="<p>The comment that you specified in the <code>CreateTrafficPolicyVersion</code> request, if any.</p>"]
     pub comment: Option<String>,
@@ -1126,7 +1128,7 @@ pub struct CreateTrafficPolicyVersionRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicyVersion</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateTrafficPolicyVersionResponse {
     #[doc="<p>A unique URL that represents a new traffic policy version.</p>"]
     pub location: String,
@@ -1179,7 +1181,7 @@ impl CreateTrafficPolicyVersionResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the request to authorize associating a VPC with your private hosted zone. Authorization is only required when a private hosted zone and a VPC were created by using different accounts.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateVPCAssociationAuthorizationRequest {
     #[doc="<p>The ID of the private hosted zone that you want to authorize associating a VPC with.</p>"]
     pub hosted_zone_id: String,
@@ -1188,7 +1190,7 @@ pub struct CreateVPCAssociationAuthorizationRequest {
 }
 
 #[doc="<p>A complex type that contains the response information from a <code>CreateVPCAssociationAuthorization</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateVPCAssociationAuthorizationResponse {
     #[doc="<p>The ID of the hosted zone that you authorized associating a VPC with.</p>"]
     pub hosted_zone_id: String,
@@ -1282,7 +1284,7 @@ impl DNSRCodeDeserializer {
     }
 }
 #[doc="<p>A complex type that lists the name servers in a delegation set, as well as the <code>CallerReference</code> and the <code>ID</code> for the delegation set.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DelegationSet {
     #[doc="<p>The value that you specified for <code>CallerReference</code> when you created the reusable delegation set.</p>"]
     pub caller_reference: Option<String>,
@@ -1427,14 +1429,14 @@ impl DelegationSetsDeserializer {
     }
 }
 #[doc="<p>This action deletes a health check.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteHealthCheckRequest {
     #[doc="<p>The ID of the health check that you want to delete.</p>"]
     pub health_check_id: String,
 }
 
 #[doc="<p>An empty element.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteHealthCheckResponse;
 
 struct DeleteHealthCheckResponseDeserializer;
@@ -1454,14 +1456,14 @@ impl DeleteHealthCheckResponseDeserializer {
     }
 }
 #[doc="<p>A request to delete a hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteHostedZoneRequest {
     #[doc="<p>The ID of the hosted zone you want to delete.</p>"]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>DeleteHostedZone</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteHostedZoneResponse {
     #[doc="<p>A complex type that contains the ID, the status, and the date and time of a request to delete a hosted zone.</p>"]
     pub change_info: ChangeInfo,
@@ -1510,14 +1512,14 @@ impl DeleteHostedZoneResponseDeserializer {
     }
 }
 #[doc="<p>A request to delete a reusable delegation set.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteReusableDelegationSetRequest {
     #[doc="<p>The ID of the reusable delegation set that you want to delete.</p>"]
     pub id: String,
 }
 
 #[doc="<p>An empty element.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteReusableDelegationSetResponse;
 
 struct DeleteReusableDelegationSetResponseDeserializer;
@@ -1538,14 +1540,14 @@ impl DeleteReusableDelegationSetResponseDeserializer {
     }
 }
 #[doc="<p>A request to delete a specified traffic policy instance.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteTrafficPolicyInstanceRequest {
     #[doc="<p>The ID of the traffic policy instance that you want to delete. </p> <important> <p>When you delete a traffic policy instance, Amazon Route 53 also deletes all of the resource record sets that were created when you created the traffic policy instance.</p> </important>"]
     pub id: String,
 }
 
 #[doc="<p>An empty element.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteTrafficPolicyInstanceResponse;
 
 struct DeleteTrafficPolicyInstanceResponseDeserializer;
@@ -1566,7 +1568,7 @@ impl DeleteTrafficPolicyInstanceResponseDeserializer {
     }
 }
 #[doc="<p>A request to delete a specified traffic policy version.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteTrafficPolicyRequest {
     #[doc="<p>The ID of the traffic policy that you want to delete.</p>"]
     pub id: String,
@@ -1575,7 +1577,7 @@ pub struct DeleteTrafficPolicyRequest {
 }
 
 #[doc="<p>An empty element.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteTrafficPolicyResponse;
 
 struct DeleteTrafficPolicyResponseDeserializer;
@@ -1595,7 +1597,7 @@ impl DeleteTrafficPolicyResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the request to remove authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteVPCAssociationAuthorizationRequest {
     #[doc="<p>When removing authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account, the ID of the hosted zone.</p>"]
     pub hosted_zone_id: String,
@@ -1604,7 +1606,7 @@ pub struct DeleteVPCAssociationAuthorizationRequest {
 }
 
 #[doc="<p>Empty response for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteVPCAssociationAuthorizationResponse;
 
 struct DeleteVPCAssociationAuthorizationResponseDeserializer;
@@ -1625,7 +1627,7 @@ impl DeleteVPCAssociationAuthorizationResponseDeserializer {
     }
 }
 #[doc="<p>For the metric that the CloudWatch alarm is associated with, a complex type that contains information about one dimension.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Dimension {
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the name of one dimension.</p>"]
     pub name: String,
@@ -1745,7 +1747,7 @@ impl DisassociateVPCCommentSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the VPC that you want to disassociate from a specified private hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DisassociateVPCFromHostedZoneRequest {
     #[doc="<p> <i>Optional:</i> A comment about the disassociation request.</p>"]
     pub comment: Option<String>,
@@ -1756,7 +1758,7 @@ pub struct DisassociateVPCFromHostedZoneRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the disassociate request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DisassociateVPCFromHostedZoneResponse {
     #[doc="<p>A complex type that describes the changes made to the specified private hosted zone.</p>"]
     pub change_info: ChangeInfo,
@@ -1895,7 +1897,7 @@ impl FullyQualifiedDomainNameSerializer {
 }
 
 #[doc="<p>A complex type that contains information about a geo location.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GeoLocation {
     #[doc="<p>The two-letter code for the continent.</p> <p>Valid values: <code>AF</code> | <code>AN</code> | <code>AS</code> | <code>EU</code> | <code>OC</code> | <code>NA</code> | <code>SA</code> </p> <p>Constraint: Specifying <code>ContinentCode</code> with either <code>CountryCode</code> or <code>SubdivisionCode</code> returns an <code>InvalidInput</code> error.</p>"]
     pub continent_code: Option<String>,
@@ -2053,7 +2055,7 @@ impl GeoLocationCountryNameDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the codes and full continent, country, and subdivision names for the specified <code>geolocation</code> code.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GeoLocationDetails {
     #[doc="<p>The two-letter code for the continent.</p>"]
     pub continent_code: Option<String>,
@@ -2210,14 +2212,14 @@ impl GeoLocationSubdivisionNameDeserializer {
     }
 }
 #[doc="<p>The input for a GetChange request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetChangeRequest {
     #[doc="<p>The ID of the change batch request. The value that you specify here is the value that <code>ChangeResourceRecordSets</code> returned in the <code>Id</code> element when you submitted the request.</p>"]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contains the <code>ChangeInfo</code> element.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetChangeResponse {
     #[doc="<p>A complex type that contains information about the specified change batch.</p>"]
     pub change_info: ChangeInfo,
@@ -2265,10 +2267,10 @@ impl GetChangeResponseDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetCheckerIpRangesRequest;
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetCheckerIpRangesResponse {
     pub checker_ip_ranges: Vec<String>,
 }
@@ -2317,7 +2319,7 @@ impl GetCheckerIpRangesResponseDeserializer {
     }
 }
 #[doc="<p>A request for information about whether a specified geographic location is supported for Amazon Route 53 geolocation resource record sets.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetGeoLocationRequest {
     #[doc="<p>Amazon Route 53 supports the following continent codes:</p> <ul> <li> <p> <b>AF</b>: Africa</p> </li> <li> <p> <b>AN</b>: Antarctica</p> </li> <li> <p> <b>AS</b>: Asia</p> </li> <li> <p> <b>EU</b>: Europe</p> </li> <li> <p> <b>OC</b>: Oceania</p> </li> <li> <p> <b>NA</b>: North America</p> </li> <li> <p> <b>SA</b>: South America</p> </li> </ul>"]
     pub continent_code: Option<String>,
@@ -2328,7 +2330,7 @@ pub struct GetGeoLocationRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the specified geolocation code.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetGeoLocationResponse {
     #[doc="<p>A complex type that contains the codes and full continent, country, and subdivision names for the specified geolocation code.</p>"]
     pub geo_location_details: GeoLocationDetails,
@@ -2378,11 +2380,11 @@ impl GetGeoLocationResponseDeserializer {
     }
 }
 #[doc="<p>A request for the number of health checks that are associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHealthCheckCountRequest;
 
 #[doc="<p>A complex type that contains the response to a <code>GetHealthCheckCount</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHealthCheckCountResponse {
     #[doc="<p>The number of health checks associated with the current AWS account.</p>"]
     pub health_check_count: i64,
@@ -2432,14 +2434,14 @@ impl GetHealthCheckCountResponseDeserializer {
     }
 }
 #[doc="<p>A request for the reason that a health check failed most recently.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHealthCheckLastFailureReasonRequest {
     #[doc="<p>The ID for the health check for which you want the last failure reason. When you created the health check, <code>CreateHealthCheck</code> returned the ID in the response, in the <code>HealthCheckId</code> element.</p>"]
     pub health_check_id: String,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>GetHealthCheckLastFailureReason</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHealthCheckLastFailureReasonResponse {
     #[doc="<p>A list that contains one <code>Observation</code> element for each Amazon Route 53 health checker that is reporting a last failure reason. </p>"]
     pub health_check_observations: Vec<HealthCheckObservation>,
@@ -2490,14 +2492,14 @@ impl GetHealthCheckLastFailureReasonResponseDeserializer {
     }
 }
 #[doc="<p>A request to get information about a specified health check. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHealthCheckRequest {
     #[doc="<p>The identifier that Amazon Route 53 assigned to the health check when you created it. When you add or update a resource record set, you use this value to specify which health check to use. The value can be up to 64 characters long.</p>"]
     pub health_check_id: String,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>GetHealthCheck</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHealthCheckResponse {
     #[doc="<p>A complex type that contains information about one health check that is associated with the current AWS account.</p>"]
     pub health_check: HealthCheck,
@@ -2546,14 +2548,14 @@ impl GetHealthCheckResponseDeserializer {
     }
 }
 #[doc="<p>A request to get the status for a health check.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHealthCheckStatusRequest {
     #[doc="<p>The ID for the health check that you want the current status for. When you created the health check, <code>CreateHealthCheck</code> returned the ID in the response, in the <code>HealthCheckId</code> element.</p> <note> <p>If you want to check the status of a calculated health check, you must use the Amazon Route 53 console or the CloudWatch console. You can't use <code>GetHealthCheckStatus</code> to get the status of a calculated health check.</p> </note>"]
     pub health_check_id: String,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>GetHealthCheck</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHealthCheckStatusResponse {
     #[doc="<p>A list that contains one <code>HealthCheckObservation</code> element for each Amazon Route 53 health checker that is reporting a status about the health check endpoint.</p>"]
     pub health_check_observations: Vec<HealthCheckObservation>,
@@ -2603,11 +2605,11 @@ impl GetHealthCheckStatusResponseDeserializer {
     }
 }
 #[doc="<p>A request to retrieve a count of all the hosted zones that are associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHostedZoneCountRequest;
 
 #[doc="<p>A complex type that contains the response to a <code>GetHostedZoneCount</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHostedZoneCountResponse {
     #[doc="<p>The total number of public and private hosted zones that are associated with the current AWS account.</p>"]
     pub hosted_zone_count: i64,
@@ -2657,14 +2659,14 @@ impl GetHostedZoneCountResponseDeserializer {
     }
 }
 #[doc="<p>A request to get information about a specified hosted zone. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHostedZoneRequest {
     #[doc="<p>The ID of the hosted zone that you want to get information about.</p>"]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contain the response to a <code>GetHostedZone</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetHostedZoneResponse {
     #[doc="<p>A complex type that lists the Amazon Route 53 name servers for the specified hosted zone.</p>"]
     pub delegation_set: Option<DelegationSet>,
@@ -2725,14 +2727,14 @@ impl GetHostedZoneResponseDeserializer {
     }
 }
 #[doc="<p>A request to get information about a specified reusable delegation set.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetReusableDelegationSetRequest {
     #[doc="<p>The ID of the reusable delegation set that you want to get a list of name servers for.</p>"]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contains the response to the <code>GetReusableDelegationSet</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetReusableDelegationSetResponse {
     #[doc="<p>A complex type that contains information about the reusable delegation set.</p>"]
     pub delegation_set: DelegationSet,
@@ -2783,11 +2785,11 @@ impl GetReusableDelegationSetResponseDeserializer {
     }
 }
 #[doc="<p>Request to get the number of traffic policy instances that are associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetTrafficPolicyInstanceCountRequest;
 
 #[doc="<p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetTrafficPolicyInstanceCountResponse {
     #[doc="<p>The number of traffic policy instances that are associated with the current AWS account.</p>"]
     pub traffic_policy_instance_count: i64,
@@ -2838,14 +2840,14 @@ impl GetTrafficPolicyInstanceCountResponseDeserializer {
     }
 }
 #[doc="<p>Gets information about a specified traffic policy instance.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetTrafficPolicyInstanceRequest {
     #[doc="<p>The ID of the traffic policy instance that you want to get information about.</p>"]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetTrafficPolicyInstanceResponse {
     #[doc="<p>A complex type that contains settings for the traffic policy instance.</p>"]
     pub traffic_policy_instance: TrafficPolicyInstance,
@@ -2896,7 +2898,7 @@ impl GetTrafficPolicyInstanceResponseDeserializer {
     }
 }
 #[doc="<p>Gets information about a specific traffic policy version.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetTrafficPolicyRequest {
     #[doc="<p>The ID of the traffic policy that you want to get information about.</p>"]
     pub id: String,
@@ -2905,7 +2907,7 @@ pub struct GetTrafficPolicyRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetTrafficPolicyResponse {
     #[doc="<p>A complex type that contains settings for the specified traffic policy.</p>"]
     pub traffic_policy: TrafficPolicy,
@@ -2955,7 +2957,7 @@ impl GetTrafficPolicyResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about one health check that is associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct HealthCheck {
     #[doc="<p>A unique string that you specified when you created the health check.</p>"]
     pub caller_reference: String,
@@ -3029,7 +3031,7 @@ impl HealthCheckDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the health check.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct HealthCheckConfig {
     #[doc="<p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>"]
     pub alarm_identifier: Option<AlarmIdentifier>,
@@ -3298,7 +3300,7 @@ impl HealthCheckNonceSerializer {
 }
 
 #[doc="<p>A complex type that contains the last failure reason as reported by one Amazon Route 53 health checker.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct HealthCheckObservation {
     #[doc="<p>The IP address of the Amazon Route 53 health checker that provided the failure reason in <code>StatusReport</code>.</p>"]
     pub ip_address: Option<String>,
@@ -3599,7 +3601,7 @@ impl HealthThresholdSerializer {
 }
 
 #[doc="<p>A complex type that contains general information about the hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct HostedZone {
     #[doc="<p>The value that you specified for <code>CallerReference</code> when you created the hosted zone.</p>"]
     pub caller_reference: String,
@@ -3672,7 +3674,7 @@ impl HostedZoneDeserializer {
     }
 }
 #[doc="<p>A complex type that contains an optional comment about your hosted zone. If you don't want to specify a comment, omit both the <code>HostedZoneConfig</code> and <code>Comment</code> elements.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct HostedZoneConfig {
     #[doc="<p>Any comments that you want to include about the hosted zone.</p>"]
     pub comment: Option<String>,
@@ -3929,7 +3931,7 @@ impl IsPrivateZoneSerializer {
 }
 
 #[doc="<p>A request to get a list of geographic locations that Amazon Route 53 supports for geolocation resource record sets. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListGeoLocationsRequest {
     #[doc="<p>(Optional) The maximum number of geolocations to be included in the response body for this request. If more than <code>MaxItems</code> geolocations remain to be listed, then the value of the <code>IsTruncated</code> element in the response is <code>true</code>.</p>"]
     pub max_items: Option<String>,
@@ -3942,7 +3944,7 @@ pub struct ListGeoLocationsRequest {
 }
 
 #[doc="<p>A complex type containing the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListGeoLocationsResponse {
     #[doc="<p>A complex type that contains one <code>GeoLocationDetails</code> element for each location that Amazon Route 53 supports for geolocation.</p>"]
     pub geo_location_details_list: Vec<GeoLocationDetails>,
@@ -4021,7 +4023,7 @@ impl ListGeoLocationsResponseDeserializer {
     }
 }
 #[doc="<p>A request to retrieve a list of the health checks that are associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListHealthChecksRequest {
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more health checks. To get another group, submit another <code>ListHealthChecks</code> request. </p> <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code> from the previous response, which is the ID of the first health check that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more health checks to get.</p>"]
     pub marker: Option<String>,
@@ -4030,7 +4032,7 @@ pub struct ListHealthChecksRequest {
 }
 
 #[doc="<p>A complex type that contains the response to a <code>ListHealthChecks</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListHealthChecksResponse {
     #[doc="<p>A complex type that contains one <code>HealthCheck</code> element for each health check that is associated with the current AWS account.</p>"]
     pub health_checks: Vec<HealthCheck>,
@@ -4103,7 +4105,7 @@ impl ListHealthChecksResponseDeserializer {
     }
 }
 #[doc="<p>Retrieves a list of the public and private hosted zones that are associated with the current AWS account in ASCII order by domain name. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListHostedZonesByNameRequest {
     #[doc="<p>(Optional) For your first request to <code>ListHostedZonesByName</code>, include the <code>dnsname</code> parameter only if you want to specify the name of the first hosted zone in the response. If you don't include the <code>dnsname</code> parameter, Amazon Route 53 returns all of the hosted zones that were created by the current AWS account, in ASCII order. For subsequent requests, include both <code>dnsname</code> and <code>hostedzoneid</code> parameters. For <code>dnsname</code>, specify the value of <code>NextDNSName</code> from the previous response.</p>"]
     pub dns_name: Option<String>,
@@ -4114,7 +4116,7 @@ pub struct ListHostedZonesByNameRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListHostedZonesByNameResponse {
     #[doc="<p>For the second and subsequent calls to <code>ListHostedZonesByName</code>, <code>DNSName</code> is the value that you specified for the <code>dnsname</code> parameter in the request that produced the current response.</p>"]
     pub dns_name: Option<String>,
@@ -4201,7 +4203,7 @@ impl ListHostedZonesByNameResponseDeserializer {
     }
 }
 #[doc="<p>A request to retrieve a list of the public and private hosted zones that are associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListHostedZonesRequest {
     #[doc="<p>If you're using reusable delegation sets and you want to list all of the hosted zones that are associated with a reusable delegation set, specify the ID of that reusable delegation set. </p>"]
     pub delegation_set_id: Option<String>,
@@ -4211,7 +4213,7 @@ pub struct ListHostedZonesRequest {
     pub max_items: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListHostedZonesResponse {
     #[doc="<p>A complex type that contains general information about the hosted zone.</p>"]
     pub hosted_zones: Vec<HostedZone>,
@@ -4284,7 +4286,7 @@ impl ListHostedZonesResponseDeserializer {
     }
 }
 #[doc="<p>A request for the resource record sets that are associated with a specified hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListResourceRecordSetsRequest {
     #[doc="<p>The ID of the hosted zone that contains the resource record sets that you want to list.</p>"]
     pub hosted_zone_id: String,
@@ -4299,7 +4301,7 @@ pub struct ListResourceRecordSetsRequest {
 }
 
 #[doc="<p>A complex type that contains list information for the resource record set.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListResourceRecordSetsResponse {
     #[doc="<p>A flag that indicates whether more resource record sets remain to be listed. If your results were truncated, you can make a follow-up pagination request by using the <code>NextRecordName</code> element.</p>"]
     pub is_truncated: bool,
@@ -4380,7 +4382,7 @@ impl ListResourceRecordSetsResponseDeserializer {
     }
 }
 #[doc="<p>A request to get a list of the reusable delegation sets that are associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListReusableDelegationSetsRequest {
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more reusable delegation sets. To get another group, submit another <code>ListReusableDelegationSets</code> request. </p> <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code> from the previous response, which is the ID of the first reusable delegation set that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more reusable delegation sets to get.</p>"]
     pub marker: Option<String>,
@@ -4389,7 +4391,7 @@ pub struct ListReusableDelegationSetsRequest {
 }
 
 #[doc="<p>A complex type that contains information about the reusable delegation sets that are associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListReusableDelegationSetsResponse {
     #[doc="<p>A complex type that contains one <code>DelegationSet</code> element for each reusable delegation set that was created by the current AWS account.</p>"]
     pub delegation_sets: Vec<DelegationSet>,
@@ -4464,7 +4466,7 @@ impl ListReusableDelegationSetsResponseDeserializer {
     }
 }
 #[doc="<p>A complex type containing information about a request for a list of the tags that are associated with an individual resource.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p>The ID of the resource for which you want to retrieve tags.</p>"]
     pub resource_id: String,
@@ -4473,7 +4475,7 @@ pub struct ListTagsForResourceRequest {
 }
 
 #[doc="<p>A complex type that contains information about the health checks or hosted zones for which you want to list tags.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTagsForResourceResponse {
     #[doc="<p>A <code>ResourceTagSet</code> containing tags associated with the specified resource.</p>"]
     pub resource_tag_set: ResourceTagSet,
@@ -4523,7 +4525,7 @@ impl ListTagsForResourceResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the health checks or hosted zones for which you want to list tags.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTagsForResourcesRequest {
     #[doc="<p>A complex type that contains the ResourceId element for each resource for which you want to get a list of tags.</p>"]
     pub resource_ids: Vec<String>,
@@ -4532,7 +4534,7 @@ pub struct ListTagsForResourcesRequest {
 }
 
 #[doc="<p>A complex type containing tags for the specified resources.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTagsForResourcesResponse {
     #[doc="<p>A list of <code>ResourceTagSet</code>s containing tags associated with the specified resources.</p>"]
     pub resource_tag_sets: Vec<ResourceTagSet>,
@@ -4582,7 +4584,7 @@ impl ListTagsForResourcesResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the information about the request to list the traffic policies that are associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPoliciesRequest {
     #[doc="<p>(Optional) The maximum number of traffic policies that you want Amazon Route 53 to return in response to this request. If you have more than <code>MaxItems</code> traffic policies, the value of <code>IsTruncated</code> in the response is <code>true</code>, and the value of <code>TrafficPolicyIdMarker</code> is the ID of the first traffic policy that Amazon Route 53 will return if you submit another request.</p>"]
     pub max_items: Option<String>,
@@ -4591,7 +4593,7 @@ pub struct ListTrafficPoliciesRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPoliciesResponse {
     #[doc="<p>A flag that indicates whether there are more traffic policies to be listed. If the response was truncated, you can get the next group of traffic policies by submitting another <code>ListTrafficPolicies</code> request and specifying the value of <code>TrafficPolicyIdMarker</code> in the <code>TrafficPolicyIdMarker</code> request parameter.</p>"]
     pub is_truncated: bool,
@@ -4660,7 +4662,7 @@ impl ListTrafficPoliciesResponseDeserializer {
     }
 }
 #[doc="<p>A request for the traffic policy instances that you created in a specified hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPolicyInstancesByHostedZoneRequest {
     #[doc="<p>The ID of the hosted zone that you want to list traffic policy instances for.</p>"]
     pub hosted_zone_id: String,
@@ -4673,7 +4675,7 @@ pub struct ListTrafficPolicyInstancesByHostedZoneRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPolicyInstancesByHostedZoneResponse {
     #[doc="<p>A flag that indicates whether there are more traffic policy instances to be listed. If the response was truncated, you can get the next group of traffic policy instances by submitting another <code>ListTrafficPolicyInstancesByHostedZone</code> request and specifying the values of <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and <code>TrafficPolicyInstanceTypeMarker</code> in the corresponding request parameters.</p>"]
     pub is_truncated: bool,
@@ -4750,7 +4752,7 @@ impl ListTrafficPolicyInstancesByHostedZoneResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the information about the request to list your traffic policy instances.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPolicyInstancesByPolicyRequest {
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstancesByPolicy</code> request. </p> <p>For the value of <code>hostedzoneid</code>, specify the value of <code>HostedZoneIdMarker</code> from the previous response, which is the hosted zone ID of the first traffic policy instance that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
     pub hosted_zone_id_marker: Option<String>,
@@ -4767,7 +4769,7 @@ pub struct ListTrafficPolicyInstancesByPolicyRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPolicyInstancesByPolicyResponse {
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>HostedZoneIdMarker</code> is the ID of the hosted zone of the first traffic policy instance in the next group of traffic policy instances.</p>"]
     pub hosted_zone_id_marker: Option<String>,
@@ -4851,7 +4853,7 @@ impl ListTrafficPolicyInstancesByPolicyResponseDeserializer {
     }
 }
 #[doc="<p>A request to get information about the traffic policy instances that you created by using the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPolicyInstancesRequest {
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstances</code> request. For the value of <code>HostedZoneId</code>, specify the value of <code>HostedZoneIdMarker</code> from the previous response, which is the hosted zone ID of the first traffic policy instance in the next group of traffic policy instances.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
     pub hosted_zone_id_marker: Option<String>,
@@ -4864,7 +4866,7 @@ pub struct ListTrafficPolicyInstancesRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPolicyInstancesResponse {
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>HostedZoneIdMarker</code> is the ID of the hosted zone of the first traffic policy instance that Amazon Route 53 will return if you submit another <code>ListTrafficPolicyInstances</code> request. </p>"]
     pub hosted_zone_id_marker: Option<String>,
@@ -4948,7 +4950,7 @@ impl ListTrafficPolicyInstancesResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the information about the request to list your traffic policies.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPolicyVersionsRequest {
     #[doc="<p>Specify the value of <code>Id</code> of the traffic policy for which you want to list all versions.</p>"]
     pub id: String,
@@ -4959,7 +4961,7 @@ pub struct ListTrafficPolicyVersionsRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListTrafficPolicyVersionsResponse {
     #[doc="<p>A flag that indicates whether there are more traffic policies to be listed. If the response was truncated, you can get the next group of traffic policies by submitting another <code>ListTrafficPolicyVersions</code> request and specifying the value of <code>NextMarker</code> in the <code>marker</code> parameter.</p>"]
     pub is_truncated: bool,
@@ -5029,7 +5031,7 @@ impl ListTrafficPolicyVersionsResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about that can be associated with your hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListVPCAssociationAuthorizationsRequest {
     #[doc="<p>The ID of the hosted zone for which you want a list of VPCs that can be associated with the hosted zone.</p>"]
     pub hosted_zone_id: String,
@@ -5040,7 +5042,7 @@ pub struct ListVPCAssociationAuthorizationsRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListVPCAssociationAuthorizationsResponse {
     #[doc="<p>The ID of the hosted zone that you can associate the listed VPCs with.</p>"]
     pub hosted_zone_id: String,
@@ -5553,7 +5555,7 @@ impl ResourcePathSerializer {
 }
 
 #[doc="<p>Information specific to the resource record.</p> <note> <p>If you're creating an alias resource record set, omit <code>ResourceRecord</code>.</p> </note>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ResourceRecord {
     #[doc="<p>The current or new DNS record value, not to exceed 4,000 characters. In the case of a <code>DELETE</code> action, if the current value does not match the actual value, an error is returned. For descriptions about how to format <code>Value</code> for different record types, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html\">Supported DNS Resource Record Types</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <p>You can specify more than one value for all record types except <code>CNAME</code> and <code>SOA</code>. </p> <note> <p>If you're creating an alias resource record set, omit <code>Value</code>.</p> </note>"]
     pub value: String,
@@ -5613,7 +5615,7 @@ impl ResourceRecordSerializer {
 }
 
 #[doc="<p>Information about the resource record set to create or delete.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ResourceRecordSet {
     #[doc="<p> <i>Alias resource record sets only:</i> Information about the CloudFront distribution, AWS Elastic Beanstalk environment, ELB load balancer, Amazon S3 bucket, or Amazon Route 53 resource record set to which you're redirecting queries. The AWS Elastic Beanstalk environment must have a regionalized subdomain.</p> <p>If you're creating resource records sets for a private hosted zone, note the following:</p> <ul> <li> <p>You can't create alias resource record sets for CloudFront distributions in a private hosted zone.</p> </li> <li> <p>Creating geolocation alias resource record sets or latency alias resource record sets in a private hosted zone is unsupported.</p> </li> <li> <p>For information about creating failover resource record sets in a private hosted zone, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> </li> </ul>"]
     pub alias_target: Option<AliasTarget>,
@@ -6006,7 +6008,7 @@ impl ResourceRecordsSerializer {
 }
 
 #[doc="<p>A complex type containing a resource and its associated tags.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ResourceTagSet {
     #[doc="<p>The ID for the specified resource.</p>"]
     pub resource_id: Option<String>,
@@ -6163,7 +6165,7 @@ impl StatusDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the status that one Amazon Route 53 health checker reports and the time of the health check.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StatusReport {
     #[doc="<p>The date and time that the health checker performed the health check in <a href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601 format</a> and Coordinated Universal Time (UTC). For example, the value <code>2017-03-27T17:48:16.751Z</code> represents March 27, 2017 at 17:48:16.751 UTC.</p>"]
     pub checked_time: Option<String>,
@@ -6255,7 +6257,7 @@ impl TTLSerializer {
 }
 
 #[doc="<p>A complex type that contains information about a tag that you want to add or edit for the specified health check or hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Tag {
     #[doc="<p>The value of <code>Key</code> depends on the operation that you want to perform:</p> <ul> <li> <p> <b>Add a tag to a health check or hosted zone</b>: <code>Key</code> is the name that you want to give the new tag.</p> </li> <li> <p> <b>Edit a tag</b>: <code>Key</code> is the name of the tag that you want to change the <code>Value</code> for.</p> </li> <li> <p> <b> Delete a key</b>: <code>Key</code> is the name of the tag you want to remove.</p> </li> <li> <p> <b>Give a name to a health check</b>: Edit the default <code>Name</code> tag. In the Amazon Route 53 console, the list of your health checks includes a <b>Name</b> column that lets you see the name that you've given to each health check.</p> </li> </ul>"]
     pub key: Option<String>,
@@ -6512,7 +6514,7 @@ impl TagValueSerializer {
 }
 
 #[doc="<p>Gets the value that Amazon Route 53 returns in response to a DNS request for a specified record name and type. You can optionally specify the IP address of a DNS resolver, an EDNS0 client subnet IP address, and a subnet mask. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TestDNSAnswerRequest {
     #[doc="<p>If the resolver that you specified for resolverip supports EDNS0, specify the IPv4 or IPv6 address of a client in the applicable location, for example, <code>192.0.2.44</code> or <code>2001:db8:85a3::8a2e:370:7334</code>.</p>"]
     pub edns0_client_subnet_ip: Option<String>,
@@ -6529,7 +6531,7 @@ pub struct TestDNSAnswerRequest {
 }
 
 #[doc="<p>A complex type that contains the response to a <code>TestDNSAnswer</code> request. </p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TestDNSAnswerResponse {
     #[doc="<p>The Amazon Route 53 name server used to respond to the request.</p>"]
     pub nameserver: String,
@@ -6678,7 +6680,7 @@ impl TrafficPoliciesDeserializer {
     }
 }
 #[doc="<p>A complex type that contains settings for a traffic policy.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TrafficPolicy {
     #[doc="<p>The comment that you specify in the <code>CreateTrafficPolicy</code> request, if any.</p>"]
     pub comment: Option<String>,
@@ -6833,7 +6835,7 @@ impl TrafficPolicyIdSerializer {
 }
 
 #[doc="<p>A complex type that contains settings for the new traffic policy instance.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TrafficPolicyInstance {
     #[doc="<p>The ID of the hosted zone that Amazon Route 53 created resource record sets in.</p>"]
     pub hosted_zone_id: String,
@@ -7090,7 +7092,7 @@ impl TrafficPolicySummariesDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the latest version of one traffic policy that is associated with the current AWS account.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TrafficPolicySummary {
     #[doc="<p>The ID that Amazon Route 53 assigned to the traffic policy when you created it.</p>"]
     pub id: String,
@@ -7227,7 +7229,7 @@ impl TransportProtocolDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about a request to update a health check.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateHealthCheckRequest {
     pub alarm_identifier: Option<AlarmIdentifier>,
     #[doc="<p>A complex type that contains one <code>ChildHealthCheck</code> element for each health check that you want to associate with a <code>CALCULATED</code> health check.</p>"]
@@ -7260,7 +7262,7 @@ pub struct UpdateHealthCheckRequest {
     pub search_string: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateHealthCheckResponse {
     pub health_check: HealthCheck,
 }
@@ -7308,7 +7310,7 @@ impl UpdateHealthCheckResponseDeserializer {
     }
 }
 #[doc="<p>A request to update the comment for a hosted zone.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateHostedZoneCommentRequest {
     #[doc="<p>The new comment for the hosted zone. If you don't specify a value for <code>Comment</code>, Amazon Route 53 deletes the existing value of the <code>Comment</code> element, if any.</p>"]
     pub comment: Option<String>,
@@ -7317,7 +7319,7 @@ pub struct UpdateHostedZoneCommentRequest {
 }
 
 #[doc="<p>A complex type that contains the response to the <code>UpdateHostedZoneComment</code> request.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateHostedZoneCommentResponse {
     pub hosted_zone: HostedZone,
 }
@@ -7366,7 +7368,7 @@ impl UpdateHostedZoneCommentResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the traffic policy that you want to update the comment for.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateTrafficPolicyCommentRequest {
     #[doc="<p>The new comment for the specified traffic policy and version.</p>"]
     pub comment: String,
@@ -7377,7 +7379,7 @@ pub struct UpdateTrafficPolicyCommentRequest {
 }
 
 #[doc="<p>A complex type that contains the response information for the traffic policy.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateTrafficPolicyCommentResponse {
     #[doc="<p>A complex type that contains settings for the specified traffic policy.</p>"]
     pub traffic_policy: TrafficPolicy,
@@ -7428,7 +7430,7 @@ impl UpdateTrafficPolicyCommentResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the resource record sets that you want to update based on a specified traffic policy instance.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateTrafficPolicyInstanceRequest {
     #[doc="<p>The ID of the traffic policy instance that you want to update.</p>"]
     pub id: String,
@@ -7441,7 +7443,7 @@ pub struct UpdateTrafficPolicyInstanceRequest {
 }
 
 #[doc="<p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UpdateTrafficPolicyInstanceResponse {
     #[doc="<p>A complex type that contains settings for the updated traffic policy instance.</p>"]
     pub traffic_policy_instance: TrafficPolicyInstance,
@@ -7492,7 +7494,7 @@ impl UpdateTrafficPolicyInstanceResponseDeserializer {
     }
 }
 #[doc="<p>(Private hosted zones only) A complex type that contains information about an Amazon VPC.</p>"]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct VPC {
     pub vpc_id: Option<String>,
     #[doc="<p>(Private hosted zones only) The region in which you created an Amazon VPC.</p>"]
@@ -7720,6 +7722,11 @@ impl From<HttpDispatchError> for AssociateVPCWithHostedZoneError {
         AssociateVPCWithHostedZoneError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateVPCWithHostedZoneError {
+    fn from(err: io::Error) -> AssociateVPCWithHostedZoneError {
+        AssociateVPCWithHostedZoneError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateVPCWithHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7804,6 +7811,11 @@ impl From<CredentialsError> for ChangeResourceRecordSetsError {
 impl From<HttpDispatchError> for ChangeResourceRecordSetsError {
     fn from(err: HttpDispatchError) -> ChangeResourceRecordSetsError {
         ChangeResourceRecordSetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ChangeResourceRecordSetsError {
+    fn from(err: io::Error) -> ChangeResourceRecordSetsError {
+        ChangeResourceRecordSetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ChangeResourceRecordSetsError {
@@ -7894,6 +7906,11 @@ impl From<HttpDispatchError> for ChangeTagsForResourceError {
         ChangeTagsForResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ChangeTagsForResourceError {
+    fn from(err: io::Error) -> ChangeTagsForResourceError {
+        ChangeTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ChangeTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7972,6 +7989,11 @@ impl From<CredentialsError> for CreateHealthCheckError {
 impl From<HttpDispatchError> for CreateHealthCheckError {
     fn from(err: HttpDispatchError) -> CreateHealthCheckError {
         CreateHealthCheckError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateHealthCheckError {
+    fn from(err: io::Error) -> CreateHealthCheckError {
+        CreateHealthCheckError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateHealthCheckError {
@@ -8074,6 +8096,11 @@ impl From<HttpDispatchError> for CreateHostedZoneError {
         CreateHostedZoneError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateHostedZoneError {
+    fn from(err: io::Error) -> CreateHostedZoneError {
+        CreateHostedZoneError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8166,6 +8193,11 @@ impl From<HttpDispatchError> for CreateReusableDelegationSetError {
         CreateReusableDelegationSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReusableDelegationSetError {
+    fn from(err: io::Error) -> CreateReusableDelegationSetError {
+        CreateReusableDelegationSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReusableDelegationSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8251,6 +8283,11 @@ impl From<HttpDispatchError> for CreateTrafficPolicyError {
         CreateTrafficPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTrafficPolicyError {
+    fn from(err: io::Error) -> CreateTrafficPolicyError {
+        CreateTrafficPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTrafficPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8332,6 +8369,11 @@ impl From<CredentialsError> for CreateTrafficPolicyInstanceError {
 impl From<HttpDispatchError> for CreateTrafficPolicyInstanceError {
     fn from(err: HttpDispatchError) -> CreateTrafficPolicyInstanceError {
         CreateTrafficPolicyInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateTrafficPolicyInstanceError {
+    fn from(err: io::Error) -> CreateTrafficPolicyInstanceError {
+        CreateTrafficPolicyInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateTrafficPolicyInstanceError {
@@ -8417,6 +8459,11 @@ impl From<HttpDispatchError> for CreateTrafficPolicyVersionError {
         CreateTrafficPolicyVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTrafficPolicyVersionError {
+    fn from(err: io::Error) -> CreateTrafficPolicyVersionError {
+        CreateTrafficPolicyVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTrafficPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8500,6 +8547,11 @@ impl From<HttpDispatchError> for CreateVPCAssociationAuthorizationError {
         CreateVPCAssociationAuthorizationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateVPCAssociationAuthorizationError {
+    fn from(err: io::Error) -> CreateVPCAssociationAuthorizationError {
+        CreateVPCAssociationAuthorizationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateVPCAssociationAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8580,6 +8632,11 @@ impl From<CredentialsError> for DeleteHealthCheckError {
 impl From<HttpDispatchError> for DeleteHealthCheckError {
     fn from(err: HttpDispatchError) -> DeleteHealthCheckError {
         DeleteHealthCheckError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteHealthCheckError {
+    fn from(err: io::Error) -> DeleteHealthCheckError {
+        DeleteHealthCheckError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteHealthCheckError {
@@ -8670,6 +8727,11 @@ impl From<HttpDispatchError> for DeleteHostedZoneError {
         DeleteHostedZoneError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteHostedZoneError {
+    fn from(err: io::Error) -> DeleteHostedZoneError {
+        DeleteHostedZoneError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8747,6 +8809,11 @@ impl From<CredentialsError> for DeleteReusableDelegationSetError {
 impl From<HttpDispatchError> for DeleteReusableDelegationSetError {
     fn from(err: HttpDispatchError) -> DeleteReusableDelegationSetError {
         DeleteReusableDelegationSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteReusableDelegationSetError {
+    fn from(err: io::Error) -> DeleteReusableDelegationSetError {
+        DeleteReusableDelegationSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteReusableDelegationSetError {
@@ -8831,6 +8898,11 @@ impl From<HttpDispatchError> for DeleteTrafficPolicyError {
         DeleteTrafficPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTrafficPolicyError {
+    fn from(err: io::Error) -> DeleteTrafficPolicyError {
+        DeleteTrafficPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTrafficPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8906,6 +8978,11 @@ impl From<CredentialsError> for DeleteTrafficPolicyInstanceError {
 impl From<HttpDispatchError> for DeleteTrafficPolicyInstanceError {
     fn from(err: HttpDispatchError) -> DeleteTrafficPolicyInstanceError {
         DeleteTrafficPolicyInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteTrafficPolicyInstanceError {
+    fn from(err: io::Error) -> DeleteTrafficPolicyInstanceError {
+        DeleteTrafficPolicyInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteTrafficPolicyInstanceError {
@@ -8988,6 +9065,11 @@ impl From<CredentialsError> for DeleteVPCAssociationAuthorizationError {
 impl From<HttpDispatchError> for DeleteVPCAssociationAuthorizationError {
     fn from(err: HttpDispatchError) -> DeleteVPCAssociationAuthorizationError {
         DeleteVPCAssociationAuthorizationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteVPCAssociationAuthorizationError {
+    fn from(err: io::Error) -> DeleteVPCAssociationAuthorizationError {
+        DeleteVPCAssociationAuthorizationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteVPCAssociationAuthorizationError {
@@ -9074,6 +9156,11 @@ impl From<HttpDispatchError> for DisassociateVPCFromHostedZoneError {
         DisassociateVPCFromHostedZoneError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateVPCFromHostedZoneError {
+    fn from(err: io::Error) -> DisassociateVPCFromHostedZoneError {
+        DisassociateVPCFromHostedZoneError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateVPCFromHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9153,6 +9240,11 @@ impl From<HttpDispatchError> for GetChangeError {
         GetChangeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetChangeError {
+    fn from(err: io::Error) -> GetChangeError {
+        GetChangeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetChangeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9215,6 +9307,11 @@ impl From<CredentialsError> for GetCheckerIpRangesError {
 impl From<HttpDispatchError> for GetCheckerIpRangesError {
     fn from(err: HttpDispatchError) -> GetCheckerIpRangesError {
         GetCheckerIpRangesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetCheckerIpRangesError {
+    fn from(err: io::Error) -> GetCheckerIpRangesError {
+        GetCheckerIpRangesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetCheckerIpRangesError {
@@ -9289,6 +9386,11 @@ impl From<CredentialsError> for GetGeoLocationError {
 impl From<HttpDispatchError> for GetGeoLocationError {
     fn from(err: HttpDispatchError) -> GetGeoLocationError {
         GetGeoLocationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetGeoLocationError {
+    fn from(err: io::Error) -> GetGeoLocationError {
+        GetGeoLocationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetGeoLocationError {
@@ -9370,6 +9472,11 @@ impl From<HttpDispatchError> for GetHealthCheckError {
         GetHealthCheckError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetHealthCheckError {
+    fn from(err: io::Error) -> GetHealthCheckError {
+        GetHealthCheckError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetHealthCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9433,6 +9540,11 @@ impl From<CredentialsError> for GetHealthCheckCountError {
 impl From<HttpDispatchError> for GetHealthCheckCountError {
     fn from(err: HttpDispatchError) -> GetHealthCheckCountError {
         GetHealthCheckCountError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetHealthCheckCountError {
+    fn from(err: io::Error) -> GetHealthCheckCountError {
+        GetHealthCheckCountError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetHealthCheckCountError {
@@ -9503,6 +9615,11 @@ impl From<CredentialsError> for GetHealthCheckLastFailureReasonError {
 impl From<HttpDispatchError> for GetHealthCheckLastFailureReasonError {
     fn from(err: HttpDispatchError) -> GetHealthCheckLastFailureReasonError {
         GetHealthCheckLastFailureReasonError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetHealthCheckLastFailureReasonError {
+    fn from(err: io::Error) -> GetHealthCheckLastFailureReasonError {
+        GetHealthCheckLastFailureReasonError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetHealthCheckLastFailureReasonError {
@@ -9577,6 +9694,11 @@ impl From<CredentialsError> for GetHealthCheckStatusError {
 impl From<HttpDispatchError> for GetHealthCheckStatusError {
     fn from(err: HttpDispatchError) -> GetHealthCheckStatusError {
         GetHealthCheckStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetHealthCheckStatusError {
+    fn from(err: io::Error) -> GetHealthCheckStatusError {
+        GetHealthCheckStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetHealthCheckStatusError {
@@ -9655,6 +9777,11 @@ impl From<HttpDispatchError> for GetHostedZoneError {
         GetHostedZoneError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetHostedZoneError {
+    fn from(err: io::Error) -> GetHostedZoneError {
+        GetHostedZoneError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9722,6 +9849,11 @@ impl From<CredentialsError> for GetHostedZoneCountError {
 impl From<HttpDispatchError> for GetHostedZoneCountError {
     fn from(err: HttpDispatchError) -> GetHostedZoneCountError {
         GetHostedZoneCountError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetHostedZoneCountError {
+    fn from(err: io::Error) -> GetHostedZoneCountError {
+        GetHostedZoneCountError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetHostedZoneCountError {
@@ -9796,6 +9928,11 @@ impl From<CredentialsError> for GetReusableDelegationSetError {
 impl From<HttpDispatchError> for GetReusableDelegationSetError {
     fn from(err: HttpDispatchError) -> GetReusableDelegationSetError {
         GetReusableDelegationSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetReusableDelegationSetError {
+    fn from(err: io::Error) -> GetReusableDelegationSetError {
+        GetReusableDelegationSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetReusableDelegationSetError {
@@ -9873,6 +10010,11 @@ impl From<HttpDispatchError> for GetTrafficPolicyError {
         GetTrafficPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetTrafficPolicyError {
+    fn from(err: io::Error) -> GetTrafficPolicyError {
+        GetTrafficPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetTrafficPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9943,6 +10085,11 @@ impl From<HttpDispatchError> for GetTrafficPolicyInstanceError {
         GetTrafficPolicyInstanceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetTrafficPolicyInstanceError {
+    fn from(err: io::Error) -> GetTrafficPolicyInstanceError {
+        GetTrafficPolicyInstanceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetTrafficPolicyInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10007,6 +10154,11 @@ impl From<CredentialsError> for GetTrafficPolicyInstanceCountError {
 impl From<HttpDispatchError> for GetTrafficPolicyInstanceCountError {
     fn from(err: HttpDispatchError) -> GetTrafficPolicyInstanceCountError {
         GetTrafficPolicyInstanceCountError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetTrafficPolicyInstanceCountError {
+    fn from(err: io::Error) -> GetTrafficPolicyInstanceCountError {
+        GetTrafficPolicyInstanceCountError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetTrafficPolicyInstanceCountError {
@@ -10078,6 +10230,11 @@ impl From<HttpDispatchError> for ListGeoLocationsError {
         ListGeoLocationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListGeoLocationsError {
+    fn from(err: io::Error) -> ListGeoLocationsError {
+        ListGeoLocationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListGeoLocationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10147,6 +10304,11 @@ impl From<CredentialsError> for ListHealthChecksError {
 impl From<HttpDispatchError> for ListHealthChecksError {
     fn from(err: HttpDispatchError) -> ListHealthChecksError {
         ListHealthChecksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListHealthChecksError {
+    fn from(err: io::Error) -> ListHealthChecksError {
+        ListHealthChecksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListHealthChecksError {
@@ -10224,6 +10386,11 @@ impl From<HttpDispatchError> for ListHostedZonesError {
         ListHostedZonesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListHostedZonesError {
+    fn from(err: io::Error) -> ListHostedZonesError {
+        ListHostedZonesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListHostedZonesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10295,6 +10462,11 @@ impl From<CredentialsError> for ListHostedZonesByNameError {
 impl From<HttpDispatchError> for ListHostedZonesByNameError {
     fn from(err: HttpDispatchError) -> ListHostedZonesByNameError {
         ListHostedZonesByNameError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListHostedZonesByNameError {
+    fn from(err: io::Error) -> ListHostedZonesByNameError {
+        ListHostedZonesByNameError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListHostedZonesByNameError {
@@ -10369,6 +10541,11 @@ impl From<HttpDispatchError> for ListResourceRecordSetsError {
         ListResourceRecordSetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListResourceRecordSetsError {
+    fn from(err: io::Error) -> ListResourceRecordSetsError {
+        ListResourceRecordSetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListResourceRecordSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10436,6 +10613,11 @@ impl From<CredentialsError> for ListReusableDelegationSetsError {
 impl From<HttpDispatchError> for ListReusableDelegationSetsError {
     fn from(err: HttpDispatchError) -> ListReusableDelegationSetsError {
         ListReusableDelegationSetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListReusableDelegationSetsError {
+    fn from(err: io::Error) -> ListReusableDelegationSetsError {
+        ListReusableDelegationSetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListReusableDelegationSetsError {
@@ -10520,6 +10702,11 @@ impl From<CredentialsError> for ListTagsForResourceError {
 impl From<HttpDispatchError> for ListTagsForResourceError {
     fn from(err: HttpDispatchError) -> ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForResourceError {
@@ -10610,6 +10797,11 @@ impl From<HttpDispatchError> for ListTagsForResourcesError {
         ListTagsForResourcesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTagsForResourcesError {
+    fn from(err: io::Error) -> ListTagsForResourcesError {
+        ListTagsForResourcesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTagsForResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10684,6 +10876,11 @@ impl From<HttpDispatchError> for ListTrafficPoliciesError {
         ListTrafficPoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTrafficPoliciesError {
+    fn from(err: io::Error) -> ListTrafficPoliciesError {
+        ListTrafficPoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTrafficPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10753,6 +10950,11 @@ impl From<CredentialsError> for ListTrafficPolicyInstancesError {
 impl From<HttpDispatchError> for ListTrafficPolicyInstancesError {
     fn from(err: HttpDispatchError) -> ListTrafficPolicyInstancesError {
         ListTrafficPolicyInstancesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTrafficPolicyInstancesError {
+    fn from(err: io::Error) -> ListTrafficPolicyInstancesError {
+        ListTrafficPolicyInstancesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTrafficPolicyInstancesError {
@@ -10828,6 +11030,11 @@ impl From<CredentialsError> for ListTrafficPolicyInstancesByHostedZoneError {
 impl From<HttpDispatchError> for ListTrafficPolicyInstancesByHostedZoneError {
     fn from(err: HttpDispatchError) -> ListTrafficPolicyInstancesByHostedZoneError {
         ListTrafficPolicyInstancesByHostedZoneError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTrafficPolicyInstancesByHostedZoneError {
+    fn from(err: io::Error) -> ListTrafficPolicyInstancesByHostedZoneError {
+        ListTrafficPolicyInstancesByHostedZoneError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTrafficPolicyInstancesByHostedZoneError {
@@ -10908,6 +11115,11 @@ impl From<HttpDispatchError> for ListTrafficPolicyInstancesByPolicyError {
         ListTrafficPolicyInstancesByPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTrafficPolicyInstancesByPolicyError {
+    fn from(err: io::Error) -> ListTrafficPolicyInstancesByPolicyError {
+        ListTrafficPolicyInstancesByPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTrafficPolicyInstancesByPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10983,6 +11195,11 @@ impl From<HttpDispatchError> for ListTrafficPolicyVersionsError {
         ListTrafficPolicyVersionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTrafficPolicyVersionsError {
+    fn from(err: io::Error) -> ListTrafficPolicyVersionsError {
+        ListTrafficPolicyVersionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTrafficPolicyVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11056,6 +11273,11 @@ impl From<CredentialsError> for ListVPCAssociationAuthorizationsError {
 impl From<HttpDispatchError> for ListVPCAssociationAuthorizationsError {
     fn from(err: HttpDispatchError) -> ListVPCAssociationAuthorizationsError {
         ListVPCAssociationAuthorizationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListVPCAssociationAuthorizationsError {
+    fn from(err: io::Error) -> ListVPCAssociationAuthorizationsError {
+        ListVPCAssociationAuthorizationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListVPCAssociationAuthorizationsError {
@@ -11135,6 +11357,11 @@ impl From<HttpDispatchError> for TestDNSAnswerError {
         TestDNSAnswerError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TestDNSAnswerError {
+    fn from(err: io::Error) -> TestDNSAnswerError {
+        TestDNSAnswerError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TestDNSAnswerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11210,6 +11437,11 @@ impl From<HttpDispatchError> for UpdateHealthCheckError {
         UpdateHealthCheckError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateHealthCheckError {
+    fn from(err: io::Error) -> UpdateHealthCheckError {
+        UpdateHealthCheckError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateHealthCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11281,6 +11513,11 @@ impl From<CredentialsError> for UpdateHostedZoneCommentError {
 impl From<HttpDispatchError> for UpdateHostedZoneCommentError {
     fn from(err: HttpDispatchError) -> UpdateHostedZoneCommentError {
         UpdateHostedZoneCommentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateHostedZoneCommentError {
+    fn from(err: io::Error) -> UpdateHostedZoneCommentError {
+        UpdateHostedZoneCommentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateHostedZoneCommentError {
@@ -11356,6 +11593,11 @@ impl From<CredentialsError> for UpdateTrafficPolicyCommentError {
 impl From<HttpDispatchError> for UpdateTrafficPolicyCommentError {
     fn from(err: HttpDispatchError) -> UpdateTrafficPolicyCommentError {
         UpdateTrafficPolicyCommentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateTrafficPolicyCommentError {
+    fn from(err: io::Error) -> UpdateTrafficPolicyCommentError {
+        UpdateTrafficPolicyCommentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateTrafficPolicyCommentError {
@@ -11438,6 +11680,11 @@ impl From<CredentialsError> for UpdateTrafficPolicyInstanceError {
 impl From<HttpDispatchError> for UpdateTrafficPolicyInstanceError {
     fn from(err: HttpDispatchError) -> UpdateTrafficPolicyInstanceError {
         UpdateTrafficPolicyInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateTrafficPolicyInstanceError {
+    fn from(err: io::Error) -> UpdateTrafficPolicyInstanceError {
+        UpdateTrafficPolicyInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateTrafficPolicyInstanceError {
@@ -11831,7 +12078,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11839,11 +12086,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AssociateVPCWithHostedZoneResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11854,7 +12103,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(AssociateVPCWithHostedZoneError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateVPCWithHostedZoneError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -11879,7 +12133,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11887,11 +12141,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ChangeResourceRecordSetsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11902,7 +12158,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(ChangeResourceRecordSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ChangeResourceRecordSetsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -11928,7 +12189,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11936,11 +12197,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ChangeTagsForResourceResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11952,8 +12215,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ChangeTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ChangeTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11978,7 +12242,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -11986,11 +12250,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateHealthCheckResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12005,8 +12271,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateHealthCheckError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHealthCheckError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12031,7 +12298,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12039,11 +12306,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateHostedZoneResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12058,8 +12327,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateHostedZoneError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateHostedZoneError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12085,7 +12355,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12093,11 +12363,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateReusableDelegationSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12109,7 +12381,12 @@ impl<P, D> Route53 for Route53Client<P, D>
                 result.location = value;
                 Ok(result)
             }
-            _ => Err(CreateReusableDelegationSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReusableDelegationSetError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12133,7 +12410,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12141,11 +12418,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateTrafficPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12158,8 +12437,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateTrafficPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTrafficPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12185,7 +12465,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12193,11 +12473,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateTrafficPolicyInstanceResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12209,7 +12491,12 @@ impl<P, D> Route53 for Route53Client<P, D>
                 result.location = value;
                 Ok(result)
             }
-            _ => Err(CreateTrafficPolicyInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTrafficPolicyInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12234,7 +12521,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12242,11 +12529,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateTrafficPolicyVersionResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12258,7 +12547,12 @@ impl<P, D> Route53 for Route53Client<P, D>
                 result.location = value;
                 Ok(result)
             }
-            _ => Err(CreateTrafficPolicyVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTrafficPolicyVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -12284,7 +12578,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12292,11 +12586,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateVPCAssociationAuthorizationResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12307,7 +12603,11 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(CreateVPCAssociationAuthorizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateVPCAssociationAuthorizationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12331,7 +12631,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12339,11 +12639,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteHealthCheckResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12357,8 +12659,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteHealthCheckError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteHealthCheckError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12383,7 +12686,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12391,11 +12694,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteHostedZoneResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12409,8 +12714,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteHostedZoneError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteHostedZoneError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12436,7 +12742,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12444,11 +12750,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteReusableDelegationSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12459,7 +12767,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteReusableDelegationSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReusableDelegationSetError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12484,7 +12797,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12492,11 +12805,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteTrafficPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12508,8 +12823,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteTrafficPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTrafficPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12535,7 +12851,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12543,11 +12859,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteTrafficPolicyInstanceResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12558,7 +12876,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteTrafficPolicyInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTrafficPolicyInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12584,7 +12907,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12592,11 +12915,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteVPCAssociationAuthorizationResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12607,7 +12932,11 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteVPCAssociationAuthorizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVPCAssociationAuthorizationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12632,7 +12961,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12640,11 +12969,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DisassociateVPCFromHostedZoneResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12655,7 +12986,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(DisassociateVPCFromHostedZoneError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateVPCFromHostedZoneError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -12677,7 +13013,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12685,11 +13021,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetChangeResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12701,7 +13039,11 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetChangeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetChangeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12725,7 +13067,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12733,11 +13075,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetCheckerIpRangesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12751,8 +13095,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetCheckerIpRangesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCheckerIpRangesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12788,7 +13133,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12796,11 +13141,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetGeoLocationResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12814,8 +13161,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetGeoLocationError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetGeoLocationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12840,7 +13188,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12848,11 +13196,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetHealthCheckResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12866,8 +13216,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetHealthCheckError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHealthCheckError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12892,7 +13243,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12900,11 +13251,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetHealthCheckCountResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12916,8 +13269,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetHealthCheckCountError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHealthCheckCountError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12944,7 +13298,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -12952,11 +13306,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetHealthCheckLastFailureReasonResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12967,7 +13323,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetHealthCheckLastFailureReasonError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHealthCheckLastFailureReasonError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -12992,7 +13353,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13000,11 +13361,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetHealthCheckStatusResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13016,8 +13379,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetHealthCheckStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHealthCheckStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13042,7 +13406,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13050,11 +13414,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetHostedZoneResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13067,7 +13433,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetHostedZoneError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHostedZoneError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13092,7 +13460,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13100,11 +13468,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetHostedZoneCountResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13118,8 +13488,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetHostedZoneCountError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetHostedZoneCountError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13145,7 +13516,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13153,11 +13524,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetReusableDelegationSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13168,7 +13541,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetReusableDelegationSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetReusableDelegationSetError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -13193,7 +13571,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13201,11 +13579,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetTrafficPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13219,8 +13599,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetTrafficPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTrafficPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13246,7 +13627,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13254,11 +13635,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetTrafficPolicyInstanceResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13269,7 +13652,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetTrafficPolicyInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTrafficPolicyInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -13294,7 +13682,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13302,11 +13690,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetTrafficPolicyInstanceCountResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13317,7 +13707,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetTrafficPolicyInstanceCountError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTrafficPolicyInstanceCountError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -13356,7 +13751,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13364,11 +13759,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListGeoLocationsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13382,8 +13779,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListGeoLocationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListGeoLocationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13415,7 +13813,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13423,11 +13821,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListHealthChecksResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13441,8 +13841,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListHealthChecksError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHealthChecksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13478,7 +13879,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13486,11 +13887,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListHostedZonesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13504,8 +13907,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListHostedZonesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHostedZonesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13542,7 +13946,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13550,11 +13954,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListHostedZonesByNameResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13566,8 +13972,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListHostedZonesByNameError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListHostedZonesByNameError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13608,7 +14015,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13616,11 +14023,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListResourceRecordSetsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13632,8 +14041,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListResourceRecordSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListResourceRecordSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13666,7 +14076,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13674,11 +14084,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListReusableDelegationSetsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13689,7 +14101,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListReusableDelegationSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListReusableDelegationSetsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -13714,7 +14131,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13722,11 +14139,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTagsForResourceResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13738,8 +14157,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13765,7 +14185,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13773,11 +14193,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTagsForResourcesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13789,8 +14211,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListTagsForResourcesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourcesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13822,7 +14245,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13830,11 +14253,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTrafficPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13846,8 +14271,9 @@ impl<P, D> Route53 for Route53Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListTrafficPoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTrafficPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13892,7 +14318,7 @@ impl<P, D> Route53 for Route53Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13900,11 +14326,13 @@ impl<P, D> Route53 for Route53Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTrafficPolicyInstancesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13915,7 +14343,12 @@ impl<P, D> Route53 for Route53Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListTrafficPolicyInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTrafficPolicyInstancesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -13953,7 +14386,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -13961,11 +14394,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTrafficPolicyInstancesByHostedZoneResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -13976,7 +14411,11 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
                 Ok(result)
             }
-            _ => Err(ListTrafficPolicyInstancesByHostedZoneError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTrafficPolicyInstancesByHostedZoneError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -14023,7 +14462,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -14031,11 +14470,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTrafficPolicyInstancesByPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14046,7 +14487,11 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
                 Ok(result)
             }
-            _ => Err(ListTrafficPolicyInstancesByPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTrafficPolicyInstancesByPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -14078,7 +14523,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -14086,11 +14531,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTrafficPolicyVersionsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14101,7 +14548,12 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
                 Ok(result)
             }
-            _ => Err(ListTrafficPolicyVersionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTrafficPolicyVersionsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -14133,7 +14585,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -14141,11 +14593,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListVPCAssociationAuthorizationsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14156,7 +14610,11 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
                 Ok(result)
             }
-            _ => Err(ListVPCAssociationAuthorizationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListVPCAssociationAuthorizationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -14194,7 +14652,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -14202,11 +14660,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = TestDNSAnswerResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14219,7 +14679,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
                 Ok(result)
             }
             _ => {
-                Err(TestDNSAnswerError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TestDNSAnswerError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14244,7 +14706,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -14252,11 +14714,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateHealthCheckResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14270,8 +14734,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
                 Ok(result)
             }
             _ => {
-                Err(UpdateHealthCheckError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateHealthCheckError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14297,7 +14762,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -14305,11 +14770,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateHostedZoneCommentResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14320,7 +14787,12 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
                 Ok(result)
             }
-            _ => Err(UpdateHostedZoneCommentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateHostedZoneCommentError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -14346,7 +14818,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -14354,11 +14826,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateTrafficPolicyCommentResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14369,7 +14843,12 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
                 Ok(result)
             }
-            _ => Err(UpdateTrafficPolicyCommentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateTrafficPolicyCommentError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -14394,7 +14873,7 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -14402,11 +14881,13 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateTrafficPolicyInstanceResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -14417,7 +14898,12 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
                 Ok(result)
             }
-            _ => Err(UpdateTrafficPolicyInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateTrafficPolicyInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -877,6 +879,11 @@ impl From<HttpDispatchError> for CheckDomainAvailabilityError {
         CheckDomainAvailabilityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CheckDomainAvailabilityError {
+    fn from(err: io::Error) -> CheckDomainAvailabilityError {
+        CheckDomainAvailabilityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CheckDomainAvailabilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -962,6 +969,11 @@ impl From<HttpDispatchError> for DeleteTagsForDomainError {
         DeleteTagsForDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTagsForDomainError {
+    fn from(err: io::Error) -> DeleteTagsForDomainError {
+        DeleteTagsForDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTagsForDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1043,6 +1055,11 @@ impl From<CredentialsError> for DisableDomainAutoRenewError {
 impl From<HttpDispatchError> for DisableDomainAutoRenewError {
     fn from(err: HttpDispatchError) -> DisableDomainAutoRenewError {
         DisableDomainAutoRenewError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisableDomainAutoRenewError {
+    fn from(err: io::Error) -> DisableDomainAutoRenewError {
+        DisableDomainAutoRenewError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisableDomainAutoRenewError {
@@ -1136,6 +1153,11 @@ impl From<HttpDispatchError> for DisableDomainTransferLockError {
         DisableDomainTransferLockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisableDomainTransferLockError {
+    fn from(err: io::Error) -> DisableDomainTransferLockError {
+        DisableDomainTransferLockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisableDomainTransferLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1224,6 +1246,11 @@ impl From<CredentialsError> for EnableDomainAutoRenewError {
 impl From<HttpDispatchError> for EnableDomainAutoRenewError {
     fn from(err: HttpDispatchError) -> EnableDomainAutoRenewError {
         EnableDomainAutoRenewError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for EnableDomainAutoRenewError {
+    fn from(err: io::Error) -> EnableDomainAutoRenewError {
+        EnableDomainAutoRenewError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for EnableDomainAutoRenewError {
@@ -1320,6 +1347,11 @@ impl From<HttpDispatchError> for EnableDomainTransferLockError {
         EnableDomainTransferLockError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for EnableDomainTransferLockError {
+    fn from(err: io::Error) -> EnableDomainTransferLockError {
+        EnableDomainTransferLockError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for EnableDomainTransferLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1406,6 +1438,11 @@ impl From<HttpDispatchError> for GetContactReachabilityStatusError {
         GetContactReachabilityStatusError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetContactReachabilityStatusError {
+    fn from(err: io::Error) -> GetContactReachabilityStatusError {
+        GetContactReachabilityStatusError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetContactReachabilityStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1489,6 +1526,11 @@ impl From<HttpDispatchError> for GetDomainDetailError {
         GetDomainDetailError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDomainDetailError {
+    fn from(err: io::Error) -> GetDomainDetailError {
+        GetDomainDetailError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDomainDetailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1569,6 +1611,11 @@ impl From<HttpDispatchError> for GetDomainSuggestionsError {
         GetDomainSuggestionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDomainSuggestionsError {
+    fn from(err: io::Error) -> GetDomainSuggestionsError {
+        GetDomainSuggestionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDomainSuggestionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1646,6 +1693,11 @@ impl From<HttpDispatchError> for GetOperationDetailError {
         GetOperationDetailError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetOperationDetailError {
+    fn from(err: io::Error) -> GetOperationDetailError {
+        GetOperationDetailError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetOperationDetailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1720,6 +1772,11 @@ impl From<HttpDispatchError> for ListDomainsError {
         ListDomainsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDomainsError {
+    fn from(err: io::Error) -> ListDomainsError {
+        ListDomainsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1792,6 +1849,11 @@ impl From<CredentialsError> for ListOperationsError {
 impl From<HttpDispatchError> for ListOperationsError {
     fn from(err: HttpDispatchError) -> ListOperationsError {
         ListOperationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListOperationsError {
+    fn from(err: io::Error) -> ListOperationsError {
+        ListOperationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListOperationsError {
@@ -1876,6 +1938,11 @@ impl From<CredentialsError> for ListTagsForDomainError {
 impl From<HttpDispatchError> for ListTagsForDomainError {
     fn from(err: HttpDispatchError) -> ListTagsForDomainError {
         ListTagsForDomainError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListTagsForDomainError {
+    fn from(err: io::Error) -> ListTagsForDomainError {
+        ListTagsForDomainError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListTagsForDomainError {
@@ -1981,6 +2048,11 @@ impl From<HttpDispatchError> for RegisterDomainError {
         RegisterDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterDomainError {
+    fn from(err: io::Error) -> RegisterDomainError {
+        RegisterDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2078,6 +2150,11 @@ impl From<HttpDispatchError> for RenewDomainError {
         RenewDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RenewDomainError {
+    fn from(err: io::Error) -> RenewDomainError {
+        RenewDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RenewDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2158,6 +2235,11 @@ impl From<CredentialsError> for ResendContactReachabilityEmailError {
 impl From<HttpDispatchError> for ResendContactReachabilityEmailError {
     fn from(err: HttpDispatchError) -> ResendContactReachabilityEmailError {
         ResendContactReachabilityEmailError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResendContactReachabilityEmailError {
+    fn from(err: io::Error) -> ResendContactReachabilityEmailError {
+        ResendContactReachabilityEmailError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResendContactReachabilityEmailError {
@@ -2241,6 +2323,11 @@ impl From<CredentialsError> for RetrieveDomainAuthCodeError {
 impl From<HttpDispatchError> for RetrieveDomainAuthCodeError {
     fn from(err: HttpDispatchError) -> RetrieveDomainAuthCodeError {
         RetrieveDomainAuthCodeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RetrieveDomainAuthCodeError {
+    fn from(err: io::Error) -> RetrieveDomainAuthCodeError {
+        RetrieveDomainAuthCodeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RetrieveDomainAuthCodeError {
@@ -2345,6 +2432,11 @@ impl From<HttpDispatchError> for TransferDomainError {
         TransferDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for TransferDomainError {
+    fn from(err: io::Error) -> TransferDomainError {
+        TransferDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for TransferDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2442,6 +2534,11 @@ impl From<HttpDispatchError> for UpdateDomainContactError {
         UpdateDomainContactError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDomainContactError {
+    fn from(err: io::Error) -> UpdateDomainContactError {
+        UpdateDomainContactError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDomainContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2534,6 +2631,11 @@ impl From<CredentialsError> for UpdateDomainContactPrivacyError {
 impl From<HttpDispatchError> for UpdateDomainContactPrivacyError {
     fn from(err: HttpDispatchError) -> UpdateDomainContactPrivacyError {
         UpdateDomainContactPrivacyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateDomainContactPrivacyError {
+    fn from(err: io::Error) -> UpdateDomainContactPrivacyError {
+        UpdateDomainContactPrivacyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateDomainContactPrivacyError {
@@ -2634,6 +2736,11 @@ impl From<HttpDispatchError> for UpdateDomainNameserversError {
         UpdateDomainNameserversError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDomainNameserversError {
+    fn from(err: io::Error) -> UpdateDomainNameserversError {
+        UpdateDomainNameserversError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDomainNameserversError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2722,6 +2829,11 @@ impl From<HttpDispatchError> for UpdateTagsForDomainError {
         UpdateTagsForDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateTagsForDomainError {
+    fn from(err: io::Error) -> UpdateTagsForDomainError {
+        UpdateTagsForDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateTagsForDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2796,6 +2908,11 @@ impl From<CredentialsError> for ViewBillingError {
 impl From<HttpDispatchError> for ViewBillingError {
     fn from(err: HttpDispatchError) -> ViewBillingError {
         ViewBillingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ViewBillingError {
+    fn from(err: io::Error) -> ViewBillingError {
+        ViewBillingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ViewBillingError {
@@ -3006,13 +3123,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CheckDomainAvailabilityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CheckDomainAvailabilityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CheckDomainAvailabilityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CheckDomainAvailabilityError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -3031,15 +3155,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteTagsForDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteTagsForDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteTagsForDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTagsForDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3060,15 +3187,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisableDomainAutoRenewResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisableDomainAutoRenewResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DisableDomainAutoRenewError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableDomainAutoRenewError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3089,13 +3219,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisableDomainTransferLockResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DisableDomainTransferLockError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisableDomainTransferLockResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableDomainTransferLockError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -3115,15 +3252,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EnableDomainAutoRenewResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EnableDomainAutoRenewResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(EnableDomainAutoRenewError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableDomainAutoRenewError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3144,13 +3284,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EnableDomainTransferLockResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(EnableDomainTransferLockError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<EnableDomainTransferLockResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(EnableDomainTransferLockError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -3170,13 +3317,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetContactReachabilityStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetContactReachabilityStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetContactReachabilityStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetContactReachabilityStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -3194,15 +3348,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDomainDetailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDomainDetailResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetDomainDetailError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDomainDetailError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3223,15 +3382,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDomainSuggestionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDomainSuggestionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetDomainSuggestionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDomainSuggestionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3251,15 +3413,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetOperationDetailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetOperationDetailResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetOperationDetailError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetOperationDetailError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3278,13 +3443,21 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDomainsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListDomainsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDomainsResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDomainsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3302,15 +3475,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListOperationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListOperationsResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListOperationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOperationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3329,15 +3507,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTagsForDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3356,15 +3537,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterDomainResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RegisterDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3383,13 +3569,21 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RenewDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RenewDomainError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RenewDomainResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RenewDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3409,13 +3603,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ResendContactReachabilityEmailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ResendContactReachabilityEmailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ResendContactReachabilityEmailResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResendContactReachabilityEmailError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -3435,15 +3636,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RetrieveDomainAuthCodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RetrieveDomainAuthCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RetrieveDomainAuthCodeError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RetrieveDomainAuthCodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3462,15 +3666,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TransferDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<TransferDomainResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(TransferDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TransferDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3490,15 +3699,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDomainContactResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDomainContactResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateDomainContactError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDomainContactError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3519,13 +3731,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDomainContactPrivacyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateDomainContactPrivacyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDomainContactPrivacyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDomainContactPrivacyError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -3545,13 +3764,20 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDomainNameserversResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateDomainNameserversError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDomainNameserversResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDomainNameserversError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -3570,15 +3796,18 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateTagsForDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateTagsForDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateTagsForDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateTagsForDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3597,13 +3826,21 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ViewBillingResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ViewBillingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ViewBillingResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ViewBillingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/s3/src/custom/custom_tests.rs
+++ b/rusoto/services/s3/src/custom/custom_tests.rs
@@ -257,8 +257,8 @@ fn should_parse_sample_list_buckets_response() {
 fn should_parse_headers() {
     let mock = MockRequestDispatcher::with_status(200)
         .with_body("")
-        .with_header("x-amz-expiration".to_string(), "foo".to_string())
-        .with_header("x-amz-restore".to_string(), "bar".to_string());
+        .with_header("x-amz-expiration", "foo")
+        .with_header("x-amz-restore", "bar");
 
     let client = S3Client::new(mock, MockCredentialsProvider, Region::UsEast1);
     let request = HeadObjectRequest::default();

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -40,7 +42,7 @@ enum DeserializerNext {
 use md5;
 use rustc_serialize::base64::{ToBase64, Config, CharacterSet, Newline};
 #[doc="Specifies the days since the initiation of an Incomplete Multipart Upload that Lifecycle will wait before permanently removing all parts of the upload."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AbortIncompleteMultipartUpload {
     #[doc="Indicates the number of days that must pass since initiation for Lifecycle to abort an Incomplete Multipart Upload."]
     pub days_after_initiation: Option<i64>,
@@ -104,7 +106,7 @@ impl AbortIncompleteMultipartUploadSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AbortMultipartUploadOutput {
     pub request_charged: Option<String>,
 }
@@ -125,7 +127,7 @@ impl AbortMultipartUploadOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AbortMultipartUploadRequest {
     pub bucket: String,
     pub key: String,
@@ -133,7 +135,7 @@ pub struct AbortMultipartUploadRequest {
     pub upload_id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AccelerateConfiguration {
     #[doc="The accelerate configuration of the bucket."]
     pub status: Option<String>,
@@ -153,7 +155,7 @@ impl AccelerateConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AccessControlPolicy {
     #[doc="A list of grants."]
     pub grants: Option<Vec<Grant>>,
@@ -400,7 +402,7 @@ impl AllowedOriginsSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AnalyticsAndOperator {
     #[doc="The prefix to use when evaluating an AND predicate."]
     pub prefix: Option<String>,
@@ -470,7 +472,7 @@ impl AnalyticsAndOperatorSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AnalyticsConfiguration {
     #[doc="The filter used to describe a set of objects for analyses. A filter must have exactly one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided, all objects will be considered in any analysis."]
     pub filter: Option<AnalyticsFilter>,
@@ -576,7 +578,7 @@ impl AnalyticsConfigurationListDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AnalyticsExportDestination {
     #[doc="A destination signifying output to an S3 bucket."]
     pub s3_bucket_destination: AnalyticsS3BucketDestination,
@@ -639,7 +641,7 @@ impl AnalyticsExportDestinationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AnalyticsFilter {
     #[doc="A conjunction (logical AND) of predicates, which is used in evaluating an analytics filter. The operator must have at least two predicates."]
     pub and: Option<AnalyticsAndOperator>,
@@ -744,7 +746,7 @@ impl AnalyticsIdSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct AnalyticsS3BucketDestination {
     #[doc="The Amazon resource name (ARN) of the bucket to which data is exported."]
     pub bucket: String,
@@ -855,6 +857,27 @@ impl AnalyticsS3ExportFileFormatSerializer {
     }
 }
 
+pub struct StreamingBody(Box<Read>);
+
+impl fmt::Debug for StreamingBody {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "<Body: streaming content>")
+    }
+}
+
+impl ::std::ops::Deref for StreamingBody {
+    type Target = Box<Read>;
+
+    fn deref(&self) -> &Box<Read> {
+        &self.0
+    }
+}
+
+impl ::std::ops::DerefMut for StreamingBody {
+    fn deref_mut(&mut self) -> &mut Box<Read> {
+        &mut self.0
+    }
+}
 
 pub struct BodySerializer;
 impl BodySerializer {
@@ -866,7 +889,7 @@ impl BodySerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Bucket {
     #[doc="Date the bucket was created."]
     pub creation_date: Option<String>,
@@ -946,7 +969,7 @@ impl BucketAccelerateStatusSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct BucketLifecycleConfiguration {
     pub rules: Vec<LifecycleRule>,
 }
@@ -988,7 +1011,7 @@ impl BucketLocationConstraintSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct BucketLoggingStatus {
     pub logging_enabled: Option<LoggingEnabled>,
 }
@@ -1123,7 +1146,7 @@ impl BucketsDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CORSConfiguration {
     pub cors_rules: Vec<CORSRule>,
 }
@@ -1140,7 +1163,7 @@ impl CORSConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CORSRule {
     #[doc="Specifies which headers are allowed in a pre-flight OPTIONS request."]
     pub allowed_headers: Option<Vec<String>>,
@@ -1305,7 +1328,7 @@ impl CloudFunctionSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CloudFunctionConfiguration {
     pub cloud_function: Option<String>,
     pub events: Option<Vec<String>>,
@@ -1429,7 +1452,7 @@ impl CodeDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CommonPrefix {
     pub prefix: Option<String>,
 }
@@ -1504,7 +1527,7 @@ impl CommonPrefixListDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CompleteMultipartUploadOutput {
     pub bucket: Option<String>,
     #[doc="Entity tag of the object."]
@@ -1574,7 +1597,7 @@ impl CompleteMultipartUploadOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CompleteMultipartUploadRequest {
     pub bucket: String,
     pub key: String,
@@ -1583,7 +1606,7 @@ pub struct CompleteMultipartUploadRequest {
     pub upload_id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CompletedMultipartUpload {
     pub parts: Option<Vec<CompletedPart>>,
 }
@@ -1602,7 +1625,7 @@ impl CompletedMultipartUploadSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CompletedPart {
     #[doc="Entity tag returned when the part was uploaded."]
     pub e_tag: Option<String>,
@@ -1640,7 +1663,7 @@ impl CompletedPartListSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Condition {
     #[doc="The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applied. Required when parent element Condition is specified and sibling KeyPrefixEquals is not specified. If both are specified, then both must be true for the redirect to be applied."]
     pub http_error_code_returned_equals: Option<String>,
@@ -1712,7 +1735,7 @@ impl ConditionSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CopyObjectOutput {
     pub copy_object_result: Option<CopyObjectResult>,
     pub copy_source_version_id: Option<String>,
@@ -1774,7 +1797,7 @@ impl CopyObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CopyObjectRequest {
     #[doc="The canned ACL to apply to the object."]
     pub acl: Option<String>,
@@ -1841,7 +1864,7 @@ pub struct CopyObjectRequest {
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CopyObjectResult {
     pub e_tag: Option<String>,
     pub last_modified: Option<String>,
@@ -1893,7 +1916,7 @@ impl CopyObjectResultDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CopyPartResult {
     #[doc="Entity tag of the object."]
     pub e_tag: Option<String>,
@@ -1947,7 +1970,7 @@ impl CopyPartResultDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateBucketConfiguration {
     #[doc="Specifies the region where the bucket will be created. If you don't specify a region, the bucket will be created in US Standard."]
     pub location_constraint: Option<String>,
@@ -1968,7 +1991,7 @@ impl CreateBucketConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateBucketOutput {
     pub location: Option<String>,
 }
@@ -1989,7 +2012,7 @@ impl CreateBucketOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateBucketRequest {
     #[doc="The canned ACL to apply to the bucket."]
     pub acl: Option<String>,
@@ -2007,7 +2030,7 @@ pub struct CreateBucketRequest {
     pub grant_write_acp: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateMultipartUploadOutput {
     #[doc="Date when multipart upload will become eligible for abort operation by lifecycle."]
     pub abort_date: Option<String>,
@@ -2080,7 +2103,7 @@ impl CreateMultipartUploadOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct CreateMultipartUploadRequest {
     #[doc="The canned ACL to apply to the object."]
     pub acl: Option<String>,
@@ -2214,7 +2237,7 @@ impl DaysAfterInitiationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Delete {
     pub objects: Vec<ObjectIdentifier>,
     #[doc="Element to enable quiet mode for the request. When you add this element, you must set its value to true."]
@@ -2236,7 +2259,7 @@ impl DeleteSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketAnalyticsConfigurationRequest {
     #[doc="The name of the bucket from which an analytics configuration is deleted."]
     pub bucket: String,
@@ -2244,12 +2267,12 @@ pub struct DeleteBucketAnalyticsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketCorsRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketInventoryConfigurationRequest {
     #[doc="The name of the bucket containing the inventory configuration to delete."]
     pub bucket: String,
@@ -2257,12 +2280,12 @@ pub struct DeleteBucketInventoryConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketLifecycleRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketMetricsConfigurationRequest {
     #[doc="The name of the bucket containing the metrics configuration to delete."]
     pub bucket: String,
@@ -2270,27 +2293,27 @@ pub struct DeleteBucketMetricsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketPolicyRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketReplicationRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketTaggingRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteBucketWebsiteRequest {
     pub bucket: String,
 }
@@ -2309,7 +2332,7 @@ impl DeleteMarkerDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteMarkerEntry {
     #[doc="Specifies whether the object is (true) or is not (false) the latest version of an object."]
     pub is_latest: Option<bool>,
@@ -2422,7 +2445,7 @@ impl DeleteMarkersDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteObjectOutput {
     #[doc="Specifies whether the versioned object that was permanently deleted was (true) or was not (false) a delete marker."]
     pub delete_marker: Option<bool>,
@@ -2447,7 +2470,7 @@ impl DeleteObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteObjectRequest {
     pub bucket: String,
     pub key: String,
@@ -2458,7 +2481,7 @@ pub struct DeleteObjectRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteObjectTaggingOutput {
     #[doc="The versionId of the object the tag-set was removed from."]
     pub version_id: Option<String>,
@@ -2480,7 +2503,7 @@ impl DeleteObjectTaggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteObjectTaggingRequest {
     pub bucket: String,
     pub key: String,
@@ -2488,7 +2511,7 @@ pub struct DeleteObjectTaggingRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteObjectsOutput {
     pub deleted: Option<Vec<DeletedObject>>,
     pub errors: Option<Vec<S3Error>>,
@@ -2542,7 +2565,7 @@ impl DeleteObjectsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeleteObjectsRequest {
     pub bucket: String,
     pub delete: Delete,
@@ -2551,7 +2574,7 @@ pub struct DeleteObjectsRequest {
     pub request_payer: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct DeletedObject {
     pub delete_marker: Option<bool>,
     pub delete_marker_version_id: Option<String>,
@@ -2668,7 +2691,7 @@ impl DelimiterSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Destination {
     #[doc="Amazon resource name (ARN) of the bucket where you want Amazon S3 to store replicas of the object identified by the rule."]
     pub bucket: String,
@@ -2837,7 +2860,7 @@ impl EncodingTypeSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct S3Error {
     pub code: Option<String>,
     pub key: Option<String>,
@@ -2898,7 +2921,7 @@ impl S3ErrorDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ErrorDocument {
     #[doc="The object key name to use when a 4XX class error occurs."]
     pub key: String,
@@ -3179,7 +3202,7 @@ impl FetchOwnerSerializer {
 }
 
 #[doc="Container for key value pair that defines the criteria for the filter rule."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct FilterRule {
     #[doc="Object key name prefix or suffix identifying one or more objects to which the filtering rule applies. Maximum prefix length can be up to 1,024 characters. Overlapping prefixes and suffixes are not supported. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the Amazon Simple Storage Service Developer Guide."]
     pub name: Option<String>,
@@ -3340,7 +3363,7 @@ impl FilterRuleValueSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketAccelerateConfigurationOutput {
     #[doc="The accelerate configuration of the bucket."]
     pub status: Option<String>,
@@ -3390,13 +3413,13 @@ impl GetBucketAccelerateConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketAccelerateConfigurationRequest {
     #[doc="Name of the bucket for which the accelerate configuration is retrieved."]
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketAclOutput {
     #[doc="A list of grants."]
     pub grants: Option<Vec<Grant>>,
@@ -3448,12 +3471,12 @@ impl GetBucketAclOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketAclRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketAnalyticsConfigurationOutput {
     #[doc="The configuration and any analyses for the analytics filter."]
     pub analytics_configuration: Option<AnalyticsConfiguration>,
@@ -3503,7 +3526,7 @@ impl GetBucketAnalyticsConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketAnalyticsConfigurationRequest {
     #[doc="The name of the bucket from which an analytics configuration is retrieved."]
     pub bucket: String,
@@ -3511,7 +3534,7 @@ pub struct GetBucketAnalyticsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketCorsOutput {
     pub cors_rules: Option<Vec<CORSRule>>,
 }
@@ -3558,12 +3581,12 @@ impl GetBucketCorsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketCorsRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketInventoryConfigurationOutput {
     #[doc="Specifies the inventory configuration."]
     pub inventory_configuration: Option<InventoryConfiguration>,
@@ -3613,7 +3636,7 @@ impl GetBucketInventoryConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketInventoryConfigurationRequest {
     #[doc="The name of the bucket containing the inventory configuration to retrieve."]
     pub bucket: String,
@@ -3621,7 +3644,7 @@ pub struct GetBucketInventoryConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketLifecycleConfigurationOutput {
     pub rules: Option<Vec<LifecycleRule>>,
 }
@@ -3669,12 +3692,12 @@ impl GetBucketLifecycleConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketLifecycleConfigurationRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketLifecycleOutput {
     pub rules: Option<Vec<Rule>>,
 }
@@ -3720,12 +3743,12 @@ impl GetBucketLifecycleOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketLifecycleRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketLocationOutput {
     pub location_constraint: Option<String>,
 }
@@ -3743,12 +3766,12 @@ impl GetBucketLocationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketLocationRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketLoggingOutput {
     pub logging_enabled: Option<LoggingEnabled>,
 }
@@ -3796,12 +3819,12 @@ impl GetBucketLoggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketLoggingRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketMetricsConfigurationOutput {
     #[doc="Specifies the metrics configuration."]
     pub metrics_configuration: Option<MetricsConfiguration>,
@@ -3851,7 +3874,7 @@ impl GetBucketMetricsConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketMetricsConfigurationRequest {
     #[doc="The name of the bucket containing the metrics configuration to retrieve."]
     pub bucket: String,
@@ -3859,24 +3882,24 @@ pub struct GetBucketMetricsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketNotificationConfigurationRequest {
     #[doc="Name of the bucket to get the notification configuration for."]
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketPolicyOutput {
     #[doc="The bucket policy as a JSON document."]
     pub policy: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketPolicyRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketReplicationOutput {
     pub replication_configuration: Option<ReplicationConfiguration>,
 }
@@ -3922,12 +3945,12 @@ impl GetBucketReplicationOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketReplicationRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketRequestPaymentOutput {
     #[doc="Specifies who pays for the download and request fees."]
     pub payer: Option<String>,
@@ -3974,12 +3997,12 @@ impl GetBucketRequestPaymentOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketRequestPaymentRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketTaggingOutput {
     pub tag_set: Vec<Tag>,
 }
@@ -4025,12 +4048,12 @@ impl GetBucketTaggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketTaggingRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketVersioningOutput {
     #[doc="Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."]
     pub mfa_delete: Option<String>,
@@ -4086,12 +4109,12 @@ impl GetBucketVersioningOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketVersioningRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketWebsiteOutput {
     pub error_document: Option<ErrorDocument>,
     pub index_document: Option<IndexDocument>,
@@ -4157,12 +4180,12 @@ impl GetBucketWebsiteOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetBucketWebsiteRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetObjectAclOutput {
     #[doc="A list of grants."]
     pub grants: Option<Vec<Grant>>,
@@ -4215,7 +4238,7 @@ impl GetObjectAclOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetObjectAclRequest {
     pub bucket: String,
     pub key: String,
@@ -4224,11 +4247,11 @@ pub struct GetObjectAclRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetObjectOutput {
     pub accept_ranges: Option<String>,
     #[doc="Object data."]
-    pub body: Option<Vec<u8>>,
+    pub body: Option<StreamingBody>,
     #[doc="Specifies caching behavior along the request/reply chain."]
     pub cache_control: Option<String>,
     #[doc="Specifies presentational information for the object."]
@@ -4280,7 +4303,7 @@ pub struct GetObjectOutput {
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetObjectRequest {
     pub bucket: String,
     #[doc="Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed)."]
@@ -4319,7 +4342,7 @@ pub struct GetObjectRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetObjectTaggingOutput {
     pub tag_set: Vec<Tag>,
     pub version_id: Option<String>,
@@ -4366,27 +4389,27 @@ impl GetObjectTaggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetObjectTaggingRequest {
     pub bucket: String,
     pub key: String,
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetObjectTorrentOutput {
-    pub body: Option<Vec<u8>>,
+    pub body: Option<StreamingBody>,
     pub request_charged: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GetObjectTorrentRequest {
     pub bucket: String,
     pub key: String,
     pub request_payer: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct GlacierJobParameters {
     #[doc="Glacier retrieval tier at which the restore will be processed."]
     pub tier: String,
@@ -4404,7 +4427,7 @@ impl GlacierJobParametersSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Grant {
     pub grantee: Option<Grantee>,
     #[doc="Specifies the permission given to the grantee."]
@@ -4474,7 +4497,7 @@ impl GrantSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Grantee {
     #[doc="Screen name of the grantee."]
     pub display_name: Option<String>,
@@ -4625,12 +4648,12 @@ impl GrantsSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct HeadBucketRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct HeadObjectOutput {
     pub accept_ranges: Option<String>,
     #[doc="Specifies caching behavior along the request/reply chain."]
@@ -4696,7 +4719,7 @@ impl HeadObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct HeadObjectRequest {
     pub bucket: String,
     #[doc="Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed)."]
@@ -4823,7 +4846,7 @@ impl IDSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct IndexDocument {
     #[doc="A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character."]
     pub suffix: String,
@@ -4896,7 +4919,7 @@ impl InitiatedDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Initiator {
     #[doc="Name of the Principal."]
     pub display_name: Option<String>,
@@ -4950,7 +4973,7 @@ impl InitiatorDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct InventoryConfiguration {
     #[doc="Contains information about where to publish the inventory results."]
     pub destination: InventoryDestination,
@@ -5086,7 +5109,7 @@ impl InventoryConfigurationListDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct InventoryDestination {
     #[doc="Contains the bucket name, file format, bucket owner (optional), and prefix (optional) where inventory results are published."]
     pub s3_bucket_destination: InventoryS3BucketDestination,
@@ -5149,7 +5172,7 @@ impl InventoryDestinationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct InventoryFilter {
     #[doc="The prefix that an object must have to be included in the inventory results."]
     pub prefix: String,
@@ -5390,7 +5413,7 @@ impl InventoryOptionalFieldsSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct InventoryS3BucketDestination {
     #[doc="The ID of the account that owns the destination bucket."]
     pub account_id: Option<String>,
@@ -5474,7 +5497,7 @@ impl InventoryS3BucketDestinationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct InventorySchedule {
     #[doc="Specifies how frequently inventory results are produced."]
     pub frequency: String,
@@ -5678,7 +5701,7 @@ impl LambdaFunctionArnSerializer {
 }
 
 #[doc="Container for specifying the AWS Lambda notification configuration."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LambdaFunctionConfiguration {
     pub events: Vec<String>,
     pub filter: Option<NotificationConfigurationFilter>,
@@ -5817,7 +5840,7 @@ impl LastModifiedDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LifecycleConfiguration {
     pub rules: Vec<Rule>,
 }
@@ -5834,7 +5857,7 @@ impl LifecycleConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LifecycleExpiration {
     #[doc="Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format."]
     pub date: Option<String>,
@@ -5912,7 +5935,7 @@ impl LifecycleExpirationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LifecycleRule {
     pub abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUpload>,
     pub expiration: Option<LifecycleExpiration>,
@@ -6032,7 +6055,7 @@ impl LifecycleRuleSerializer {
 }
 
 #[doc="This is used in a Lifecycle Rule Filter to apply a logical AND to two or more predicates. The Lifecycle Rule will apply to any object matching all of the predicates configured inside the And operator."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LifecycleRuleAndOperator {
     pub prefix: Option<String>,
     #[doc="All of these tags must exist in the object's tag set in order for the rule to apply."]
@@ -6102,7 +6125,7 @@ impl LifecycleRuleAndOperatorSerializer {
 }
 
 #[doc="The Filter is used to identify objects that a Lifecycle Rule applies to. A Filter must have exactly one of Prefix, Tag, or And specified."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LifecycleRuleFilter {
     pub and: Option<LifecycleRuleAndOperator>,
     #[doc="Prefix identifying one or more objects to which the rule applies."]
@@ -6220,7 +6243,7 @@ impl LifecycleRulesSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListBucketAnalyticsConfigurationsOutput {
     #[doc="The list of analytics configurations for a bucket."]
     pub analytics_configuration_list: Option<Vec<AnalyticsConfiguration>>,
@@ -6289,7 +6312,7 @@ impl ListBucketAnalyticsConfigurationsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListBucketAnalyticsConfigurationsRequest {
     #[doc="The name of the bucket from which analytics configurations are retrieved."]
     pub bucket: String,
@@ -6297,7 +6320,7 @@ pub struct ListBucketAnalyticsConfigurationsRequest {
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListBucketInventoryConfigurationsOutput {
     #[doc="If sent in the request, the marker that is used as a starting point for this inventory configuration list response."]
     pub continuation_token: Option<String>,
@@ -6366,7 +6389,7 @@ impl ListBucketInventoryConfigurationsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListBucketInventoryConfigurationsRequest {
     #[doc="The name of the bucket containing the inventory configurations to retrieve."]
     pub bucket: String,
@@ -6374,7 +6397,7 @@ pub struct ListBucketInventoryConfigurationsRequest {
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListBucketMetricsConfigurationsOutput {
     #[doc="The marker that is used as a starting point for this metrics configuration list response. This value is present if it was sent in the request."]
     pub continuation_token: Option<String>,
@@ -6443,7 +6466,7 @@ impl ListBucketMetricsConfigurationsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListBucketMetricsConfigurationsRequest {
     #[doc="The name of the bucket containing the metrics configurations to retrieve."]
     pub bucket: String,
@@ -6451,7 +6474,7 @@ pub struct ListBucketMetricsConfigurationsRequest {
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListBucketsOutput {
     pub buckets: Option<Vec<Bucket>>,
     pub owner: Option<Owner>,
@@ -6502,7 +6525,7 @@ impl ListBucketsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListMultipartUploadsOutput {
     #[doc="Name of the bucket to which the multipart upload was initiated."]
     pub bucket: Option<String>,
@@ -6621,7 +6644,7 @@ impl ListMultipartUploadsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListMultipartUploadsRequest {
     pub bucket: String,
     #[doc="Character you use to group keys."]
@@ -6637,7 +6660,7 @@ pub struct ListMultipartUploadsRequest {
     pub upload_id_marker: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListObjectVersionsOutput {
     pub common_prefixes: Option<Vec<CommonPrefix>>,
     pub delete_markers: Option<Vec<DeleteMarkerEntry>>,
@@ -6757,7 +6780,7 @@ impl ListObjectVersionsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListObjectVersionsRequest {
     pub bucket: String,
     #[doc="A delimiter is a character you use to group keys."]
@@ -6773,7 +6796,7 @@ pub struct ListObjectVersionsRequest {
     pub version_id_marker: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListObjectsOutput {
     pub common_prefixes: Option<Vec<CommonPrefix>>,
     pub contents: Option<Vec<Object>>,
@@ -6872,7 +6895,7 @@ impl ListObjectsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListObjectsRequest {
     pub bucket: String,
     #[doc="A delimiter is a character you use to group keys."]
@@ -6888,7 +6911,7 @@ pub struct ListObjectsRequest {
     pub request_payer: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListObjectsV2Output {
     #[doc="CommonPrefixes contains all (if there are any) keys between Prefix and the next occurrence of the string specified by delimiter"]
     pub common_prefixes: Option<Vec<CommonPrefix>>,
@@ -7008,7 +7031,7 @@ impl ListObjectsV2OutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListObjectsV2Request {
     #[doc="Name of the bucket to list."]
     pub bucket: String,
@@ -7030,7 +7053,7 @@ pub struct ListObjectsV2Request {
     pub start_after: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListPartsOutput {
     #[doc="Date when multipart upload will become eligible for abort operation by lifecycle."]
     pub abort_date: Option<String>,
@@ -7143,7 +7166,7 @@ impl ListPartsOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ListPartsRequest {
     pub bucket: String,
     pub key: String,
@@ -7170,7 +7193,7 @@ impl LocationDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct LoggingEnabled {
     #[doc="Specifies the bucket where you want Amazon S3 to store server access logs. You can have your logs delivered to any bucket that you own, including the same bucket that is being logged. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case you should choose a different TargetPrefix for each source bucket so that the delivered log files can be distinguished by key."]
     pub target_bucket: Option<String>,
@@ -7416,7 +7439,7 @@ impl MessageDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct MetricsAndOperator {
     #[doc="The prefix used when evaluating an AND predicate."]
     pub prefix: Option<String>,
@@ -7486,7 +7509,7 @@ impl MetricsAndOperatorSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct MetricsConfiguration {
     #[doc="Specifies a metrics configuration filter. The metrics configuration will only include objects that meet the filter's criteria. A filter must be a prefix, a tag, or a conjunction (MetricsAndOperator)."]
     pub filter: Option<MetricsFilter>,
@@ -7582,7 +7605,7 @@ impl MetricsConfigurationListDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct MetricsFilter {
     #[doc="A conjunction (logical AND) of predicates, which is used in evaluating a metrics filter. The operator must have at least two predicates, and an object must match all of the predicates in order for the filter to apply."]
     pub and: Option<MetricsAndOperator>,
@@ -7687,7 +7710,7 @@ impl MetricsIdSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct MultipartUpload {
     #[doc="Date and time at which the multipart upload was initiated."]
     pub initiated: Option<String>,
@@ -7902,7 +7925,7 @@ impl NextVersionIdMarkerDeserializer {
     }
 }
 #[doc="Specifies when noncurrent object versions expire. Upon expiration, Amazon S3 permanently deletes the noncurrent object versions. You set this lifecycle configuration action on a bucket that has versioning enabled (or suspended) to request that Amazon S3 delete noncurrent object versions at a specific period in the object's lifetime."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct NoncurrentVersionExpiration {
     #[doc="Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html\">How Amazon S3 Calculates When an Object Became Noncurrent</a> in the Amazon Simple Storage Service Developer Guide."]
     pub noncurrent_days: Option<i64>,
@@ -7965,7 +7988,7 @@ impl NoncurrentVersionExpirationSerializer {
 }
 
 #[doc="Container for the transition rule that describes when noncurrent objects transition to the STANDARD_IA or GLACIER storage class. If your bucket is versioning-enabled (or versioning is suspended), you can set this action to request that Amazon S3 transition noncurrent object versions to the STANDARD_IA or GLACIER storage class at a specific period in the object's lifetime."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct NoncurrentVersionTransition {
     #[doc="Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html\">How Amazon S3 Calculates When an Object Became Noncurrent</a> in the Amazon Simple Storage Service Developer Guide."]
     pub noncurrent_days: Option<i64>,
@@ -8081,7 +8104,7 @@ impl NoncurrentVersionTransitionListSerializer {
 }
 
 #[doc="Container for specifying the notification configuration of the bucket. If this element is empty, notifications are turned off on the bucket."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct NotificationConfiguration {
     pub lambda_function_configurations: Option<Vec<LambdaFunctionConfiguration>>,
     pub queue_configurations: Option<Vec<QueueConfiguration>>,
@@ -8160,7 +8183,7 @@ impl NotificationConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct NotificationConfigurationDeprecated {
     pub cloud_function_configuration: Option<CloudFunctionConfiguration>,
     pub queue_configuration: Option<QueueConfigurationDeprecated>,
@@ -8239,7 +8262,7 @@ impl NotificationConfigurationDeprecatedSerializer {
 }
 
 #[doc="Container for object key name filtering rules. For information about key name filtering, go to <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the Amazon Simple Storage Service Developer Guide."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct NotificationConfigurationFilter {
     pub key: Option<S3KeyFilter>,
 }
@@ -8326,7 +8349,7 @@ impl NotificationIdSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Object {
     pub e_tag: Option<String>,
     pub key: Option<String>,
@@ -8397,7 +8420,7 @@ impl ObjectDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ObjectIdentifier {
     #[doc="Key name of the object to delete."]
     pub key: String,
@@ -8500,7 +8523,7 @@ impl ObjectStorageClassDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ObjectVersion {
     pub e_tag: Option<String>,
     #[doc="Specifies whether the object is (true) or is not (false) the latest version of an object."]
@@ -8652,7 +8675,7 @@ impl ObjectVersionStorageClassDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Owner {
     pub display_name: Option<String>,
     pub id: Option<String>,
@@ -8721,7 +8744,7 @@ impl OwnerSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Part {
     #[doc="Entity tag returned when the part was uploaded."]
     pub e_tag: Option<String>,
@@ -8976,7 +8999,7 @@ impl ProtocolSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketAccelerateConfigurationRequest {
     #[doc="Specifies the Accelerate Configuration you want to set for the bucket."]
     pub accelerate_configuration: AccelerateConfiguration,
@@ -8984,7 +9007,7 @@ pub struct PutBucketAccelerateConfigurationRequest {
     pub bucket: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketAclRequest {
     #[doc="The canned ACL to apply to the bucket."]
     pub acl: Option<String>,
@@ -9003,7 +9026,7 @@ pub struct PutBucketAclRequest {
     pub grant_write_acp: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketAnalyticsConfigurationRequest {
     #[doc="The configuration and any analyses for the analytics filter."]
     pub analytics_configuration: AnalyticsConfiguration,
@@ -9013,14 +9036,14 @@ pub struct PutBucketAnalyticsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketCorsRequest {
     pub bucket: String,
     pub cors_configuration: CORSConfiguration,
     pub content_md5: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketInventoryConfigurationRequest {
     #[doc="The name of the bucket where the inventory configuration will be stored."]
     pub bucket: String,
@@ -9030,27 +9053,27 @@ pub struct PutBucketInventoryConfigurationRequest {
     pub inventory_configuration: InventoryConfiguration,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketLifecycleConfigurationRequest {
     pub bucket: String,
     pub lifecycle_configuration: Option<BucketLifecycleConfiguration>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketLifecycleRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub lifecycle_configuration: Option<LifecycleConfiguration>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketLoggingRequest {
     pub bucket: String,
     pub bucket_logging_status: BucketLoggingStatus,
     pub content_md5: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketMetricsConfigurationRequest {
     #[doc="The name of the bucket for which the metrics configuration is set."]
     pub bucket: String,
@@ -9060,20 +9083,20 @@ pub struct PutBucketMetricsConfigurationRequest {
     pub metrics_configuration: MetricsConfiguration,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketNotificationConfigurationRequest {
     pub bucket: String,
     pub notification_configuration: NotificationConfiguration,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketNotificationRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub notification_configuration: NotificationConfigurationDeprecated,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketPolicyRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
@@ -9081,28 +9104,28 @@ pub struct PutBucketPolicyRequest {
     pub policy: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketReplicationRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub replication_configuration: ReplicationConfiguration,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketRequestPaymentRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub request_payment_configuration: RequestPaymentConfiguration,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketTaggingRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub tagging: Tagging,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketVersioningRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
@@ -9111,14 +9134,14 @@ pub struct PutBucketVersioningRequest {
     pub versioning_configuration: VersioningConfiguration,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutBucketWebsiteRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub website_configuration: WebsiteConfiguration,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutObjectAclOutput {
     pub request_charged: Option<String>,
 }
@@ -9139,7 +9162,7 @@ impl PutObjectAclOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutObjectAclRequest {
     #[doc="The canned ACL to apply to the object."]
     pub acl: Option<String>,
@@ -9162,7 +9185,7 @@ pub struct PutObjectAclRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutObjectOutput {
     #[doc="Entity tag for the uploaded object."]
     pub e_tag: Option<String>,
@@ -9197,7 +9220,7 @@ impl PutObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutObjectRequest {
     #[doc="The canned ACL to apply to the object."]
     pub acl: Option<String>,
@@ -9252,7 +9275,7 @@ pub struct PutObjectRequest {
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutObjectTaggingOutput {
     pub version_id: Option<String>,
 }
@@ -9273,7 +9296,7 @@ impl PutObjectTaggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct PutObjectTaggingRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
@@ -9308,7 +9331,7 @@ impl QueueArnSerializer {
 }
 
 #[doc="Container for specifying an configuration when you want Amazon S3 to publish events to an Amazon Simple Queue Service (Amazon SQS) queue."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct QueueConfiguration {
     pub events: Vec<String>,
     pub filter: Option<NotificationConfigurationFilter>,
@@ -9387,7 +9410,7 @@ impl QueueConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct QueueConfigurationDeprecated {
     pub events: Option<Vec<String>>,
     pub id: Option<String>,
@@ -9516,7 +9539,7 @@ impl QuietSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Redirect {
     #[doc="The host name to use in the redirect request."]
     pub host_name: Option<String>,
@@ -9619,7 +9642,7 @@ impl RedirectSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct RedirectAllRequestsTo {
     #[doc="Name of the host where requests will be redirected."]
     pub host_name: String,
@@ -9739,7 +9762,7 @@ impl ReplaceKeyWithSerializer {
 }
 
 #[doc="Container for replication rules. You can add as many as 1,000 rules. Total replication configuration size can be up to 2 MB."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ReplicationConfiguration {
     #[doc="Amazon Resource Name (ARN) of an IAM role for Amazon S3 to assume when replicating the objects."]
     pub role: String,
@@ -9805,7 +9828,7 @@ impl ReplicationConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct ReplicationRule {
     pub destination: Destination,
     #[doc="Unique identifier for the rule. The value cannot be longer than 255 characters."]
@@ -9952,7 +9975,7 @@ impl ReplicationRulesSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct RequestPaymentConfiguration {
     #[doc="Specifies who pays for the download and request fees."]
     pub payer: String,
@@ -10036,7 +10059,7 @@ impl ResponseExpiresSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct RestoreObjectOutput {
     pub request_charged: Option<String>,
 }
@@ -10057,7 +10080,7 @@ impl RestoreObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct RestoreObjectRequest {
     pub bucket: String,
     pub key: String,
@@ -10066,7 +10089,7 @@ pub struct RestoreObjectRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct RestoreRequest {
     #[doc="Lifetime of the active copy in days"]
     pub days: i64,
@@ -10114,7 +10137,7 @@ impl RoleSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct RoutingRule {
     #[doc="A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the /docs folder, redirect to the /documents folder. 2. If request results in HTTP error 4xx, redirect request to another host where you might process the error."]
     pub condition: Option<Condition>,
@@ -10239,7 +10262,7 @@ impl RoutingRulesSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Rule {
     pub abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUpload>,
     pub expiration: Option<LifecycleExpiration>,
@@ -10396,7 +10419,7 @@ impl RulesSerializer {
 }
 
 #[doc="Container for object key name prefix and suffix filtering rules."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct S3KeyFilter {
     pub filter_rules: Option<Vec<FilterRule>>,
 }
@@ -10522,7 +10545,7 @@ impl StorageClassSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StorageClassAnalysis {
     #[doc="A container used to describe how data related to the storage class analysis should be exported."]
     pub data_export: Option<StorageClassAnalysisDataExport>,
@@ -10583,7 +10606,7 @@ impl StorageClassAnalysisSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct StorageClassAnalysisDataExport {
     #[doc="The place to store the data for an analysis."]
     pub destination: AnalyticsExportDestination,
@@ -10702,7 +10725,7 @@ impl SuffixSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Tag {
     #[doc="Name of the tag."]
     pub key: String,
@@ -10823,7 +10846,7 @@ impl TagSetSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Tagging {
     pub tag_set: Vec<Tag>,
 }
@@ -10865,7 +10888,7 @@ impl TargetBucketSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TargetGrant {
     pub grantee: Option<Grantee>,
     #[doc="Logging permissions assigned to the Grantee for the bucket."]
@@ -11079,7 +11102,7 @@ impl TopicArnSerializer {
 }
 
 #[doc="Container for specifying the configuration when you want Amazon S3 to publish events to an Amazon Simple Notification Service (Amazon SNS) topic."]
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TopicConfiguration {
     pub events: Vec<String>,
     pub filter: Option<NotificationConfigurationFilter>,
@@ -11158,7 +11181,7 @@ impl TopicConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct TopicConfigurationDeprecated {
     pub events: Option<Vec<String>>,
     pub id: Option<String>,
@@ -11277,7 +11300,7 @@ impl TopicConfigurationListSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct Transition {
     #[doc="Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format."]
     pub date: Option<String>,
@@ -11497,7 +11520,7 @@ impl UploadIdMarkerSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UploadPartCopyOutput {
     pub copy_part_result: Option<CopyPartResult>,
     #[doc="The version of the source object that was copied, if you have enabled versioning on the source bucket."]
@@ -11556,7 +11579,7 @@ impl UploadPartCopyOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UploadPartCopyRequest {
     pub bucket: String,
     #[doc="The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded."]
@@ -11591,7 +11614,7 @@ pub struct UploadPartCopyRequest {
     pub upload_id: String,
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UploadPartOutput {
     #[doc="Entity tag for the uploaded object."]
     pub e_tag: Option<String>,
@@ -11622,7 +11645,7 @@ impl UploadPartOutputDeserializer {
 
     }
 }
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct UploadPartRequest {
     #[doc="Object data."]
     pub body: Option<Vec<u8>>,
@@ -11697,7 +11720,7 @@ impl VersionIdMarkerSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct VersioningConfiguration {
     #[doc="Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."]
     pub mfa_delete: Option<String>,
@@ -11722,7 +11745,7 @@ impl VersioningConfigurationSerializer {
     }
 }
 
-#[derive(Default,Clone,Debug)]
+#[derive(Default,Debug)]
 pub struct WebsiteConfiguration {
     pub error_document: Option<ErrorDocument>,
     pub index_document: Option<IndexDocument>,
@@ -11806,6 +11829,11 @@ impl From<HttpDispatchError> for AbortMultipartUploadError {
         AbortMultipartUploadError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AbortMultipartUploadError {
+    fn from(err: io::Error) -> AbortMultipartUploadError {
+        AbortMultipartUploadError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AbortMultipartUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11869,6 +11897,11 @@ impl From<CredentialsError> for CompleteMultipartUploadError {
 impl From<HttpDispatchError> for CompleteMultipartUploadError {
     fn from(err: HttpDispatchError) -> CompleteMultipartUploadError {
         CompleteMultipartUploadError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CompleteMultipartUploadError {
+    fn from(err: io::Error) -> CompleteMultipartUploadError {
+        CompleteMultipartUploadError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CompleteMultipartUploadError {
@@ -11936,6 +11969,11 @@ impl From<CredentialsError> for CopyObjectError {
 impl From<HttpDispatchError> for CopyObjectError {
     fn from(err: HttpDispatchError) -> CopyObjectError {
         CopyObjectError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CopyObjectError {
+    fn from(err: io::Error) -> CopyObjectError {
+        CopyObjectError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CopyObjectError {
@@ -12009,6 +12047,11 @@ impl From<HttpDispatchError> for CreateBucketError {
         CreateBucketError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateBucketError {
+    fn from(err: io::Error) -> CreateBucketError {
+        CreateBucketError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateBucketError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12071,6 +12114,11 @@ impl From<CredentialsError> for CreateMultipartUploadError {
 impl From<HttpDispatchError> for CreateMultipartUploadError {
     fn from(err: HttpDispatchError) -> CreateMultipartUploadError {
         CreateMultipartUploadError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateMultipartUploadError {
+    fn from(err: io::Error) -> CreateMultipartUploadError {
+        CreateMultipartUploadError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateMultipartUploadError {
@@ -12137,6 +12185,11 @@ impl From<HttpDispatchError> for DeleteBucketError {
         DeleteBucketError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteBucketError {
+    fn from(err: io::Error) -> DeleteBucketError {
+        DeleteBucketError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteBucketError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12197,6 +12250,11 @@ impl From<CredentialsError> for DeleteBucketAnalyticsConfigurationError {
 impl From<HttpDispatchError> for DeleteBucketAnalyticsConfigurationError {
     fn from(err: HttpDispatchError) -> DeleteBucketAnalyticsConfigurationError {
         DeleteBucketAnalyticsConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBucketAnalyticsConfigurationError {
+    fn from(err: io::Error) -> DeleteBucketAnalyticsConfigurationError {
+        DeleteBucketAnalyticsConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBucketAnalyticsConfigurationError {
@@ -12263,6 +12321,11 @@ impl From<HttpDispatchError> for DeleteBucketCorsError {
         DeleteBucketCorsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteBucketCorsError {
+    fn from(err: io::Error) -> DeleteBucketCorsError {
+        DeleteBucketCorsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteBucketCorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12323,6 +12386,11 @@ impl From<CredentialsError> for DeleteBucketInventoryConfigurationError {
 impl From<HttpDispatchError> for DeleteBucketInventoryConfigurationError {
     fn from(err: HttpDispatchError) -> DeleteBucketInventoryConfigurationError {
         DeleteBucketInventoryConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBucketInventoryConfigurationError {
+    fn from(err: io::Error) -> DeleteBucketInventoryConfigurationError {
+        DeleteBucketInventoryConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBucketInventoryConfigurationError {
@@ -12389,6 +12457,11 @@ impl From<HttpDispatchError> for DeleteBucketLifecycleError {
         DeleteBucketLifecycleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteBucketLifecycleError {
+    fn from(err: io::Error) -> DeleteBucketLifecycleError {
+        DeleteBucketLifecycleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteBucketLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12451,6 +12524,11 @@ impl From<CredentialsError> for DeleteBucketMetricsConfigurationError {
 impl From<HttpDispatchError> for DeleteBucketMetricsConfigurationError {
     fn from(err: HttpDispatchError) -> DeleteBucketMetricsConfigurationError {
         DeleteBucketMetricsConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBucketMetricsConfigurationError {
+    fn from(err: io::Error) -> DeleteBucketMetricsConfigurationError {
+        DeleteBucketMetricsConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBucketMetricsConfigurationError {
@@ -12517,6 +12595,11 @@ impl From<HttpDispatchError> for DeleteBucketPolicyError {
         DeleteBucketPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteBucketPolicyError {
+    fn from(err: io::Error) -> DeleteBucketPolicyError {
+        DeleteBucketPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteBucketPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12579,6 +12662,11 @@ impl From<CredentialsError> for DeleteBucketReplicationError {
 impl From<HttpDispatchError> for DeleteBucketReplicationError {
     fn from(err: HttpDispatchError) -> DeleteBucketReplicationError {
         DeleteBucketReplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBucketReplicationError {
+    fn from(err: io::Error) -> DeleteBucketReplicationError {
+        DeleteBucketReplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBucketReplicationError {
@@ -12645,6 +12733,11 @@ impl From<HttpDispatchError> for DeleteBucketTaggingError {
         DeleteBucketTaggingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteBucketTaggingError {
+    fn from(err: io::Error) -> DeleteBucketTaggingError {
+        DeleteBucketTaggingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteBucketTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12707,6 +12800,11 @@ impl From<CredentialsError> for DeleteBucketWebsiteError {
 impl From<HttpDispatchError> for DeleteBucketWebsiteError {
     fn from(err: HttpDispatchError) -> DeleteBucketWebsiteError {
         DeleteBucketWebsiteError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBucketWebsiteError {
+    fn from(err: io::Error) -> DeleteBucketWebsiteError {
+        DeleteBucketWebsiteError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBucketWebsiteError {
@@ -12773,6 +12871,11 @@ impl From<HttpDispatchError> for DeleteObjectError {
         DeleteObjectError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteObjectError {
+    fn from(err: io::Error) -> DeleteObjectError {
+        DeleteObjectError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12833,6 +12936,11 @@ impl From<CredentialsError> for DeleteObjectTaggingError {
 impl From<HttpDispatchError> for DeleteObjectTaggingError {
     fn from(err: HttpDispatchError) -> DeleteObjectTaggingError {
         DeleteObjectTaggingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteObjectTaggingError {
+    fn from(err: io::Error) -> DeleteObjectTaggingError {
+        DeleteObjectTaggingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteObjectTaggingError {
@@ -12899,6 +13007,11 @@ impl From<HttpDispatchError> for DeleteObjectsError {
         DeleteObjectsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteObjectsError {
+    fn from(err: io::Error) -> DeleteObjectsError {
+        DeleteObjectsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteObjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -12959,6 +13072,11 @@ impl From<CredentialsError> for GetBucketAccelerateConfigurationError {
 impl From<HttpDispatchError> for GetBucketAccelerateConfigurationError {
     fn from(err: HttpDispatchError) -> GetBucketAccelerateConfigurationError {
         GetBucketAccelerateConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBucketAccelerateConfigurationError {
+    fn from(err: io::Error) -> GetBucketAccelerateConfigurationError {
+        GetBucketAccelerateConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBucketAccelerateConfigurationError {
@@ -13025,6 +13143,11 @@ impl From<HttpDispatchError> for GetBucketAclError {
         GetBucketAclError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketAclError {
+    fn from(err: io::Error) -> GetBucketAclError {
+        GetBucketAclError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13085,6 +13208,11 @@ impl From<CredentialsError> for GetBucketAnalyticsConfigurationError {
 impl From<HttpDispatchError> for GetBucketAnalyticsConfigurationError {
     fn from(err: HttpDispatchError) -> GetBucketAnalyticsConfigurationError {
         GetBucketAnalyticsConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBucketAnalyticsConfigurationError {
+    fn from(err: io::Error) -> GetBucketAnalyticsConfigurationError {
+        GetBucketAnalyticsConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBucketAnalyticsConfigurationError {
@@ -13151,6 +13279,11 @@ impl From<HttpDispatchError> for GetBucketCorsError {
         GetBucketCorsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketCorsError {
+    fn from(err: io::Error) -> GetBucketCorsError {
+        GetBucketCorsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketCorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13211,6 +13344,11 @@ impl From<CredentialsError> for GetBucketInventoryConfigurationError {
 impl From<HttpDispatchError> for GetBucketInventoryConfigurationError {
     fn from(err: HttpDispatchError) -> GetBucketInventoryConfigurationError {
         GetBucketInventoryConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBucketInventoryConfigurationError {
+    fn from(err: io::Error) -> GetBucketInventoryConfigurationError {
+        GetBucketInventoryConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBucketInventoryConfigurationError {
@@ -13277,6 +13415,11 @@ impl From<HttpDispatchError> for GetBucketLifecycleError {
         GetBucketLifecycleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketLifecycleError {
+    fn from(err: io::Error) -> GetBucketLifecycleError {
+        GetBucketLifecycleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13339,6 +13482,11 @@ impl From<CredentialsError> for GetBucketLifecycleConfigurationError {
 impl From<HttpDispatchError> for GetBucketLifecycleConfigurationError {
     fn from(err: HttpDispatchError) -> GetBucketLifecycleConfigurationError {
         GetBucketLifecycleConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBucketLifecycleConfigurationError {
+    fn from(err: io::Error) -> GetBucketLifecycleConfigurationError {
+        GetBucketLifecycleConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBucketLifecycleConfigurationError {
@@ -13405,6 +13553,11 @@ impl From<HttpDispatchError> for GetBucketLocationError {
         GetBucketLocationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketLocationError {
+    fn from(err: io::Error) -> GetBucketLocationError {
+        GetBucketLocationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketLocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13469,6 +13622,11 @@ impl From<HttpDispatchError> for GetBucketLoggingError {
         GetBucketLoggingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketLoggingError {
+    fn from(err: io::Error) -> GetBucketLoggingError {
+        GetBucketLoggingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13529,6 +13687,11 @@ impl From<CredentialsError> for GetBucketMetricsConfigurationError {
 impl From<HttpDispatchError> for GetBucketMetricsConfigurationError {
     fn from(err: HttpDispatchError) -> GetBucketMetricsConfigurationError {
         GetBucketMetricsConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBucketMetricsConfigurationError {
+    fn from(err: io::Error) -> GetBucketMetricsConfigurationError {
+        GetBucketMetricsConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBucketMetricsConfigurationError {
@@ -13595,6 +13758,11 @@ impl From<HttpDispatchError> for GetBucketNotificationError {
         GetBucketNotificationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketNotificationError {
+    fn from(err: io::Error) -> GetBucketNotificationError {
+        GetBucketNotificationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13657,6 +13825,11 @@ impl From<CredentialsError> for GetBucketNotificationConfigurationError {
 impl From<HttpDispatchError> for GetBucketNotificationConfigurationError {
     fn from(err: HttpDispatchError) -> GetBucketNotificationConfigurationError {
         GetBucketNotificationConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBucketNotificationConfigurationError {
+    fn from(err: io::Error) -> GetBucketNotificationConfigurationError {
+        GetBucketNotificationConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBucketNotificationConfigurationError {
@@ -13723,6 +13896,11 @@ impl From<HttpDispatchError> for GetBucketPolicyError {
         GetBucketPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketPolicyError {
+    fn from(err: io::Error) -> GetBucketPolicyError {
+        GetBucketPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13783,6 +13961,11 @@ impl From<CredentialsError> for GetBucketReplicationError {
 impl From<HttpDispatchError> for GetBucketReplicationError {
     fn from(err: HttpDispatchError) -> GetBucketReplicationError {
         GetBucketReplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBucketReplicationError {
+    fn from(err: io::Error) -> GetBucketReplicationError {
+        GetBucketReplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBucketReplicationError {
@@ -13849,6 +14032,11 @@ impl From<HttpDispatchError> for GetBucketRequestPaymentError {
         GetBucketRequestPaymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketRequestPaymentError {
+    fn from(err: io::Error) -> GetBucketRequestPaymentError {
+        GetBucketRequestPaymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketRequestPaymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13913,6 +14101,11 @@ impl From<HttpDispatchError> for GetBucketTaggingError {
         GetBucketTaggingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketTaggingError {
+    fn from(err: io::Error) -> GetBucketTaggingError {
+        GetBucketTaggingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -13973,6 +14166,11 @@ impl From<CredentialsError> for GetBucketVersioningError {
 impl From<HttpDispatchError> for GetBucketVersioningError {
     fn from(err: HttpDispatchError) -> GetBucketVersioningError {
         GetBucketVersioningError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetBucketVersioningError {
+    fn from(err: io::Error) -> GetBucketVersioningError {
+        GetBucketVersioningError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetBucketVersioningError {
@@ -14039,6 +14237,11 @@ impl From<HttpDispatchError> for GetBucketWebsiteError {
         GetBucketWebsiteError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetBucketWebsiteError {
+    fn from(err: io::Error) -> GetBucketWebsiteError {
+        GetBucketWebsiteError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetBucketWebsiteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14102,6 +14305,11 @@ impl From<CredentialsError> for GetObjectError {
 impl From<HttpDispatchError> for GetObjectError {
     fn from(err: HttpDispatchError) -> GetObjectError {
         GetObjectError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetObjectError {
+    fn from(err: io::Error) -> GetObjectError {
+        GetObjectError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetObjectError {
@@ -14170,6 +14378,11 @@ impl From<HttpDispatchError> for GetObjectAclError {
         GetObjectAclError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetObjectAclError {
+    fn from(err: io::Error) -> GetObjectAclError {
+        GetObjectAclError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetObjectAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14233,6 +14446,11 @@ impl From<HttpDispatchError> for GetObjectTaggingError {
         GetObjectTaggingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetObjectTaggingError {
+    fn from(err: io::Error) -> GetObjectTaggingError {
+        GetObjectTaggingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetObjectTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14293,6 +14511,11 @@ impl From<CredentialsError> for GetObjectTorrentError {
 impl From<HttpDispatchError> for GetObjectTorrentError {
     fn from(err: HttpDispatchError) -> GetObjectTorrentError {
         GetObjectTorrentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetObjectTorrentError {
+    fn from(err: io::Error) -> GetObjectTorrentError {
+        GetObjectTorrentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetObjectTorrentError {
@@ -14362,6 +14585,11 @@ impl From<HttpDispatchError> for HeadBucketError {
         HeadBucketError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for HeadBucketError {
+    fn from(err: io::Error) -> HeadBucketError {
+        HeadBucketError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for HeadBucketError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14428,6 +14656,11 @@ impl From<HttpDispatchError> for HeadObjectError {
         HeadObjectError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for HeadObjectError {
+    fn from(err: io::Error) -> HeadObjectError {
+        HeadObjectError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for HeadObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14489,6 +14722,11 @@ impl From<CredentialsError> for ListBucketAnalyticsConfigurationsError {
 impl From<HttpDispatchError> for ListBucketAnalyticsConfigurationsError {
     fn from(err: HttpDispatchError) -> ListBucketAnalyticsConfigurationsError {
         ListBucketAnalyticsConfigurationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListBucketAnalyticsConfigurationsError {
+    fn from(err: io::Error) -> ListBucketAnalyticsConfigurationsError {
+        ListBucketAnalyticsConfigurationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListBucketAnalyticsConfigurationsError {
@@ -14555,6 +14793,11 @@ impl From<HttpDispatchError> for ListBucketInventoryConfigurationsError {
         ListBucketInventoryConfigurationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListBucketInventoryConfigurationsError {
+    fn from(err: io::Error) -> ListBucketInventoryConfigurationsError {
+        ListBucketInventoryConfigurationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListBucketInventoryConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14617,6 +14860,11 @@ impl From<CredentialsError> for ListBucketMetricsConfigurationsError {
 impl From<HttpDispatchError> for ListBucketMetricsConfigurationsError {
     fn from(err: HttpDispatchError) -> ListBucketMetricsConfigurationsError {
         ListBucketMetricsConfigurationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListBucketMetricsConfigurationsError {
+    fn from(err: io::Error) -> ListBucketMetricsConfigurationsError {
+        ListBucketMetricsConfigurationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListBucketMetricsConfigurationsError {
@@ -14683,6 +14931,11 @@ impl From<HttpDispatchError> for ListBucketsError {
         ListBucketsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListBucketsError {
+    fn from(err: io::Error) -> ListBucketsError {
+        ListBucketsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListBucketsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14743,6 +14996,11 @@ impl From<CredentialsError> for ListMultipartUploadsError {
 impl From<HttpDispatchError> for ListMultipartUploadsError {
     fn from(err: HttpDispatchError) -> ListMultipartUploadsError {
         ListMultipartUploadsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListMultipartUploadsError {
+    fn from(err: io::Error) -> ListMultipartUploadsError {
+        ListMultipartUploadsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListMultipartUploadsError {
@@ -14807,6 +15065,11 @@ impl From<CredentialsError> for ListObjectVersionsError {
 impl From<HttpDispatchError> for ListObjectVersionsError {
     fn from(err: HttpDispatchError) -> ListObjectVersionsError {
         ListObjectVersionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListObjectVersionsError {
+    fn from(err: io::Error) -> ListObjectVersionsError {
+        ListObjectVersionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListObjectVersionsError {
@@ -14878,6 +15141,11 @@ impl From<HttpDispatchError> for ListObjectsError {
         ListObjectsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListObjectsError {
+    fn from(err: io::Error) -> ListObjectsError {
+        ListObjectsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListObjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -14946,6 +15214,11 @@ impl From<HttpDispatchError> for ListObjectsV2Error {
         ListObjectsV2Error::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListObjectsV2Error {
+    fn from(err: io::Error) -> ListObjectsV2Error {
+        ListObjectsV2Error::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListObjectsV2Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15009,6 +15282,11 @@ impl From<HttpDispatchError> for ListPartsError {
         ListPartsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPartsError {
+    fn from(err: io::Error) -> ListPartsError {
+        ListPartsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPartsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15069,6 +15347,11 @@ impl From<CredentialsError> for PutBucketAccelerateConfigurationError {
 impl From<HttpDispatchError> for PutBucketAccelerateConfigurationError {
     fn from(err: HttpDispatchError) -> PutBucketAccelerateConfigurationError {
         PutBucketAccelerateConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutBucketAccelerateConfigurationError {
+    fn from(err: io::Error) -> PutBucketAccelerateConfigurationError {
+        PutBucketAccelerateConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutBucketAccelerateConfigurationError {
@@ -15135,6 +15418,11 @@ impl From<HttpDispatchError> for PutBucketAclError {
         PutBucketAclError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketAclError {
+    fn from(err: io::Error) -> PutBucketAclError {
+        PutBucketAclError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15195,6 +15483,11 @@ impl From<CredentialsError> for PutBucketAnalyticsConfigurationError {
 impl From<HttpDispatchError> for PutBucketAnalyticsConfigurationError {
     fn from(err: HttpDispatchError) -> PutBucketAnalyticsConfigurationError {
         PutBucketAnalyticsConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutBucketAnalyticsConfigurationError {
+    fn from(err: io::Error) -> PutBucketAnalyticsConfigurationError {
+        PutBucketAnalyticsConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutBucketAnalyticsConfigurationError {
@@ -15261,6 +15554,11 @@ impl From<HttpDispatchError> for PutBucketCorsError {
         PutBucketCorsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketCorsError {
+    fn from(err: io::Error) -> PutBucketCorsError {
+        PutBucketCorsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketCorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15321,6 +15619,11 @@ impl From<CredentialsError> for PutBucketInventoryConfigurationError {
 impl From<HttpDispatchError> for PutBucketInventoryConfigurationError {
     fn from(err: HttpDispatchError) -> PutBucketInventoryConfigurationError {
         PutBucketInventoryConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutBucketInventoryConfigurationError {
+    fn from(err: io::Error) -> PutBucketInventoryConfigurationError {
+        PutBucketInventoryConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutBucketInventoryConfigurationError {
@@ -15387,6 +15690,11 @@ impl From<HttpDispatchError> for PutBucketLifecycleError {
         PutBucketLifecycleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketLifecycleError {
+    fn from(err: io::Error) -> PutBucketLifecycleError {
+        PutBucketLifecycleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15449,6 +15757,11 @@ impl From<CredentialsError> for PutBucketLifecycleConfigurationError {
 impl From<HttpDispatchError> for PutBucketLifecycleConfigurationError {
     fn from(err: HttpDispatchError) -> PutBucketLifecycleConfigurationError {
         PutBucketLifecycleConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutBucketLifecycleConfigurationError {
+    fn from(err: io::Error) -> PutBucketLifecycleConfigurationError {
+        PutBucketLifecycleConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutBucketLifecycleConfigurationError {
@@ -15515,6 +15828,11 @@ impl From<HttpDispatchError> for PutBucketLoggingError {
         PutBucketLoggingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketLoggingError {
+    fn from(err: io::Error) -> PutBucketLoggingError {
+        PutBucketLoggingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15575,6 +15893,11 @@ impl From<CredentialsError> for PutBucketMetricsConfigurationError {
 impl From<HttpDispatchError> for PutBucketMetricsConfigurationError {
     fn from(err: HttpDispatchError) -> PutBucketMetricsConfigurationError {
         PutBucketMetricsConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutBucketMetricsConfigurationError {
+    fn from(err: io::Error) -> PutBucketMetricsConfigurationError {
+        PutBucketMetricsConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutBucketMetricsConfigurationError {
@@ -15641,6 +15964,11 @@ impl From<HttpDispatchError> for PutBucketNotificationError {
         PutBucketNotificationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketNotificationError {
+    fn from(err: io::Error) -> PutBucketNotificationError {
+        PutBucketNotificationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15703,6 +16031,11 @@ impl From<CredentialsError> for PutBucketNotificationConfigurationError {
 impl From<HttpDispatchError> for PutBucketNotificationConfigurationError {
     fn from(err: HttpDispatchError) -> PutBucketNotificationConfigurationError {
         PutBucketNotificationConfigurationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutBucketNotificationConfigurationError {
+    fn from(err: io::Error) -> PutBucketNotificationConfigurationError {
+        PutBucketNotificationConfigurationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutBucketNotificationConfigurationError {
@@ -15769,6 +16102,11 @@ impl From<HttpDispatchError> for PutBucketPolicyError {
         PutBucketPolicyError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketPolicyError {
+    fn from(err: io::Error) -> PutBucketPolicyError {
+        PutBucketPolicyError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15829,6 +16167,11 @@ impl From<CredentialsError> for PutBucketReplicationError {
 impl From<HttpDispatchError> for PutBucketReplicationError {
     fn from(err: HttpDispatchError) -> PutBucketReplicationError {
         PutBucketReplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutBucketReplicationError {
+    fn from(err: io::Error) -> PutBucketReplicationError {
+        PutBucketReplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutBucketReplicationError {
@@ -15895,6 +16238,11 @@ impl From<HttpDispatchError> for PutBucketRequestPaymentError {
         PutBucketRequestPaymentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketRequestPaymentError {
+    fn from(err: io::Error) -> PutBucketRequestPaymentError {
+        PutBucketRequestPaymentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketRequestPaymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -15959,6 +16307,11 @@ impl From<HttpDispatchError> for PutBucketTaggingError {
         PutBucketTaggingError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketTaggingError {
+    fn from(err: io::Error) -> PutBucketTaggingError {
+        PutBucketTaggingError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16019,6 +16372,11 @@ impl From<CredentialsError> for PutBucketVersioningError {
 impl From<HttpDispatchError> for PutBucketVersioningError {
     fn from(err: HttpDispatchError) -> PutBucketVersioningError {
         PutBucketVersioningError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutBucketVersioningError {
+    fn from(err: io::Error) -> PutBucketVersioningError {
+        PutBucketVersioningError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutBucketVersioningError {
@@ -16085,6 +16443,11 @@ impl From<HttpDispatchError> for PutBucketWebsiteError {
         PutBucketWebsiteError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutBucketWebsiteError {
+    fn from(err: io::Error) -> PutBucketWebsiteError {
+        PutBucketWebsiteError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutBucketWebsiteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16145,6 +16508,11 @@ impl From<CredentialsError> for PutObjectError {
 impl From<HttpDispatchError> for PutObjectError {
     fn from(err: HttpDispatchError) -> PutObjectError {
         PutObjectError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutObjectError {
+    fn from(err: io::Error) -> PutObjectError {
+        PutObjectError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutObjectError {
@@ -16212,6 +16580,11 @@ impl From<HttpDispatchError> for PutObjectAclError {
         PutObjectAclError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutObjectAclError {
+    fn from(err: io::Error) -> PutObjectAclError {
+        PutObjectAclError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutObjectAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16273,6 +16646,11 @@ impl From<CredentialsError> for PutObjectTaggingError {
 impl From<HttpDispatchError> for PutObjectTaggingError {
     fn from(err: HttpDispatchError) -> PutObjectTaggingError {
         PutObjectTaggingError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutObjectTaggingError {
+    fn from(err: io::Error) -> PutObjectTaggingError {
+        PutObjectTaggingError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutObjectTaggingError {
@@ -16340,6 +16718,11 @@ impl From<HttpDispatchError> for RestoreObjectError {
         RestoreObjectError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RestoreObjectError {
+    fn from(err: io::Error) -> RestoreObjectError {
+        RestoreObjectError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RestoreObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16403,6 +16786,11 @@ impl From<HttpDispatchError> for UploadPartError {
         UploadPartError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UploadPartError {
+    fn from(err: io::Error) -> UploadPartError {
+        UploadPartError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UploadPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -16463,6 +16851,11 @@ impl From<CredentialsError> for UploadPartCopyError {
 impl From<HttpDispatchError> for UploadPartCopyError {
     fn from(err: HttpDispatchError) -> UploadPartCopyError {
         UploadPartCopyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UploadPartCopyError {
+    fn from(err: io::Error) -> UploadPartCopyError {
+        UploadPartCopyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UploadPartCopyError {
@@ -16970,7 +17363,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -16978,11 +17371,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = AbortMultipartUploadOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -16999,8 +17394,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(AbortMultipartUploadError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AbortMultipartUploadError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17042,7 +17438,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17050,11 +17446,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CompleteMultipartUploadOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17088,7 +17486,12 @@ impl<P, D> S3 for S3Client<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(CompleteMultipartUploadError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CompleteMultipartUploadError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -17241,7 +17644,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17249,11 +17652,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CopyObjectOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17307,7 +17712,11 @@ impl<P, D> S3 for S3Client<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(CopyObjectError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CopyObjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -17361,7 +17770,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17369,11 +17778,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateBucketOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17389,7 +17800,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateBucketError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateBucketError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17497,7 +17910,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17505,11 +17918,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateMultipartUploadOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17558,8 +17973,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateMultipartUploadError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateMultipartUploadError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17582,7 +17998,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17593,7 +18009,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteBucketError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17619,7 +18037,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17629,7 +18047,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteBucketAnalyticsConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketAnalyticsConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -17653,7 +18075,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17664,8 +18086,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteBucketCorsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketCorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17691,7 +18114,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17701,7 +18124,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteBucketInventoryConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketInventoryConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -17725,7 +18152,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17736,8 +18163,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteBucketLifecycleError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketLifecycleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17762,7 +18190,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17772,7 +18200,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteBucketMetricsConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketMetricsConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -17796,7 +18228,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17807,8 +18239,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteBucketPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17833,7 +18266,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17843,7 +18276,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(DeleteBucketReplicationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketReplicationError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -17867,7 +18305,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17878,8 +18316,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteBucketTaggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketTaggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17904,7 +18343,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17915,8 +18354,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteBucketWebsiteError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBucketWebsiteError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -17952,7 +18392,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -17960,11 +18400,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteObjectOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -17988,7 +18430,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteObjectError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteObjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18017,7 +18461,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18025,11 +18469,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteObjectTaggingOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18046,8 +18492,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteObjectTaggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteObjectTaggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18089,7 +18536,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18097,11 +18544,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteObjectsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18117,7 +18566,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteObjectsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteObjectsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18143,7 +18594,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18151,11 +18602,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketAccelerateConfigurationOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18166,7 +18619,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetBucketAccelerateConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketAccelerateConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -18190,7 +18647,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18198,11 +18655,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketAclOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18215,7 +18674,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketAclError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketAclError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18241,7 +18702,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18249,11 +18710,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketAnalyticsConfigurationOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18264,7 +18727,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetBucketAnalyticsConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketAnalyticsConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -18288,7 +18756,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18296,11 +18764,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketCorsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18313,7 +18783,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketCorsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketCorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18339,7 +18811,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18347,11 +18819,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketInventoryConfigurationOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18362,7 +18836,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetBucketInventoryConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketInventoryConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -18386,7 +18865,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18394,11 +18873,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketLifecycleOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18412,8 +18893,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketLifecycleError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketLifecycleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18439,7 +18921,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18447,11 +18929,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketLifecycleConfigurationOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18462,7 +18946,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetBucketLifecycleConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketLifecycleConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -18486,7 +18975,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18494,11 +18983,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketLocationOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18512,8 +19003,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketLocationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketLocationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18538,7 +19030,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18546,11 +19038,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketLoggingOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18564,8 +19058,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketLoggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketLoggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18591,7 +19086,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18599,11 +19094,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketMetricsConfigurationOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18614,7 +19111,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetBucketMetricsConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketMetricsConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -18639,7 +19141,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18647,11 +19149,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = NotificationConfigurationDeprecated::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18663,8 +19167,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketNotificationError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketNotificationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18690,7 +19195,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18698,11 +19203,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = NotificationConfiguration::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18715,7 +19222,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetBucketNotificationConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketNotificationConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -18739,22 +19250,26 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
             StatusCode::NoContent |
             StatusCode::PartialContent => {
 
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+
                 let mut result = GetBucketPolicyOutput::default();
-                result.policy = Some(String::from_utf8_lossy(&response.body).into_owned());
+                result.policy = Some(String::from_utf8_lossy(&body).into_owned());
 
 
                 Ok(result)
             }
             _ => {
-                Err(GetBucketPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18779,7 +19294,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18787,11 +19302,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketReplicationOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18805,8 +19322,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketReplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketReplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18832,7 +19350,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18840,11 +19358,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketRequestPaymentOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18855,7 +19375,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(GetBucketRequestPaymentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketRequestPaymentError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -18879,7 +19404,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18887,11 +19412,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketTaggingOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18905,8 +19432,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketTaggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketTaggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18931,7 +19459,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18939,11 +19467,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketVersioningOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -18957,8 +19487,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketVersioningError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketVersioningError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -18983,7 +19514,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -18991,11 +19522,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetBucketWebsiteOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19009,8 +19542,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetBucketWebsiteError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetBucketWebsiteError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -19103,15 +19637,17 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
             StatusCode::NoContent |
             StatusCode::PartialContent => {
 
+
+
                 let mut result = GetObjectOutput::default();
-                result.body = Some(response.body);
+                result.body = Some(StreamingBody(response.body));
 
                 if let Some(accept_ranges) = response.headers.get("accept-ranges") {
                     let value = accept_ranges.to_owned();
@@ -19238,7 +19774,11 @@ impl<P, D> S3 for S3Client<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(GetObjectError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetObjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -19269,7 +19809,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19277,11 +19817,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetObjectAclOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19297,7 +19839,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetObjectAclError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetObjectAclError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -19326,7 +19870,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19334,11 +19878,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetObjectTaggingOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19355,8 +19901,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetObjectTaggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetObjectTaggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -19385,15 +19932,17 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
             StatusCode::NoContent |
             StatusCode::PartialContent => {
 
+
+
                 let mut result = GetObjectTorrentOutput::default();
-                result.body = Some(response.body);
+                result.body = Some(StreamingBody(response.body));
 
                 if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
                     let value = request_charged.to_owned();
@@ -19402,8 +19951,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetObjectTorrentError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetObjectTorrentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -19426,7 +19976,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19436,7 +19986,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(HeadBucketError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(HeadBucketError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -19504,7 +20058,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19512,11 +20066,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = HeadObjectOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19642,7 +20198,11 @@ impl<P, D> S3 for S3Client<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(HeadObjectError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(HeadObjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -19670,7 +20230,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19678,11 +20238,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListBucketAnalyticsConfigurationsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19693,7 +20255,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListBucketAnalyticsConfigurationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListBucketAnalyticsConfigurationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -19721,7 +20287,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19729,11 +20295,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListBucketInventoryConfigurationsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19744,7 +20312,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListBucketInventoryConfigurationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListBucketInventoryConfigurationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -19772,7 +20344,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19780,11 +20352,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListBucketMetricsConfigurationsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19795,7 +20369,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListBucketMetricsConfigurationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListBucketMetricsConfigurationsError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -19817,7 +20396,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19825,11 +20404,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListBucketsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19841,7 +20422,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListBucketsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListBucketsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -19888,7 +20473,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19896,11 +20481,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListMultipartUploadsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19914,8 +20501,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListMultipartUploadsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListMultipartUploadsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -19963,7 +20551,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -19971,11 +20559,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListObjectVersionsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -19989,8 +20579,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListObjectVersionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListObjectVersionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20037,7 +20628,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20045,11 +20636,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListObjectsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -20061,7 +20654,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(ListObjectsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListObjectsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -20115,7 +20712,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20123,11 +20720,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListObjectsV2Output::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -20140,7 +20739,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListObjectsV2Error::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListObjectsV2Error::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20175,7 +20776,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20183,11 +20784,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListPartsOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -20210,7 +20813,11 @@ impl<P, D> S3 for S3Client<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(ListPartsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPartsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -20239,7 +20846,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20249,7 +20856,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutBucketAccelerateConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketAccelerateConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -20310,7 +20921,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20321,7 +20932,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketAclError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketAclError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20351,7 +20964,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20361,7 +20974,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutBucketAnalyticsConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketAnalyticsConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -20398,7 +21016,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20409,7 +21027,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketCorsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketCorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20439,7 +21059,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20449,7 +21069,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutBucketInventoryConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketInventoryConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -20495,7 +21120,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20506,8 +21131,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketLifecycleError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketLifecycleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20552,7 +21178,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20562,7 +21188,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutBucketLifecycleConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketLifecycleConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -20594,7 +21225,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20605,8 +21236,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketLoggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketLoggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20636,7 +21268,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20646,7 +21278,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutBucketMetricsConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketMetricsConfigurationError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -20676,7 +21313,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20687,8 +21324,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketNotificationError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketNotificationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20720,7 +21358,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20730,7 +21368,11 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutBucketNotificationConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketNotificationConfigurationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -20760,7 +21402,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20771,8 +21413,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20813,7 +21456,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20824,8 +21467,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketReplicationError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketReplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20856,7 +21500,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20866,7 +21510,12 @@ impl<P, D> S3 for S3Client<P, D>
 
                 Ok(result)
             }
-            _ => Err(PutBucketRequestPaymentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketRequestPaymentError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -20903,7 +21552,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20914,8 +21563,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketTaggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketTaggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20952,7 +21602,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -20963,8 +21613,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketVersioningError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketVersioningError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -20997,7 +21648,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -21008,8 +21659,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutBucketWebsiteError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutBucketWebsiteError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -21129,7 +21781,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -21137,11 +21789,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PutObjectOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -21194,7 +21848,11 @@ impl<P, D> S3 for S3Client<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(PutObjectError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutObjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -21265,7 +21923,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -21273,11 +21931,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PutObjectAclOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -21293,7 +21953,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutObjectAclError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutObjectAclError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -21328,7 +21990,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -21336,11 +21998,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PutObjectTaggingOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -21357,8 +22021,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(PutObjectTaggingError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutObjectTaggingError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -21399,7 +22064,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -21407,11 +22072,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = RestoreObjectOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -21427,7 +22094,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(RestoreObjectError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RestoreObjectError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -21481,7 +22150,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -21489,11 +22158,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UploadPartOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -21538,7 +22209,11 @@ impl<P, D> S3 for S3Client<P, D>
                 };
                 Ok(result)
             }
-            _ => Err(UploadPartError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UploadPartError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -21623,7 +22298,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok |
@@ -21631,11 +22306,13 @@ impl<P, D> S3 for S3Client<P, D>
             StatusCode::PartialContent => {
 
                 let mut result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UploadPartCopyOutput::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -21682,8 +22359,9 @@ impl<P, D> S3 for S3Client<P, D>
                 Ok(result)
             }
             _ => {
-                Err(UploadPartCopyError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UploadPartCopyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1921,6 +1923,11 @@ impl From<HttpDispatchError> for AcceptPortfolioShareError {
         AcceptPortfolioShareError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AcceptPortfolioShareError {
+    fn from(err: io::Error) -> AcceptPortfolioShareError {
+        AcceptPortfolioShareError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AcceptPortfolioShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2003,6 +2010,11 @@ impl From<HttpDispatchError> for AssociatePrincipalWithPortfolioError {
         AssociatePrincipalWithPortfolioError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociatePrincipalWithPortfolioError {
+    fn from(err: io::Error) -> AssociatePrincipalWithPortfolioError {
+        AssociatePrincipalWithPortfolioError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociatePrincipalWithPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2083,6 +2095,11 @@ impl From<CredentialsError> for AssociateProductWithPortfolioError {
 impl From<HttpDispatchError> for AssociateProductWithPortfolioError {
     fn from(err: HttpDispatchError) -> AssociateProductWithPortfolioError {
         AssociateProductWithPortfolioError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AssociateProductWithPortfolioError {
+    fn from(err: io::Error) -> AssociateProductWithPortfolioError {
+        AssociateProductWithPortfolioError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AssociateProductWithPortfolioError {
@@ -2178,6 +2195,11 @@ impl From<HttpDispatchError> for CreateConstraintError {
         CreateConstraintError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateConstraintError {
+    fn from(err: io::Error) -> CreateConstraintError {
+        CreateConstraintError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateConstraintError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2258,6 +2280,11 @@ impl From<CredentialsError> for CreatePortfolioError {
 impl From<HttpDispatchError> for CreatePortfolioError {
     fn from(err: HttpDispatchError) -> CreatePortfolioError {
         CreatePortfolioError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePortfolioError {
+    fn from(err: io::Error) -> CreatePortfolioError {
+        CreatePortfolioError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePortfolioError {
@@ -2345,6 +2372,11 @@ impl From<HttpDispatchError> for CreatePortfolioShareError {
         CreatePortfolioShareError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreatePortfolioShareError {
+    fn from(err: io::Error) -> CreatePortfolioShareError {
+        CreatePortfolioShareError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreatePortfolioShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2428,6 +2460,11 @@ impl From<HttpDispatchError> for CreateProductError {
         CreateProductError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateProductError {
+    fn from(err: io::Error) -> CreateProductError {
+        CreateProductError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2507,6 +2544,11 @@ impl From<CredentialsError> for CreateProvisioningArtifactError {
 impl From<HttpDispatchError> for CreateProvisioningArtifactError {
     fn from(err: HttpDispatchError) -> CreateProvisioningArtifactError {
         CreateProvisioningArtifactError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateProvisioningArtifactError {
+    fn from(err: io::Error) -> CreateProvisioningArtifactError {
+        CreateProvisioningArtifactError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateProvisioningArtifactError {
@@ -2590,6 +2632,11 @@ impl From<CredentialsError> for DeleteConstraintError {
 impl From<HttpDispatchError> for DeleteConstraintError {
     fn from(err: HttpDispatchError) -> DeleteConstraintError {
         DeleteConstraintError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteConstraintError {
+    fn from(err: io::Error) -> DeleteConstraintError {
+        DeleteConstraintError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteConstraintError {
@@ -2677,6 +2724,11 @@ impl From<HttpDispatchError> for DeletePortfolioError {
         DeletePortfolioError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePortfolioError {
+    fn from(err: io::Error) -> DeletePortfolioError {
+        DeletePortfolioError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2751,6 +2803,11 @@ impl From<CredentialsError> for DeletePortfolioShareError {
 impl From<HttpDispatchError> for DeletePortfolioShareError {
     fn from(err: HttpDispatchError) -> DeletePortfolioShareError {
         DeletePortfolioShareError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeletePortfolioShareError {
+    fn from(err: io::Error) -> DeletePortfolioShareError {
+        DeletePortfolioShareError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeletePortfolioShareError {
@@ -2839,6 +2896,11 @@ impl From<HttpDispatchError> for DeleteProductError {
         DeleteProductError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteProductError {
+    fn from(err: io::Error) -> DeleteProductError {
+        DeleteProductError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2921,6 +2983,11 @@ impl From<HttpDispatchError> for DeleteProvisioningArtifactError {
         DeleteProvisioningArtifactError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteProvisioningArtifactError {
+    fn from(err: io::Error) -> DeleteProvisioningArtifactError {
+        DeleteProvisioningArtifactError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2999,6 +3066,11 @@ impl From<HttpDispatchError> for DescribeConstraintError {
         DescribeConstraintError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeConstraintError {
+    fn from(err: io::Error) -> DescribeConstraintError {
+        DescribeConstraintError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeConstraintError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3073,6 +3145,11 @@ impl From<CredentialsError> for DescribePortfolioError {
 impl From<HttpDispatchError> for DescribePortfolioError {
     fn from(err: HttpDispatchError) -> DescribePortfolioError {
         DescribePortfolioError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribePortfolioError {
+    fn from(err: io::Error) -> DescribePortfolioError {
+        DescribePortfolioError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribePortfolioError {
@@ -3156,6 +3233,11 @@ impl From<HttpDispatchError> for DescribeProductError {
         DescribeProductError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeProductError {
+    fn from(err: io::Error) -> DescribeProductError {
+        DescribeProductError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3229,6 +3311,11 @@ impl From<CredentialsError> for DescribeProductAsAdminError {
 impl From<HttpDispatchError> for DescribeProductAsAdminError {
     fn from(err: HttpDispatchError) -> DescribeProductAsAdminError {
         DescribeProductAsAdminError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeProductAsAdminError {
+    fn from(err: io::Error) -> DescribeProductAsAdminError {
+        DescribeProductAsAdminError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeProductAsAdminError {
@@ -3312,6 +3399,11 @@ impl From<HttpDispatchError> for DescribeProductViewError {
         DescribeProductViewError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeProductViewError {
+    fn from(err: io::Error) -> DescribeProductViewError {
+        DescribeProductViewError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeProductViewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3387,6 +3479,11 @@ impl From<HttpDispatchError> for DescribeProvisionedProductError {
         DescribeProvisionedProductError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeProvisionedProductError {
+    fn from(err: io::Error) -> DescribeProvisionedProductError {
+        DescribeProvisionedProductError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeProvisionedProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3459,6 +3556,11 @@ impl From<CredentialsError> for DescribeProvisioningArtifactError {
 impl From<HttpDispatchError> for DescribeProvisioningArtifactError {
     fn from(err: HttpDispatchError) -> DescribeProvisioningArtifactError {
         DescribeProvisioningArtifactError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeProvisioningArtifactError {
+    fn from(err: io::Error) -> DescribeProvisioningArtifactError {
+        DescribeProvisioningArtifactError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeProvisioningArtifactError {
@@ -3538,6 +3640,11 @@ impl From<HttpDispatchError> for DescribeProvisioningParametersError {
         DescribeProvisioningParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeProvisioningParametersError {
+    fn from(err: io::Error) -> DescribeProvisioningParametersError {
+        DescribeProvisioningParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeProvisioningParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3615,6 +3722,11 @@ impl From<HttpDispatchError> for DescribeRecordError {
         DescribeRecordError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeRecordError {
+    fn from(err: io::Error) -> DescribeRecordError {
+        DescribeRecordError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeRecordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3689,6 +3801,11 @@ impl From<CredentialsError> for DisassociatePrincipalFromPortfolioError {
 impl From<HttpDispatchError> for DisassociatePrincipalFromPortfolioError {
     fn from(err: HttpDispatchError) -> DisassociatePrincipalFromPortfolioError {
         DisassociatePrincipalFromPortfolioError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DisassociatePrincipalFromPortfolioError {
+    fn from(err: io::Error) -> DisassociatePrincipalFromPortfolioError {
+        DisassociatePrincipalFromPortfolioError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DisassociatePrincipalFromPortfolioError {
@@ -3769,6 +3886,11 @@ impl From<HttpDispatchError> for DisassociateProductFromPortfolioError {
         DisassociateProductFromPortfolioError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateProductFromPortfolioError {
+    fn from(err: io::Error) -> DisassociateProductFromPortfolioError {
+        DisassociateProductFromPortfolioError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateProductFromPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3842,6 +3964,11 @@ impl From<CredentialsError> for ListAcceptedPortfolioSharesError {
 impl From<HttpDispatchError> for ListAcceptedPortfolioSharesError {
     fn from(err: HttpDispatchError) -> ListAcceptedPortfolioSharesError {
         ListAcceptedPortfolioSharesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAcceptedPortfolioSharesError {
+    fn from(err: io::Error) -> ListAcceptedPortfolioSharesError {
+        ListAcceptedPortfolioSharesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAcceptedPortfolioSharesError {
@@ -3919,6 +4046,11 @@ impl From<CredentialsError> for ListConstraintsForPortfolioError {
 impl From<HttpDispatchError> for ListConstraintsForPortfolioError {
     fn from(err: HttpDispatchError) -> ListConstraintsForPortfolioError {
         ListConstraintsForPortfolioError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListConstraintsForPortfolioError {
+    fn from(err: io::Error) -> ListConstraintsForPortfolioError {
+        ListConstraintsForPortfolioError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListConstraintsForPortfolioError {
@@ -4003,6 +4135,11 @@ impl From<HttpDispatchError> for ListLaunchPathsError {
         ListLaunchPathsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListLaunchPathsError {
+    fn from(err: io::Error) -> ListLaunchPathsError {
+        ListLaunchPathsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListLaunchPathsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4076,6 +4213,11 @@ impl From<CredentialsError> for ListPortfolioAccessError {
 impl From<HttpDispatchError> for ListPortfolioAccessError {
     fn from(err: HttpDispatchError) -> ListPortfolioAccessError {
         ListPortfolioAccessError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPortfolioAccessError {
+    fn from(err: io::Error) -> ListPortfolioAccessError {
+        ListPortfolioAccessError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPortfolioAccessError {
@@ -4154,6 +4296,11 @@ impl From<HttpDispatchError> for ListPortfoliosError {
         ListPortfoliosError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPortfoliosError {
+    fn from(err: io::Error) -> ListPortfoliosError {
+        ListPortfoliosError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPortfoliosError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4229,6 +4376,11 @@ impl From<CredentialsError> for ListPortfoliosForProductError {
 impl From<HttpDispatchError> for ListPortfoliosForProductError {
     fn from(err: HttpDispatchError) -> ListPortfoliosForProductError {
         ListPortfoliosForProductError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPortfoliosForProductError {
+    fn from(err: io::Error) -> ListPortfoliosForProductError {
+        ListPortfoliosForProductError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPortfoliosForProductError {
@@ -4309,6 +4461,11 @@ impl From<HttpDispatchError> for ListPrincipalsForPortfolioError {
         ListPrincipalsForPortfolioError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPrincipalsForPortfolioError {
+    fn from(err: io::Error) -> ListPrincipalsForPortfolioError {
+        ListPrincipalsForPortfolioError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPrincipalsForPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4387,6 +4544,11 @@ impl From<HttpDispatchError> for ListProvisioningArtifactsError {
         ListProvisioningArtifactsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListProvisioningArtifactsError {
+    fn from(err: io::Error) -> ListProvisioningArtifactsError {
+        ListProvisioningArtifactsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListProvisioningArtifactsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4462,6 +4624,11 @@ impl From<CredentialsError> for ListRecordHistoryError {
 impl From<HttpDispatchError> for ListRecordHistoryError {
     fn from(err: HttpDispatchError) -> ListRecordHistoryError {
         ListRecordHistoryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRecordHistoryError {
+    fn from(err: io::Error) -> ListRecordHistoryError {
+        ListRecordHistoryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRecordHistoryError {
@@ -4550,6 +4717,11 @@ impl From<HttpDispatchError> for ProvisionProductError {
         ProvisionProductError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ProvisionProductError {
+    fn from(err: io::Error) -> ProvisionProductError {
+        ProvisionProductError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ProvisionProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4624,6 +4796,11 @@ impl From<CredentialsError> for RejectPortfolioShareError {
 impl From<HttpDispatchError> for RejectPortfolioShareError {
     fn from(err: HttpDispatchError) -> RejectPortfolioShareError {
         RejectPortfolioShareError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RejectPortfolioShareError {
+    fn from(err: io::Error) -> RejectPortfolioShareError {
+        RejectPortfolioShareError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RejectPortfolioShareError {
@@ -4702,6 +4879,11 @@ impl From<HttpDispatchError> for ScanProvisionedProductsError {
         ScanProvisionedProductsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ScanProvisionedProductsError {
+    fn from(err: io::Error) -> ScanProvisionedProductsError {
+        ScanProvisionedProductsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ScanProvisionedProductsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4776,6 +4958,11 @@ impl From<CredentialsError> for SearchProductsError {
 impl From<HttpDispatchError> for SearchProductsError {
     fn from(err: HttpDispatchError) -> SearchProductsError {
         SearchProductsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SearchProductsError {
+    fn from(err: io::Error) -> SearchProductsError {
+        SearchProductsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SearchProductsError {
@@ -4857,6 +5044,11 @@ impl From<HttpDispatchError> for SearchProductsAsAdminError {
         SearchProductsAsAdminError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SearchProductsAsAdminError {
+    fn from(err: io::Error) -> SearchProductsAsAdminError {
+        SearchProductsAsAdminError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SearchProductsAsAdminError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4930,6 +5122,11 @@ impl From<CredentialsError> for TerminateProvisionedProductError {
 impl From<HttpDispatchError> for TerminateProvisionedProductError {
     fn from(err: HttpDispatchError) -> TerminateProvisionedProductError {
         TerminateProvisionedProductError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TerminateProvisionedProductError {
+    fn from(err: io::Error) -> TerminateProvisionedProductError {
+        TerminateProvisionedProductError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TerminateProvisionedProductError {
@@ -5011,6 +5208,11 @@ impl From<CredentialsError> for UpdateConstraintError {
 impl From<HttpDispatchError> for UpdateConstraintError {
     fn from(err: HttpDispatchError) -> UpdateConstraintError {
         UpdateConstraintError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateConstraintError {
+    fn from(err: io::Error) -> UpdateConstraintError {
+        UpdateConstraintError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateConstraintError {
@@ -5098,6 +5300,11 @@ impl From<HttpDispatchError> for UpdatePortfolioError {
         UpdatePortfolioError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdatePortfolioError {
+    fn from(err: io::Error) -> UpdatePortfolioError {
+        UpdatePortfolioError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdatePortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5179,6 +5386,11 @@ impl From<HttpDispatchError> for UpdateProductError {
         UpdateProductError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateProductError {
+    fn from(err: io::Error) -> UpdateProductError {
+        UpdateProductError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5257,6 +5469,11 @@ impl From<HttpDispatchError> for UpdateProvisionedProductError {
         UpdateProvisionedProductError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateProvisionedProductError {
+    fn from(err: io::Error) -> UpdateProvisionedProductError {
+        UpdateProvisionedProductError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateProvisionedProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5333,6 +5550,11 @@ impl From<CredentialsError> for UpdateProvisioningArtifactError {
 impl From<HttpDispatchError> for UpdateProvisioningArtifactError {
     fn from(err: HttpDispatchError) -> UpdateProvisioningArtifactError {
         UpdateProvisioningArtifactError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateProvisioningArtifactError {
+    fn from(err: io::Error) -> UpdateProvisioningArtifactError {
+        UpdateProvisioningArtifactError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateProvisioningArtifactError {
@@ -5681,15 +5903,18 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AcceptPortfolioShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AcceptPortfolioShareOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AcceptPortfolioShareError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AcceptPortfolioShareError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5710,13 +5935,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AssociatePrincipalWithPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AssociatePrincipalWithPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AssociatePrincipalWithPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociatePrincipalWithPortfolioError::from_body(String::from_utf8_lossy(&body)
+                                                                        .as_ref()))
+            }
         }
     }
 
@@ -5736,13 +5968,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AssociateProductWithPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(AssociateProductWithPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AssociateProductWithPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateProductWithPortfolioError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -5761,15 +6000,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateConstraintOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateConstraintOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateConstraintError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateConstraintError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5789,15 +6033,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreatePortfolioOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreatePortfolioError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePortfolioError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5817,15 +6066,18 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePortfolioShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreatePortfolioShareOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreatePortfolioShareError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePortfolioShareError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5844,14 +6096,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateProductOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateProductError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateProductError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5872,13 +6130,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateProvisioningArtifactOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateProvisioningArtifactError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateProvisioningArtifactOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateProvisioningArtifactError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5897,15 +6162,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteConstraintOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteConstraintOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteConstraintError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteConstraintError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5925,15 +6195,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeletePortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeletePortfolioOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeletePortfolioError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePortfolioError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5953,15 +6228,18 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeletePortfolioShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeletePortfolioShareOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeletePortfolioShareError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePortfolioShareError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5980,14 +6258,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteProductOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteProductError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteProductError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6008,13 +6292,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteProvisioningArtifactOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteProvisioningArtifactError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteProvisioningArtifactOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteProvisioningArtifactError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6033,15 +6324,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeConstraintOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeConstraintOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeConstraintError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConstraintError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6061,15 +6357,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribePortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribePortfolioOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribePortfolioError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePortfolioError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6089,15 +6390,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeProductOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeProductError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeProductError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6118,15 +6424,18 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeProductAsAdminOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeProductAsAdminOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeProductAsAdminError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeProductAsAdminError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6146,15 +6455,18 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeProductViewOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeProductViewOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeProductViewError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeProductViewError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6175,13 +6487,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeProvisionedProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeProvisionedProductError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeProvisionedProductOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeProvisionedProductError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6201,13 +6520,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeProvisioningArtifactOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeProvisioningArtifactError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeProvisioningArtifactOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeProvisioningArtifactError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -6227,13 +6553,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeProvisioningParametersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeProvisioningParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeProvisioningParametersOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeProvisioningParametersError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -6251,15 +6584,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeRecordOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeRecordOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeRecordError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeRecordError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6281,13 +6619,19 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisassociatePrincipalFromPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DisassociatePrincipalFromPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisassociatePrincipalFromPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociatePrincipalFromPortfolioError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6307,13 +6651,19 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisassociateProductFromPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DisassociateProductFromPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisassociateProductFromPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateProductFromPortfolioError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6333,13 +6683,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAcceptedPortfolioSharesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListAcceptedPortfolioSharesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAcceptedPortfolioSharesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAcceptedPortfolioSharesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -6359,13 +6716,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListConstraintsForPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListConstraintsForPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListConstraintsForPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListConstraintsForPortfolioError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -6384,15 +6748,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListLaunchPathsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListLaunchPathsOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListLaunchPathsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListLaunchPathsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6412,15 +6781,18 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPortfolioAccessOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPortfolioAccessOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListPortfolioAccessError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPortfolioAccessError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6439,15 +6811,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPortfoliosOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPortfoliosOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListPortfoliosError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPortfoliosError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6468,13 +6845,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPortfoliosForProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListPortfoliosForProductError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPortfoliosForProductOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPortfoliosForProductError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -6494,13 +6878,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPrincipalsForPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListPrincipalsForPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListPrincipalsForPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPrincipalsForPortfolioError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6520,13 +6911,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListProvisioningArtifactsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListProvisioningArtifactsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListProvisioningArtifactsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListProvisioningArtifactsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -6545,15 +6943,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRecordHistoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRecordHistoryOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListRecordHistoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRecordHistoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6573,15 +6976,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ProvisionProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ProvisionProductOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ProvisionProductError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ProvisionProductError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6601,15 +7009,18 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RejectPortfolioShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RejectPortfolioShareOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RejectPortfolioShareError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RejectPortfolioShareError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6630,13 +7041,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ScanProvisionedProductsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ScanProvisionedProductsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ScanProvisionedProductsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ScanProvisionedProductsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6654,15 +7072,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SearchProductsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SearchProductsOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(SearchProductsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SearchProductsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6683,15 +7106,18 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SearchProductsAsAdminOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SearchProductsAsAdminOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(SearchProductsAsAdminError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SearchProductsAsAdminError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6712,13 +7138,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TerminateProvisionedProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(TerminateProvisionedProductError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<TerminateProvisionedProductOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TerminateProvisionedProductError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -6737,15 +7170,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateConstraintOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateConstraintOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateConstraintError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateConstraintError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6765,15 +7203,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdatePortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdatePortfolioOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdatePortfolioError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdatePortfolioError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6792,14 +7235,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateProductOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateProductError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateProductError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6820,13 +7269,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateProvisionedProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateProvisionedProductError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateProvisionedProductOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateProvisionedProductError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -6846,13 +7302,20 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateProvisioningArtifactOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateProvisioningArtifactError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateProvisioningArtifactOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateProvisioningArtifactError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -6571,6 +6573,11 @@ impl From<HttpDispatchError> for CloneReceiptRuleSetError {
         CloneReceiptRuleSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CloneReceiptRuleSetError {
+    fn from(err: io::Error) -> CloneReceiptRuleSetError {
+        CloneReceiptRuleSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CloneReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6645,6 +6652,11 @@ impl From<CredentialsError> for CreateConfigurationSetError {
 impl From<HttpDispatchError> for CreateConfigurationSetError {
     fn from(err: HttpDispatchError) -> CreateConfigurationSetError {
         CreateConfigurationSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateConfigurationSetError {
+    fn from(err: io::Error) -> CreateConfigurationSetError {
+        CreateConfigurationSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateConfigurationSetError {
@@ -6729,6 +6741,11 @@ impl From<HttpDispatchError> for CreateConfigurationSetEventDestinationError {
         CreateConfigurationSetEventDestinationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateConfigurationSetEventDestinationError {
+    fn from(err: io::Error) -> CreateConfigurationSetEventDestinationError {
+        CreateConfigurationSetEventDestinationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateConfigurationSetEventDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6808,6 +6825,11 @@ impl From<CredentialsError> for CreateReceiptFilterError {
 impl From<HttpDispatchError> for CreateReceiptFilterError {
     fn from(err: HttpDispatchError) -> CreateReceiptFilterError {
         CreateReceiptFilterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateReceiptFilterError {
+    fn from(err: io::Error) -> CreateReceiptFilterError {
+        CreateReceiptFilterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateReceiptFilterError {
@@ -6905,6 +6927,11 @@ impl From<HttpDispatchError> for CreateReceiptRuleError {
         CreateReceiptRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReceiptRuleError {
+    fn from(err: io::Error) -> CreateReceiptRuleError {
+        CreateReceiptRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReceiptRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6986,6 +7013,11 @@ impl From<HttpDispatchError> for CreateReceiptRuleSetError {
         CreateReceiptRuleSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReceiptRuleSetError {
+    fn from(err: io::Error) -> CreateReceiptRuleSetError {
+        CreateReceiptRuleSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7053,6 +7085,11 @@ impl From<CredentialsError> for DeleteConfigurationSetError {
 impl From<HttpDispatchError> for DeleteConfigurationSetError {
     fn from(err: HttpDispatchError) -> DeleteConfigurationSetError {
         DeleteConfigurationSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteConfigurationSetError {
+    fn from(err: io::Error) -> DeleteConfigurationSetError {
+        DeleteConfigurationSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteConfigurationSetError {
@@ -7126,6 +7163,11 @@ impl From<HttpDispatchError> for DeleteConfigurationSetEventDestinationError {
         DeleteConfigurationSetEventDestinationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteConfigurationSetEventDestinationError {
+    fn from(err: io::Error) -> DeleteConfigurationSetEventDestinationError {
+        DeleteConfigurationSetEventDestinationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteConfigurationSetEventDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7192,6 +7234,11 @@ impl From<HttpDispatchError> for DeleteIdentityError {
         DeleteIdentityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteIdentityError {
+    fn from(err: io::Error) -> DeleteIdentityError {
+        DeleteIdentityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7252,6 +7299,11 @@ impl From<CredentialsError> for DeleteIdentityPolicyError {
 impl From<HttpDispatchError> for DeleteIdentityPolicyError {
     fn from(err: HttpDispatchError) -> DeleteIdentityPolicyError {
         DeleteIdentityPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteIdentityPolicyError {
+    fn from(err: io::Error) -> DeleteIdentityPolicyError {
+        DeleteIdentityPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteIdentityPolicyError {
@@ -7316,6 +7368,11 @@ impl From<CredentialsError> for DeleteReceiptFilterError {
 impl From<HttpDispatchError> for DeleteReceiptFilterError {
     fn from(err: HttpDispatchError) -> DeleteReceiptFilterError {
         DeleteReceiptFilterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteReceiptFilterError {
+    fn from(err: io::Error) -> DeleteReceiptFilterError {
+        DeleteReceiptFilterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteReceiptFilterError {
@@ -7383,6 +7440,11 @@ impl From<CredentialsError> for DeleteReceiptRuleError {
 impl From<HttpDispatchError> for DeleteReceiptRuleError {
     fn from(err: HttpDispatchError) -> DeleteReceiptRuleError {
         DeleteReceiptRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteReceiptRuleError {
+    fn from(err: io::Error) -> DeleteReceiptRuleError {
+        DeleteReceiptRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteReceiptRuleError {
@@ -7455,6 +7517,11 @@ impl From<HttpDispatchError> for DeleteReceiptRuleSetError {
         DeleteReceiptRuleSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteReceiptRuleSetError {
+    fn from(err: io::Error) -> DeleteReceiptRuleSetError {
+        DeleteReceiptRuleSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7520,6 +7587,11 @@ impl From<HttpDispatchError> for DeleteVerifiedEmailAddressError {
         DeleteVerifiedEmailAddressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteVerifiedEmailAddressError {
+    fn from(err: io::Error) -> DeleteVerifiedEmailAddressError {
+        DeleteVerifiedEmailAddressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteVerifiedEmailAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7582,6 +7654,11 @@ impl From<CredentialsError> for DescribeActiveReceiptRuleSetError {
 impl From<HttpDispatchError> for DescribeActiveReceiptRuleSetError {
     fn from(err: HttpDispatchError) -> DescribeActiveReceiptRuleSetError {
         DescribeActiveReceiptRuleSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeActiveReceiptRuleSetError {
+    fn from(err: io::Error) -> DescribeActiveReceiptRuleSetError {
+        DescribeActiveReceiptRuleSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeActiveReceiptRuleSetError {
@@ -7649,6 +7726,11 @@ impl From<CredentialsError> for DescribeConfigurationSetError {
 impl From<HttpDispatchError> for DescribeConfigurationSetError {
     fn from(err: HttpDispatchError) -> DescribeConfigurationSetError {
         DescribeConfigurationSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeConfigurationSetError {
+    fn from(err: io::Error) -> DescribeConfigurationSetError {
+        DescribeConfigurationSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeConfigurationSetError {
@@ -7722,6 +7804,11 @@ impl From<HttpDispatchError> for DescribeReceiptRuleError {
         DescribeReceiptRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReceiptRuleError {
+    fn from(err: io::Error) -> DescribeReceiptRuleError {
+        DescribeReceiptRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReceiptRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7791,6 +7878,11 @@ impl From<HttpDispatchError> for DescribeReceiptRuleSetError {
         DescribeReceiptRuleSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeReceiptRuleSetError {
+    fn from(err: io::Error) -> DescribeReceiptRuleSetError {
+        DescribeReceiptRuleSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7854,6 +7946,11 @@ impl From<CredentialsError> for GetIdentityDkimAttributesError {
 impl From<HttpDispatchError> for GetIdentityDkimAttributesError {
     fn from(err: HttpDispatchError) -> GetIdentityDkimAttributesError {
         GetIdentityDkimAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetIdentityDkimAttributesError {
+    fn from(err: io::Error) -> GetIdentityDkimAttributesError {
+        GetIdentityDkimAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetIdentityDkimAttributesError {
@@ -7920,6 +8017,11 @@ impl From<HttpDispatchError> for GetIdentityMailFromDomainAttributesError {
         GetIdentityMailFromDomainAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetIdentityMailFromDomainAttributesError {
+    fn from(err: io::Error) -> GetIdentityMailFromDomainAttributesError {
+        GetIdentityMailFromDomainAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetIdentityMailFromDomainAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7982,6 +8084,11 @@ impl From<CredentialsError> for GetIdentityNotificationAttributesError {
 impl From<HttpDispatchError> for GetIdentityNotificationAttributesError {
     fn from(err: HttpDispatchError) -> GetIdentityNotificationAttributesError {
         GetIdentityNotificationAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetIdentityNotificationAttributesError {
+    fn from(err: io::Error) -> GetIdentityNotificationAttributesError {
+        GetIdentityNotificationAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetIdentityNotificationAttributesError {
@@ -8048,6 +8155,11 @@ impl From<HttpDispatchError> for GetIdentityPoliciesError {
         GetIdentityPoliciesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetIdentityPoliciesError {
+    fn from(err: io::Error) -> GetIdentityPoliciesError {
+        GetIdentityPoliciesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetIdentityPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8110,6 +8222,11 @@ impl From<CredentialsError> for GetIdentityVerificationAttributesError {
 impl From<HttpDispatchError> for GetIdentityVerificationAttributesError {
     fn from(err: HttpDispatchError) -> GetIdentityVerificationAttributesError {
         GetIdentityVerificationAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetIdentityVerificationAttributesError {
+    fn from(err: io::Error) -> GetIdentityVerificationAttributesError {
+        GetIdentityVerificationAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetIdentityVerificationAttributesError {
@@ -8176,6 +8293,11 @@ impl From<HttpDispatchError> for GetSendQuotaError {
         GetSendQuotaError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSendQuotaError {
+    fn from(err: io::Error) -> GetSendQuotaError {
+        GetSendQuotaError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSendQuotaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8236,6 +8358,11 @@ impl From<CredentialsError> for GetSendStatisticsError {
 impl From<HttpDispatchError> for GetSendStatisticsError {
     fn from(err: HttpDispatchError) -> GetSendStatisticsError {
         GetSendStatisticsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSendStatisticsError {
+    fn from(err: io::Error) -> GetSendStatisticsError {
+        GetSendStatisticsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSendStatisticsError {
@@ -8302,6 +8429,11 @@ impl From<HttpDispatchError> for ListConfigurationSetsError {
         ListConfigurationSetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListConfigurationSetsError {
+    fn from(err: io::Error) -> ListConfigurationSetsError {
+        ListConfigurationSetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListConfigurationSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8366,6 +8498,11 @@ impl From<HttpDispatchError> for ListIdentitiesError {
         ListIdentitiesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListIdentitiesError {
+    fn from(err: io::Error) -> ListIdentitiesError {
+        ListIdentitiesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListIdentitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8426,6 +8563,11 @@ impl From<CredentialsError> for ListIdentityPoliciesError {
 impl From<HttpDispatchError> for ListIdentityPoliciesError {
     fn from(err: HttpDispatchError) -> ListIdentityPoliciesError {
         ListIdentityPoliciesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListIdentityPoliciesError {
+    fn from(err: io::Error) -> ListIdentityPoliciesError {
+        ListIdentityPoliciesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListIdentityPoliciesError {
@@ -8492,6 +8634,11 @@ impl From<HttpDispatchError> for ListReceiptFiltersError {
         ListReceiptFiltersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListReceiptFiltersError {
+    fn from(err: io::Error) -> ListReceiptFiltersError {
+        ListReceiptFiltersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListReceiptFiltersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8556,6 +8703,11 @@ impl From<HttpDispatchError> for ListReceiptRuleSetsError {
         ListReceiptRuleSetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListReceiptRuleSetsError {
+    fn from(err: io::Error) -> ListReceiptRuleSetsError {
+        ListReceiptRuleSetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListReceiptRuleSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8618,6 +8770,11 @@ impl From<CredentialsError> for ListVerifiedEmailAddressesError {
 impl From<HttpDispatchError> for ListVerifiedEmailAddressesError {
     fn from(err: HttpDispatchError) -> ListVerifiedEmailAddressesError {
         ListVerifiedEmailAddressesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListVerifiedEmailAddressesError {
+    fn from(err: io::Error) -> ListVerifiedEmailAddressesError {
+        ListVerifiedEmailAddressesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListVerifiedEmailAddressesError {
@@ -8687,6 +8844,11 @@ impl From<CredentialsError> for PutIdentityPolicyError {
 impl From<HttpDispatchError> for PutIdentityPolicyError {
     fn from(err: HttpDispatchError) -> PutIdentityPolicyError {
         PutIdentityPolicyError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutIdentityPolicyError {
+    fn from(err: io::Error) -> PutIdentityPolicyError {
+        PutIdentityPolicyError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutIdentityPolicyError {
@@ -8760,6 +8922,11 @@ impl From<HttpDispatchError> for ReorderReceiptRuleSetError {
         ReorderReceiptRuleSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReorderReceiptRuleSetError {
+    fn from(err: io::Error) -> ReorderReceiptRuleSetError {
+        ReorderReceiptRuleSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReorderReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8829,6 +8996,11 @@ impl From<CredentialsError> for SendBounceError {
 impl From<HttpDispatchError> for SendBounceError {
     fn from(err: HttpDispatchError) -> SendBounceError {
         SendBounceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SendBounceError {
+    fn from(err: io::Error) -> SendBounceError {
+        SendBounceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SendBounceError {
@@ -8903,6 +9075,11 @@ impl From<CredentialsError> for SendEmailError {
 impl From<HttpDispatchError> for SendEmailError {
     fn from(err: HttpDispatchError) -> SendEmailError {
         SendEmailError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SendEmailError {
+    fn from(err: io::Error) -> SendEmailError {
+        SendEmailError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SendEmailError {
@@ -8981,6 +9158,11 @@ impl From<HttpDispatchError> for SendRawEmailError {
         SendRawEmailError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SendRawEmailError {
+    fn from(err: io::Error) -> SendRawEmailError {
+        SendRawEmailError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SendRawEmailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9049,6 +9231,11 @@ impl From<HttpDispatchError> for SetActiveReceiptRuleSetError {
         SetActiveReceiptRuleSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetActiveReceiptRuleSetError {
+    fn from(err: io::Error) -> SetActiveReceiptRuleSetError {
+        SetActiveReceiptRuleSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetActiveReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9112,6 +9299,11 @@ impl From<CredentialsError> for SetIdentityDkimEnabledError {
 impl From<HttpDispatchError> for SetIdentityDkimEnabledError {
     fn from(err: HttpDispatchError) -> SetIdentityDkimEnabledError {
         SetIdentityDkimEnabledError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetIdentityDkimEnabledError {
+    fn from(err: io::Error) -> SetIdentityDkimEnabledError {
+        SetIdentityDkimEnabledError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetIdentityDkimEnabledError {
@@ -9178,6 +9370,11 @@ impl From<HttpDispatchError> for SetIdentityFeedbackForwardingEnabledError {
         SetIdentityFeedbackForwardingEnabledError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetIdentityFeedbackForwardingEnabledError {
+    fn from(err: io::Error) -> SetIdentityFeedbackForwardingEnabledError {
+        SetIdentityFeedbackForwardingEnabledError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetIdentityFeedbackForwardingEnabledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9240,6 +9437,11 @@ impl From<CredentialsError> for SetIdentityHeadersInNotificationsEnabledError {
 impl From<HttpDispatchError> for SetIdentityHeadersInNotificationsEnabledError {
     fn from(err: HttpDispatchError) -> SetIdentityHeadersInNotificationsEnabledError {
         SetIdentityHeadersInNotificationsEnabledError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetIdentityHeadersInNotificationsEnabledError {
+    fn from(err: io::Error) -> SetIdentityHeadersInNotificationsEnabledError {
+        SetIdentityHeadersInNotificationsEnabledError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetIdentityHeadersInNotificationsEnabledError {
@@ -9308,6 +9510,11 @@ impl From<HttpDispatchError> for SetIdentityMailFromDomainError {
         SetIdentityMailFromDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetIdentityMailFromDomainError {
+    fn from(err: io::Error) -> SetIdentityMailFromDomainError {
+        SetIdentityMailFromDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetIdentityMailFromDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9370,6 +9577,11 @@ impl From<CredentialsError> for SetIdentityNotificationTopicError {
 impl From<HttpDispatchError> for SetIdentityNotificationTopicError {
     fn from(err: HttpDispatchError) -> SetIdentityNotificationTopicError {
         SetIdentityNotificationTopicError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetIdentityNotificationTopicError {
+    fn from(err: io::Error) -> SetIdentityNotificationTopicError {
+        SetIdentityNotificationTopicError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetIdentityNotificationTopicError {
@@ -9440,6 +9652,11 @@ impl From<CredentialsError> for SetReceiptRulePositionError {
 impl From<HttpDispatchError> for SetReceiptRulePositionError {
     fn from(err: HttpDispatchError) -> SetReceiptRulePositionError {
         SetReceiptRulePositionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetReceiptRulePositionError {
+    fn from(err: io::Error) -> SetReceiptRulePositionError {
+        SetReceiptRulePositionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetReceiptRulePositionError {
@@ -9518,6 +9735,11 @@ impl From<CredentialsError> for UpdateConfigurationSetEventDestinationError {
 impl From<HttpDispatchError> for UpdateConfigurationSetEventDestinationError {
     fn from(err: HttpDispatchError) -> UpdateConfigurationSetEventDestinationError {
         UpdateConfigurationSetEventDestinationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateConfigurationSetEventDestinationError {
+    fn from(err: io::Error) -> UpdateConfigurationSetEventDestinationError {
+        UpdateConfigurationSetEventDestinationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateConfigurationSetEventDestinationError {
@@ -9614,6 +9836,11 @@ impl From<HttpDispatchError> for UpdateReceiptRuleError {
         UpdateReceiptRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateReceiptRuleError {
+    fn from(err: io::Error) -> UpdateReceiptRuleError {
+        UpdateReceiptRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateReceiptRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9684,6 +9911,11 @@ impl From<HttpDispatchError> for VerifyDomainDkimError {
         VerifyDomainDkimError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for VerifyDomainDkimError {
+    fn from(err: io::Error) -> VerifyDomainDkimError {
+        VerifyDomainDkimError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for VerifyDomainDkimError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9744,6 +9976,11 @@ impl From<CredentialsError> for VerifyDomainIdentityError {
 impl From<HttpDispatchError> for VerifyDomainIdentityError {
     fn from(err: HttpDispatchError) -> VerifyDomainIdentityError {
         VerifyDomainIdentityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for VerifyDomainIdentityError {
+    fn from(err: io::Error) -> VerifyDomainIdentityError {
+        VerifyDomainIdentityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for VerifyDomainIdentityError {
@@ -9810,6 +10047,11 @@ impl From<HttpDispatchError> for VerifyEmailAddressError {
         VerifyEmailAddressError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for VerifyEmailAddressError {
+    fn from(err: io::Error) -> VerifyEmailAddressError {
+        VerifyEmailAddressError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for VerifyEmailAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9872,6 +10114,11 @@ impl From<CredentialsError> for VerifyEmailIdentityError {
 impl From<HttpDispatchError> for VerifyEmailIdentityError {
     fn from(err: HttpDispatchError) -> VerifyEmailIdentityError {
         VerifyEmailIdentityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for VerifyEmailIdentityError {
+    fn from(err: io::Error) -> VerifyEmailIdentityError {
+        VerifyEmailIdentityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for VerifyEmailIdentityError {
@@ -10234,16 +10481,18 @@ impl<P, D> Ses for SesClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CloneReceiptRuleSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10258,8 +10507,9 @@ impl<P, D> Ses for SesClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CloneReceiptRuleSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CloneReceiptRuleSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10279,16 +10529,18 @@ impl<P, D> Ses for SesClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateConfigurationSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10304,8 +10556,9 @@ impl<P, D> Ses for SesClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreateConfigurationSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateConfigurationSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10322,16 +10575,18 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateConfigurationSetEventDestinationResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10345,8 +10600,10 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(CreateConfigurationSetEventDestinationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateConfigurationSetEventDestinationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10364,16 +10621,18 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateReceiptFilterResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10388,8 +10647,9 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
                 Ok(result)
             }
             _ => {
-                Err(CreateReceiptFilterError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReceiptFilterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10408,16 +10668,18 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateReceiptRuleResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10432,8 +10694,9 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
                 Ok(result)
             }
             _ => {
-                Err(CreateReceiptRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReceiptRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10453,16 +10716,18 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateReceiptRuleSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10478,8 +10743,9 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
                 Ok(result)
             }
             _ => {
-                Err(CreateReceiptRuleSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReceiptRuleSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10499,16 +10765,18 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteConfigurationSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10524,8 +10792,9 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
                 Ok(result)
             }
             _ => {
-                Err(DeleteConfigurationSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteConfigurationSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10542,16 +10811,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteConfigurationSetEventDestinationResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10565,8 +10836,10 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(DeleteConfigurationSetEventDestinationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteConfigurationSetEventDestinationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -10584,16 +10857,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteIdentityResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10608,8 +10883,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(DeleteIdentityError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10629,16 +10905,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteIdentityPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10654,8 +10932,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(DeleteIdentityPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIdentityPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10674,16 +10953,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteReceiptFilterResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10698,8 +10979,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(DeleteReceiptFilterError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReceiptFilterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10718,16 +11000,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteReceiptRuleResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10742,8 +11026,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(DeleteReceiptRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReceiptRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10763,16 +11048,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteReceiptRuleSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10788,8 +11075,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(DeleteReceiptRuleSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReceiptRuleSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10808,15 +11096,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeleteVerifiedEmailAddressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVerifiedEmailAddressError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -10835,16 +11126,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeActiveReceiptRuleSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10858,8 +11151,11 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(DescribeActiveReceiptRuleSetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeActiveReceiptRuleSetError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -10878,16 +11174,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeConfigurationSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10903,8 +11201,11 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(DescribeConfigurationSetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeConfigurationSetError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -10922,16 +11223,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeReceiptRuleResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10946,8 +11249,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(DescribeReceiptRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReceiptRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -10967,16 +11271,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DescribeReceiptRuleSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -10992,8 +11298,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(DescribeReceiptRuleSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeReceiptRuleSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11013,16 +11320,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetIdentityDkimAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11036,8 +11345,11 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(GetIdentityDkimAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIdentityDkimAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -11057,16 +11369,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetIdentityMailFromDomainAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11080,8 +11394,10 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(GetIdentityMailFromDomainAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIdentityMailFromDomainAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11101,16 +11417,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetIdentityNotificationAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11124,8 +11442,10 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(GetIdentityNotificationAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIdentityNotificationAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11143,16 +11463,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetIdentityPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11167,8 +11489,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(GetIdentityPoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIdentityPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11189,16 +11512,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetIdentityVerificationAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11212,8 +11537,10 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(GetIdentityVerificationAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIdentityVerificationAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11229,16 +11556,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetSendQuotaResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11253,7 +11582,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(GetSendQuotaError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSendQuotaError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11270,16 +11601,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetSendStatisticsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11294,8 +11627,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(GetSendStatisticsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSendStatisticsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11315,16 +11649,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListConfigurationSetsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11340,8 +11676,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(ListConfigurationSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListConfigurationSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11360,16 +11697,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListIdentitiesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11384,8 +11723,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(ListIdentitiesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListIdentitiesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11405,16 +11745,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListIdentityPoliciesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11430,8 +11772,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(ListIdentityPoliciesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListIdentityPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11450,16 +11793,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListReceiptFiltersResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11474,8 +11819,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(ListReceiptFiltersError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListReceiptFiltersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11494,16 +11840,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListReceiptRuleSetsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11518,8 +11866,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(ListReceiptRuleSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListReceiptRuleSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11538,16 +11887,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListVerifiedEmailAddressesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11561,8 +11912,11 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(ListVerifiedEmailAddressesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListVerifiedEmailAddressesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -11580,16 +11934,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PutIdentityPolicyResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11604,8 +11960,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(PutIdentityPolicyError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutIdentityPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11625,16 +11982,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReorderReceiptRuleSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11650,8 +12009,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(ReorderReceiptRuleSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReorderReceiptRuleSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11670,16 +12030,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SendBounceResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11693,7 +12055,11 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 }
                 Ok(result)
             }
-            _ => Err(SendBounceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendBounceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11709,16 +12075,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SendEmailResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11732,7 +12100,11 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 }
                 Ok(result)
             }
-            _ => Err(SendEmailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendEmailError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11750,16 +12122,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SendRawEmailResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11774,7 +12148,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(SendRawEmailError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendRawEmailError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11794,16 +12170,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetActiveReceiptRuleSetResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11819,8 +12197,11 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(SetActiveReceiptRuleSetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetActiveReceiptRuleSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -11839,16 +12220,18 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetIdentityDkimEnabledResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11864,8 +12247,9 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
                 Ok(result)
             }
             _ => {
-                Err(SetIdentityDkimEnabledError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetIdentityDkimEnabledError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -11882,16 +12266,18 @@ fn set_identity_feedback_forwarding_enabled(&self, input: &SetIdentityFeedbackFo
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetIdentityFeedbackForwardingEnabledResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11905,8 +12291,10 @@ fn set_identity_feedback_forwarding_enabled(&self, input: &SetIdentityFeedbackFo
                 Ok(result)
             }
             _ => {
-                            Err(SetIdentityFeedbackForwardingEnabledError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetIdentityFeedbackForwardingEnabledError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11924,16 +12312,18 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetIdentityHeadersInNotificationsEnabledResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11947,8 +12337,10 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
                 Ok(result)
             }
             _ => {
-                            Err(SetIdentityHeadersInNotificationsEnabledError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetIdentityHeadersInNotificationsEnabledError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -11967,16 +12359,18 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetIdentityMailFromDomainResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -11990,8 +12384,11 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
                 Ok(result)
             }
             _ => {
-                            Err(SetIdentityMailFromDomainError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetIdentityMailFromDomainError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -12010,16 +12407,18 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetIdentityNotificationTopicResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12033,8 +12432,11 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
                 Ok(result)
             }
             _ => {
-                            Err(SetIdentityNotificationTopicError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetIdentityNotificationTopicError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -12053,16 +12455,18 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetReceiptRulePositionResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12078,8 +12482,9 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
                 Ok(result)
             }
             _ => {
-                Err(SetReceiptRulePositionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetReceiptRulePositionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12096,16 +12501,18 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateConfigurationSetEventDestinationResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12119,8 +12526,10 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
                 Ok(result)
             }
             _ => {
-                            Err(UpdateConfigurationSetEventDestinationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateConfigurationSetEventDestinationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12138,16 +12547,18 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = UpdateReceiptRuleResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12162,8 +12573,9 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
                 Ok(result)
             }
             _ => {
-                Err(UpdateReceiptRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateReceiptRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12182,16 +12594,18 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = VerifyDomainDkimResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12206,8 +12620,9 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
                 Ok(result)
             }
             _ => {
-                Err(VerifyDomainDkimError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(VerifyDomainDkimError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12227,16 +12642,18 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = VerifyDomainIdentityResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12252,8 +12669,9 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
                 Ok(result)
             }
             _ => {
-                Err(VerifyDomainIdentityError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(VerifyDomainIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12272,15 +12690,16 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(VerifyEmailAddressError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(VerifyEmailAddressError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12299,16 +12718,18 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = VerifyEmailIdentityResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -12323,8 +12744,9 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
                 Ok(result)
             }
             _ => {
-                Err(VerifyEmailIdentityError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(VerifyEmailIdentityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -459,6 +461,11 @@ impl From<HttpDispatchError> for CreateReplicationJobError {
         CreateReplicationJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateReplicationJobError {
+    fn from(err: io::Error) -> CreateReplicationJobError {
+        CreateReplicationJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateReplicationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -554,6 +561,11 @@ impl From<HttpDispatchError> for DeleteReplicationJobError {
         DeleteReplicationJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteReplicationJobError {
+    fn from(err: io::Error) -> DeleteReplicationJobError {
+        DeleteReplicationJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteReplicationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -647,6 +659,11 @@ impl From<HttpDispatchError> for DeleteServerCatalogError {
         DeleteServerCatalogError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteServerCatalogError {
+    fn from(err: io::Error) -> DeleteServerCatalogError {
+        DeleteServerCatalogError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteServerCatalogError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -735,6 +752,11 @@ impl From<HttpDispatchError> for DisassociateConnectorError {
         DisassociateConnectorError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateConnectorError {
+    fn from(err: io::Error) -> DisassociateConnectorError {
+        DisassociateConnectorError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateConnectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -812,6 +834,11 @@ impl From<CredentialsError> for GetConnectorsError {
 impl From<HttpDispatchError> for GetConnectorsError {
     fn from(err: HttpDispatchError) -> GetConnectorsError {
         GetConnectorsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetConnectorsError {
+    fn from(err: io::Error) -> GetConnectorsError {
+        GetConnectorsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetConnectorsError {
@@ -894,6 +921,11 @@ impl From<CredentialsError> for GetReplicationJobsError {
 impl From<HttpDispatchError> for GetReplicationJobsError {
     fn from(err: HttpDispatchError) -> GetReplicationJobsError {
         GetReplicationJobsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetReplicationJobsError {
+    fn from(err: io::Error) -> GetReplicationJobsError {
+        GetReplicationJobsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetReplicationJobsError {
@@ -982,6 +1014,11 @@ impl From<HttpDispatchError> for GetReplicationRunsError {
         GetReplicationRunsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetReplicationRunsError {
+    fn from(err: io::Error) -> GetReplicationRunsError {
+        GetReplicationRunsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetReplicationRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1056,6 +1093,11 @@ impl From<CredentialsError> for GetServersError {
 impl From<HttpDispatchError> for GetServersError {
     fn from(err: HttpDispatchError) -> GetServersError {
         GetServersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetServersError {
+    fn from(err: io::Error) -> GetServersError {
+        GetServersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetServersError {
@@ -1150,6 +1192,11 @@ impl From<HttpDispatchError> for ImportServerCatalogError {
         ImportServerCatalogError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ImportServerCatalogError {
+    fn from(err: io::Error) -> ImportServerCatalogError {
+        ImportServerCatalogError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ImportServerCatalogError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1238,6 +1285,11 @@ impl From<CredentialsError> for StartOnDemandReplicationRunError {
 impl From<HttpDispatchError> for StartOnDemandReplicationRunError {
     fn from(err: HttpDispatchError) -> StartOnDemandReplicationRunError {
         StartOnDemandReplicationRunError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StartOnDemandReplicationRunError {
+    fn from(err: io::Error) -> StartOnDemandReplicationRunError {
+        StartOnDemandReplicationRunError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StartOnDemandReplicationRunError {
@@ -1338,6 +1390,11 @@ impl From<CredentialsError> for UpdateReplicationJobError {
 impl From<HttpDispatchError> for UpdateReplicationJobError {
     fn from(err: HttpDispatchError) -> UpdateReplicationJobError {
         UpdateReplicationJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateReplicationJobError {
+    fn from(err: io::Error) -> UpdateReplicationJobError {
+        UpdateReplicationJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateReplicationJobError {
@@ -1476,15 +1533,18 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateReplicationJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateReplicationJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateReplicationJobError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateReplicationJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1505,15 +1565,18 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteReplicationJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteReplicationJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteReplicationJobError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteReplicationJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1531,15 +1594,18 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteServerCatalogResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteServerCatalogResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteServerCatalogError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteServerCatalogError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1560,15 +1626,18 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisassociateConnectorResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisassociateConnectorResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DisassociateConnectorError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateConnectorError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1588,14 +1657,20 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetConnectorsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetConnectorsResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetConnectorsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetConnectorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1615,15 +1690,18 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetReplicationJobsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetReplicationJobsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetReplicationJobsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetReplicationJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1643,15 +1721,18 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetReplicationRunsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetReplicationRunsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetReplicationRunsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetReplicationRunsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1671,13 +1752,21 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetServersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetServersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetServersResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetServersError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1694,15 +1783,18 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ImportServerCatalogResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ImportServerCatalogResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ImportServerCatalogError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ImportServerCatalogError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1723,13 +1815,20 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartOnDemandReplicationRunResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StartOnDemandReplicationRunError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartOnDemandReplicationRunResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartOnDemandReplicationRunError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -1749,15 +1848,18 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateReplicationJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateReplicationJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateReplicationJobError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateReplicationJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -900,6 +902,11 @@ impl From<HttpDispatchError> for CancelClusterError {
         CancelClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelClusterError {
+    fn from(err: io::Error) -> CancelClusterError {
+        CancelClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -984,6 +991,11 @@ impl From<HttpDispatchError> for CancelJobError {
         CancelJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelJobError {
+    fn from(err: io::Error) -> CancelJobError {
+        CancelJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1063,6 +1075,11 @@ impl From<CredentialsError> for CreateAddressError {
 impl From<HttpDispatchError> for CreateAddressError {
     fn from(err: HttpDispatchError) -> CreateAddressError {
         CreateAddressError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAddressError {
+    fn from(err: io::Error) -> CreateAddressError {
+        CreateAddressError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAddressError {
@@ -1148,6 +1165,11 @@ impl From<CredentialsError> for CreateClusterError {
 impl From<HttpDispatchError> for CreateClusterError {
     fn from(err: HttpDispatchError) -> CreateClusterError {
         CreateClusterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateClusterError {
+    fn from(err: io::Error) -> CreateClusterError {
+        CreateClusterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateClusterError {
@@ -1239,6 +1261,11 @@ impl From<HttpDispatchError> for CreateJobError {
         CreateJobError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateJobError {
+    fn from(err: io::Error) -> CreateJobError {
+        CreateJobError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1314,6 +1341,11 @@ impl From<CredentialsError> for DescribeAddressError {
 impl From<HttpDispatchError> for DescribeAddressError {
     fn from(err: HttpDispatchError) -> DescribeAddressError {
         DescribeAddressError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAddressError {
+    fn from(err: io::Error) -> DescribeAddressError {
+        DescribeAddressError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAddressError {
@@ -1395,6 +1427,11 @@ impl From<HttpDispatchError> for DescribeAddressesError {
         DescribeAddressesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAddressesError {
+    fn from(err: io::Error) -> DescribeAddressesError {
+        DescribeAddressesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAddressesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1472,6 +1509,11 @@ impl From<HttpDispatchError> for DescribeClusterError {
         DescribeClusterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeClusterError {
+    fn from(err: io::Error) -> DescribeClusterError {
+        DescribeClusterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1544,6 +1586,11 @@ impl From<CredentialsError> for DescribeJobError {
 impl From<HttpDispatchError> for DescribeJobError {
     fn from(err: HttpDispatchError) -> DescribeJobError {
         DescribeJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeJobError {
+    fn from(err: io::Error) -> DescribeJobError {
+        DescribeJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeJobError {
@@ -1623,6 +1670,11 @@ impl From<CredentialsError> for GetJobManifestError {
 impl From<HttpDispatchError> for GetJobManifestError {
     fn from(err: HttpDispatchError) -> GetJobManifestError {
         GetJobManifestError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetJobManifestError {
+    fn from(err: io::Error) -> GetJobManifestError {
+        GetJobManifestError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetJobManifestError {
@@ -1705,6 +1757,11 @@ impl From<HttpDispatchError> for GetJobUnlockCodeError {
         GetJobUnlockCodeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetJobUnlockCodeError {
+    fn from(err: io::Error) -> GetJobUnlockCodeError {
+        GetJobUnlockCodeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetJobUnlockCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1773,6 +1830,11 @@ impl From<CredentialsError> for GetSnowballUsageError {
 impl From<HttpDispatchError> for GetSnowballUsageError {
     fn from(err: HttpDispatchError) -> GetSnowballUsageError {
         GetSnowballUsageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSnowballUsageError {
+    fn from(err: io::Error) -> GetSnowballUsageError {
+        GetSnowballUsageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSnowballUsageError {
@@ -1853,6 +1915,11 @@ impl From<HttpDispatchError> for ListClusterJobsError {
         ListClusterJobsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListClusterJobsError {
+    fn from(err: io::Error) -> ListClusterJobsError {
+        ListClusterJobsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListClusterJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1928,6 +1995,11 @@ impl From<HttpDispatchError> for ListClustersError {
         ListClustersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListClustersError {
+    fn from(err: io::Error) -> ListClustersError {
+        ListClustersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1998,6 +2070,11 @@ impl From<CredentialsError> for ListJobsError {
 impl From<HttpDispatchError> for ListJobsError {
     fn from(err: HttpDispatchError) -> ListJobsError {
         ListJobsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListJobsError {
+    fn from(err: io::Error) -> ListJobsError {
+        ListJobsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListJobsError {
@@ -2087,6 +2164,11 @@ impl From<CredentialsError> for UpdateClusterError {
 impl From<HttpDispatchError> for UpdateClusterError {
     fn from(err: HttpDispatchError) -> UpdateClusterError {
         UpdateClusterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateClusterError {
+    fn from(err: io::Error) -> UpdateClusterError {
+        UpdateClusterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateClusterError {
@@ -2182,6 +2264,11 @@ impl From<CredentialsError> for UpdateJobError {
 impl From<HttpDispatchError> for UpdateJobError {
     fn from(err: HttpDispatchError) -> UpdateJobError {
         UpdateJobError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateJobError {
+    fn from(err: io::Error) -> UpdateJobError {
+        UpdateJobError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateJobError {
@@ -2338,14 +2425,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CancelClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelClusterResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CancelClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2363,15 +2456,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<CancelJobResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelJobResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(CancelJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2390,14 +2488,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAddressResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAddressResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateAddressError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAddressError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2417,14 +2521,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateClusterResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2442,15 +2552,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<CreateJobResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateJobResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(CreateJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2469,15 +2584,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAddressResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAddressResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeAddressError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAddressError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2497,15 +2617,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAddressesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAddressesResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeAddressesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAddressesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2525,15 +2650,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeClusterResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeClusterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2553,13 +2683,21 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeJobResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeJobResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2578,15 +2716,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetJobManifestResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetJobManifestResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetJobManifestError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetJobManifestError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2606,15 +2749,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetJobUnlockCodeResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetJobUnlockCodeResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetJobUnlockCodeError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetJobUnlockCodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2631,15 +2779,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetSnowballUsageResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSnowballUsageResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetSnowballUsageError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSnowballUsageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2659,15 +2812,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListClusterJobsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListClusterJobsResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListClusterJobsError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListClusterJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2687,14 +2845,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListClustersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListClustersResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListClustersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListClustersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2711,15 +2875,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListJobsResult>(String::from_utf8_lossy(&response.body)
-                                                              .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListJobsResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ListJobsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListJobsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2738,14 +2907,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateClusterResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateClusterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateClusterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2763,15 +2938,20 @@ impl<P, D> Snowball for SnowballClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<UpdateJobResult>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateJobResult>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(UpdateJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateJobError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2611,6 +2613,11 @@ impl From<HttpDispatchError> for AddPermissionError {
         AddPermissionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddPermissionError {
+    fn from(err: io::Error) -> AddPermissionError {
+        AddPermissionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2687,6 +2694,11 @@ impl From<CredentialsError> for CheckIfPhoneNumberIsOptedOutError {
 impl From<HttpDispatchError> for CheckIfPhoneNumberIsOptedOutError {
     fn from(err: HttpDispatchError) -> CheckIfPhoneNumberIsOptedOutError {
         CheckIfPhoneNumberIsOptedOutError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CheckIfPhoneNumberIsOptedOutError {
+    fn from(err: io::Error) -> CheckIfPhoneNumberIsOptedOutError {
+        CheckIfPhoneNumberIsOptedOutError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CheckIfPhoneNumberIsOptedOutError {
@@ -2776,6 +2788,11 @@ impl From<HttpDispatchError> for ConfirmSubscriptionError {
         ConfirmSubscriptionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ConfirmSubscriptionError {
+    fn from(err: io::Error) -> ConfirmSubscriptionError {
+        ConfirmSubscriptionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ConfirmSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2852,6 +2869,11 @@ impl From<CredentialsError> for CreatePlatformApplicationError {
 impl From<HttpDispatchError> for CreatePlatformApplicationError {
     fn from(err: HttpDispatchError) -> CreatePlatformApplicationError {
         CreatePlatformApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePlatformApplicationError {
+    fn from(err: io::Error) -> CreatePlatformApplicationError {
+        CreatePlatformApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePlatformApplicationError {
@@ -2933,6 +2955,11 @@ impl From<CredentialsError> for CreatePlatformEndpointError {
 impl From<HttpDispatchError> for CreatePlatformEndpointError {
     fn from(err: HttpDispatchError) -> CreatePlatformEndpointError {
         CreatePlatformEndpointError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreatePlatformEndpointError {
+    fn from(err: io::Error) -> CreatePlatformEndpointError {
+        CreatePlatformEndpointError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreatePlatformEndpointError {
@@ -3023,6 +3050,11 @@ impl From<HttpDispatchError> for CreateTopicError {
         CreateTopicError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTopicError {
+    fn from(err: io::Error) -> CreateTopicError {
+        CreateTopicError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTopicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3104,6 +3136,11 @@ impl From<HttpDispatchError> for DeleteEndpointError {
         DeleteEndpointError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteEndpointError {
+    fn from(err: io::Error) -> DeleteEndpointError {
+        DeleteEndpointError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3176,6 +3213,11 @@ impl From<CredentialsError> for DeletePlatformApplicationError {
 impl From<HttpDispatchError> for DeletePlatformApplicationError {
     fn from(err: HttpDispatchError) -> DeletePlatformApplicationError {
         DeletePlatformApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeletePlatformApplicationError {
+    fn from(err: io::Error) -> DeletePlatformApplicationError {
+        DeletePlatformApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeletePlatformApplicationError {
@@ -3265,6 +3307,11 @@ impl From<HttpDispatchError> for DeleteTopicError {
         DeleteTopicError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTopicError {
+    fn from(err: io::Error) -> DeleteTopicError {
+        DeleteTopicError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTopicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3345,6 +3392,11 @@ impl From<HttpDispatchError> for GetEndpointAttributesError {
         GetEndpointAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetEndpointAttributesError {
+    fn from(err: io::Error) -> GetEndpointAttributesError {
+        GetEndpointAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetEndpointAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3423,6 +3475,11 @@ impl From<CredentialsError> for GetPlatformApplicationAttributesError {
 impl From<HttpDispatchError> for GetPlatformApplicationAttributesError {
     fn from(err: HttpDispatchError) -> GetPlatformApplicationAttributesError {
         GetPlatformApplicationAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetPlatformApplicationAttributesError {
+    fn from(err: io::Error) -> GetPlatformApplicationAttributesError {
+        GetPlatformApplicationAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetPlatformApplicationAttributesError {
@@ -3511,6 +3568,11 @@ impl From<HttpDispatchError> for GetSMSAttributesError {
         GetSMSAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSMSAttributesError {
+    fn from(err: io::Error) -> GetSMSAttributesError {
+        GetSMSAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSMSAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3589,6 +3651,11 @@ impl From<CredentialsError> for GetSubscriptionAttributesError {
 impl From<HttpDispatchError> for GetSubscriptionAttributesError {
     fn from(err: HttpDispatchError) -> GetSubscriptionAttributesError {
         GetSubscriptionAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSubscriptionAttributesError {
+    fn from(err: io::Error) -> GetSubscriptionAttributesError {
+        GetSubscriptionAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSubscriptionAttributesError {
@@ -3675,6 +3742,11 @@ impl From<HttpDispatchError> for GetTopicAttributesError {
         GetTopicAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetTopicAttributesError {
+    fn from(err: io::Error) -> GetTopicAttributesError {
+        GetTopicAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetTopicAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3753,6 +3825,11 @@ impl From<CredentialsError> for ListEndpointsByPlatformApplicationError {
 impl From<HttpDispatchError> for ListEndpointsByPlatformApplicationError {
     fn from(err: HttpDispatchError) -> ListEndpointsByPlatformApplicationError {
         ListEndpointsByPlatformApplicationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListEndpointsByPlatformApplicationError {
+    fn from(err: io::Error) -> ListEndpointsByPlatformApplicationError {
+        ListEndpointsByPlatformApplicationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListEndpointsByPlatformApplicationError {
@@ -3837,6 +3914,11 @@ impl From<HttpDispatchError> for ListPhoneNumbersOptedOutError {
         ListPhoneNumbersOptedOutError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListPhoneNumbersOptedOutError {
+    fn from(err: io::Error) -> ListPhoneNumbersOptedOutError {
+        ListPhoneNumbersOptedOutError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListPhoneNumbersOptedOutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3912,6 +3994,11 @@ impl From<CredentialsError> for ListPlatformApplicationsError {
 impl From<HttpDispatchError> for ListPlatformApplicationsError {
     fn from(err: HttpDispatchError) -> ListPlatformApplicationsError {
         ListPlatformApplicationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListPlatformApplicationsError {
+    fn from(err: io::Error) -> ListPlatformApplicationsError {
+        ListPlatformApplicationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListPlatformApplicationsError {
@@ -3994,6 +4081,11 @@ impl From<HttpDispatchError> for ListSubscriptionsError {
         ListSubscriptionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListSubscriptionsError {
+    fn from(err: io::Error) -> ListSubscriptionsError {
+        ListSubscriptionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4073,6 +4165,11 @@ impl From<CredentialsError> for ListSubscriptionsByTopicError {
 impl From<HttpDispatchError> for ListSubscriptionsByTopicError {
     fn from(err: HttpDispatchError) -> ListSubscriptionsByTopicError {
         ListSubscriptionsByTopicError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListSubscriptionsByTopicError {
+    fn from(err: io::Error) -> ListSubscriptionsByTopicError {
+        ListSubscriptionsByTopicError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListSubscriptionsByTopicError {
@@ -4158,6 +4255,11 @@ impl From<HttpDispatchError> for ListTopicsError {
         ListTopicsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTopicsError {
+    fn from(err: io::Error) -> ListTopicsError {
+        ListTopicsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTopicsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4239,6 +4341,11 @@ impl From<CredentialsError> for OptInPhoneNumberError {
 impl From<HttpDispatchError> for OptInPhoneNumberError {
     fn from(err: HttpDispatchError) -> OptInPhoneNumberError {
         OptInPhoneNumberError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for OptInPhoneNumberError {
+    fn from(err: io::Error) -> OptInPhoneNumberError {
+        OptInPhoneNumberError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for OptInPhoneNumberError {
@@ -4340,6 +4447,11 @@ impl From<HttpDispatchError> for PublishError {
         PublishError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PublishError {
+    fn from(err: io::Error) -> PublishError {
+        PublishError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PublishError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4427,6 +4539,11 @@ impl From<HttpDispatchError> for RemovePermissionError {
         RemovePermissionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RemovePermissionError {
+    fn from(err: io::Error) -> RemovePermissionError {
+        RemovePermissionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RemovePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4507,6 +4624,11 @@ impl From<HttpDispatchError> for SetEndpointAttributesError {
         SetEndpointAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetEndpointAttributesError {
+    fn from(err: io::Error) -> SetEndpointAttributesError {
+        SetEndpointAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetEndpointAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4585,6 +4707,11 @@ impl From<CredentialsError> for SetPlatformApplicationAttributesError {
 impl From<HttpDispatchError> for SetPlatformApplicationAttributesError {
     fn from(err: HttpDispatchError) -> SetPlatformApplicationAttributesError {
         SetPlatformApplicationAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetPlatformApplicationAttributesError {
+    fn from(err: io::Error) -> SetPlatformApplicationAttributesError {
+        SetPlatformApplicationAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetPlatformApplicationAttributesError {
@@ -4673,6 +4800,11 @@ impl From<HttpDispatchError> for SetSMSAttributesError {
         SetSMSAttributesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SetSMSAttributesError {
+    fn from(err: io::Error) -> SetSMSAttributesError {
+        SetSMSAttributesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SetSMSAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4751,6 +4883,11 @@ impl From<CredentialsError> for SetSubscriptionAttributesError {
 impl From<HttpDispatchError> for SetSubscriptionAttributesError {
     fn from(err: HttpDispatchError) -> SetSubscriptionAttributesError {
         SetSubscriptionAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetSubscriptionAttributesError {
+    fn from(err: io::Error) -> SetSubscriptionAttributesError {
+        SetSubscriptionAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetSubscriptionAttributesError {
@@ -4835,6 +4972,11 @@ impl From<CredentialsError> for SetTopicAttributesError {
 impl From<HttpDispatchError> for SetTopicAttributesError {
     fn from(err: HttpDispatchError) -> SetTopicAttributesError {
         SetTopicAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetTopicAttributesError {
+    fn from(err: io::Error) -> SetTopicAttributesError {
+        SetTopicAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetTopicAttributesError {
@@ -4928,6 +5070,11 @@ impl From<HttpDispatchError> for SubscribeError {
         SubscribeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SubscribeError {
+    fn from(err: io::Error) -> SubscribeError {
+        SubscribeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SubscribeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5013,6 +5160,11 @@ impl From<CredentialsError> for UnsubscribeError {
 impl From<HttpDispatchError> for UnsubscribeError {
     fn from(err: HttpDispatchError) -> UnsubscribeError {
         UnsubscribeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UnsubscribeError {
+    fn from(err: io::Error) -> UnsubscribeError {
+        UnsubscribeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UnsubscribeError {
@@ -5249,14 +5401,16 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AddPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddPermissionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5276,16 +5430,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CheckIfPhoneNumberIsOptedOutResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5299,8 +5455,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CheckIfPhoneNumberIsOptedOutError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CheckIfPhoneNumberIsOptedOutError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -5318,16 +5477,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ConfirmSubscriptionResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5342,8 +5503,9 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ConfirmSubscriptionError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ConfirmSubscriptionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5363,16 +5525,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreatePlatformApplicationResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5386,8 +5550,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(CreatePlatformApplicationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePlatformApplicationError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5405,16 +5572,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateEndpointResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5429,8 +5598,9 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(CreatePlatformEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePlatformEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5449,16 +5619,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateTopicResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5472,7 +5644,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateTopicError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTopicError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5488,15 +5664,16 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteEndpointError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteEndpointError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5515,15 +5692,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(DeletePlatformApplicationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePlatformApplicationError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5539,13 +5719,17 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteTopicError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTopicError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5564,16 +5748,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetEndpointAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5589,8 +5775,9 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetEndpointAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetEndpointAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5610,16 +5797,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetPlatformApplicationAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5633,8 +5822,10 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(GetPlatformApplicationAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPlatformApplicationAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5652,16 +5843,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetSMSAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5676,8 +5869,9 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetSMSAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSMSAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5697,16 +5891,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetSubscriptionAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5720,8 +5916,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(GetSubscriptionAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSubscriptionAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5739,16 +5938,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetTopicAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5763,8 +5964,9 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetTopicAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetTopicAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5785,16 +5987,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListEndpointsByPlatformApplicationResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5808,8 +6012,10 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListEndpointsByPlatformApplicationError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListEndpointsByPlatformApplicationError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5828,16 +6034,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListPhoneNumbersOptedOutResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5853,8 +6061,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListPhoneNumbersOptedOutError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPhoneNumbersOptedOutError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -5873,16 +6084,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListPlatformApplicationsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5898,8 +6111,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListPlatformApplicationsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListPlatformApplicationsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -5917,16 +6133,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListSubscriptionsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5941,8 +6159,9 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ListSubscriptionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSubscriptionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5962,16 +6181,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListSubscriptionsByTopicResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -5987,8 +6208,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListSubscriptionsByTopicError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSubscriptionsByTopicError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -6004,16 +6228,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListTopicsResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -6027,7 +6253,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListTopicsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTopicsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6045,16 +6275,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = OptInPhoneNumberResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -6069,8 +6301,9 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(OptInPhoneNumberError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(OptInPhoneNumberError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6087,16 +6320,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = PublishResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -6110,7 +6345,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(PublishError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PublishError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6128,15 +6367,16 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(RemovePermissionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemovePermissionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6155,15 +6395,16 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SetEndpointAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetEndpointAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6182,15 +6423,17 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(SetPlatformApplicationAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetPlatformApplicationAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6208,16 +6451,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SetSMSAttributesResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -6232,8 +6477,9 @@ impl<P, D> Sns for SnsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SetSMSAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetSMSAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6252,15 +6498,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(SetSubscriptionAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetSubscriptionAttributesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -6278,15 +6527,16 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SetTopicAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetTopicAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6303,16 +6553,18 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SubscribeResponse::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -6326,7 +6578,11 @@ impl<P, D> Sns for SnsClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(SubscribeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SubscribeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6342,13 +6598,17 @@ impl<P, D> Sns for SnsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(UnsubscribeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UnsubscribeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2205,6 +2207,11 @@ impl From<HttpDispatchError> for AddPermissionError {
         AddPermissionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddPermissionError {
+    fn from(err: io::Error) -> AddPermissionError {
+        AddPermissionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2272,6 +2279,11 @@ impl From<CredentialsError> for ChangeMessageVisibilityError {
 impl From<HttpDispatchError> for ChangeMessageVisibilityError {
     fn from(err: HttpDispatchError) -> ChangeMessageVisibilityError {
         ChangeMessageVisibilityError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ChangeMessageVisibilityError {
+    fn from(err: io::Error) -> ChangeMessageVisibilityError {
+        ChangeMessageVisibilityError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ChangeMessageVisibilityError {
@@ -2352,6 +2364,11 @@ impl From<HttpDispatchError> for ChangeMessageVisibilityBatchError {
         ChangeMessageVisibilityBatchError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ChangeMessageVisibilityBatchError {
+    fn from(err: io::Error) -> ChangeMessageVisibilityBatchError {
+        ChangeMessageVisibilityBatchError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ChangeMessageVisibilityBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2430,6 +2447,11 @@ impl From<HttpDispatchError> for CreateQueueError {
         CreateQueueError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateQueueError {
+    fn from(err: io::Error) -> CreateQueueError {
+        CreateQueueError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2500,6 +2522,11 @@ impl From<CredentialsError> for DeleteMessageError {
 impl From<HttpDispatchError> for DeleteMessageError {
     fn from(err: HttpDispatchError) -> DeleteMessageError {
         DeleteMessageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteMessageError {
+    fn from(err: io::Error) -> DeleteMessageError {
+        DeleteMessageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteMessageError {
@@ -2578,6 +2605,11 @@ impl From<HttpDispatchError> for DeleteMessageBatchError {
         DeleteMessageBatchError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteMessageBatchError {
+    fn from(err: io::Error) -> DeleteMessageBatchError {
+        DeleteMessageBatchError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteMessageBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2646,6 +2678,11 @@ impl From<HttpDispatchError> for DeleteQueueError {
         DeleteQueueError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteQueueError {
+    fn from(err: io::Error) -> DeleteQueueError {
+        DeleteQueueError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2709,6 +2746,11 @@ impl From<CredentialsError> for GetQueueAttributesError {
 impl From<HttpDispatchError> for GetQueueAttributesError {
     fn from(err: HttpDispatchError) -> GetQueueAttributesError {
         GetQueueAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetQueueAttributesError {
+    fn from(err: io::Error) -> GetQueueAttributesError {
+        GetQueueAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetQueueAttributesError {
@@ -2781,6 +2823,11 @@ impl From<HttpDispatchError> for GetQueueUrlError {
         GetQueueUrlError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetQueueUrlError {
+    fn from(err: io::Error) -> GetQueueUrlError {
+        GetQueueUrlError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetQueueUrlError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2847,6 +2894,11 @@ impl From<HttpDispatchError> for ListDeadLetterSourceQueuesError {
         ListDeadLetterSourceQueuesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDeadLetterSourceQueuesError {
+    fn from(err: io::Error) -> ListDeadLetterSourceQueuesError {
+        ListDeadLetterSourceQueuesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDeadLetterSourceQueuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2910,6 +2962,11 @@ impl From<CredentialsError> for ListQueuesError {
 impl From<HttpDispatchError> for ListQueuesError {
     fn from(err: HttpDispatchError) -> ListQueuesError {
         ListQueuesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListQueuesError {
+    fn from(err: io::Error) -> ListQueuesError {
+        ListQueuesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListQueuesError {
@@ -2984,6 +3041,11 @@ impl From<HttpDispatchError> for PurgeQueueError {
         PurgeQueueError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PurgeQueueError {
+    fn from(err: io::Error) -> PurgeQueueError {
+        PurgeQueueError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PurgeQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3053,6 +3115,11 @@ impl From<HttpDispatchError> for ReceiveMessageError {
         ReceiveMessageError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ReceiveMessageError {
+    fn from(err: io::Error) -> ReceiveMessageError {
+        ReceiveMessageError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ReceiveMessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3114,6 +3181,11 @@ impl From<CredentialsError> for RemovePermissionError {
 impl From<HttpDispatchError> for RemovePermissionError {
     fn from(err: HttpDispatchError) -> RemovePermissionError {
         RemovePermissionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemovePermissionError {
+    fn from(err: io::Error) -> RemovePermissionError {
+        RemovePermissionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemovePermissionError {
@@ -3186,6 +3258,11 @@ impl From<CredentialsError> for SendMessageError {
 impl From<HttpDispatchError> for SendMessageError {
     fn from(err: HttpDispatchError) -> SendMessageError {
         SendMessageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SendMessageError {
+    fn from(err: io::Error) -> SendMessageError {
+        SendMessageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SendMessageError {
@@ -3272,6 +3349,11 @@ impl From<HttpDispatchError> for SendMessageBatchError {
         SendMessageBatchError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SendMessageBatchError {
+    fn from(err: io::Error) -> SendMessageBatchError {
+        SendMessageBatchError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SendMessageBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3341,6 +3423,11 @@ impl From<CredentialsError> for SetQueueAttributesError {
 impl From<HttpDispatchError> for SetQueueAttributesError {
     fn from(err: HttpDispatchError) -> SetQueueAttributesError {
         SetQueueAttributesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetQueueAttributesError {
+    fn from(err: io::Error) -> SetQueueAttributesError {
+        SetQueueAttributesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetQueueAttributesError {
@@ -3494,14 +3581,16 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(AddPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddPermissionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3520,15 +3609,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                            Err(ChangeMessageVisibilityError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ChangeMessageVisibilityError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -3547,16 +3639,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ChangeMessageVisibilityBatchResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3570,8 +3664,11 @@ impl<P, D> Sqs for SqsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ChangeMessageVisibilityBatchError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ChangeMessageVisibilityBatchError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -3589,16 +3686,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = CreateQueueResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3612,7 +3711,11 @@ impl<P, D> Sqs for SqsClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(CreateQueueError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3628,14 +3731,16 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(DeleteMessageError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteMessageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3654,16 +3759,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = DeleteMessageBatchResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3678,8 +3785,9 @@ impl<P, D> Sqs for SqsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(DeleteMessageBatchError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteMessageBatchError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3696,13 +3804,17 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(DeleteQueueError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3720,16 +3832,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetQueueAttributesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3744,8 +3858,9 @@ impl<P, D> Sqs for SqsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(GetQueueAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetQueueAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3764,16 +3879,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = GetQueueUrlResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3787,7 +3904,11 @@ impl<P, D> Sqs for SqsClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(GetQueueUrlError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetQueueUrlError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3806,16 +3927,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListDeadLetterSourceQueuesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3831,8 +3954,11 @@ impl<P, D> Sqs for SqsClient<P, D>
                 Ok(result)
             }
             _ => {
-                            Err(ListDeadLetterSourceQueuesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDeadLetterSourceQueuesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -3848,16 +3974,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ListQueuesResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3871,7 +3999,11 @@ impl<P, D> Sqs for SqsClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(ListQueuesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListQueuesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3887,13 +4019,17 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
-            _ => Err(PurgeQueueError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PurgeQueueError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -3911,16 +4047,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = ReceiveMessageResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -3935,8 +4073,9 @@ impl<P, D> Sqs for SqsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(ReceiveMessageError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ReceiveMessageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3955,15 +4094,16 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(RemovePermissionError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemovePermissionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -3982,16 +4122,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SendMessageResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -4005,7 +4147,11 @@ impl<P, D> Sqs for SqsClient<P, D>
                 }
                 Ok(result)
             }
-            _ => Err(SendMessageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendMessageError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -4023,16 +4169,18 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
 
                 let result;
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
 
-                if response.body.is_empty() {
+                if body.is_empty() {
                     result = SendMessageBatchResult::default();
                 } else {
-                    let reader = EventReader::new_with_config(response.body.as_slice(),
+                    let reader = EventReader::new_with_config(body.as_slice(),
                                                               ParserConfig::new()
                                                                   .trim_whitespace(true));
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
@@ -4047,8 +4195,9 @@ impl<P, D> Sqs for SqsClient<P, D>
                 Ok(result)
             }
             _ => {
-                Err(SendMessageBatchError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendMessageBatchError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -4067,15 +4216,16 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.set_params(params);
 
         request.sign(&try!(self.credentials_provider.credentials()));
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
             StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
             _ => {
-                Err(SetQueueAttributesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetQueueAttributesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -4243,6 +4245,11 @@ impl From<HttpDispatchError> for AddTagsToResourceError {
         AddTagsToResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddTagsToResourceError {
+    fn from(err: io::Error) -> AddTagsToResourceError {
+        AddTagsToResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4337,6 +4344,11 @@ impl From<HttpDispatchError> for CancelCommandError {
         CancelCommandError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelCommandError {
+    fn from(err: io::Error) -> CancelCommandError {
+        CancelCommandError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelCommandError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4412,6 +4424,11 @@ impl From<CredentialsError> for CreateActivationError {
 impl From<HttpDispatchError> for CreateActivationError {
     fn from(err: HttpDispatchError) -> CreateActivationError {
         CreateActivationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateActivationError {
+    fn from(err: io::Error) -> CreateActivationError {
+        CreateActivationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateActivationError {
@@ -4532,6 +4549,11 @@ impl From<CredentialsError> for CreateAssociationError {
 impl From<HttpDispatchError> for CreateAssociationError {
     fn from(err: HttpDispatchError) -> CreateAssociationError {
         CreateAssociationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateAssociationError {
+    fn from(err: io::Error) -> CreateAssociationError {
+        CreateAssociationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateAssociationError {
@@ -4658,6 +4680,11 @@ impl From<HttpDispatchError> for CreateAssociationBatchError {
         CreateAssociationBatchError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateAssociationBatchError {
+    fn from(err: io::Error) -> CreateAssociationBatchError {
+        CreateAssociationBatchError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateAssociationBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4767,6 +4794,11 @@ impl From<HttpDispatchError> for CreateDocumentError {
         CreateDocumentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateDocumentError {
+    fn from(err: io::Error) -> CreateDocumentError {
+        CreateDocumentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4848,6 +4880,11 @@ impl From<CredentialsError> for CreateMaintenanceWindowError {
 impl From<HttpDispatchError> for CreateMaintenanceWindowError {
     fn from(err: HttpDispatchError) -> CreateMaintenanceWindowError {
         CreateMaintenanceWindowError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateMaintenanceWindowError {
+    fn from(err: io::Error) -> CreateMaintenanceWindowError {
+        CreateMaintenanceWindowError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateMaintenanceWindowError {
@@ -4936,6 +4973,11 @@ impl From<HttpDispatchError> for CreatePatchBaselineError {
         CreatePatchBaselineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreatePatchBaselineError {
+    fn from(err: io::Error) -> CreatePatchBaselineError {
+        CreatePatchBaselineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreatePatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5022,6 +5064,11 @@ impl From<CredentialsError> for DeleteActivationError {
 impl From<HttpDispatchError> for DeleteActivationError {
     fn from(err: HttpDispatchError) -> DeleteActivationError {
         DeleteActivationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteActivationError {
+    fn from(err: io::Error) -> DeleteActivationError {
+        DeleteActivationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteActivationError {
@@ -5120,6 +5167,11 @@ impl From<HttpDispatchError> for DeleteAssociationError {
         DeleteAssociationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteAssociationError {
+    fn from(err: io::Error) -> DeleteAssociationError {
+        DeleteAssociationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5215,6 +5267,11 @@ impl From<HttpDispatchError> for DeleteDocumentError {
         DeleteDocumentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteDocumentError {
+    fn from(err: io::Error) -> DeleteDocumentError {
+        DeleteDocumentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5288,6 +5345,11 @@ impl From<CredentialsError> for DeleteMaintenanceWindowError {
 impl From<HttpDispatchError> for DeleteMaintenanceWindowError {
     fn from(err: HttpDispatchError) -> DeleteMaintenanceWindowError {
         DeleteMaintenanceWindowError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteMaintenanceWindowError {
+    fn from(err: io::Error) -> DeleteMaintenanceWindowError {
+        DeleteMaintenanceWindowError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteMaintenanceWindowError {
@@ -5371,6 +5433,11 @@ impl From<HttpDispatchError> for DeleteParameterError {
         DeleteParameterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteParameterError {
+    fn from(err: io::Error) -> DeleteParameterError {
+        DeleteParameterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteParameterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5444,6 +5511,11 @@ impl From<CredentialsError> for DeleteParametersError {
 impl From<HttpDispatchError> for DeleteParametersError {
     fn from(err: HttpDispatchError) -> DeleteParametersError {
         DeleteParametersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteParametersError {
+    fn from(err: io::Error) -> DeleteParametersError {
+        DeleteParametersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteParametersError {
@@ -5525,6 +5597,11 @@ impl From<HttpDispatchError> for DeletePatchBaselineError {
         DeletePatchBaselineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeletePatchBaselineError {
+    fn from(err: io::Error) -> DeletePatchBaselineError {
+        DeletePatchBaselineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeletePatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5601,6 +5678,11 @@ impl From<CredentialsError> for DeregisterManagedInstanceError {
 impl From<HttpDispatchError> for DeregisterManagedInstanceError {
     fn from(err: HttpDispatchError) -> DeregisterManagedInstanceError {
         DeregisterManagedInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeregisterManagedInstanceError {
+    fn from(err: io::Error) -> DeregisterManagedInstanceError {
+        DeregisterManagedInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeregisterManagedInstanceError {
@@ -5682,6 +5764,11 @@ impl From<HttpDispatchError> for DeregisterPatchBaselineForPatchGroupError {
         DeregisterPatchBaselineForPatchGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterPatchBaselineForPatchGroupError {
+    fn from(err: io::Error) -> DeregisterPatchBaselineForPatchGroupError {
+        DeregisterPatchBaselineForPatchGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterPatchBaselineForPatchGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5761,6 +5848,11 @@ impl From<HttpDispatchError> for DeregisterTargetFromMaintenanceWindowError {
         DeregisterTargetFromMaintenanceWindowError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeregisterTargetFromMaintenanceWindowError {
+    fn from(err: io::Error) -> DeregisterTargetFromMaintenanceWindowError {
+        DeregisterTargetFromMaintenanceWindowError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeregisterTargetFromMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5838,6 +5930,11 @@ impl From<CredentialsError> for DeregisterTaskFromMaintenanceWindowError {
 impl From<HttpDispatchError> for DeregisterTaskFromMaintenanceWindowError {
     fn from(err: HttpDispatchError) -> DeregisterTaskFromMaintenanceWindowError {
         DeregisterTaskFromMaintenanceWindowError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeregisterTaskFromMaintenanceWindowError {
+    fn from(err: io::Error) -> DeregisterTaskFromMaintenanceWindowError {
+        DeregisterTaskFromMaintenanceWindowError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeregisterTaskFromMaintenanceWindowError {
@@ -5925,6 +6022,11 @@ impl From<CredentialsError> for DescribeActivationsError {
 impl From<HttpDispatchError> for DescribeActivationsError {
     fn from(err: HttpDispatchError) -> DescribeActivationsError {
         DescribeActivationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeActivationsError {
+    fn from(err: io::Error) -> DescribeActivationsError {
+        DescribeActivationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeActivationsError {
@@ -6018,6 +6120,11 @@ impl From<HttpDispatchError> for DescribeAssociationError {
         DescribeAssociationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAssociationError {
+    fn from(err: io::Error) -> DescribeAssociationError {
+        DescribeAssociationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6098,6 +6205,11 @@ impl From<HttpDispatchError> for DescribeAutomationExecutionsError {
         DescribeAutomationExecutionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAutomationExecutionsError {
+    fn from(err: io::Error) -> DescribeAutomationExecutionsError {
+        DescribeAutomationExecutionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAutomationExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6171,6 +6283,11 @@ impl From<CredentialsError> for DescribeAvailablePatchesError {
 impl From<HttpDispatchError> for DescribeAvailablePatchesError {
     fn from(err: HttpDispatchError) -> DescribeAvailablePatchesError {
         DescribeAvailablePatchesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeAvailablePatchesError {
+    fn from(err: io::Error) -> DescribeAvailablePatchesError {
+        DescribeAvailablePatchesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeAvailablePatchesError {
@@ -6259,6 +6376,11 @@ impl From<HttpDispatchError> for DescribeDocumentError {
         DescribeDocumentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDocumentError {
+    fn from(err: io::Error) -> DescribeDocumentError {
+        DescribeDocumentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6337,6 +6459,11 @@ impl From<CredentialsError> for DescribeDocumentPermissionError {
 impl From<HttpDispatchError> for DescribeDocumentPermissionError {
     fn from(err: HttpDispatchError) -> DescribeDocumentPermissionError {
         DescribeDocumentPermissionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeDocumentPermissionError {
+    fn from(err: io::Error) -> DescribeDocumentPermissionError {
+        DescribeDocumentPermissionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeDocumentPermissionError {
@@ -6422,6 +6549,11 @@ impl From<HttpDispatchError> for DescribeEffectiveInstanceAssociationsError {
         DescribeEffectiveInstanceAssociationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeEffectiveInstanceAssociationsError {
+    fn from(err: io::Error) -> DescribeEffectiveInstanceAssociationsError {
+        DescribeEffectiveInstanceAssociationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeEffectiveInstanceAssociationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6500,6 +6632,11 @@ impl From<CredentialsError> for DescribeEffectivePatchesForPatchBaselineError {
 impl From<HttpDispatchError> for DescribeEffectivePatchesForPatchBaselineError {
     fn from(err: HttpDispatchError) -> DescribeEffectivePatchesForPatchBaselineError {
         DescribeEffectivePatchesForPatchBaselineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeEffectivePatchesForPatchBaselineError {
+    fn from(err: io::Error) -> DescribeEffectivePatchesForPatchBaselineError {
+        DescribeEffectivePatchesForPatchBaselineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeEffectivePatchesForPatchBaselineError {
@@ -6585,6 +6722,11 @@ impl From<CredentialsError> for DescribeInstanceAssociationsStatusError {
 impl From<HttpDispatchError> for DescribeInstanceAssociationsStatusError {
     fn from(err: HttpDispatchError) -> DescribeInstanceAssociationsStatusError {
         DescribeInstanceAssociationsStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeInstanceAssociationsStatusError {
+    fn from(err: io::Error) -> DescribeInstanceAssociationsStatusError {
+        DescribeInstanceAssociationsStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeInstanceAssociationsStatusError {
@@ -6675,6 +6817,11 @@ impl From<HttpDispatchError> for DescribeInstanceInformationError {
         DescribeInstanceInformationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeInstanceInformationError {
+    fn from(err: io::Error) -> DescribeInstanceInformationError {
+        DescribeInstanceInformationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeInstanceInformationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6758,6 +6905,11 @@ impl From<HttpDispatchError> for DescribeInstancePatchStatesError {
         DescribeInstancePatchStatesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeInstancePatchStatesError {
+    fn from(err: io::Error) -> DescribeInstancePatchStatesError {
+        DescribeInstancePatchStatesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeInstancePatchStatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6835,6 +6987,11 @@ impl From<CredentialsError> for DescribeInstancePatchStatesForPatchGroupError {
 impl From<HttpDispatchError> for DescribeInstancePatchStatesForPatchGroupError {
     fn from(err: HttpDispatchError) -> DescribeInstancePatchStatesForPatchGroupError {
         DescribeInstancePatchStatesForPatchGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeInstancePatchStatesForPatchGroupError {
+    fn from(err: io::Error) -> DescribeInstancePatchStatesForPatchGroupError {
+        DescribeInstancePatchStatesForPatchGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeInstancePatchStatesForPatchGroupError {
@@ -6930,6 +7087,11 @@ impl From<HttpDispatchError> for DescribeInstancePatchesError {
         DescribeInstancePatchesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeInstancePatchesError {
+    fn from(err: io::Error) -> DescribeInstancePatchesError {
+        DescribeInstancePatchesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeInstancePatchesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7012,6 +7174,11 @@ impl From<HttpDispatchError> for DescribeMaintenanceWindowExecutionTaskInvocatio
         DescribeMaintenanceWindowExecutionTaskInvocationsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeMaintenanceWindowExecutionTaskInvocationsError {
+    fn from(err: io::Error) -> DescribeMaintenanceWindowExecutionTaskInvocationsError {
+        DescribeMaintenanceWindowExecutionTaskInvocationsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeMaintenanceWindowExecutionTaskInvocationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7090,6 +7257,11 @@ impl From<HttpDispatchError> for DescribeMaintenanceWindowExecutionTasksError {
         DescribeMaintenanceWindowExecutionTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeMaintenanceWindowExecutionTasksError {
+    fn from(err: io::Error) -> DescribeMaintenanceWindowExecutionTasksError {
+        DescribeMaintenanceWindowExecutionTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeMaintenanceWindowExecutionTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7164,6 +7336,11 @@ impl From<CredentialsError> for DescribeMaintenanceWindowExecutionsError {
 impl From<HttpDispatchError> for DescribeMaintenanceWindowExecutionsError {
     fn from(err: HttpDispatchError) -> DescribeMaintenanceWindowExecutionsError {
         DescribeMaintenanceWindowExecutionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeMaintenanceWindowExecutionsError {
+    fn from(err: io::Error) -> DescribeMaintenanceWindowExecutionsError {
+        DescribeMaintenanceWindowExecutionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeMaintenanceWindowExecutionsError {
@@ -7241,6 +7418,11 @@ impl From<CredentialsError> for DescribeMaintenanceWindowTargetsError {
 impl From<HttpDispatchError> for DescribeMaintenanceWindowTargetsError {
     fn from(err: HttpDispatchError) -> DescribeMaintenanceWindowTargetsError {
         DescribeMaintenanceWindowTargetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeMaintenanceWindowTargetsError {
+    fn from(err: io::Error) -> DescribeMaintenanceWindowTargetsError {
+        DescribeMaintenanceWindowTargetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeMaintenanceWindowTargetsError {
@@ -7321,6 +7503,11 @@ impl From<HttpDispatchError> for DescribeMaintenanceWindowTasksError {
         DescribeMaintenanceWindowTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeMaintenanceWindowTasksError {
+    fn from(err: io::Error) -> DescribeMaintenanceWindowTasksError {
+        DescribeMaintenanceWindowTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeMaintenanceWindowTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7394,6 +7581,11 @@ impl From<CredentialsError> for DescribeMaintenanceWindowsError {
 impl From<HttpDispatchError> for DescribeMaintenanceWindowsError {
     fn from(err: HttpDispatchError) -> DescribeMaintenanceWindowsError {
         DescribeMaintenanceWindowsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeMaintenanceWindowsError {
+    fn from(err: io::Error) -> DescribeMaintenanceWindowsError {
+        DescribeMaintenanceWindowsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeMaintenanceWindowsError {
@@ -7492,6 +7684,11 @@ impl From<HttpDispatchError> for DescribeParametersError {
         DescribeParametersError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeParametersError {
+    fn from(err: io::Error) -> DescribeParametersError {
+        DescribeParametersError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7568,6 +7765,11 @@ impl From<CredentialsError> for DescribePatchBaselinesError {
 impl From<HttpDispatchError> for DescribePatchBaselinesError {
     fn from(err: HttpDispatchError) -> DescribePatchBaselinesError {
         DescribePatchBaselinesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribePatchBaselinesError {
+    fn from(err: io::Error) -> DescribePatchBaselinesError {
+        DescribePatchBaselinesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribePatchBaselinesError {
@@ -7649,6 +7851,11 @@ impl From<HttpDispatchError> for DescribePatchGroupStateError {
         DescribePatchGroupStateError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribePatchGroupStateError {
+    fn from(err: io::Error) -> DescribePatchGroupStateError {
+        DescribePatchGroupStateError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribePatchGroupStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7726,6 +7933,11 @@ impl From<HttpDispatchError> for DescribePatchGroupsError {
         DescribePatchGroupsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribePatchGroupsError {
+    fn from(err: io::Error) -> DescribePatchGroupsError {
+        DescribePatchGroupsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribePatchGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7801,6 +8013,11 @@ impl From<CredentialsError> for GetAutomationExecutionError {
 impl From<HttpDispatchError> for GetAutomationExecutionError {
     fn from(err: HttpDispatchError) -> GetAutomationExecutionError {
         GetAutomationExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetAutomationExecutionError {
+    fn from(err: io::Error) -> GetAutomationExecutionError {
+        GetAutomationExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetAutomationExecutionError {
@@ -7898,6 +8115,11 @@ impl From<HttpDispatchError> for GetCommandInvocationError {
         GetCommandInvocationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetCommandInvocationError {
+    fn from(err: io::Error) -> GetCommandInvocationError {
+        GetCommandInvocationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetCommandInvocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -7976,6 +8198,11 @@ impl From<HttpDispatchError> for GetDefaultPatchBaselineError {
         GetDefaultPatchBaselineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetDefaultPatchBaselineError {
+    fn from(err: io::Error) -> GetDefaultPatchBaselineError {
+        GetDefaultPatchBaselineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetDefaultPatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8049,6 +8276,11 @@ impl From<CredentialsError> for GetDeployablePatchSnapshotForInstanceError {
 impl From<HttpDispatchError> for GetDeployablePatchSnapshotForInstanceError {
     fn from(err: HttpDispatchError) -> GetDeployablePatchSnapshotForInstanceError {
         GetDeployablePatchSnapshotForInstanceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDeployablePatchSnapshotForInstanceError {
+    fn from(err: io::Error) -> GetDeployablePatchSnapshotForInstanceError {
+        GetDeployablePatchSnapshotForInstanceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDeployablePatchSnapshotForInstanceError {
@@ -8135,6 +8367,11 @@ impl From<CredentialsError> for GetDocumentError {
 impl From<HttpDispatchError> for GetDocumentError {
     fn from(err: HttpDispatchError) -> GetDocumentError {
         GetDocumentError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetDocumentError {
+    fn from(err: io::Error) -> GetDocumentError {
+        GetDocumentError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetDocumentError {
@@ -8233,6 +8470,11 @@ impl From<HttpDispatchError> for GetInventoryError {
         GetInventoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInventoryError {
+    fn from(err: io::Error) -> GetInventoryError {
+        GetInventoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInventoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8321,6 +8563,11 @@ impl From<HttpDispatchError> for GetInventorySchemaError {
         GetInventorySchemaError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetInventorySchemaError {
+    fn from(err: io::Error) -> GetInventorySchemaError {
+        GetInventorySchemaError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetInventorySchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8404,6 +8651,11 @@ impl From<HttpDispatchError> for GetMaintenanceWindowError {
         GetMaintenanceWindowError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetMaintenanceWindowError {
+    fn from(err: io::Error) -> GetMaintenanceWindowError {
+        GetMaintenanceWindowError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8480,6 +8732,11 @@ impl From<CredentialsError> for GetMaintenanceWindowExecutionError {
 impl From<HttpDispatchError> for GetMaintenanceWindowExecutionError {
     fn from(err: HttpDispatchError) -> GetMaintenanceWindowExecutionError {
         GetMaintenanceWindowExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetMaintenanceWindowExecutionError {
+    fn from(err: io::Error) -> GetMaintenanceWindowExecutionError {
+        GetMaintenanceWindowExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetMaintenanceWindowExecutionError {
@@ -8559,6 +8816,11 @@ impl From<CredentialsError> for GetMaintenanceWindowExecutionTaskError {
 impl From<HttpDispatchError> for GetMaintenanceWindowExecutionTaskError {
     fn from(err: HttpDispatchError) -> GetMaintenanceWindowExecutionTaskError {
         GetMaintenanceWindowExecutionTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetMaintenanceWindowExecutionTaskError {
+    fn from(err: io::Error) -> GetMaintenanceWindowExecutionTaskError {
+        GetMaintenanceWindowExecutionTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetMaintenanceWindowExecutionTaskError {
@@ -8644,6 +8906,11 @@ impl From<CredentialsError> for GetParameterError {
 impl From<HttpDispatchError> for GetParameterError {
     fn from(err: HttpDispatchError) -> GetParameterError {
         GetParameterError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetParameterError {
+    fn from(err: io::Error) -> GetParameterError {
+        GetParameterError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetParameterError {
@@ -8737,6 +9004,11 @@ impl From<HttpDispatchError> for GetParameterHistoryError {
         GetParameterHistoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetParameterHistoryError {
+    fn from(err: io::Error) -> GetParameterHistoryError {
+        GetParameterHistoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetParameterHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -8817,6 +9089,11 @@ impl From<CredentialsError> for GetParametersError {
 impl From<HttpDispatchError> for GetParametersError {
     fn from(err: HttpDispatchError) -> GetParametersError {
         GetParametersError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetParametersError {
+    fn from(err: io::Error) -> GetParametersError {
+        GetParametersError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetParametersError {
@@ -8919,6 +9196,11 @@ impl From<HttpDispatchError> for GetParametersByPathError {
         GetParametersByPathError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetParametersByPathError {
+    fn from(err: io::Error) -> GetParametersByPathError {
+        GetParametersByPathError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetParametersByPathError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9010,6 +9292,11 @@ impl From<HttpDispatchError> for GetPatchBaselineError {
         GetPatchBaselineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetPatchBaselineError {
+    fn from(err: io::Error) -> GetPatchBaselineError {
+        GetPatchBaselineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetPatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9082,6 +9369,11 @@ impl From<CredentialsError> for GetPatchBaselineForPatchGroupError {
 impl From<HttpDispatchError> for GetPatchBaselineForPatchGroupError {
     fn from(err: HttpDispatchError) -> GetPatchBaselineForPatchGroupError {
         GetPatchBaselineForPatchGroupError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetPatchBaselineForPatchGroupError {
+    fn from(err: io::Error) -> GetPatchBaselineForPatchGroupError {
+        GetPatchBaselineForPatchGroupError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetPatchBaselineForPatchGroupError {
@@ -9163,6 +9455,11 @@ impl From<CredentialsError> for ListAssociationsError {
 impl From<HttpDispatchError> for ListAssociationsError {
     fn from(err: HttpDispatchError) -> ListAssociationsError {
         ListAssociationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListAssociationsError {
+    fn from(err: io::Error) -> ListAssociationsError {
+        ListAssociationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListAssociationsError {
@@ -9256,6 +9553,11 @@ impl From<CredentialsError> for ListCommandInvocationsError {
 impl From<HttpDispatchError> for ListCommandInvocationsError {
     fn from(err: HttpDispatchError) -> ListCommandInvocationsError {
         ListCommandInvocationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListCommandInvocationsError {
+    fn from(err: io::Error) -> ListCommandInvocationsError {
+        ListCommandInvocationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListCommandInvocationsError {
@@ -9358,6 +9660,11 @@ impl From<HttpDispatchError> for ListCommandsError {
         ListCommandsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListCommandsError {
+    fn from(err: io::Error) -> ListCommandsError {
+        ListCommandsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListCommandsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9446,6 +9753,11 @@ impl From<HttpDispatchError> for ListDocumentVersionsError {
         ListDocumentVersionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDocumentVersionsError {
+    fn from(err: io::Error) -> ListDocumentVersionsError {
+        ListDocumentVersionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDocumentVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9532,6 +9844,11 @@ impl From<CredentialsError> for ListDocumentsError {
 impl From<HttpDispatchError> for ListDocumentsError {
     fn from(err: HttpDispatchError) -> ListDocumentsError {
         ListDocumentsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListDocumentsError {
+    fn from(err: io::Error) -> ListDocumentsError {
+        ListDocumentsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListDocumentsError {
@@ -9630,6 +9947,11 @@ impl From<HttpDispatchError> for ListInventoryEntriesError {
         ListInventoryEntriesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListInventoryEntriesError {
+    fn from(err: io::Error) -> ListInventoryEntriesError {
+        ListInventoryEntriesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListInventoryEntriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9720,6 +10042,11 @@ impl From<HttpDispatchError> for ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -9808,6 +10135,11 @@ impl From<CredentialsError> for ModifyDocumentPermissionError {
 impl From<HttpDispatchError> for ModifyDocumentPermissionError {
     fn from(err: HttpDispatchError) -> ModifyDocumentPermissionError {
         ModifyDocumentPermissionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ModifyDocumentPermissionError {
+    fn from(err: io::Error) -> ModifyDocumentPermissionError {
+        ModifyDocumentPermissionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ModifyDocumentPermissionError {
@@ -9924,6 +10256,11 @@ impl From<CredentialsError> for PutInventoryError {
 impl From<HttpDispatchError> for PutInventoryError {
     fn from(err: HttpDispatchError) -> PutInventoryError {
         PutInventoryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PutInventoryError {
+    fn from(err: io::Error) -> PutInventoryError {
+        PutInventoryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PutInventoryError {
@@ -10051,6 +10388,11 @@ impl From<HttpDispatchError> for PutParameterError {
         PutParameterError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PutParameterError {
+    fn from(err: io::Error) -> PutParameterError {
+        PutParameterError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PutParameterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10138,6 +10480,11 @@ impl From<CredentialsError> for RegisterDefaultPatchBaselineError {
 impl From<HttpDispatchError> for RegisterDefaultPatchBaselineError {
     fn from(err: HttpDispatchError) -> RegisterDefaultPatchBaselineError {
         RegisterDefaultPatchBaselineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterDefaultPatchBaselineError {
+    fn from(err: io::Error) -> RegisterDefaultPatchBaselineError {
+        RegisterDefaultPatchBaselineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterDefaultPatchBaselineError {
@@ -10229,6 +10576,11 @@ impl From<HttpDispatchError> for RegisterPatchBaselineForPatchGroupError {
         RegisterPatchBaselineForPatchGroupError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterPatchBaselineForPatchGroupError {
+    fn from(err: io::Error) -> RegisterPatchBaselineForPatchGroupError {
+        RegisterPatchBaselineForPatchGroupError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterPatchBaselineForPatchGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10315,6 +10667,11 @@ impl From<CredentialsError> for RegisterTargetWithMaintenanceWindowError {
 impl From<HttpDispatchError> for RegisterTargetWithMaintenanceWindowError {
     fn from(err: HttpDispatchError) -> RegisterTargetWithMaintenanceWindowError {
         RegisterTargetWithMaintenanceWindowError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterTargetWithMaintenanceWindowError {
+    fn from(err: io::Error) -> RegisterTargetWithMaintenanceWindowError {
+        RegisterTargetWithMaintenanceWindowError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterTargetWithMaintenanceWindowError {
@@ -10406,6 +10763,11 @@ impl From<HttpDispatchError> for RegisterTaskWithMaintenanceWindowError {
         RegisterTaskWithMaintenanceWindowError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterTaskWithMaintenanceWindowError {
+    fn from(err: io::Error) -> RegisterTaskWithMaintenanceWindowError {
+        RegisterTaskWithMaintenanceWindowError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterTaskWithMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10489,6 +10851,11 @@ impl From<CredentialsError> for RemoveTagsFromResourceError {
 impl From<HttpDispatchError> for RemoveTagsFromResourceError {
     fn from(err: HttpDispatchError) -> RemoveTagsFromResourceError {
         RemoveTagsFromResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveTagsFromResourceError {
+    fn from(err: io::Error) -> RemoveTagsFromResourceError {
+        RemoveTagsFromResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveTagsFromResourceError {
@@ -10612,6 +10979,11 @@ impl From<HttpDispatchError> for SendCommandError {
         SendCommandError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SendCommandError {
+    fn from(err: io::Error) -> SendCommandError {
+        SendCommandError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SendCommandError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10705,6 +11077,11 @@ impl From<HttpDispatchError> for StartAutomationExecutionError {
         StartAutomationExecutionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartAutomationExecutionError {
+    fn from(err: io::Error) -> StartAutomationExecutionError {
+        StartAutomationExecutionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartAutomationExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -10784,6 +11161,11 @@ impl From<CredentialsError> for StopAutomationExecutionError {
 impl From<HttpDispatchError> for StopAutomationExecutionError {
     fn from(err: HttpDispatchError) -> StopAutomationExecutionError {
         StopAutomationExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopAutomationExecutionError {
+    fn from(err: io::Error) -> StopAutomationExecutionError {
+        StopAutomationExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopAutomationExecutionError {
@@ -10908,6 +11290,11 @@ impl From<HttpDispatchError> for UpdateAssociationError {
         UpdateAssociationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateAssociationError {
+    fn from(err: io::Error) -> UpdateAssociationError {
+        UpdateAssociationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11012,6 +11399,11 @@ impl From<CredentialsError> for UpdateAssociationStatusError {
 impl From<HttpDispatchError> for UpdateAssociationStatusError {
     fn from(err: HttpDispatchError) -> UpdateAssociationStatusError {
         UpdateAssociationStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateAssociationStatusError {
+    fn from(err: io::Error) -> UpdateAssociationStatusError {
+        UpdateAssociationStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateAssociationStatusError {
@@ -11126,6 +11518,11 @@ impl From<HttpDispatchError> for UpdateDocumentError {
         UpdateDocumentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDocumentError {
+    fn from(err: io::Error) -> UpdateDocumentError {
+        UpdateDocumentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11214,6 +11611,11 @@ impl From<HttpDispatchError> for UpdateDocumentDefaultVersionError {
         UpdateDocumentDefaultVersionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateDocumentDefaultVersionError {
+    fn from(err: io::Error) -> UpdateDocumentDefaultVersionError {
+        UpdateDocumentDefaultVersionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateDocumentDefaultVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11296,6 +11698,11 @@ impl From<HttpDispatchError> for UpdateMaintenanceWindowError {
         UpdateMaintenanceWindowError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateMaintenanceWindowError {
+    fn from(err: io::Error) -> UpdateMaintenanceWindowError {
+        UpdateMaintenanceWindowError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -11372,6 +11779,11 @@ impl From<CredentialsError> for UpdateManagedInstanceRoleError {
 impl From<HttpDispatchError> for UpdateManagedInstanceRoleError {
     fn from(err: HttpDispatchError) -> UpdateManagedInstanceRoleError {
         UpdateManagedInstanceRoleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateManagedInstanceRoleError {
+    fn from(err: io::Error) -> UpdateManagedInstanceRoleError {
+        UpdateManagedInstanceRoleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateManagedInstanceRoleError {
@@ -11454,6 +11866,11 @@ impl From<CredentialsError> for UpdatePatchBaselineError {
 impl From<HttpDispatchError> for UpdatePatchBaselineError {
     fn from(err: HttpDispatchError) -> UpdatePatchBaselineError {
         UpdatePatchBaselineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdatePatchBaselineError {
+    fn from(err: io::Error) -> UpdatePatchBaselineError {
+        UpdatePatchBaselineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdatePatchBaselineError {
@@ -12042,15 +12459,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddTagsToResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsToResourceResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12069,14 +12491,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CancelCommandResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelCommandResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CancelCommandError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelCommandError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12095,15 +12523,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateActivationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateActivationResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateActivationError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateActivationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12122,15 +12555,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAssociationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAssociationResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateAssociationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAssociationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12150,15 +12588,18 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateAssociationBatchResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateAssociationBatchResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateAssociationBatchError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateAssociationBatchError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12177,15 +12618,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateDocumentResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateDocumentError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateDocumentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12205,13 +12651,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateMaintenanceWindowError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -12229,15 +12682,18 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreatePatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreatePatchBaselineError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreatePatchBaselineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12256,15 +12712,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteActivationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteActivationResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteActivationError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteActivationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12283,15 +12744,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteAssociationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteAssociationResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteAssociationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteAssociationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12310,15 +12776,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteDocumentResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteDocumentError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteDocumentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12338,13 +12809,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteMaintenanceWindowError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -12362,15 +12840,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteParameterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteParameterResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteParameterError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteParameterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12389,15 +12872,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteParametersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteParametersResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteParametersError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteParametersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12416,15 +12904,18 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeletePatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeletePatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeletePatchBaselineError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeletePatchBaselineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12444,13 +12935,20 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeregisterManagedInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeregisterManagedInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeregisterManagedInstanceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterManagedInstanceError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -12471,13 +12969,19 @@ impl<P, D> Ssm for SsmClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeregisterPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeregisterPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeregisterPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12494,13 +12998,19 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeregisterTargetFromMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeregisterTargetFromMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeregisterTargetFromMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterTargetFromMaintenanceWindowError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12521,13 +13031,19 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeregisterTaskFromMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeregisterTaskFromMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeregisterTaskFromMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeregisterTaskFromMaintenanceWindowError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12545,15 +13061,18 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeActivationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeActivationsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeActivationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeActivationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12572,15 +13091,18 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAssociationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAssociationResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeAssociationError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAssociationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12600,13 +13122,20 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAutomationExecutionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeAutomationExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAutomationExecutionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAutomationExecutionsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -12625,13 +13154,20 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAvailablePatchesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeAvailablePatchesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAvailablePatchesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAvailablePatchesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -12649,15 +13185,20 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDocumentResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeDocumentError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDocumentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -12677,13 +13218,20 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeDocumentPermissionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeDocumentPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeDocumentPermissionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDocumentPermissionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -12700,13 +13248,19 @@ fn describe_effective_instance_associations(&self, input: &DescribeEffectiveInst
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEffectiveInstanceAssociationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeEffectiveInstanceAssociationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEffectiveInstanceAssociationsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEffectiveInstanceAssociationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12723,13 +13277,19 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeEffectivePatchesForPatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeEffectivePatchesForPatchBaselineError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeEffectivePatchesForPatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeEffectivePatchesForPatchBaselineError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12750,13 +13310,19 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeInstanceAssociationsStatusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeInstanceAssociationsStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeInstanceAssociationsStatusResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstanceAssociationsStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12775,13 +13341,20 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeInstanceInformationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeInstanceInformationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeInstanceInformationResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstanceInformationError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12800,13 +13373,20 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeInstancePatchStatesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeInstancePatchStatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeInstancePatchStatesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstancePatchStatesError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -12823,13 +13403,19 @@ fn describe_instance_patch_states_for_patch_group(&self, input: &DescribeInstanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeInstancePatchStatesForPatchGroupResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeInstancePatchStatesForPatchGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeInstancePatchStatesForPatchGroupResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstancePatchStatesForPatchGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12848,13 +13434,20 @@ fn describe_instance_patch_states_for_patch_group(&self, input: &DescribeInstanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeInstancePatchesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeInstancePatchesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeInstancePatchesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeInstancePatchesError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -12871,13 +13464,19 @@ fn describe_maintenance_window_execution_task_invocations(&self, input: &Describ
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionTaskInvocationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeMaintenanceWindowExecutionTaskInvocationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionTaskInvocationsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMaintenanceWindowExecutionTaskInvocationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12894,13 +13493,19 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionTasksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeMaintenanceWindowExecutionTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionTasksResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMaintenanceWindowExecutionTasksError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12921,13 +13526,19 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeMaintenanceWindowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMaintenanceWindowExecutionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12946,13 +13557,19 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMaintenanceWindowTargetsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeMaintenanceWindowTargetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMaintenanceWindowTargetsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMaintenanceWindowTargetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -12971,13 +13588,20 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMaintenanceWindowTasksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeMaintenanceWindowTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMaintenanceWindowTasksResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMaintenanceWindowTasksError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -12996,13 +13620,20 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMaintenanceWindowsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeMaintenanceWindowsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMaintenanceWindowsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMaintenanceWindowsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -13020,15 +13651,20 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeParametersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeParametersResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeParametersError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeParametersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13048,15 +13684,18 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribePatchBaselinesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribePatchBaselinesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribePatchBaselinesError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePatchBaselinesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13076,13 +13715,20 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribePatchGroupStateResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribePatchGroupStateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribePatchGroupStateResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePatchGroupStateError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -13100,15 +13746,18 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribePatchGroupsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribePatchGroupsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribePatchGroupsError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribePatchGroupsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13128,15 +13777,18 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetAutomationExecutionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetAutomationExecutionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetAutomationExecutionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetAutomationExecutionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13155,15 +13807,18 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetCommandInvocationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetCommandInvocationResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetCommandInvocationError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetCommandInvocationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13181,13 +13836,20 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDefaultPatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetDefaultPatchBaselineError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDefaultPatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDefaultPatchBaselineError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -13204,13 +13866,19 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDeployablePatchSnapshotForInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetDeployablePatchSnapshotForInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDeployablePatchSnapshotForInstanceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDeployablePatchSnapshotForInstanceError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13228,13 +13896,21 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetDocumentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetDocumentResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetDocumentError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13252,14 +13928,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInventoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInventoryResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetInventoryError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInventoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13278,15 +13960,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetInventorySchemaResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetInventorySchemaResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetInventorySchemaError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetInventorySchemaError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13305,15 +13992,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetMaintenanceWindowError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13333,13 +14023,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetMaintenanceWindowExecutionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetMaintenanceWindowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetMaintenanceWindowExecutionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetMaintenanceWindowExecutionError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -13359,13 +14056,19 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetMaintenanceWindowExecutionTaskResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetMaintenanceWindowExecutionTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetMaintenanceWindowExecutionTaskResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetMaintenanceWindowExecutionTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13383,14 +14086,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetParameterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetParameterResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetParameterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetParameterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13409,15 +14118,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetParameterHistoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetParameterHistoryResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetParameterHistoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetParameterHistoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13436,14 +14148,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetParametersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetParametersResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetParametersError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13462,15 +14180,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetParametersByPathResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetParametersByPathResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetParametersByPathError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetParametersByPathError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13489,15 +14210,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetPatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetPatchBaselineResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetPatchBaselineError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPatchBaselineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13517,13 +14243,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -13541,15 +14274,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListAssociationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListAssociationsResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListAssociationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListAssociationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13569,15 +14307,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListCommandInvocationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListCommandInvocationsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListCommandInvocationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCommandInvocationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13596,14 +14337,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListCommandsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListCommandsResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListCommandsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListCommandsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13622,15 +14369,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDocumentVersionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDocumentVersionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListDocumentVersionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDocumentVersionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13649,14 +14399,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListDocumentsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListDocumentsResult>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListDocumentsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDocumentsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13675,15 +14431,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListInventoryEntriesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListInventoryEntriesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListInventoryEntriesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListInventoryEntriesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13702,15 +14461,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13730,13 +14492,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyDocumentPermissionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ModifyDocumentPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyDocumentPermissionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyDocumentPermissionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -13754,14 +14523,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutInventoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutInventoryResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutInventoryError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutInventoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13780,14 +14555,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PutParameterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PutParameterResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(PutParameterError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PutParameterError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13807,13 +14588,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterDefaultPatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RegisterDefaultPatchBaselineError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterDefaultPatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterDefaultPatchBaselineError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -13834,13 +14622,19 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RegisterPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13861,13 +14655,19 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterTargetWithMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RegisterTargetWithMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterTargetWithMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterTargetWithMaintenanceWindowError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13887,13 +14687,19 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterTaskWithMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RegisterTaskWithMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RegisterTaskWithMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterTaskWithMaintenanceWindowError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13912,15 +14718,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTagsFromResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTagsFromResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -13939,13 +14748,21 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SendCommandResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(SendCommandError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SendCommandResult>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendCommandError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -13964,13 +14781,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartAutomationExecutionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StartAutomationExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartAutomationExecutionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartAutomationExecutionError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -13989,13 +14813,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopAutomationExecutionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(StopAutomationExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopAutomationExecutionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopAutomationExecutionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -14013,15 +14844,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateAssociationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateAssociationResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateAssociationError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAssociationError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14041,13 +14877,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateAssociationStatusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateAssociationStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateAssociationStatusResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateAssociationStatusError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -14065,15 +14908,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDocumentResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateDocumentError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDocumentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -14093,13 +14941,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateDocumentDefaultVersionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateDocumentDefaultVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateDocumentDefaultVersionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateDocumentDefaultVersionError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -14118,13 +14973,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateMaintenanceWindowError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -14143,13 +15005,20 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateManagedInstanceRoleResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateManagedInstanceRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateManagedInstanceRoleResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateManagedInstanceRoleError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -14167,15 +15036,18 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdatePatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdatePatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdatePatchBaselineError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdatePatchBaselineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -796,6 +798,11 @@ impl From<HttpDispatchError> for CreateActivityError {
         CreateActivityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateActivityError {
+    fn from(err: io::Error) -> CreateActivityError {
+        CreateActivityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateActivityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -892,6 +899,11 @@ impl From<HttpDispatchError> for CreateStateMachineError {
         CreateStateMachineError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateStateMachineError {
+    fn from(err: io::Error) -> CreateStateMachineError {
+        CreateStateMachineError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateStateMachineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -971,6 +983,11 @@ impl From<HttpDispatchError> for DeleteActivityError {
         DeleteActivityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteActivityError {
+    fn from(err: io::Error) -> DeleteActivityError {
+        DeleteActivityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteActivityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1043,6 +1060,11 @@ impl From<CredentialsError> for DeleteStateMachineError {
 impl From<HttpDispatchError> for DeleteStateMachineError {
     fn from(err: HttpDispatchError) -> DeleteStateMachineError {
         DeleteStateMachineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteStateMachineError {
+    fn from(err: io::Error) -> DeleteStateMachineError {
+        DeleteStateMachineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteStateMachineError {
@@ -1124,6 +1146,11 @@ impl From<HttpDispatchError> for DescribeActivityError {
         DescribeActivityError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeActivityError {
+    fn from(err: io::Error) -> DescribeActivityError {
+        DescribeActivityError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeActivityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1200,6 +1227,11 @@ impl From<CredentialsError> for DescribeExecutionError {
 impl From<HttpDispatchError> for DescribeExecutionError {
     fn from(err: HttpDispatchError) -> DescribeExecutionError {
         DescribeExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeExecutionError {
+    fn from(err: io::Error) -> DescribeExecutionError {
+        DescribeExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeExecutionError {
@@ -1280,6 +1312,11 @@ impl From<CredentialsError> for DescribeStateMachineError {
 impl From<HttpDispatchError> for DescribeStateMachineError {
     fn from(err: HttpDispatchError) -> DescribeStateMachineError {
         DescribeStateMachineError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeStateMachineError {
+    fn from(err: io::Error) -> DescribeStateMachineError {
+        DescribeStateMachineError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeStateMachineError {
@@ -1363,6 +1400,11 @@ impl From<CredentialsError> for GetActivityTaskError {
 impl From<HttpDispatchError> for GetActivityTaskError {
     fn from(err: HttpDispatchError) -> GetActivityTaskError {
         GetActivityTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetActivityTaskError {
+    fn from(err: io::Error) -> GetActivityTaskError {
+        GetActivityTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetActivityTaskError {
@@ -1451,6 +1493,11 @@ impl From<HttpDispatchError> for GetExecutionHistoryError {
         GetExecutionHistoryError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetExecutionHistoryError {
+    fn from(err: io::Error) -> GetExecutionHistoryError {
+        GetExecutionHistoryError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetExecutionHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1527,6 +1574,11 @@ impl From<CredentialsError> for ListActivitiesError {
 impl From<HttpDispatchError> for ListActivitiesError {
     fn from(err: HttpDispatchError) -> ListActivitiesError {
         ListActivitiesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListActivitiesError {
+    fn from(err: io::Error) -> ListActivitiesError {
+        ListActivitiesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListActivitiesError {
@@ -1611,6 +1663,11 @@ impl From<HttpDispatchError> for ListExecutionsError {
         ListExecutionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListExecutionsError {
+    fn from(err: io::Error) -> ListExecutionsError {
+        ListExecutionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1685,6 +1742,11 @@ impl From<CredentialsError> for ListStateMachinesError {
 impl From<HttpDispatchError> for ListStateMachinesError {
     fn from(err: HttpDispatchError) -> ListStateMachinesError {
         ListStateMachinesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListStateMachinesError {
+    fn from(err: io::Error) -> ListStateMachinesError {
+        ListStateMachinesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListStateMachinesError {
@@ -1773,6 +1835,11 @@ impl From<HttpDispatchError> for SendTaskFailureError {
         SendTaskFailureError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for SendTaskFailureError {
+    fn from(err: io::Error) -> SendTaskFailureError {
+        SendTaskFailureError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for SendTaskFailureError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1857,6 +1924,11 @@ impl From<CredentialsError> for SendTaskHeartbeatError {
 impl From<HttpDispatchError> for SendTaskHeartbeatError {
     fn from(err: HttpDispatchError) -> SendTaskHeartbeatError {
         SendTaskHeartbeatError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SendTaskHeartbeatError {
+    fn from(err: io::Error) -> SendTaskHeartbeatError {
+        SendTaskHeartbeatError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SendTaskHeartbeatError {
@@ -1950,6 +2022,11 @@ impl From<CredentialsError> for SendTaskSuccessError {
 impl From<HttpDispatchError> for SendTaskSuccessError {
     fn from(err: HttpDispatchError) -> SendTaskSuccessError {
         SendTaskSuccessError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SendTaskSuccessError {
+    fn from(err: io::Error) -> SendTaskSuccessError {
+        SendTaskSuccessError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SendTaskSuccessError {
@@ -2055,6 +2132,11 @@ impl From<HttpDispatchError> for StartExecutionError {
         StartExecutionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartExecutionError {
+    fn from(err: io::Error) -> StartExecutionError {
+        StartExecutionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2136,6 +2218,11 @@ impl From<CredentialsError> for StopExecutionError {
 impl From<HttpDispatchError> for StopExecutionError {
     fn from(err: HttpDispatchError) -> StopExecutionError {
         StopExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for StopExecutionError {
+    fn from(err: io::Error) -> StopExecutionError {
+        StopExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for StopExecutionError {
@@ -2298,15 +2385,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateActivityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateActivityOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateActivityError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateActivityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2325,15 +2417,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateStateMachineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateStateMachineOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateStateMachineError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStateMachineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2352,15 +2449,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteActivityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteActivityOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteActivityError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteActivityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2379,15 +2481,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteStateMachineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteStateMachineOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteStateMachineError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteStateMachineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2406,15 +2513,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeActivityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeActivityOutput>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeActivityError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeActivityError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2433,15 +2545,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeExecutionOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeExecutionError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeExecutionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2460,15 +2577,18 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeStateMachineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeStateMachineOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeStateMachineError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStateMachineError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2487,15 +2607,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetActivityTaskOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetActivityTaskOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetActivityTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetActivityTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2514,15 +2639,18 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetExecutionHistoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetExecutionHistoryOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetExecutionHistoryError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetExecutionHistoryError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2541,15 +2669,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListActivitiesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListActivitiesOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListActivitiesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListActivitiesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2568,15 +2701,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListExecutionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListExecutionsOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListExecutionsError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListExecutionsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2595,15 +2733,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListStateMachinesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListStateMachinesOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListStateMachinesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListStateMachinesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2622,15 +2765,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SendTaskFailureOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SendTaskFailureOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(SendTaskFailureError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendTaskFailureError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2649,15 +2797,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SendTaskHeartbeatOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SendTaskHeartbeatOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(SendTaskHeartbeatError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendTaskHeartbeatError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2676,15 +2829,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SendTaskSuccessOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SendTaskSuccessOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(SendTaskSuccessError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SendTaskSuccessError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2703,15 +2861,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartExecutionOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StartExecutionError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartExecutionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2730,14 +2893,20 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopExecutionOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StopExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopExecutionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2057,6 +2059,11 @@ impl From<HttpDispatchError> for ActivateGatewayError {
         ActivateGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ActivateGatewayError {
+    fn from(err: io::Error) -> ActivateGatewayError {
+        ActivateGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ActivateGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2133,6 +2140,11 @@ impl From<CredentialsError> for AddCacheError {
 impl From<HttpDispatchError> for AddCacheError {
     fn from(err: HttpDispatchError) -> AddCacheError {
         AddCacheError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddCacheError {
+    fn from(err: io::Error) -> AddCacheError {
+        AddCacheError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddCacheError {
@@ -2213,6 +2225,11 @@ impl From<CredentialsError> for AddTagsToResourceError {
 impl From<HttpDispatchError> for AddTagsToResourceError {
     fn from(err: HttpDispatchError) -> AddTagsToResourceError {
         AddTagsToResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddTagsToResourceError {
+    fn from(err: io::Error) -> AddTagsToResourceError {
+        AddTagsToResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddTagsToResourceError {
@@ -2297,6 +2314,11 @@ impl From<HttpDispatchError> for AddUploadBufferError {
         AddUploadBufferError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddUploadBufferError {
+    fn from(err: io::Error) -> AddUploadBufferError {
+        AddUploadBufferError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddUploadBufferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2375,6 +2397,11 @@ impl From<CredentialsError> for AddWorkingStorageError {
 impl From<HttpDispatchError> for AddWorkingStorageError {
     fn from(err: HttpDispatchError) -> AddWorkingStorageError {
         AddWorkingStorageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddWorkingStorageError {
+    fn from(err: io::Error) -> AddWorkingStorageError {
+        AddWorkingStorageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddWorkingStorageError {
@@ -2459,6 +2486,11 @@ impl From<HttpDispatchError> for CancelArchivalError {
         CancelArchivalError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelArchivalError {
+    fn from(err: io::Error) -> CancelArchivalError {
+        CancelArchivalError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelArchivalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2539,6 +2571,11 @@ impl From<HttpDispatchError> for CancelRetrievalError {
         CancelRetrievalError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CancelRetrievalError {
+    fn from(err: io::Error) -> CancelRetrievalError {
+        CancelRetrievalError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CancelRetrievalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2613,6 +2650,11 @@ impl From<CredentialsError> for CreateCachediSCSIVolumeError {
 impl From<HttpDispatchError> for CreateCachediSCSIVolumeError {
     fn from(err: HttpDispatchError) -> CreateCachediSCSIVolumeError {
         CreateCachediSCSIVolumeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateCachediSCSIVolumeError {
+    fn from(err: io::Error) -> CreateCachediSCSIVolumeError {
+        CreateCachediSCSIVolumeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateCachediSCSIVolumeError {
@@ -2695,6 +2737,11 @@ impl From<CredentialsError> for CreateNFSFileShareError {
 impl From<HttpDispatchError> for CreateNFSFileShareError {
     fn from(err: HttpDispatchError) -> CreateNFSFileShareError {
         CreateNFSFileShareError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateNFSFileShareError {
+    fn from(err: io::Error) -> CreateNFSFileShareError {
+        CreateNFSFileShareError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateNFSFileShareError {
@@ -2784,6 +2831,11 @@ impl From<HttpDispatchError> for CreateSnapshotError {
         CreateSnapshotError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateSnapshotError {
+    fn from(err: io::Error) -> CreateSnapshotError {
+        CreateSnapshotError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2865,6 +2917,11 @@ impl From<HttpDispatchError> for CreateSnapshotFromVolumeRecoveryPointError {
         CreateSnapshotFromVolumeRecoveryPointError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateSnapshotFromVolumeRecoveryPointError {
+    fn from(err: io::Error) -> CreateSnapshotFromVolumeRecoveryPointError {
+        CreateSnapshotFromVolumeRecoveryPointError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateSnapshotFromVolumeRecoveryPointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2942,6 +2999,11 @@ impl From<CredentialsError> for CreateStorediSCSIVolumeError {
 impl From<HttpDispatchError> for CreateStorediSCSIVolumeError {
     fn from(err: HttpDispatchError) -> CreateStorediSCSIVolumeError {
         CreateStorediSCSIVolumeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateStorediSCSIVolumeError {
+    fn from(err: io::Error) -> CreateStorediSCSIVolumeError {
+        CreateStorediSCSIVolumeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateStorediSCSIVolumeError {
@@ -3022,6 +3084,11 @@ impl From<CredentialsError> for CreateTapeWithBarcodeError {
 impl From<HttpDispatchError> for CreateTapeWithBarcodeError {
     fn from(err: HttpDispatchError) -> CreateTapeWithBarcodeError {
         CreateTapeWithBarcodeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateTapeWithBarcodeError {
+    fn from(err: io::Error) -> CreateTapeWithBarcodeError {
+        CreateTapeWithBarcodeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateTapeWithBarcodeError {
@@ -3106,6 +3173,11 @@ impl From<HttpDispatchError> for CreateTapesError {
         CreateTapesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTapesError {
+    fn from(err: io::Error) -> CreateTapesError {
+        CreateTapesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTapesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3180,6 +3252,11 @@ impl From<CredentialsError> for DeleteBandwidthRateLimitError {
 impl From<HttpDispatchError> for DeleteBandwidthRateLimitError {
     fn from(err: HttpDispatchError) -> DeleteBandwidthRateLimitError {
         DeleteBandwidthRateLimitError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteBandwidthRateLimitError {
+    fn from(err: io::Error) -> DeleteBandwidthRateLimitError {
+        DeleteBandwidthRateLimitError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteBandwidthRateLimitError {
@@ -3260,6 +3337,11 @@ impl From<CredentialsError> for DeleteChapCredentialsError {
 impl From<HttpDispatchError> for DeleteChapCredentialsError {
     fn from(err: HttpDispatchError) -> DeleteChapCredentialsError {
         DeleteChapCredentialsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteChapCredentialsError {
+    fn from(err: io::Error) -> DeleteChapCredentialsError {
+        DeleteChapCredentialsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteChapCredentialsError {
@@ -3344,6 +3426,11 @@ impl From<HttpDispatchError> for DeleteFileShareError {
         DeleteFileShareError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteFileShareError {
+    fn from(err: io::Error) -> DeleteFileShareError {
+        DeleteFileShareError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteFileShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3424,6 +3511,11 @@ impl From<HttpDispatchError> for DeleteGatewayError {
         DeleteGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteGatewayError {
+    fn from(err: io::Error) -> DeleteGatewayError {
+        DeleteGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3498,6 +3590,11 @@ impl From<CredentialsError> for DeleteSnapshotScheduleError {
 impl From<HttpDispatchError> for DeleteSnapshotScheduleError {
     fn from(err: HttpDispatchError) -> DeleteSnapshotScheduleError {
         DeleteSnapshotScheduleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSnapshotScheduleError {
+    fn from(err: io::Error) -> DeleteSnapshotScheduleError {
+        DeleteSnapshotScheduleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSnapshotScheduleError {
@@ -3580,6 +3677,11 @@ impl From<HttpDispatchError> for DeleteTapeError {
         DeleteTapeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTapeError {
+    fn from(err: io::Error) -> DeleteTapeError {
+        DeleteTapeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTapeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3658,6 +3760,11 @@ impl From<CredentialsError> for DeleteTapeArchiveError {
 impl From<HttpDispatchError> for DeleteTapeArchiveError {
     fn from(err: HttpDispatchError) -> DeleteTapeArchiveError {
         DeleteTapeArchiveError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteTapeArchiveError {
+    fn from(err: io::Error) -> DeleteTapeArchiveError {
+        DeleteTapeArchiveError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteTapeArchiveError {
@@ -3742,6 +3849,11 @@ impl From<HttpDispatchError> for DeleteVolumeError {
         DeleteVolumeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteVolumeError {
+    fn from(err: io::Error) -> DeleteVolumeError {
+        DeleteVolumeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3816,6 +3928,11 @@ impl From<CredentialsError> for DescribeBandwidthRateLimitError {
 impl From<HttpDispatchError> for DescribeBandwidthRateLimitError {
     fn from(err: HttpDispatchError) -> DescribeBandwidthRateLimitError {
         DescribeBandwidthRateLimitError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeBandwidthRateLimitError {
+    fn from(err: io::Error) -> DescribeBandwidthRateLimitError {
+        DescribeBandwidthRateLimitError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeBandwidthRateLimitError {
@@ -3900,6 +4017,11 @@ impl From<HttpDispatchError> for DescribeCacheError {
         DescribeCacheError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCacheError {
+    fn from(err: io::Error) -> DescribeCacheError {
+        DescribeCacheError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3974,6 +4096,11 @@ impl From<CredentialsError> for DescribeCachediSCSIVolumesError {
 impl From<HttpDispatchError> for DescribeCachediSCSIVolumesError {
     fn from(err: HttpDispatchError) -> DescribeCachediSCSIVolumesError {
         DescribeCachediSCSIVolumesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCachediSCSIVolumesError {
+    fn from(err: io::Error) -> DescribeCachediSCSIVolumesError {
+        DescribeCachediSCSIVolumesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCachediSCSIVolumesError {
@@ -4054,6 +4181,11 @@ impl From<HttpDispatchError> for DescribeChapCredentialsError {
         DescribeChapCredentialsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeChapCredentialsError {
+    fn from(err: io::Error) -> DescribeChapCredentialsError {
+        DescribeChapCredentialsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeChapCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4132,6 +4264,11 @@ impl From<HttpDispatchError> for DescribeGatewayInformationError {
         DescribeGatewayInformationError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeGatewayInformationError {
+    fn from(err: io::Error) -> DescribeGatewayInformationError {
+        DescribeGatewayInformationError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeGatewayInformationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4208,6 +4345,11 @@ impl From<CredentialsError> for DescribeMaintenanceStartTimeError {
 impl From<HttpDispatchError> for DescribeMaintenanceStartTimeError {
     fn from(err: HttpDispatchError) -> DescribeMaintenanceStartTimeError {
         DescribeMaintenanceStartTimeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeMaintenanceStartTimeError {
+    fn from(err: io::Error) -> DescribeMaintenanceStartTimeError {
+        DescribeMaintenanceStartTimeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeMaintenanceStartTimeError {
@@ -4290,6 +4432,11 @@ impl From<HttpDispatchError> for DescribeNFSFileSharesError {
         DescribeNFSFileSharesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeNFSFileSharesError {
+    fn from(err: io::Error) -> DescribeNFSFileSharesError {
+        DescribeNFSFileSharesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeNFSFileSharesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4368,6 +4515,11 @@ impl From<HttpDispatchError> for DescribeSnapshotScheduleError {
         DescribeSnapshotScheduleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeSnapshotScheduleError {
+    fn from(err: io::Error) -> DescribeSnapshotScheduleError {
+        DescribeSnapshotScheduleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeSnapshotScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4444,6 +4596,11 @@ impl From<CredentialsError> for DescribeStorediSCSIVolumesError {
 impl From<HttpDispatchError> for DescribeStorediSCSIVolumesError {
     fn from(err: HttpDispatchError) -> DescribeStorediSCSIVolumesError {
         DescribeStorediSCSIVolumesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeStorediSCSIVolumesError {
+    fn from(err: io::Error) -> DescribeStorediSCSIVolumesError {
+        DescribeStorediSCSIVolumesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeStorediSCSIVolumesError {
@@ -4526,6 +4683,11 @@ impl From<HttpDispatchError> for DescribeTapeArchivesError {
         DescribeTapeArchivesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTapeArchivesError {
+    fn from(err: io::Error) -> DescribeTapeArchivesError {
+        DescribeTapeArchivesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTapeArchivesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4602,6 +4764,11 @@ impl From<CredentialsError> for DescribeTapeRecoveryPointsError {
 impl From<HttpDispatchError> for DescribeTapeRecoveryPointsError {
     fn from(err: HttpDispatchError) -> DescribeTapeRecoveryPointsError {
         DescribeTapeRecoveryPointsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTapeRecoveryPointsError {
+    fn from(err: io::Error) -> DescribeTapeRecoveryPointsError {
+        DescribeTapeRecoveryPointsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTapeRecoveryPointsError {
@@ -4686,6 +4853,11 @@ impl From<HttpDispatchError> for DescribeTapesError {
         DescribeTapesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTapesError {
+    fn from(err: io::Error) -> DescribeTapesError {
+        DescribeTapesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTapesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4762,6 +4934,11 @@ impl From<CredentialsError> for DescribeUploadBufferError {
 impl From<HttpDispatchError> for DescribeUploadBufferError {
     fn from(err: HttpDispatchError) -> DescribeUploadBufferError {
         DescribeUploadBufferError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeUploadBufferError {
+    fn from(err: io::Error) -> DescribeUploadBufferError {
+        DescribeUploadBufferError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeUploadBufferError {
@@ -4846,6 +5023,11 @@ impl From<HttpDispatchError> for DescribeVTLDevicesError {
         DescribeVTLDevicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeVTLDevicesError {
+    fn from(err: io::Error) -> DescribeVTLDevicesError {
+        DescribeVTLDevicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeVTLDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4922,6 +5104,11 @@ impl From<CredentialsError> for DescribeWorkingStorageError {
 impl From<HttpDispatchError> for DescribeWorkingStorageError {
     fn from(err: HttpDispatchError) -> DescribeWorkingStorageError {
         DescribeWorkingStorageError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeWorkingStorageError {
+    fn from(err: io::Error) -> DescribeWorkingStorageError {
+        DescribeWorkingStorageError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeWorkingStorageError {
@@ -5006,6 +5193,11 @@ impl From<HttpDispatchError> for DisableGatewayError {
         DisableGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisableGatewayError {
+    fn from(err: io::Error) -> DisableGatewayError {
+        DisableGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisableGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5084,6 +5276,11 @@ impl From<CredentialsError> for ListFileSharesError {
 impl From<HttpDispatchError> for ListFileSharesError {
     fn from(err: HttpDispatchError) -> ListFileSharesError {
         ListFileSharesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListFileSharesError {
+    fn from(err: io::Error) -> ListFileSharesError {
+        ListFileSharesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListFileSharesError {
@@ -5166,6 +5363,11 @@ impl From<HttpDispatchError> for ListGatewaysError {
         ListGatewaysError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListGatewaysError {
+    fn from(err: io::Error) -> ListGatewaysError {
+        ListGatewaysError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListGatewaysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5244,6 +5446,11 @@ impl From<CredentialsError> for ListLocalDisksError {
 impl From<HttpDispatchError> for ListLocalDisksError {
     fn from(err: HttpDispatchError) -> ListLocalDisksError {
         ListLocalDisksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListLocalDisksError {
+    fn from(err: io::Error) -> ListLocalDisksError {
+        ListLocalDisksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListLocalDisksError {
@@ -5326,6 +5533,11 @@ impl From<HttpDispatchError> for ListTagsForResourceError {
         ListTagsForResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTagsForResourceError {
+    fn from(err: io::Error) -> ListTagsForResourceError {
+        ListTagsForResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5406,6 +5618,11 @@ impl From<HttpDispatchError> for ListTapesError {
         ListTapesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListTapesError {
+    fn from(err: io::Error) -> ListTapesError {
+        ListTapesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListTapesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5484,6 +5701,11 @@ impl From<HttpDispatchError> for ListVolumeInitiatorsError {
         ListVolumeInitiatorsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListVolumeInitiatorsError {
+    fn from(err: io::Error) -> ListVolumeInitiatorsError {
+        ListVolumeInitiatorsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListVolumeInitiatorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5560,6 +5782,11 @@ impl From<CredentialsError> for ListVolumeRecoveryPointsError {
 impl From<HttpDispatchError> for ListVolumeRecoveryPointsError {
     fn from(err: HttpDispatchError) -> ListVolumeRecoveryPointsError {
         ListVolumeRecoveryPointsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListVolumeRecoveryPointsError {
+    fn from(err: io::Error) -> ListVolumeRecoveryPointsError {
+        ListVolumeRecoveryPointsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListVolumeRecoveryPointsError {
@@ -5644,6 +5871,11 @@ impl From<HttpDispatchError> for ListVolumesError {
         ListVolumesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListVolumesError {
+    fn from(err: io::Error) -> ListVolumesError {
+        ListVolumesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListVolumesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5724,6 +5956,11 @@ impl From<HttpDispatchError> for RefreshCacheError {
         RefreshCacheError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RefreshCacheError {
+    fn from(err: io::Error) -> RefreshCacheError {
+        RefreshCacheError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RefreshCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5798,6 +6035,11 @@ impl From<CredentialsError> for RemoveTagsFromResourceError {
 impl From<HttpDispatchError> for RemoveTagsFromResourceError {
     fn from(err: HttpDispatchError) -> RemoveTagsFromResourceError {
         RemoveTagsFromResourceError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RemoveTagsFromResourceError {
+    fn from(err: io::Error) -> RemoveTagsFromResourceError {
+        RemoveTagsFromResourceError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RemoveTagsFromResourceError {
@@ -5880,6 +6122,11 @@ impl From<HttpDispatchError> for ResetCacheError {
         ResetCacheError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ResetCacheError {
+    fn from(err: io::Error) -> ResetCacheError {
+        ResetCacheError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ResetCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5960,6 +6207,11 @@ impl From<HttpDispatchError> for RetrieveTapeArchiveError {
         RetrieveTapeArchiveError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RetrieveTapeArchiveError {
+    fn from(err: io::Error) -> RetrieveTapeArchiveError {
+        RetrieveTapeArchiveError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RetrieveTapeArchiveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6038,6 +6290,11 @@ impl From<HttpDispatchError> for RetrieveTapeRecoveryPointError {
         RetrieveTapeRecoveryPointError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RetrieveTapeRecoveryPointError {
+    fn from(err: io::Error) -> RetrieveTapeRecoveryPointError {
+        RetrieveTapeRecoveryPointError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RetrieveTapeRecoveryPointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6114,6 +6371,11 @@ impl From<CredentialsError> for SetLocalConsolePasswordError {
 impl From<HttpDispatchError> for SetLocalConsolePasswordError {
     fn from(err: HttpDispatchError) -> SetLocalConsolePasswordError {
         SetLocalConsolePasswordError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SetLocalConsolePasswordError {
+    fn from(err: io::Error) -> SetLocalConsolePasswordError {
+        SetLocalConsolePasswordError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SetLocalConsolePasswordError {
@@ -6198,6 +6460,11 @@ impl From<HttpDispatchError> for ShutdownGatewayError {
         ShutdownGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ShutdownGatewayError {
+    fn from(err: io::Error) -> ShutdownGatewayError {
+        ShutdownGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ShutdownGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6278,6 +6545,11 @@ impl From<HttpDispatchError> for StartGatewayError {
         StartGatewayError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartGatewayError {
+    fn from(err: io::Error) -> StartGatewayError {
+        StartGatewayError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6352,6 +6624,11 @@ impl From<CredentialsError> for UpdateBandwidthRateLimitError {
 impl From<HttpDispatchError> for UpdateBandwidthRateLimitError {
     fn from(err: HttpDispatchError) -> UpdateBandwidthRateLimitError {
         UpdateBandwidthRateLimitError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateBandwidthRateLimitError {
+    fn from(err: io::Error) -> UpdateBandwidthRateLimitError {
+        UpdateBandwidthRateLimitError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateBandwidthRateLimitError {
@@ -6434,6 +6711,11 @@ impl From<HttpDispatchError> for UpdateChapCredentialsError {
         UpdateChapCredentialsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateChapCredentialsError {
+    fn from(err: io::Error) -> UpdateChapCredentialsError {
+        UpdateChapCredentialsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateChapCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6510,6 +6792,11 @@ impl From<CredentialsError> for UpdateGatewayInformationError {
 impl From<HttpDispatchError> for UpdateGatewayInformationError {
     fn from(err: HttpDispatchError) -> UpdateGatewayInformationError {
         UpdateGatewayInformationError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateGatewayInformationError {
+    fn from(err: io::Error) -> UpdateGatewayInformationError {
+        UpdateGatewayInformationError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateGatewayInformationError {
@@ -6590,6 +6877,11 @@ impl From<HttpDispatchError> for UpdateGatewaySoftwareNowError {
         UpdateGatewaySoftwareNowError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateGatewaySoftwareNowError {
+    fn from(err: io::Error) -> UpdateGatewaySoftwareNowError {
+        UpdateGatewaySoftwareNowError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateGatewaySoftwareNowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6666,6 +6958,11 @@ impl From<CredentialsError> for UpdateMaintenanceStartTimeError {
 impl From<HttpDispatchError> for UpdateMaintenanceStartTimeError {
     fn from(err: HttpDispatchError) -> UpdateMaintenanceStartTimeError {
         UpdateMaintenanceStartTimeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateMaintenanceStartTimeError {
+    fn from(err: io::Error) -> UpdateMaintenanceStartTimeError {
+        UpdateMaintenanceStartTimeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateMaintenanceStartTimeError {
@@ -6750,6 +7047,11 @@ impl From<HttpDispatchError> for UpdateNFSFileShareError {
         UpdateNFSFileShareError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateNFSFileShareError {
+    fn from(err: io::Error) -> UpdateNFSFileShareError {
+        UpdateNFSFileShareError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateNFSFileShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6826,6 +7128,11 @@ impl From<CredentialsError> for UpdateSnapshotScheduleError {
 impl From<HttpDispatchError> for UpdateSnapshotScheduleError {
     fn from(err: HttpDispatchError) -> UpdateSnapshotScheduleError {
         UpdateSnapshotScheduleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateSnapshotScheduleError {
+    fn from(err: io::Error) -> UpdateSnapshotScheduleError {
+        UpdateSnapshotScheduleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateSnapshotScheduleError {
@@ -6908,6 +7215,11 @@ impl From<CredentialsError> for UpdateVTLDeviceTypeError {
 impl From<HttpDispatchError> for UpdateVTLDeviceTypeError {
     fn from(err: HttpDispatchError) -> UpdateVTLDeviceTypeError {
         UpdateVTLDeviceTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateVTLDeviceTypeError {
+    fn from(err: io::Error) -> UpdateVTLDeviceTypeError {
+        UpdateVTLDeviceTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateVTLDeviceTypeError {
@@ -7358,15 +7670,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ActivateGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ActivateGatewayOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ActivateGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ActivateGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7383,15 +7700,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<AddCacheOutput>(String::from_utf8_lossy(&response.body)
-                                                              .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddCacheOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(AddCacheError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddCacheError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7409,15 +7731,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddTagsToResourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddTagsToResourceOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddTagsToResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7436,15 +7763,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddUploadBufferOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddUploadBufferOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AddUploadBufferError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddUploadBufferError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7463,15 +7795,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddWorkingStorageOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddWorkingStorageOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AddWorkingStorageError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddWorkingStorageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7490,15 +7827,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CancelArchivalOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelArchivalOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CancelArchivalError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelArchivalError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7517,15 +7859,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CancelRetrievalOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CancelRetrievalOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CancelRetrievalError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CancelRetrievalError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7546,13 +7893,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateCachediSCSIVolumeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateCachediSCSIVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateCachediSCSIVolumeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCachediSCSIVolumeError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -7570,15 +7924,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateNFSFileShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateNFSFileShareOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateNFSFileShareError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateNFSFileShareError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7597,15 +7956,20 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateSnapshotOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateSnapshotOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateSnapshotError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSnapshotError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7623,13 +7987,19 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateSnapshotFromVolumeRecoveryPointOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateSnapshotFromVolumeRecoveryPointError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateSnapshotFromVolumeRecoveryPointOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSnapshotFromVolumeRecoveryPointError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7649,13 +8019,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateStorediSCSIVolumeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateStorediSCSIVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateStorediSCSIVolumeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateStorediSCSIVolumeError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -7675,15 +8052,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateTapeWithBarcodeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateTapeWithBarcodeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateTapeWithBarcodeError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTapeWithBarcodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7702,13 +8082,21 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateTapesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateTapesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateTapesOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTapesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7728,13 +8116,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteBandwidthRateLimitOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteBandwidthRateLimitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteBandwidthRateLimitOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteBandwidthRateLimitError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -7754,15 +8149,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteChapCredentialsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteChapCredentialsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteChapCredentialsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteChapCredentialsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7781,15 +8179,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteFileShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteFileShareOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteFileShareError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteFileShareError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7808,14 +8211,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteGatewayOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteGatewayError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7836,15 +8245,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteSnapshotScheduleOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteSnapshotScheduleOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteSnapshotScheduleError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSnapshotScheduleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7861,13 +8273,21 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteTapeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteTapeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteTapeOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTapeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7885,15 +8305,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteTapeArchiveOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteTapeArchiveOutput>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteTapeArchiveError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTapeArchiveError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7912,14 +8337,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteVolumeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteVolumeOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteVolumeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7940,13 +8371,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeBandwidthRateLimitOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeBandwidthRateLimitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeBandwidthRateLimitOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeBandwidthRateLimitError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -7964,14 +8402,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCacheOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCacheOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeCacheError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCacheError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7992,13 +8436,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCachediSCSIVolumesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeCachediSCSIVolumesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCachediSCSIVolumesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCachediSCSIVolumesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -8018,13 +8469,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeChapCredentialsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeChapCredentialsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeChapCredentialsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeChapCredentialsError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -8044,13 +8502,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeGatewayInformationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeGatewayInformationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeGatewayInformationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeGatewayInformationError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -8070,13 +8535,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeMaintenanceStartTimeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeMaintenanceStartTimeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeMaintenanceStartTimeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeMaintenanceStartTimeError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -8096,15 +8568,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeNFSFileSharesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeNFSFileSharesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeNFSFileSharesError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeNFSFileSharesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8125,13 +8600,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeSnapshotScheduleOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeSnapshotScheduleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeSnapshotScheduleOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSnapshotScheduleError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8151,13 +8633,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeStorediSCSIVolumesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeStorediSCSIVolumesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeStorediSCSIVolumesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeStorediSCSIVolumesError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -8176,15 +8665,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTapeArchivesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTapeArchivesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeTapeArchivesError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTapeArchivesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8205,13 +8697,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTapeRecoveryPointsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeTapeRecoveryPointsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTapeRecoveryPointsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTapeRecoveryPointsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -8229,14 +8728,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTapesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTapesOutput>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTapesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTapesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8256,15 +8761,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeUploadBufferOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeUploadBufferOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeUploadBufferError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeUploadBufferError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8283,15 +8791,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeVTLDevicesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeVTLDevicesOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeVTLDevicesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeVTLDevicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8312,15 +8825,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeWorkingStorageOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeWorkingStorageOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeWorkingStorageError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeWorkingStorageError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8339,15 +8855,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisableGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisableGatewayOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DisableGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisableGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8366,15 +8887,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListFileSharesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListFileSharesOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListFileSharesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListFileSharesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8393,14 +8919,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListGatewaysOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListGatewaysOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListGatewaysError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListGatewaysError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8419,15 +8951,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListLocalDisksOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListLocalDisksOutput>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListLocalDisksError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListLocalDisksError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8447,15 +8984,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListTagsForResourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTagsForResourceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTagsForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8472,15 +9012,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListTapesOutput>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListTapesOutput>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ListTapesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListTapesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8499,15 +9044,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListVolumeInitiatorsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListVolumeInitiatorsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListVolumeInitiatorsError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListVolumeInitiatorsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8528,13 +9076,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListVolumeRecoveryPointsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListVolumeRecoveryPointsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListVolumeRecoveryPointsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListVolumeRecoveryPointsError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8552,13 +9107,21 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListVolumesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListVolumesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListVolumesOutput>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListVolumesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8576,14 +9139,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RefreshCacheOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RefreshCacheOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RefreshCacheError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RefreshCacheError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8604,15 +9173,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RemoveTagsFromResourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RemoveTagsFromResourceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RemoveTagsFromResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8629,13 +9201,21 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ResetCacheOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ResetCacheError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ResetCacheOutput>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResetCacheError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -8654,15 +9234,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RetrieveTapeArchiveOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RetrieveTapeArchiveOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(RetrieveTapeArchiveError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RetrieveTapeArchiveError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8683,13 +9266,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RetrieveTapeRecoveryPointOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RetrieveTapeRecoveryPointError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RetrieveTapeRecoveryPointOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RetrieveTapeRecoveryPointError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -8709,13 +9299,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<SetLocalConsolePasswordOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(SetLocalConsolePasswordError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<SetLocalConsolePasswordOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SetLocalConsolePasswordError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -8733,15 +9330,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ShutdownGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ShutdownGatewayOutput>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ShutdownGatewayError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ShutdownGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8760,14 +9362,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartGatewayOutput>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StartGatewayError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartGatewayError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8788,13 +9396,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateBandwidthRateLimitOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateBandwidthRateLimitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateBandwidthRateLimitOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateBandwidthRateLimitError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8814,15 +9429,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateChapCredentialsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateChapCredentialsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateChapCredentialsError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateChapCredentialsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8843,13 +9461,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateGatewayInformationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateGatewayInformationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateGatewayInformationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateGatewayInformationError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8869,13 +9494,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateGatewaySoftwareNowOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateGatewaySoftwareNowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateGatewaySoftwareNowOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateGatewaySoftwareNowError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -8895,13 +9527,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateMaintenanceStartTimeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateMaintenanceStartTimeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateMaintenanceStartTimeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateMaintenanceStartTimeError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -8919,15 +9558,20 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateNFSFileShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateNFSFileShareOutput>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateNFSFileShareError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateNFSFileShareError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8948,15 +9592,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateSnapshotScheduleOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateSnapshotScheduleOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateSnapshotScheduleError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateSnapshotScheduleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -8976,15 +9623,18 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateVTLDeviceTypeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateVTLDeviceTypeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateVTLDeviceTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateVTLDeviceTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -756,6 +758,11 @@ impl From<HttpDispatchError> for AddAttachmentsToSetError {
         AddAttachmentsToSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AddAttachmentsToSetError {
+    fn from(err: io::Error) -> AddAttachmentsToSetError {
+        AddAttachmentsToSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AddAttachmentsToSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -843,6 +850,11 @@ impl From<CredentialsError> for AddCommunicationToCaseError {
 impl From<HttpDispatchError> for AddCommunicationToCaseError {
     fn from(err: HttpDispatchError) -> AddCommunicationToCaseError {
         AddCommunicationToCaseError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for AddCommunicationToCaseError {
+    fn from(err: io::Error) -> AddCommunicationToCaseError {
+        AddCommunicationToCaseError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for AddCommunicationToCaseError {
@@ -937,6 +949,11 @@ impl From<HttpDispatchError> for CreateCaseError {
         CreateCaseError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateCaseError {
+    fn from(err: io::Error) -> CreateCaseError {
+        CreateCaseError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateCaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1022,6 +1039,11 @@ impl From<HttpDispatchError> for DescribeAttachmentError {
         DescribeAttachmentError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeAttachmentError {
+    fn from(err: io::Error) -> DescribeAttachmentError {
+        DescribeAttachmentError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeAttachmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1105,6 +1127,11 @@ impl From<HttpDispatchError> for DescribeCasesError {
         DescribeCasesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeCasesError {
+    fn from(err: io::Error) -> DescribeCasesError {
+        DescribeCasesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeCasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1181,6 +1208,11 @@ impl From<CredentialsError> for DescribeCommunicationsError {
 impl From<HttpDispatchError> for DescribeCommunicationsError {
     fn from(err: HttpDispatchError) -> DescribeCommunicationsError {
         DescribeCommunicationsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeCommunicationsError {
+    fn from(err: io::Error) -> DescribeCommunicationsError {
+        DescribeCommunicationsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeCommunicationsError {
@@ -1260,6 +1292,11 @@ impl From<HttpDispatchError> for DescribeServicesError {
         DescribeServicesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeServicesError {
+    fn from(err: io::Error) -> DescribeServicesError {
+        DescribeServicesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1330,6 +1367,11 @@ impl From<CredentialsError> for DescribeSeverityLevelsError {
 impl From<HttpDispatchError> for DescribeSeverityLevelsError {
     fn from(err: HttpDispatchError) -> DescribeSeverityLevelsError {
         DescribeSeverityLevelsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeSeverityLevelsError {
+    fn from(err: io::Error) -> DescribeSeverityLevelsError {
+        DescribeSeverityLevelsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeSeverityLevelsError {
@@ -1404,6 +1446,11 @@ impl From<CredentialsError> for DescribeTrustedAdvisorCheckRefreshStatusesError 
 impl From<HttpDispatchError> for DescribeTrustedAdvisorCheckRefreshStatusesError {
     fn from(err: HttpDispatchError) -> DescribeTrustedAdvisorCheckRefreshStatusesError {
         DescribeTrustedAdvisorCheckRefreshStatusesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTrustedAdvisorCheckRefreshStatusesError {
+    fn from(err: io::Error) -> DescribeTrustedAdvisorCheckRefreshStatusesError {
+        DescribeTrustedAdvisorCheckRefreshStatusesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTrustedAdvisorCheckRefreshStatusesError {
@@ -1485,6 +1532,11 @@ impl From<HttpDispatchError> for DescribeTrustedAdvisorCheckResultError {
         DescribeTrustedAdvisorCheckResultError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTrustedAdvisorCheckResultError {
+    fn from(err: io::Error) -> DescribeTrustedAdvisorCheckResultError {
+        DescribeTrustedAdvisorCheckResultError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTrustedAdvisorCheckResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1558,6 +1610,11 @@ impl From<CredentialsError> for DescribeTrustedAdvisorCheckSummariesError {
 impl From<HttpDispatchError> for DescribeTrustedAdvisorCheckSummariesError {
     fn from(err: HttpDispatchError) -> DescribeTrustedAdvisorCheckSummariesError {
         DescribeTrustedAdvisorCheckSummariesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeTrustedAdvisorCheckSummariesError {
+    fn from(err: io::Error) -> DescribeTrustedAdvisorCheckSummariesError {
+        DescribeTrustedAdvisorCheckSummariesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeTrustedAdvisorCheckSummariesError {
@@ -1634,6 +1691,11 @@ impl From<HttpDispatchError> for DescribeTrustedAdvisorChecksError {
         DescribeTrustedAdvisorChecksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTrustedAdvisorChecksError {
+    fn from(err: io::Error) -> DescribeTrustedAdvisorChecksError {
+        DescribeTrustedAdvisorChecksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTrustedAdvisorChecksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1706,6 +1768,11 @@ impl From<CredentialsError> for RefreshTrustedAdvisorCheckError {
 impl From<HttpDispatchError> for RefreshTrustedAdvisorCheckError {
     fn from(err: HttpDispatchError) -> RefreshTrustedAdvisorCheckError {
         RefreshTrustedAdvisorCheckError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RefreshTrustedAdvisorCheckError {
+    fn from(err: io::Error) -> RefreshTrustedAdvisorCheckError {
+        RefreshTrustedAdvisorCheckError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RefreshTrustedAdvisorCheckError {
@@ -1787,6 +1854,11 @@ impl From<CredentialsError> for ResolveCaseError {
 impl From<HttpDispatchError> for ResolveCaseError {
     fn from(err: HttpDispatchError) -> ResolveCaseError {
         ResolveCaseError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ResolveCaseError {
+    fn from(err: io::Error) -> ResolveCaseError {
+        ResolveCaseError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ResolveCaseError {
@@ -1934,15 +2006,18 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddAttachmentsToSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddAttachmentsToSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AddAttachmentsToSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddAttachmentsToSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1962,15 +2037,18 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AddCommunicationToCaseResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AddCommunicationToCaseResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(AddCommunicationToCaseError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AddCommunicationToCaseError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1989,13 +2067,21 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateCaseResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateCaseError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateCaseResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateCaseError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2013,15 +2099,18 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeAttachmentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeAttachmentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeAttachmentError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeAttachmentError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2040,14 +2129,20 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCasesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCasesResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeCasesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCasesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2067,15 +2162,18 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCommunicationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeCommunicationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeCommunicationsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeCommunicationsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2094,15 +2192,20 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeServicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeServicesResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeServicesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeServicesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2122,15 +2225,18 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeSeverityLevelsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeSeverityLevelsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DescribeSeverityLevelsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeSeverityLevelsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2148,13 +2254,19 @@ fn describe_trusted_advisor_check_refresh_statuses(&self, input: &DescribeTruste
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckRefreshStatusesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeTrustedAdvisorCheckRefreshStatusesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckRefreshStatusesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTrustedAdvisorCheckRefreshStatusesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2175,13 +2287,19 @@ fn describe_trusted_advisor_check_refresh_statuses(&self, input: &DescribeTruste
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckResultResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeTrustedAdvisorCheckResultError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckResultResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTrustedAdvisorCheckResultError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2198,13 +2316,19 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckSummariesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeTrustedAdvisorCheckSummariesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckSummariesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTrustedAdvisorCheckSummariesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2224,13 +2348,20 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTrustedAdvisorChecksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeTrustedAdvisorChecksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTrustedAdvisorChecksResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTrustedAdvisorChecksError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -2250,13 +2381,20 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RefreshTrustedAdvisorCheckResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RefreshTrustedAdvisorCheckError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RefreshTrustedAdvisorCheckResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RefreshTrustedAdvisorCheckError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -2274,13 +2412,21 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ResolveCaseResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ResolveCaseError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ResolveCaseResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ResolveCaseError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -2774,6 +2776,11 @@ impl From<HttpDispatchError> for CountClosedWorkflowExecutionsError {
         CountClosedWorkflowExecutionsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CountClosedWorkflowExecutionsError {
+    fn from(err: io::Error) -> CountClosedWorkflowExecutionsError {
+        CountClosedWorkflowExecutionsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CountClosedWorkflowExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2850,6 +2857,11 @@ impl From<CredentialsError> for CountOpenWorkflowExecutionsError {
 impl From<HttpDispatchError> for CountOpenWorkflowExecutionsError {
     fn from(err: HttpDispatchError) -> CountOpenWorkflowExecutionsError {
         CountOpenWorkflowExecutionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CountOpenWorkflowExecutionsError {
+    fn from(err: io::Error) -> CountOpenWorkflowExecutionsError {
+        CountOpenWorkflowExecutionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CountOpenWorkflowExecutionsError {
@@ -2930,6 +2942,11 @@ impl From<HttpDispatchError> for CountPendingActivityTasksError {
         CountPendingActivityTasksError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CountPendingActivityTasksError {
+    fn from(err: io::Error) -> CountPendingActivityTasksError {
+        CountPendingActivityTasksError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CountPendingActivityTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3006,6 +3023,11 @@ impl From<CredentialsError> for CountPendingDecisionTasksError {
 impl From<HttpDispatchError> for CountPendingDecisionTasksError {
     fn from(err: HttpDispatchError) -> CountPendingDecisionTasksError {
         CountPendingDecisionTasksError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CountPendingDecisionTasksError {
+    fn from(err: io::Error) -> CountPendingDecisionTasksError {
+        CountPendingDecisionTasksError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CountPendingDecisionTasksError {
@@ -3089,6 +3111,11 @@ impl From<CredentialsError> for DeprecateActivityTypeError {
 impl From<HttpDispatchError> for DeprecateActivityTypeError {
     fn from(err: HttpDispatchError) -> DeprecateActivityTypeError {
         DeprecateActivityTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeprecateActivityTypeError {
+    fn from(err: io::Error) -> DeprecateActivityTypeError {
+        DeprecateActivityTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeprecateActivityTypeError {
@@ -3177,6 +3204,11 @@ impl From<HttpDispatchError> for DeprecateDomainError {
         DeprecateDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeprecateDomainError {
+    fn from(err: io::Error) -> DeprecateDomainError {
+        DeprecateDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeprecateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3259,6 +3291,11 @@ impl From<HttpDispatchError> for DeprecateWorkflowTypeError {
         DeprecateWorkflowTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeprecateWorkflowTypeError {
+    fn from(err: io::Error) -> DeprecateWorkflowTypeError {
+        DeprecateWorkflowTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeprecateWorkflowTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3338,6 +3375,11 @@ impl From<CredentialsError> for DescribeActivityTypeError {
 impl From<HttpDispatchError> for DescribeActivityTypeError {
     fn from(err: HttpDispatchError) -> DescribeActivityTypeError {
         DescribeActivityTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeActivityTypeError {
+    fn from(err: io::Error) -> DescribeActivityTypeError {
+        DescribeActivityTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeActivityTypeError {
@@ -3422,6 +3464,11 @@ impl From<HttpDispatchError> for DescribeDomainError {
         DescribeDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeDomainError {
+    fn from(err: io::Error) -> DescribeDomainError {
+        DescribeDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3496,6 +3543,11 @@ impl From<CredentialsError> for DescribeWorkflowExecutionError {
 impl From<HttpDispatchError> for DescribeWorkflowExecutionError {
     fn from(err: HttpDispatchError) -> DescribeWorkflowExecutionError {
         DescribeWorkflowExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeWorkflowExecutionError {
+    fn from(err: io::Error) -> DescribeWorkflowExecutionError {
+        DescribeWorkflowExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeWorkflowExecutionError {
@@ -3578,6 +3630,11 @@ impl From<HttpDispatchError> for DescribeWorkflowTypeError {
         DescribeWorkflowTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeWorkflowTypeError {
+    fn from(err: io::Error) -> DescribeWorkflowTypeError {
+        DescribeWorkflowTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeWorkflowTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3654,6 +3711,11 @@ impl From<CredentialsError> for GetWorkflowExecutionHistoryError {
 impl From<HttpDispatchError> for GetWorkflowExecutionHistoryError {
     fn from(err: HttpDispatchError) -> GetWorkflowExecutionHistoryError {
         GetWorkflowExecutionHistoryError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetWorkflowExecutionHistoryError {
+    fn from(err: io::Error) -> GetWorkflowExecutionHistoryError {
+        GetWorkflowExecutionHistoryError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetWorkflowExecutionHistoryError {
@@ -3736,6 +3798,11 @@ impl From<HttpDispatchError> for ListActivityTypesError {
         ListActivityTypesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListActivityTypesError {
+    fn from(err: io::Error) -> ListActivityTypesError {
+        ListActivityTypesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListActivityTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3812,6 +3879,11 @@ impl From<CredentialsError> for ListClosedWorkflowExecutionsError {
 impl From<HttpDispatchError> for ListClosedWorkflowExecutionsError {
     fn from(err: HttpDispatchError) -> ListClosedWorkflowExecutionsError {
         ListClosedWorkflowExecutionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListClosedWorkflowExecutionsError {
+    fn from(err: io::Error) -> ListClosedWorkflowExecutionsError {
+        ListClosedWorkflowExecutionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListClosedWorkflowExecutionsError {
@@ -3891,6 +3963,11 @@ impl From<HttpDispatchError> for ListDomainsError {
         ListDomainsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListDomainsError {
+    fn from(err: io::Error) -> ListDomainsError {
+        ListDomainsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3964,6 +4041,11 @@ impl From<CredentialsError> for ListOpenWorkflowExecutionsError {
 impl From<HttpDispatchError> for ListOpenWorkflowExecutionsError {
     fn from(err: HttpDispatchError) -> ListOpenWorkflowExecutionsError {
         ListOpenWorkflowExecutionsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListOpenWorkflowExecutionsError {
+    fn from(err: io::Error) -> ListOpenWorkflowExecutionsError {
+        ListOpenWorkflowExecutionsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListOpenWorkflowExecutionsError {
@@ -4044,6 +4126,11 @@ impl From<CredentialsError> for ListWorkflowTypesError {
 impl From<HttpDispatchError> for ListWorkflowTypesError {
     fn from(err: HttpDispatchError) -> ListWorkflowTypesError {
         ListWorkflowTypesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListWorkflowTypesError {
+    fn from(err: io::Error) -> ListWorkflowTypesError {
+        ListWorkflowTypesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListWorkflowTypesError {
@@ -4129,6 +4216,11 @@ impl From<CredentialsError> for PollForActivityTaskError {
 impl From<HttpDispatchError> for PollForActivityTaskError {
     fn from(err: HttpDispatchError) -> PollForActivityTaskError {
         PollForActivityTaskError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for PollForActivityTaskError {
+    fn from(err: io::Error) -> PollForActivityTaskError {
+        PollForActivityTaskError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for PollForActivityTaskError {
@@ -4217,6 +4309,11 @@ impl From<HttpDispatchError> for PollForDecisionTaskError {
         PollForDecisionTaskError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for PollForDecisionTaskError {
+    fn from(err: io::Error) -> PollForDecisionTaskError {
+        PollForDecisionTaskError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for PollForDecisionTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4294,6 +4391,11 @@ impl From<CredentialsError> for RecordActivityTaskHeartbeatError {
 impl From<HttpDispatchError> for RecordActivityTaskHeartbeatError {
     fn from(err: HttpDispatchError) -> RecordActivityTaskHeartbeatError {
         RecordActivityTaskHeartbeatError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RecordActivityTaskHeartbeatError {
+    fn from(err: io::Error) -> RecordActivityTaskHeartbeatError {
+        RecordActivityTaskHeartbeatError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RecordActivityTaskHeartbeatError {
@@ -4382,6 +4484,11 @@ impl From<CredentialsError> for RegisterActivityTypeError {
 impl From<HttpDispatchError> for RegisterActivityTypeError {
     fn from(err: HttpDispatchError) -> RegisterActivityTypeError {
         RegisterActivityTypeError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RegisterActivityTypeError {
+    fn from(err: io::Error) -> RegisterActivityTypeError {
+        RegisterActivityTypeError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RegisterActivityTypeError {
@@ -4473,6 +4580,11 @@ impl From<HttpDispatchError> for RegisterDomainError {
         RegisterDomainError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterDomainError {
+    fn from(err: io::Error) -> RegisterDomainError {
+        RegisterDomainError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4560,6 +4672,11 @@ impl From<HttpDispatchError> for RegisterWorkflowTypeError {
         RegisterWorkflowTypeError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RegisterWorkflowTypeError {
+    fn from(err: io::Error) -> RegisterWorkflowTypeError {
+        RegisterWorkflowTypeError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RegisterWorkflowTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4640,6 +4757,11 @@ impl From<HttpDispatchError> for RequestCancelWorkflowExecutionError {
         RequestCancelWorkflowExecutionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RequestCancelWorkflowExecutionError {
+    fn from(err: io::Error) -> RequestCancelWorkflowExecutionError {
+        RequestCancelWorkflowExecutionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RequestCancelWorkflowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4716,6 +4838,11 @@ impl From<CredentialsError> for RespondActivityTaskCanceledError {
 impl From<HttpDispatchError> for RespondActivityTaskCanceledError {
     fn from(err: HttpDispatchError) -> RespondActivityTaskCanceledError {
         RespondActivityTaskCanceledError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RespondActivityTaskCanceledError {
+    fn from(err: io::Error) -> RespondActivityTaskCanceledError {
+        RespondActivityTaskCanceledError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RespondActivityTaskCanceledError {
@@ -4796,6 +4923,11 @@ impl From<HttpDispatchError> for RespondActivityTaskCompletedError {
         RespondActivityTaskCompletedError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RespondActivityTaskCompletedError {
+    fn from(err: io::Error) -> RespondActivityTaskCompletedError {
+        RespondActivityTaskCompletedError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RespondActivityTaskCompletedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4872,6 +5004,11 @@ impl From<CredentialsError> for RespondActivityTaskFailedError {
 impl From<HttpDispatchError> for RespondActivityTaskFailedError {
     fn from(err: HttpDispatchError) -> RespondActivityTaskFailedError {
         RespondActivityTaskFailedError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RespondActivityTaskFailedError {
+    fn from(err: io::Error) -> RespondActivityTaskFailedError {
+        RespondActivityTaskFailedError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RespondActivityTaskFailedError {
@@ -4952,6 +5089,11 @@ impl From<HttpDispatchError> for RespondDecisionTaskCompletedError {
         RespondDecisionTaskCompletedError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RespondDecisionTaskCompletedError {
+    fn from(err: io::Error) -> RespondDecisionTaskCompletedError {
+        RespondDecisionTaskCompletedError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RespondDecisionTaskCompletedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5028,6 +5170,11 @@ impl From<CredentialsError> for SignalWorkflowExecutionError {
 impl From<HttpDispatchError> for SignalWorkflowExecutionError {
     fn from(err: HttpDispatchError) -> SignalWorkflowExecutionError {
         SignalWorkflowExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for SignalWorkflowExecutionError {
+    fn from(err: io::Error) -> SignalWorkflowExecutionError {
+        SignalWorkflowExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for SignalWorkflowExecutionError {
@@ -5122,6 +5269,11 @@ impl From<HttpDispatchError> for StartWorkflowExecutionError {
         StartWorkflowExecutionError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartWorkflowExecutionError {
+    fn from(err: io::Error) -> StartWorkflowExecutionError {
+        StartWorkflowExecutionError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartWorkflowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5202,6 +5354,11 @@ impl From<CredentialsError> for TerminateWorkflowExecutionError {
 impl From<HttpDispatchError> for TerminateWorkflowExecutionError {
     fn from(err: HttpDispatchError) -> TerminateWorkflowExecutionError {
         TerminateWorkflowExecutionError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TerminateWorkflowExecutionError {
+    fn from(err: io::Error) -> TerminateWorkflowExecutionError {
+        TerminateWorkflowExecutionError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TerminateWorkflowExecutionError {
@@ -5452,13 +5609,22 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<WorkflowExecutionCount>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CountClosedWorkflowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<WorkflowExecutionCount>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CountClosedWorkflowExecutionsError::from_body(String::from_utf8_lossy(&body)
+                                                                      .as_ref()))
+            }
         }
     }
 
@@ -5478,13 +5644,22 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<WorkflowExecutionCount>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CountOpenWorkflowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<WorkflowExecutionCount>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CountOpenWorkflowExecutionsError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -5503,13 +5678,22 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PendingTaskCount>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CountPendingActivityTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PendingTaskCount>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CountPendingActivityTasksError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5528,13 +5712,22 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<PendingTaskCount>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CountPendingDecisionTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<PendingTaskCount>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CountPendingDecisionTasksError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5553,13 +5746,14 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeprecateActivityTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeprecateActivityTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5576,13 +5770,14 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeprecateDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeprecateDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5602,13 +5797,14 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(DeprecateWorkflowTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                              .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeprecateWorkflowTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5627,15 +5823,20 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ActivityTypeDetail>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ActivityTypeDetail>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeActivityTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeActivityTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5654,17 +5855,19 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DomainDetail>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DomainDetail>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(DescribeDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5685,13 +5888,22 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<WorkflowExecutionDetail>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<WorkflowExecutionDetail>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeWorkflowExecutionError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -5709,15 +5921,20 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<WorkflowTypeDetail>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<WorkflowTypeDetail>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeWorkflowTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeWorkflowTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5737,15 +5954,21 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<History>(String::from_utf8_lossy(&response.body)
-                                                       .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<History>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetWorkflowExecutionHistoryError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetWorkflowExecutionHistoryError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -5763,15 +5986,20 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ActivityTypeInfos>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ActivityTypeInfos>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListActivityTypesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListActivityTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5792,13 +6020,22 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<WorkflowExecutionInfos>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListClosedWorkflowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<WorkflowExecutionInfos>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListClosedWorkflowExecutionsError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -5814,15 +6051,20 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DomainInfos>(String::from_utf8_lossy(&response.body)
-                                                           .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DomainInfos>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(ListDomainsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListDomainsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -5842,13 +6084,22 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<WorkflowExecutionInfos>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListOpenWorkflowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<WorkflowExecutionInfos>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListOpenWorkflowExecutionsError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -5866,15 +6117,20 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<WorkflowTypeInfos>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<WorkflowTypeInfos>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListWorkflowTypesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListWorkflowTypesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5893,17 +6149,19 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ActivityTask>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ActivityTask>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(PollForActivityTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PollForActivityTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5922,17 +6180,19 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DecisionTask>(String::from_utf8_lossy(&response.body)
-                                                            .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DecisionTask>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
             _ => {
-                Err(PollForDecisionTaskError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(PollForDecisionTaskError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -5953,13 +6213,22 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ActivityTaskStatus>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(RecordActivityTaskHeartbeatError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ActivityTaskStatus>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RecordActivityTaskHeartbeatError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -5977,13 +6246,14 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(RegisterActivityTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterActivityTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6000,13 +6270,14 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(RegisterDomainError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterDomainError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6025,13 +6296,14 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
             _ => {
-                Err(RegisterWorkflowTypeError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RegisterWorkflowTypeError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6051,11 +6323,16 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RequestCancelWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RequestCancelWorkflowExecutionError::from_body(String::from_utf8_lossy(&body)
+                                                                       .as_ref()))
+            }
         }
     }
 
@@ -6074,11 +6351,16 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RespondActivityTaskCanceledError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RespondActivityTaskCanceledError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -6097,11 +6379,16 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RespondActivityTaskCompletedError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RespondActivityTaskCompletedError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -6120,11 +6407,16 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RespondActivityTaskFailedError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RespondActivityTaskFailedError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -6143,11 +6435,16 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(RespondDecisionTaskCompletedError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RespondDecisionTaskCompletedError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -6166,11 +6463,16 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(SignalWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(SignalWorkflowExecutionError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6189,16 +6491,18 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<Run>(String::from_utf8_lossy(&response.body).as_ref())
-                       .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<Run>(String::from_utf8_lossy(&body).as_ref()).unwrap())
             }
             _ => {
-                Err(StartWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartWorkflowExecutionError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6218,11 +6522,16 @@ impl<P, D> Swf for SwfClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => Ok(()),
-            _ => Err(TerminateWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TerminateWorkflowExecutionError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1575,6 +1577,11 @@ impl From<HttpDispatchError> for AssociateWebACLError {
         AssociateWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for AssociateWebACLError {
+    fn from(err: io::Error) -> AssociateWebACLError {
+        AssociateWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for AssociateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1676,6 +1683,11 @@ impl From<CredentialsError> for CreateByteMatchSetError {
 impl From<HttpDispatchError> for CreateByteMatchSetError {
     fn from(err: HttpDispatchError) -> CreateByteMatchSetError {
         CreateByteMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateByteMatchSetError {
+    fn from(err: io::Error) -> CreateByteMatchSetError {
+        CreateByteMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateByteMatchSetError {
@@ -1784,6 +1796,11 @@ impl From<HttpDispatchError> for CreateIPSetError {
         CreateIPSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateIPSetError {
+    fn from(err: io::Error) -> CreateIPSetError {
+        CreateIPSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1883,6 +1900,11 @@ impl From<HttpDispatchError> for CreateRateBasedRuleError {
         CreateRateBasedRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRateBasedRuleError {
+    fn from(err: io::Error) -> CreateRateBasedRuleError {
+        CreateRateBasedRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1979,6 +2001,11 @@ impl From<CredentialsError> for CreateRuleError {
 impl From<HttpDispatchError> for CreateRuleError {
     fn from(err: HttpDispatchError) -> CreateRuleError {
         CreateRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateRuleError {
+    fn from(err: io::Error) -> CreateRuleError {
+        CreateRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateRuleError {
@@ -2082,6 +2109,11 @@ impl From<HttpDispatchError> for CreateSizeConstraintSetError {
         CreateSizeConstraintSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateSizeConstraintSetError {
+    fn from(err: io::Error) -> CreateSizeConstraintSetError {
+        CreateSizeConstraintSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2176,6 +2208,11 @@ impl From<CredentialsError> for CreateSqlInjectionMatchSetError {
 impl From<HttpDispatchError> for CreateSqlInjectionMatchSetError {
     fn from(err: HttpDispatchError) -> CreateSqlInjectionMatchSetError {
         CreateSqlInjectionMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateSqlInjectionMatchSetError {
+    fn from(err: io::Error) -> CreateSqlInjectionMatchSetError {
+        CreateSqlInjectionMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateSqlInjectionMatchSetError {
@@ -2284,6 +2321,11 @@ impl From<HttpDispatchError> for CreateWebACLError {
         CreateWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateWebACLError {
+    fn from(err: io::Error) -> CreateWebACLError {
+        CreateWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2386,6 +2428,11 @@ impl From<CredentialsError> for CreateXssMatchSetError {
 impl From<HttpDispatchError> for CreateXssMatchSetError {
     fn from(err: HttpDispatchError) -> CreateXssMatchSetError {
         CreateXssMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateXssMatchSetError {
+    fn from(err: io::Error) -> CreateXssMatchSetError {
+        CreateXssMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateXssMatchSetError {
@@ -2494,6 +2541,11 @@ impl From<HttpDispatchError> for DeleteByteMatchSetError {
         DeleteByteMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteByteMatchSetError {
+    fn from(err: io::Error) -> DeleteByteMatchSetError {
+        DeleteByteMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2600,6 +2652,11 @@ impl From<HttpDispatchError> for DeleteIPSetError {
         DeleteIPSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteIPSetError {
+    fn from(err: io::Error) -> DeleteIPSetError {
+        DeleteIPSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2702,6 +2759,11 @@ impl From<CredentialsError> for DeleteRateBasedRuleError {
 impl From<HttpDispatchError> for DeleteRateBasedRuleError {
     fn from(err: HttpDispatchError) -> DeleteRateBasedRuleError {
         DeleteRateBasedRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteRateBasedRuleError {
+    fn from(err: io::Error) -> DeleteRateBasedRuleError {
+        DeleteRateBasedRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteRateBasedRuleError {
@@ -2808,6 +2870,11 @@ impl From<HttpDispatchError> for DeleteRuleError {
         DeleteRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRuleError {
+    fn from(err: io::Error) -> DeleteRuleError {
+        DeleteRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2910,6 +2977,11 @@ impl From<HttpDispatchError> for DeleteSizeConstraintSetError {
         DeleteSizeConstraintSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteSizeConstraintSetError {
+    fn from(err: io::Error) -> DeleteSizeConstraintSetError {
+        DeleteSizeConstraintSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3004,6 +3076,11 @@ impl From<CredentialsError> for DeleteSqlInjectionMatchSetError {
 impl From<HttpDispatchError> for DeleteSqlInjectionMatchSetError {
     fn from(err: HttpDispatchError) -> DeleteSqlInjectionMatchSetError {
         DeleteSqlInjectionMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSqlInjectionMatchSetError {
+    fn from(err: io::Error) -> DeleteSqlInjectionMatchSetError {
+        DeleteSqlInjectionMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSqlInjectionMatchSetError {
@@ -3112,6 +3189,11 @@ impl From<HttpDispatchError> for DeleteWebACLError {
         DeleteWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteWebACLError {
+    fn from(err: io::Error) -> DeleteWebACLError {
+        DeleteWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3216,6 +3298,11 @@ impl From<HttpDispatchError> for DeleteXssMatchSetError {
         DeleteXssMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteXssMatchSetError {
+    fn from(err: io::Error) -> DeleteXssMatchSetError {
+        DeleteXssMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3312,6 +3399,11 @@ impl From<HttpDispatchError> for DisassociateWebACLError {
         DisassociateWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DisassociateWebACLError {
+    fn from(err: io::Error) -> DisassociateWebACLError {
+        DisassociateWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DisassociateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3401,6 +3493,11 @@ impl From<HttpDispatchError> for GetByteMatchSetError {
         GetByteMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetByteMatchSetError {
+    fn from(err: io::Error) -> GetByteMatchSetError {
+        GetByteMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3475,6 +3572,11 @@ impl From<CredentialsError> for GetChangeTokenError {
 impl From<HttpDispatchError> for GetChangeTokenError {
     fn from(err: HttpDispatchError) -> GetChangeTokenError {
         GetChangeTokenError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetChangeTokenError {
+    fn from(err: io::Error) -> GetChangeTokenError {
+        GetChangeTokenError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetChangeTokenError {
@@ -3554,6 +3656,11 @@ impl From<CredentialsError> for GetChangeTokenStatusError {
 impl From<HttpDispatchError> for GetChangeTokenStatusError {
     fn from(err: HttpDispatchError) -> GetChangeTokenStatusError {
         GetChangeTokenStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetChangeTokenStatusError {
+    fn from(err: io::Error) -> GetChangeTokenStatusError {
+        GetChangeTokenStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetChangeTokenStatusError {
@@ -3639,6 +3746,11 @@ impl From<CredentialsError> for GetIPSetError {
 impl From<HttpDispatchError> for GetIPSetError {
     fn from(err: HttpDispatchError) -> GetIPSetError {
         GetIPSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetIPSetError {
+    fn from(err: io::Error) -> GetIPSetError {
+        GetIPSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetIPSetError {
@@ -3727,6 +3839,11 @@ impl From<HttpDispatchError> for GetRateBasedRuleError {
         GetRateBasedRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRateBasedRuleError {
+    fn from(err: io::Error) -> GetRateBasedRuleError {
+        GetRateBasedRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3808,6 +3925,11 @@ impl From<CredentialsError> for GetRateBasedRuleManagedKeysError {
 impl From<HttpDispatchError> for GetRateBasedRuleManagedKeysError {
     fn from(err: HttpDispatchError) -> GetRateBasedRuleManagedKeysError {
         GetRateBasedRuleManagedKeysError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetRateBasedRuleManagedKeysError {
+    fn from(err: io::Error) -> GetRateBasedRuleManagedKeysError {
+        GetRateBasedRuleManagedKeysError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetRateBasedRuleManagedKeysError {
@@ -3897,6 +4019,11 @@ impl From<HttpDispatchError> for GetRuleError {
         GetRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRuleError {
+    fn from(err: io::Error) -> GetRuleError {
+        GetRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3976,6 +4103,11 @@ impl From<CredentialsError> for GetSampledRequestsError {
 impl From<HttpDispatchError> for GetSampledRequestsError {
     fn from(err: HttpDispatchError) -> GetSampledRequestsError {
         GetSampledRequestsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSampledRequestsError {
+    fn from(err: io::Error) -> GetSampledRequestsError {
+        GetSampledRequestsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSampledRequestsError {
@@ -4065,6 +4197,11 @@ impl From<HttpDispatchError> for GetSizeConstraintSetError {
         GetSizeConstraintSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSizeConstraintSetError {
+    fn from(err: io::Error) -> GetSizeConstraintSetError {
+        GetSizeConstraintSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4151,6 +4288,11 @@ impl From<HttpDispatchError> for GetSqlInjectionMatchSetError {
         GetSqlInjectionMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSqlInjectionMatchSetError {
+    fn from(err: io::Error) -> GetSqlInjectionMatchSetError {
+        GetSqlInjectionMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4235,6 +4377,11 @@ impl From<CredentialsError> for GetWebACLError {
 impl From<HttpDispatchError> for GetWebACLError {
     fn from(err: HttpDispatchError) -> GetWebACLError {
         GetWebACLError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetWebACLError {
+    fn from(err: io::Error) -> GetWebACLError {
+        GetWebACLError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetWebACLError {
@@ -4333,6 +4480,11 @@ impl From<HttpDispatchError> for GetWebACLForResourceError {
         GetWebACLForResourceError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetWebACLForResourceError {
+    fn from(err: io::Error) -> GetWebACLForResourceError {
+        GetWebACLForResourceError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetWebACLForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4423,6 +4575,11 @@ impl From<HttpDispatchError> for GetXssMatchSetError {
         GetXssMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetXssMatchSetError {
+    fn from(err: io::Error) -> GetXssMatchSetError {
+        GetXssMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4502,6 +4659,11 @@ impl From<CredentialsError> for ListByteMatchSetsError {
 impl From<HttpDispatchError> for ListByteMatchSetsError {
     fn from(err: HttpDispatchError) -> ListByteMatchSetsError {
         ListByteMatchSetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListByteMatchSetsError {
+    fn from(err: io::Error) -> ListByteMatchSetsError {
+        ListByteMatchSetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListByteMatchSetsError {
@@ -4584,6 +4746,11 @@ impl From<HttpDispatchError> for ListIPSetsError {
         ListIPSetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListIPSetsError {
+    fn from(err: io::Error) -> ListIPSetsError {
+        ListIPSetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListIPSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4662,6 +4829,11 @@ impl From<CredentialsError> for ListRateBasedRulesError {
 impl From<HttpDispatchError> for ListRateBasedRulesError {
     fn from(err: HttpDispatchError) -> ListRateBasedRulesError {
         ListRateBasedRulesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRateBasedRulesError {
+    fn from(err: io::Error) -> ListRateBasedRulesError {
+        ListRateBasedRulesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRateBasedRulesError {
@@ -4751,6 +4923,11 @@ impl From<HttpDispatchError> for ListResourcesForWebACLError {
         ListResourcesForWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListResourcesForWebACLError {
+    fn from(err: io::Error) -> ListResourcesForWebACLError {
+        ListResourcesForWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListResourcesForWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4830,6 +5007,11 @@ impl From<CredentialsError> for ListRulesError {
 impl From<HttpDispatchError> for ListRulesError {
     fn from(err: HttpDispatchError) -> ListRulesError {
         ListRulesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRulesError {
+    fn from(err: io::Error) -> ListRulesError {
+        ListRulesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRulesError {
@@ -4912,6 +5094,11 @@ impl From<HttpDispatchError> for ListSizeConstraintSetsError {
         ListSizeConstraintSetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListSizeConstraintSetsError {
+    fn from(err: io::Error) -> ListSizeConstraintSetsError {
+        ListSizeConstraintSetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListSizeConstraintSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4988,6 +5175,11 @@ impl From<CredentialsError> for ListSqlInjectionMatchSetsError {
 impl From<HttpDispatchError> for ListSqlInjectionMatchSetsError {
     fn from(err: HttpDispatchError) -> ListSqlInjectionMatchSetsError {
         ListSqlInjectionMatchSetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListSqlInjectionMatchSetsError {
+    fn from(err: io::Error) -> ListSqlInjectionMatchSetsError {
+        ListSqlInjectionMatchSetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListSqlInjectionMatchSetsError {
@@ -5072,6 +5264,11 @@ impl From<HttpDispatchError> for ListWebACLsError {
         ListWebACLsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListWebACLsError {
+    fn from(err: io::Error) -> ListWebACLsError {
+        ListWebACLsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListWebACLsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5150,6 +5347,11 @@ impl From<CredentialsError> for ListXssMatchSetsError {
 impl From<HttpDispatchError> for ListXssMatchSetsError {
     fn from(err: HttpDispatchError) -> ListXssMatchSetsError {
         ListXssMatchSetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListXssMatchSetsError {
+    fn from(err: io::Error) -> ListXssMatchSetsError {
+        ListXssMatchSetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListXssMatchSetsError {
@@ -5258,6 +5460,11 @@ impl From<CredentialsError> for UpdateByteMatchSetError {
 impl From<HttpDispatchError> for UpdateByteMatchSetError {
     fn from(err: HttpDispatchError) -> UpdateByteMatchSetError {
         UpdateByteMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateByteMatchSetError {
+    fn from(err: io::Error) -> UpdateByteMatchSetError {
+        UpdateByteMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateByteMatchSetError {
@@ -5383,6 +5590,11 @@ impl From<HttpDispatchError> for UpdateIPSetError {
         UpdateIPSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateIPSetError {
+    fn from(err: io::Error) -> UpdateIPSetError {
+        UpdateIPSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5501,6 +5713,11 @@ impl From<CredentialsError> for UpdateRateBasedRuleError {
 impl From<HttpDispatchError> for UpdateRateBasedRuleError {
     fn from(err: HttpDispatchError) -> UpdateRateBasedRuleError {
         UpdateRateBasedRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateRateBasedRuleError {
+    fn from(err: io::Error) -> UpdateRateBasedRuleError {
+        UpdateRateBasedRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateRateBasedRuleError {
@@ -5625,6 +5842,11 @@ impl From<HttpDispatchError> for UpdateRuleError {
         UpdateRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateRuleError {
+    fn from(err: io::Error) -> UpdateRuleError {
+        UpdateRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5739,6 +5961,11 @@ impl From<HttpDispatchError> for UpdateSizeConstraintSetError {
         UpdateSizeConstraintSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateSizeConstraintSetError {
+    fn from(err: io::Error) -> UpdateSizeConstraintSetError {
+        UpdateSizeConstraintSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5842,6 +6069,11 @@ impl From<CredentialsError> for UpdateSqlInjectionMatchSetError {
 impl From<HttpDispatchError> for UpdateSqlInjectionMatchSetError {
     fn from(err: HttpDispatchError) -> UpdateSqlInjectionMatchSetError {
         UpdateSqlInjectionMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateSqlInjectionMatchSetError {
+    fn from(err: io::Error) -> UpdateSqlInjectionMatchSetError {
+        UpdateSqlInjectionMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateSqlInjectionMatchSetError {
@@ -5967,6 +6199,11 @@ impl From<HttpDispatchError> for UpdateWebACLError {
         UpdateWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateWebACLError {
+    fn from(err: io::Error) -> UpdateWebACLError {
+        UpdateWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -6082,6 +6319,11 @@ impl From<CredentialsError> for UpdateXssMatchSetError {
 impl From<HttpDispatchError> for UpdateXssMatchSetError {
     fn from(err: HttpDispatchError) -> UpdateXssMatchSetError {
         UpdateXssMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateXssMatchSetError {
+    fn from(err: io::Error) -> UpdateXssMatchSetError {
+        UpdateXssMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateXssMatchSetError {
@@ -6442,15 +6684,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AssociateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<AssociateWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(AssociateWebACLError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(AssociateWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6470,15 +6717,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateByteMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateByteMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6497,13 +6747,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateIPSetResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateIPSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6522,15 +6780,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateRateBasedRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRateBasedRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6549,13 +6810,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateRuleResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6575,13 +6844,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSizeConstraintSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6601,13 +6877,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6625,14 +6908,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6651,15 +6940,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateXssMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateXssMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6679,15 +6971,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteByteMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteByteMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6706,13 +7001,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteIPSetResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIPSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6731,15 +7034,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteRateBasedRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRateBasedRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6758,13 +7064,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRuleResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6784,13 +7098,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSizeConstraintSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6810,13 +7131,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6834,14 +7162,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6860,15 +7194,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteXssMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteXssMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6888,15 +7225,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DisassociateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DisassociateWebACLResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DisassociateWebACLError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DisassociateWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6915,15 +7255,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetByteMatchSetResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetByteMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetByteMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6939,15 +7284,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetChangeTokenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetChangeTokenResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetChangeTokenError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetChangeTokenError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6968,15 +7318,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetChangeTokenStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetChangeTokenStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetChangeTokenStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetChangeTokenStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6993,13 +7346,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetIPSetResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIPSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7017,15 +7378,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRateBasedRuleResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetRateBasedRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRateBasedRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7046,13 +7412,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRateBasedRuleManagedKeysResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetRateBasedRuleManagedKeysError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRateBasedRuleManagedKeysResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRateBasedRuleManagedKeysError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -7068,15 +7441,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetRuleResponse>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRuleResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7095,15 +7473,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetSampledRequestsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSampledRequestsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetSampledRequestsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSampledRequestsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7124,15 +7505,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSizeConstraintSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7153,13 +7537,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -7175,13 +7566,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7201,15 +7600,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetWebACLForResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetWebACLForResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetWebACLForResourceError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetWebACLForResourceError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7228,15 +7630,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetXssMatchSetResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetXssMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetXssMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7255,15 +7662,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListByteMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListByteMatchSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListByteMatchSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListByteMatchSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7282,13 +7692,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListIPSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListIPSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListIPSetsResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListIPSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7307,15 +7725,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRateBasedRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRateBasedRulesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListRateBasedRulesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRateBasedRulesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7336,15 +7757,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListResourcesForWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListResourcesForWebACLResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListResourcesForWebACLError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListResourcesForWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7361,13 +7785,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListRulesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRulesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7387,15 +7819,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListSizeConstraintSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListSizeConstraintSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListSizeConstraintSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSizeConstraintSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7416,13 +7851,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListSqlInjectionMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListSqlInjectionMatchSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListSqlInjectionMatchSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSqlInjectionMatchSetsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -7440,13 +7882,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListWebACLsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListWebACLsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListWebACLsResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListWebACLsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7464,15 +7914,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListXssMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListXssMatchSetsResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListXssMatchSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListXssMatchSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7492,15 +7947,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateByteMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateByteMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7519,13 +7977,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateIPSetResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateIPSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7544,15 +8010,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateRateBasedRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRateBasedRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7571,13 +8040,21 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateRuleResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7597,13 +8074,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateSizeConstraintSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -7623,13 +8107,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -7647,14 +8138,20 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7673,15 +8170,18 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateXssMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateXssMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -1527,6 +1529,11 @@ impl From<HttpDispatchError> for CreateByteMatchSetError {
         CreateByteMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateByteMatchSetError {
+    fn from(err: io::Error) -> CreateByteMatchSetError {
+        CreateByteMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1633,6 +1640,11 @@ impl From<HttpDispatchError> for CreateIPSetError {
         CreateIPSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateIPSetError {
+    fn from(err: io::Error) -> CreateIPSetError {
+        CreateIPSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1732,6 +1744,11 @@ impl From<HttpDispatchError> for CreateRateBasedRuleError {
         CreateRateBasedRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateRateBasedRuleError {
+    fn from(err: io::Error) -> CreateRateBasedRuleError {
+        CreateRateBasedRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1828,6 +1845,11 @@ impl From<CredentialsError> for CreateRuleError {
 impl From<HttpDispatchError> for CreateRuleError {
     fn from(err: HttpDispatchError) -> CreateRuleError {
         CreateRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateRuleError {
+    fn from(err: io::Error) -> CreateRuleError {
+        CreateRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateRuleError {
@@ -1931,6 +1953,11 @@ impl From<HttpDispatchError> for CreateSizeConstraintSetError {
         CreateSizeConstraintSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateSizeConstraintSetError {
+    fn from(err: io::Error) -> CreateSizeConstraintSetError {
+        CreateSizeConstraintSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2025,6 +2052,11 @@ impl From<CredentialsError> for CreateSqlInjectionMatchSetError {
 impl From<HttpDispatchError> for CreateSqlInjectionMatchSetError {
     fn from(err: HttpDispatchError) -> CreateSqlInjectionMatchSetError {
         CreateSqlInjectionMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateSqlInjectionMatchSetError {
+    fn from(err: io::Error) -> CreateSqlInjectionMatchSetError {
+        CreateSqlInjectionMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateSqlInjectionMatchSetError {
@@ -2133,6 +2165,11 @@ impl From<HttpDispatchError> for CreateWebACLError {
         CreateWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateWebACLError {
+    fn from(err: io::Error) -> CreateWebACLError {
+        CreateWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2235,6 +2272,11 @@ impl From<CredentialsError> for CreateXssMatchSetError {
 impl From<HttpDispatchError> for CreateXssMatchSetError {
     fn from(err: HttpDispatchError) -> CreateXssMatchSetError {
         CreateXssMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for CreateXssMatchSetError {
+    fn from(err: io::Error) -> CreateXssMatchSetError {
+        CreateXssMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for CreateXssMatchSetError {
@@ -2343,6 +2385,11 @@ impl From<HttpDispatchError> for DeleteByteMatchSetError {
         DeleteByteMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteByteMatchSetError {
+    fn from(err: io::Error) -> DeleteByteMatchSetError {
+        DeleteByteMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2449,6 +2496,11 @@ impl From<HttpDispatchError> for DeleteIPSetError {
         DeleteIPSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteIPSetError {
+    fn from(err: io::Error) -> DeleteIPSetError {
+        DeleteIPSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2551,6 +2603,11 @@ impl From<CredentialsError> for DeleteRateBasedRuleError {
 impl From<HttpDispatchError> for DeleteRateBasedRuleError {
     fn from(err: HttpDispatchError) -> DeleteRateBasedRuleError {
         DeleteRateBasedRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteRateBasedRuleError {
+    fn from(err: io::Error) -> DeleteRateBasedRuleError {
+        DeleteRateBasedRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteRateBasedRuleError {
@@ -2657,6 +2714,11 @@ impl From<HttpDispatchError> for DeleteRuleError {
         DeleteRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteRuleError {
+    fn from(err: io::Error) -> DeleteRuleError {
+        DeleteRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2759,6 +2821,11 @@ impl From<HttpDispatchError> for DeleteSizeConstraintSetError {
         DeleteSizeConstraintSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteSizeConstraintSetError {
+    fn from(err: io::Error) -> DeleteSizeConstraintSetError {
+        DeleteSizeConstraintSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -2853,6 +2920,11 @@ impl From<CredentialsError> for DeleteSqlInjectionMatchSetError {
 impl From<HttpDispatchError> for DeleteSqlInjectionMatchSetError {
     fn from(err: HttpDispatchError) -> DeleteSqlInjectionMatchSetError {
         DeleteSqlInjectionMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DeleteSqlInjectionMatchSetError {
+    fn from(err: io::Error) -> DeleteSqlInjectionMatchSetError {
+        DeleteSqlInjectionMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DeleteSqlInjectionMatchSetError {
@@ -2961,6 +3033,11 @@ impl From<HttpDispatchError> for DeleteWebACLError {
         DeleteWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteWebACLError {
+    fn from(err: io::Error) -> DeleteWebACLError {
+        DeleteWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3065,6 +3142,11 @@ impl From<HttpDispatchError> for DeleteXssMatchSetError {
         DeleteXssMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteXssMatchSetError {
+    fn from(err: io::Error) -> DeleteXssMatchSetError {
+        DeleteXssMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3156,6 +3238,11 @@ impl From<HttpDispatchError> for GetByteMatchSetError {
         GetByteMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetByteMatchSetError {
+    fn from(err: io::Error) -> GetByteMatchSetError {
+        GetByteMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3230,6 +3317,11 @@ impl From<CredentialsError> for GetChangeTokenError {
 impl From<HttpDispatchError> for GetChangeTokenError {
     fn from(err: HttpDispatchError) -> GetChangeTokenError {
         GetChangeTokenError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetChangeTokenError {
+    fn from(err: io::Error) -> GetChangeTokenError {
+        GetChangeTokenError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetChangeTokenError {
@@ -3309,6 +3401,11 @@ impl From<CredentialsError> for GetChangeTokenStatusError {
 impl From<HttpDispatchError> for GetChangeTokenStatusError {
     fn from(err: HttpDispatchError) -> GetChangeTokenStatusError {
         GetChangeTokenStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetChangeTokenStatusError {
+    fn from(err: io::Error) -> GetChangeTokenStatusError {
+        GetChangeTokenStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetChangeTokenStatusError {
@@ -3394,6 +3491,11 @@ impl From<CredentialsError> for GetIPSetError {
 impl From<HttpDispatchError> for GetIPSetError {
     fn from(err: HttpDispatchError) -> GetIPSetError {
         GetIPSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetIPSetError {
+    fn from(err: io::Error) -> GetIPSetError {
+        GetIPSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetIPSetError {
@@ -3482,6 +3584,11 @@ impl From<HttpDispatchError> for GetRateBasedRuleError {
         GetRateBasedRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRateBasedRuleError {
+    fn from(err: io::Error) -> GetRateBasedRuleError {
+        GetRateBasedRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3563,6 +3670,11 @@ impl From<CredentialsError> for GetRateBasedRuleManagedKeysError {
 impl From<HttpDispatchError> for GetRateBasedRuleManagedKeysError {
     fn from(err: HttpDispatchError) -> GetRateBasedRuleManagedKeysError {
         GetRateBasedRuleManagedKeysError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetRateBasedRuleManagedKeysError {
+    fn from(err: io::Error) -> GetRateBasedRuleManagedKeysError {
+        GetRateBasedRuleManagedKeysError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetRateBasedRuleManagedKeysError {
@@ -3652,6 +3764,11 @@ impl From<HttpDispatchError> for GetRuleError {
         GetRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetRuleError {
+    fn from(err: io::Error) -> GetRuleError {
+        GetRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3731,6 +3848,11 @@ impl From<CredentialsError> for GetSampledRequestsError {
 impl From<HttpDispatchError> for GetSampledRequestsError {
     fn from(err: HttpDispatchError) -> GetSampledRequestsError {
         GetSampledRequestsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSampledRequestsError {
+    fn from(err: io::Error) -> GetSampledRequestsError {
+        GetSampledRequestsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSampledRequestsError {
@@ -3820,6 +3942,11 @@ impl From<HttpDispatchError> for GetSizeConstraintSetError {
         GetSizeConstraintSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetSizeConstraintSetError {
+    fn from(err: io::Error) -> GetSizeConstraintSetError {
+        GetSizeConstraintSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -3904,6 +4031,11 @@ impl From<CredentialsError> for GetSqlInjectionMatchSetError {
 impl From<HttpDispatchError> for GetSqlInjectionMatchSetError {
     fn from(err: HttpDispatchError) -> GetSqlInjectionMatchSetError {
         GetSqlInjectionMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetSqlInjectionMatchSetError {
+    fn from(err: io::Error) -> GetSqlInjectionMatchSetError {
+        GetSqlInjectionMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for GetSqlInjectionMatchSetError {
@@ -3992,6 +4124,11 @@ impl From<HttpDispatchError> for GetWebACLError {
         GetWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetWebACLError {
+    fn from(err: io::Error) -> GetWebACLError {
+        GetWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4078,6 +4215,11 @@ impl From<HttpDispatchError> for GetXssMatchSetError {
         GetXssMatchSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for GetXssMatchSetError {
+    fn from(err: io::Error) -> GetXssMatchSetError {
+        GetXssMatchSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for GetXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4157,6 +4299,11 @@ impl From<CredentialsError> for ListByteMatchSetsError {
 impl From<HttpDispatchError> for ListByteMatchSetsError {
     fn from(err: HttpDispatchError) -> ListByteMatchSetsError {
         ListByteMatchSetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListByteMatchSetsError {
+    fn from(err: io::Error) -> ListByteMatchSetsError {
+        ListByteMatchSetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListByteMatchSetsError {
@@ -4239,6 +4386,11 @@ impl From<HttpDispatchError> for ListIPSetsError {
         ListIPSetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListIPSetsError {
+    fn from(err: io::Error) -> ListIPSetsError {
+        ListIPSetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListIPSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4317,6 +4469,11 @@ impl From<CredentialsError> for ListRateBasedRulesError {
 impl From<HttpDispatchError> for ListRateBasedRulesError {
     fn from(err: HttpDispatchError) -> ListRateBasedRulesError {
         ListRateBasedRulesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListRateBasedRulesError {
+    fn from(err: io::Error) -> ListRateBasedRulesError {
+        ListRateBasedRulesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListRateBasedRulesError {
@@ -4399,6 +4556,11 @@ impl From<HttpDispatchError> for ListRulesError {
         ListRulesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListRulesError {
+    fn from(err: io::Error) -> ListRulesError {
+        ListRulesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4479,6 +4641,11 @@ impl From<HttpDispatchError> for ListSizeConstraintSetsError {
         ListSizeConstraintSetsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListSizeConstraintSetsError {
+    fn from(err: io::Error) -> ListSizeConstraintSetsError {
+        ListSizeConstraintSetsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListSizeConstraintSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4555,6 +4722,11 @@ impl From<CredentialsError> for ListSqlInjectionMatchSetsError {
 impl From<HttpDispatchError> for ListSqlInjectionMatchSetsError {
     fn from(err: HttpDispatchError) -> ListSqlInjectionMatchSetsError {
         ListSqlInjectionMatchSetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListSqlInjectionMatchSetsError {
+    fn from(err: io::Error) -> ListSqlInjectionMatchSetsError {
+        ListSqlInjectionMatchSetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListSqlInjectionMatchSetsError {
@@ -4639,6 +4811,11 @@ impl From<HttpDispatchError> for ListWebACLsError {
         ListWebACLsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ListWebACLsError {
+    fn from(err: io::Error) -> ListWebACLsError {
+        ListWebACLsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ListWebACLsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -4717,6 +4894,11 @@ impl From<CredentialsError> for ListXssMatchSetsError {
 impl From<HttpDispatchError> for ListXssMatchSetsError {
     fn from(err: HttpDispatchError) -> ListXssMatchSetsError {
         ListXssMatchSetsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for ListXssMatchSetsError {
+    fn from(err: io::Error) -> ListXssMatchSetsError {
+        ListXssMatchSetsError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for ListXssMatchSetsError {
@@ -4825,6 +5007,11 @@ impl From<CredentialsError> for UpdateByteMatchSetError {
 impl From<HttpDispatchError> for UpdateByteMatchSetError {
     fn from(err: HttpDispatchError) -> UpdateByteMatchSetError {
         UpdateByteMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateByteMatchSetError {
+    fn from(err: io::Error) -> UpdateByteMatchSetError {
+        UpdateByteMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateByteMatchSetError {
@@ -4950,6 +5137,11 @@ impl From<HttpDispatchError> for UpdateIPSetError {
         UpdateIPSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateIPSetError {
+    fn from(err: io::Error) -> UpdateIPSetError {
+        UpdateIPSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5068,6 +5260,11 @@ impl From<CredentialsError> for UpdateRateBasedRuleError {
 impl From<HttpDispatchError> for UpdateRateBasedRuleError {
     fn from(err: HttpDispatchError) -> UpdateRateBasedRuleError {
         UpdateRateBasedRuleError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateRateBasedRuleError {
+    fn from(err: io::Error) -> UpdateRateBasedRuleError {
+        UpdateRateBasedRuleError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateRateBasedRuleError {
@@ -5192,6 +5389,11 @@ impl From<HttpDispatchError> for UpdateRuleError {
         UpdateRuleError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateRuleError {
+    fn from(err: io::Error) -> UpdateRuleError {
+        UpdateRuleError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5306,6 +5508,11 @@ impl From<HttpDispatchError> for UpdateSizeConstraintSetError {
         UpdateSizeConstraintSetError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateSizeConstraintSetError {
+    fn from(err: io::Error) -> UpdateSizeConstraintSetError {
+        UpdateSizeConstraintSetError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5409,6 +5616,11 @@ impl From<CredentialsError> for UpdateSqlInjectionMatchSetError {
 impl From<HttpDispatchError> for UpdateSqlInjectionMatchSetError {
     fn from(err: HttpDispatchError) -> UpdateSqlInjectionMatchSetError {
         UpdateSqlInjectionMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateSqlInjectionMatchSetError {
+    fn from(err: io::Error) -> UpdateSqlInjectionMatchSetError {
+        UpdateSqlInjectionMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateSqlInjectionMatchSetError {
@@ -5534,6 +5746,11 @@ impl From<HttpDispatchError> for UpdateWebACLError {
         UpdateWebACLError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for UpdateWebACLError {
+    fn from(err: io::Error) -> UpdateWebACLError {
+        UpdateWebACLError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for UpdateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -5649,6 +5866,11 @@ impl From<CredentialsError> for UpdateXssMatchSetError {
 impl From<HttpDispatchError> for UpdateXssMatchSetError {
     fn from(err: HttpDispatchError) -> UpdateXssMatchSetError {
         UpdateXssMatchSetError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for UpdateXssMatchSetError {
+    fn from(err: io::Error) -> UpdateXssMatchSetError {
+        UpdateXssMatchSetError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for UpdateXssMatchSetError {
@@ -5983,15 +6205,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateByteMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateByteMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6010,13 +6235,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateIPSetResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateIPSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6034,15 +6267,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateRateBasedRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRateBasedRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6061,13 +6297,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateRuleResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6086,13 +6330,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSizeConstraintSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6111,13 +6362,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6135,14 +6393,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6161,15 +6425,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(CreateXssMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateXssMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6188,15 +6455,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteByteMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteByteMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6215,13 +6485,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteIPSetResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteIPSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6239,15 +6517,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteRateBasedRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRateBasedRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6266,13 +6547,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteRuleResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6291,13 +6580,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSizeConstraintSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6316,13 +6612,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -6340,14 +6643,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DeleteWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6366,15 +6675,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(DeleteXssMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteXssMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6393,15 +6705,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetByteMatchSetResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetByteMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetByteMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6417,15 +6734,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetChangeTokenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetChangeTokenResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetChangeTokenError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetChangeTokenError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6445,15 +6767,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetChangeTokenStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetChangeTokenStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetChangeTokenStatusError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetChangeTokenStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6470,13 +6795,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetIPSetResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetIPSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6494,15 +6827,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRateBasedRuleResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetRateBasedRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRateBasedRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6523,13 +6861,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRateBasedRuleManagedKeysResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetRateBasedRuleManagedKeysError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRateBasedRuleManagedKeysResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRateBasedRuleManagedKeysError::from_body(String::from_utf8_lossy(&body)
+                                                                    .as_ref()))
+            }
         }
     }
 
@@ -6545,15 +6890,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetRuleResponse>(String::from_utf8_lossy(&response.body)
-                                                               .as_ref())
-                           .unwrap())
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetRuleResponse>(String::from_utf8_lossy(&body).as_ref())
+                       .unwrap())
             }
-            _ => Err(GetRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6571,15 +6921,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetSampledRequestsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSampledRequestsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetSampledRequestsError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSampledRequestsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6599,15 +6952,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(GetSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                             .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSizeConstraintSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6627,13 +6983,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -6649,13 +7012,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(GetWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6673,15 +7044,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetXssMatchSetResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(GetXssMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetXssMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6700,15 +7076,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListByteMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListByteMatchSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListByteMatchSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListByteMatchSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6727,13 +7106,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListIPSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListIPSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListIPSetsResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListIPSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6751,15 +7138,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRateBasedRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRateBasedRulesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListRateBasedRulesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRateBasedRulesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6776,13 +7166,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListRulesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListRulesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6801,15 +7199,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListSizeConstraintSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListSizeConstraintSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(ListSizeConstraintSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                               .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSizeConstraintSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6829,13 +7230,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListSqlInjectionMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListSqlInjectionMatchSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListSqlInjectionMatchSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListSqlInjectionMatchSetsError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -6853,13 +7261,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListWebACLsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ListWebACLsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListWebACLsResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListWebACLsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6877,15 +7293,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListXssMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ListXssMatchSetsResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(ListXssMatchSetsError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ListXssMatchSetsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6904,15 +7325,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateByteMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateByteMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6931,13 +7355,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateIPSetResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateIPSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -6955,15 +7387,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateRateBasedRuleError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRateBasedRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -6982,13 +7417,21 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateRuleResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateRuleError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -7007,13 +7450,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateSizeConstraintSetError::from_body(String::from_utf8_lossy(&body)
+                                                                .as_ref()))
+            }
         }
     }
 
@@ -7032,13 +7482,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&body)
+                                                                   .as_ref()))
+            }
         }
     }
 
@@ -7056,14 +7513,20 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateWebACLResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(UpdateWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateWebACLError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -7082,15 +7545,18 @@ impl<P, D> Waf for WafClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdateXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<UpdateXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(UpdateXssMatchSetError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(UpdateXssMatchSetError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -19,6 +19,8 @@ use rusoto_core::region;
 
 use std::fmt;
 use std::error::Error;
+use std::io;
+use std::io::Read;
 use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
@@ -716,6 +718,11 @@ impl From<HttpDispatchError> for CreateTagsError {
         CreateTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateTagsError {
+    fn from(err: io::Error) -> CreateTagsError {
+        CreateTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -797,6 +804,11 @@ impl From<HttpDispatchError> for CreateWorkspacesError {
         CreateWorkspacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for CreateWorkspacesError {
+    fn from(err: io::Error) -> CreateWorkspacesError {
+        CreateWorkspacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for CreateWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -875,6 +887,11 @@ impl From<HttpDispatchError> for DeleteTagsError {
         DeleteTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DeleteTagsError {
+    fn from(err: io::Error) -> DeleteTagsError {
+        DeleteTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -950,6 +967,11 @@ impl From<HttpDispatchError> for DescribeTagsError {
         DescribeTagsError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeTagsError {
+    fn from(err: io::Error) -> DescribeTagsError {
+        DescribeTagsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1020,6 +1042,11 @@ impl From<CredentialsError> for DescribeWorkspaceBundlesError {
 impl From<HttpDispatchError> for DescribeWorkspaceBundlesError {
     fn from(err: HttpDispatchError) -> DescribeWorkspaceBundlesError {
         DescribeWorkspaceBundlesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeWorkspaceBundlesError {
+    fn from(err: io::Error) -> DescribeWorkspaceBundlesError {
+        DescribeWorkspaceBundlesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeWorkspaceBundlesError {
@@ -1094,6 +1121,11 @@ impl From<CredentialsError> for DescribeWorkspaceDirectoriesError {
 impl From<HttpDispatchError> for DescribeWorkspaceDirectoriesError {
     fn from(err: HttpDispatchError) -> DescribeWorkspaceDirectoriesError {
         DescribeWorkspaceDirectoriesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeWorkspaceDirectoriesError {
+    fn from(err: io::Error) -> DescribeWorkspaceDirectoriesError {
+        DescribeWorkspaceDirectoriesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeWorkspaceDirectoriesError {
@@ -1177,6 +1209,11 @@ impl From<HttpDispatchError> for DescribeWorkspacesError {
         DescribeWorkspacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for DescribeWorkspacesError {
+    fn from(err: io::Error) -> DescribeWorkspacesError {
+        DescribeWorkspacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for DescribeWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1251,6 +1288,11 @@ impl From<CredentialsError> for DescribeWorkspacesConnectionStatusError {
 impl From<HttpDispatchError> for DescribeWorkspacesConnectionStatusError {
     fn from(err: HttpDispatchError) -> DescribeWorkspacesConnectionStatusError {
         DescribeWorkspacesConnectionStatusError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for DescribeWorkspacesConnectionStatusError {
+    fn from(err: io::Error) -> DescribeWorkspacesConnectionStatusError {
+        DescribeWorkspacesConnectionStatusError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for DescribeWorkspacesConnectionStatusError {
@@ -1347,6 +1389,11 @@ impl From<HttpDispatchError> for ModifyWorkspacePropertiesError {
         ModifyWorkspacePropertiesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for ModifyWorkspacePropertiesError {
+    fn from(err: io::Error) -> ModifyWorkspacePropertiesError {
+        ModifyWorkspacePropertiesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for ModifyWorkspacePropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1424,6 +1471,11 @@ impl From<HttpDispatchError> for RebootWorkspacesError {
         RebootWorkspacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for RebootWorkspacesError {
+    fn from(err: io::Error) -> RebootWorkspacesError {
+        RebootWorkspacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for RebootWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1490,6 +1542,11 @@ impl From<CredentialsError> for RebuildWorkspacesError {
 impl From<HttpDispatchError> for RebuildWorkspacesError {
     fn from(err: HttpDispatchError) -> RebuildWorkspacesError {
         RebuildWorkspacesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for RebuildWorkspacesError {
+    fn from(err: io::Error) -> RebuildWorkspacesError {
+        RebuildWorkspacesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for RebuildWorkspacesError {
@@ -1562,6 +1619,11 @@ impl From<HttpDispatchError> for StartWorkspacesError {
         StartWorkspacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StartWorkspacesError {
+    fn from(err: io::Error) -> StartWorkspacesError {
+        StartWorkspacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StartWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1630,6 +1692,11 @@ impl From<HttpDispatchError> for StopWorkspacesError {
         StopWorkspacesError::HttpDispatch(err)
     }
 }
+impl From<io::Error> for StopWorkspacesError {
+    fn from(err: io::Error) -> StopWorkspacesError {
+        StopWorkspacesError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
 impl fmt::Display for StopWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
@@ -1696,6 +1763,11 @@ impl From<CredentialsError> for TerminateWorkspacesError {
 impl From<HttpDispatchError> for TerminateWorkspacesError {
     fn from(err: HttpDispatchError) -> TerminateWorkspacesError {
         TerminateWorkspacesError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for TerminateWorkspacesError {
+    fn from(err: io::Error) -> TerminateWorkspacesError {
+        TerminateWorkspacesError::HttpDispatch(HttpDispatchError::from(err))
     }
 }
 impl fmt::Display for TerminateWorkspacesError {
@@ -1839,13 +1911,21 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateTagsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(CreateTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateTagsResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1863,15 +1943,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<CreateWorkspacesResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(CreateWorkspacesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(CreateWorkspacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1888,13 +1973,21 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteTagsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DeleteTagsResult>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DeleteTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -1912,14 +2005,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeTagsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeTagsResult>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeTagsError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -1939,13 +2038,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeWorkspaceBundlesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeWorkspaceBundlesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeWorkspaceBundlesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeWorkspaceBundlesError::from_body(String::from_utf8_lossy(&body)
+                                                                 .as_ref()))
+            }
         }
     }
 
@@ -1965,13 +2071,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeWorkspaceDirectoriesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeWorkspaceDirectoriesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeWorkspaceDirectoriesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeWorkspaceDirectoriesError::from_body(String::from_utf8_lossy(&body)
+                                                                     .as_ref()))
+            }
         }
     }
 
@@ -1989,15 +2102,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeWorkspacesResult>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(DescribeWorkspacesError::from_body(String::from_utf8_lossy(&response.body)
-                                                           .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeWorkspacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2019,13 +2137,19 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeWorkspacesConnectionStatusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeWorkspacesConnectionStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<DescribeWorkspacesConnectionStatusResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(DescribeWorkspacesConnectionStatusError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
         }
     }
 
@@ -2045,13 +2169,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ModifyWorkspacePropertiesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
-            _ => Err(ModifyWorkspacePropertiesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<ModifyWorkspacePropertiesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(ModifyWorkspacePropertiesError::from_body(String::from_utf8_lossy(&body)
+                                                                  .as_ref()))
+            }
         }
     }
 
@@ -2069,15 +2200,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RebootWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RebootWorkspacesResult>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RebootWorkspacesError::from_body(String::from_utf8_lossy(&response.body)
-                                                         .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebootWorkspacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2096,15 +2232,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RebuildWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<RebuildWorkspacesResult>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(RebuildWorkspacesError::from_body(String::from_utf8_lossy(&response.body)
-                                                          .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(RebuildWorkspacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2123,15 +2264,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StartWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StartWorkspacesResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StartWorkspacesError::from_body(String::from_utf8_lossy(&response.body)
-                                                        .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StartWorkspacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2150,15 +2296,20 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<StopWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<StopWorkspacesResult>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                           .unwrap())
+            }
             _ => {
-                Err(StopWorkspacesError::from_body(String::from_utf8_lossy(&response.body)
-                                                       .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(StopWorkspacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }
@@ -2177,15 +2328,18 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TerminateWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
-                        }
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<TerminateWorkspacesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
+            }
             _ => {
-                Err(TerminateWorkspacesError::from_body(String::from_utf8_lossy(&response.body)
-                                                            .as_ref()))
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(TerminateWorkspacesError::from_body(String::from_utf8_lossy(&body).as_ref()))
             }
         }
     }

--- a/service_crategen/src/commands/generate/codegen/error_types.rs
+++ b/service_crategen/src/commands/generate/codegen/error_types.rs
@@ -55,6 +55,11 @@ pub trait GenerateErrorTypes {
                         {type_name}::HttpDispatch(err)
                     }}
                 }}
+                impl From<io::Error> for {type_name} {{
+                    fn from(err: io::Error) -> {type_name} {{
+                        {type_name}::HttpDispatch(HttpDispatchError::from(err))
+                    }}
+                }}
                 impl fmt::Display for {type_name} {{
                     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{
                         write!(f, \"{{}}\", self.description())

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -189,34 +189,40 @@ fn generate_client<P>(writer: &mut FileWriter,
 pub fn get_rust_type(service: &Service,
                      shape_name: &str,
                      shape: &Shape,
+                     streaming: bool,
                      for_timestamps: &str)
                      -> String {
-    match shape.shape_type {
-        ShapeType::Blob => "Vec<u8>".into(),
-        ShapeType::Boolean => "bool".into(),
-        ShapeType::Double => "f64".into(),
-        ShapeType::Float => "f32".into(),
-        ShapeType::Integer => "i64".into(),
-        ShapeType::Long => "i64".into(),
-        ShapeType::String => "String".into(),
-        ShapeType::Timestamp => for_timestamps.into(),
-        ShapeType::List => {
-            format!("Vec<{}>",
-                    get_rust_type(service,
-                                  shape.member_type(),
-                                  service.get_shape(&shape.member_type()).unwrap(),
-                                  for_timestamps))
+    if !streaming {
+        match shape.shape_type {
+            ShapeType::Blob => "Vec<u8>".into(),
+            ShapeType::Boolean => "bool".into(),
+            ShapeType::Double => "f64".into(),
+            ShapeType::Float => "f32".into(),
+            ShapeType::Integer => "i64".into(),
+            ShapeType::Long => "i64".into(),
+            ShapeType::String => "String".into(),
+            ShapeType::Timestamp => for_timestamps.into(),
+            ShapeType::List => {
+                format!("Vec<{}>",
+                        get_rust_type(service,
+                                      shape.member_type(),
+                                      service.get_shape(&shape.member_type()).unwrap(),
+                                      false,
+                                      for_timestamps))
+            }
+            ShapeType::Map => {
+                format!(
+                    "::std::collections::HashMap<{}, {}>",
+                    get_rust_type(service, shape.key_type(), service.get_shape(shape.key_type()).unwrap(), false, for_timestamps),
+                    get_rust_type(service, shape.value_type(), service.get_shape(shape.value_type()).unwrap(), false, for_timestamps),
+                    )
+            }
+            ShapeType::Structure => mutate_type_name(shape_name),
         }
-        ShapeType::Map => {
-            format!(
-                "::std::collections::HashMap<{}, {}>",
-                get_rust_type(service, shape.key_type(), service.get_shape(shape.key_type()).unwrap(), for_timestamps),
-                get_rust_type(service, shape.value_type(), service.get_shape(shape.value_type()).unwrap(), for_timestamps),
-            )
-        }
-        ShapeType::Structure => mutate_type_name(shape_name),
+    } else {
+        mutate_type_name_for_streaming(shape_name)
     }
-}
+                     }
 
 fn has_streaming_member(name: &str, shape: &Shape) -> bool {
     shape.shape_type == ShapeType::Structure &&
@@ -231,6 +237,12 @@ fn is_streaming_shape(service: &Service, name: &str) -> bool {
     service.shapes()
            .iter()
            .any(|(_, shape)| has_streaming_member(name, shape))
+}
+
+fn is_input_shape(service: &Service, name: &str) -> bool {
+    service.operations()
+           .iter()
+           .any(|(_, op)| op.input.is_some() && op.input.as_ref().unwrap().shape == name)
 }
 
 // do any type name mutation needed to avoid collisions with Rust types
@@ -256,7 +268,7 @@ fn mutate_type_name(type_name: &str) -> String {
 }
 
 // For types that will be used for streaming
-fn mutate_type_name_for_streaming(type_name: &str) -> String {
+pub fn mutate_type_name_for_streaming(type_name: &str) -> String {
     format!("Streaming{}", type_name)
 }
 
@@ -374,13 +386,14 @@ fn generate_struct<P>(service: &Service,
             ",
             attributes = struct_attributes,
             name = name,
-            struct_fields = generate_struct_fields(service, shape, need_serde_attrs, protocol_generator),
+            struct_fields = generate_struct_fields(service, shape, name, need_serde_attrs, protocol_generator),
         )
     }
 }
 
 fn generate_struct_fields<P: GenerateProtocol>(service: &Service,
                                                shape: &Shape,
+                                               shape_name: &str,
                                                serde_attrs: bool,
                                                protocol_generator: &P)
                                                -> String {
@@ -414,7 +427,11 @@ fn generate_struct_fields<P: GenerateProtocol>(service: &Service,
         }
 
         let member_shape = service.shape_for_member(member).unwrap();
-        let rs_type = get_rust_type(service, &member.shape, &member_shape, protocol_generator.timestamp_type());
+        let rs_type = get_rust_type(service,
+                                    &member.shape,
+                                    &member_shape,
+                                    member.streaming() && !is_input_shape(service, shape_name),
+                                    protocol_generator.timestamp_type());
         let name = generate_field_name(member_name);
 
         if shape.required(member_name) {

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -120,6 +120,7 @@ fn generate<P, E>(writer: &mut FileWriter,
 
         use std::fmt;
         use std::error::Error;
+        use std::io;
         use rusoto_core::request::HttpDispatchError;
         use rusoto_core::credential::{{CredentialsError, ProvideAwsCredentials}};
     ")?;

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -99,7 +99,7 @@ impl GenerateProtocol for QueryGenerator {
             return None;
         }
 
-        let ty = get_rust_type(service, name, shape, self.timestamp_type());
+        let ty = get_rust_type(service, name, shape, false, self.timestamp_type());
         Some(format!("
             /// Serialize `{name}` contents to a `SignedRequest`.
             struct {name}Serializer;
@@ -119,7 +119,7 @@ impl GenerateProtocol for QueryGenerator {
                              shape: &Shape,
                              service: &Service)
                              -> Option<String> {
-        let ty = get_rust_type(service, name, shape, self.timestamp_type());
+        let ty = get_rust_type(service, name, shape, false, self.timestamp_type());
         Some(xml_payload_parser::generate_deserializer(name, &ty, shape, service))
     }
 

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -39,14 +39,16 @@ impl GenerateProtocol for QueryGenerator {
                     request.set_params(params);
 
                     request.sign(&try!(self.credentials_provider.credentials()));
-                    let response = try!(self.dispatcher.dispatch(&request));
+                    let mut response = try!(self.dispatcher.dispatch(&request));
                     match response.status {{
                         StatusCode::Ok => {{
                             {parse_payload}
                             Ok(result)
                         }}
                         _ => {{
-                            Err({error_type}::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                            let mut body: Vec<u8> = Vec::new();
+                            try!(response.body.read_to_end(&mut body));
+                            Err({error_type}::from_body(String::from_utf8_lossy(&body).as_ref()))
                         }}
                     }}
                 }}

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -134,7 +134,7 @@ impl GenerateProtocol for RestXmlGenerator {
                                   _serialized: bool,
                                   _deserialized: bool)
                                   -> String {
-        let derived = vec!["Default", "Clone", "Debug"];
+        let derived = vec!["Default", "Debug"];
 
         format!("#[derive({})]", derived.join(","))
     }
@@ -144,7 +144,7 @@ impl GenerateProtocol for RestXmlGenerator {
             return None;
         }
 
-        let ty = get_rust_type(service, name, shape, self.timestamp_type());
+        let ty = get_rust_type(service, name, shape, false, self.timestamp_type());
         Some(format!("
                 pub struct {name}Serializer;
                 impl {name}Serializer {{
@@ -164,7 +164,7 @@ impl GenerateProtocol for RestXmlGenerator {
                              shape: &Shape,
                              service: &Service)
                              -> Option<String> {
-        let ty = get_rust_type(service, name, shape, self.timestamp_type());
+        let ty = get_rust_type(service, name, shape, false, self.timestamp_type());
         Some(xml_payload_parser::generate_deserializer(name, &ty, shape, service))
     }
 

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -63,7 +63,7 @@ impl GenerateProtocol for RestXmlGenerator {
                     request.set_params(params);
                     request.sign(&try!(self.credentials_provider.credentials()));
 
-                    let response = try!(self.dispatcher.dispatch(&request));
+                    let mut response = try!(self.dispatcher.dispatch(&request));
 
                     match response.status {{
                         StatusCode::Ok|StatusCode::NoContent|StatusCode::PartialContent => {{
@@ -71,7 +71,11 @@ impl GenerateProtocol for RestXmlGenerator {
                             {parse_non_payload}
                             Ok(result)
                         }},
-                        _ => Err({error_type}::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+                        _ => {{
+                            let mut body: Vec<u8> = Vec::new();
+                            try!(response.body.read_to_end(&mut body));
+                            Err({error_type}::from_body(String::from_utf8_lossy(&body).as_ref()))
+                        }}
                     }}
                 }}
                 ",


### PR DESCRIPTION
I took a stab at #481.

This is definitely not good to merge -- the tests need fixing, I dropped the `Debug` trait on practically everything, and this should be squashed first (I broke it up into easier to review pieces as I was writing the code, so that it'd be easier to grok).

Why I'm submitting the PR in this shoddy state is that I'm hoping to get some comments on the approach. I wasn't sure how to implement @mitsuhiko's idea to separate body reading step, so in order to understand the problem (and the code) better, I went ahead and tried my first idea bashed at the compiler till I got something working.

The problems I see with this approach are:

 1. All the API takes mutable `Request`s now, which seems like overkill -- maybe this can be changed to only apply to requests with a `Body`-shaped field
 2. We can't derive `Debug` or `Clone` automatically while embedding a `Read` object -- but we can manually derive a clone that skips over the `body`
 3. Having knowledge of the `Body` shape in the code seems a bit unclean

Any thoughts or comments would be appreciated.