### PR TITLE
fixing up S3 list-type=2 bug.

### DIFF
--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -9703,7 +9703,7 @@ request_uri = request_uri.replace("{Id}", &input.id.to_string());
                     let mut params = Params::new();
                     let mut request_uri = "/2016-11-25/tagging".to_string();
 
-                    params.put_key("Operation=Tag");
+                    params.put("Operation", "Tag");
                     
 
                     let mut request = SignedRequest::new("POST", "cloudfront", self.region, &request_uri);
@@ -9736,7 +9736,7 @@ request.set_payload(Some(payload));
                     let mut params = Params::new();
                     let mut request_uri = "/2016-11-25/tagging".to_string();
 
-                    params.put_key("Operation=Untag");
+                    params.put("Operation", "Untag");
                     
 
                     let mut request = SignedRequest::new("POST", "cloudfront", self.region, &request_uri);

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -18427,7 +18427,7 @@ if let Some(website_redirect_location) = response.headers.get("x-amz-website-red
                     let mut params = Params::new();
                     let mut request_uri = "/{Bucket}".to_string();
 
-                    params.put_key("list-type=2");
+                    params.put("list-type", "2");
                     request_uri = request_uri.replace("{Bucket}", &input.bucket.to_string());
 
                     let mut request = SignedRequest::new("GET", "s3", self.region, &request_uri);

--- a/service_crategen/codegen/src/generator/rest_xml.rs
+++ b/service_crategen/codegen/src/generator/rest_xml.rs
@@ -30,7 +30,16 @@ impl GenerateProtocol for RestXmlGenerator {
             let (request_uri, maybe_params) = parse_query_string(&operation.http.request_uri);
 
             let add_uri_parameters = match maybe_params {
-                Some(key) => format!("params.put_key(\"{}\");", key),
+                Some(key) => {
+                    // Sometimes the key has the query param already set, like "list-type=2"
+                    match key.find("=") {
+                        Some(_) => {
+                            let key_val_vec: Vec<&str> = key.split("=").collect();
+                            format!("params.put(\"{}\", \"{}\");", key_val_vec[0], key_val_vec[1])
+                        },
+                        None => format!("params.put_key(\"{}\");", key),
+                    }
+                },
                 _ => "".to_owned(),
             };
 

--- a/tests/s3.rs
+++ b/tests/s3.rs
@@ -15,7 +15,7 @@ use rusoto::s3::{S3, S3Client, HeadObjectRequest, CopyObjectRequest, GetObjectRe
                  PutObjectRequest, DeleteObjectRequest, PutBucketCorsRequest, CORSConfiguration,
                  CORSRule, CreateBucketRequest, DeleteBucketRequest, CreateMultipartUploadRequest,
                  UploadPartRequest, CompleteMultipartUploadRequest, CompletedMultipartUpload,
-                 CompletedPart, CompletedPartList};
+                 CompletedPart, CompletedPartList, ListObjectsV2Request};
 use rusoto::default_tls_client;
 
 type TestClient = S3Client<DefaultCredentialsProvider, Client>;
@@ -31,7 +31,6 @@ fn test_all_the_things() {
                                DefaultCredentialsProvider::new().unwrap(),
                                Region::UsEast1);
 
-    // a random number should probably be appended here too
     let test_bucket = format!("rusoto_test_bucket_{}", get_time().sec);
     let filename = format!("test_file_{}", get_time().sec);
     let binary_filename = format!("test_file_b{}", get_time().sec);
@@ -42,6 +41,9 @@ fn test_all_the_things() {
 
     // create a bucket for these tests
     test_create_bucket(&client, &test_bucket);
+
+    // list items v2
+    list_items_in_bucket(&client, &test_bucket);
 
     // do a multipart upload
     test_multipart_upload(&client, &test_bucket, &multipart_filename);
@@ -235,7 +237,17 @@ fn test_delete_object(client: &TestClient, bucket: &str, filename: &str) {
 
 fn test_list_buckets(client: &TestClient) {
     let result = client.list_buckets().unwrap();
-    println!("{:#?}", result);
+    println!("\nbuckets available: {:#?}", result);
+}
+
+fn list_items_in_bucket(client: &TestClient, bucket: &str) {
+    let list_obj_req = ListObjectsV2Request {
+        bucket: bucket.to_owned(),
+        start_after: Some("foo".to_owned()),
+        ..Default::default()
+    };
+    let result = client.list_objects_v2(&list_obj_req).unwrap();
+    println!("Items in bucket: {:#?}", result);
 }
 
 fn test_put_bucket_cors(client: &TestClient, bucket: &str) {


### PR DESCRIPTION
Handles the case where the query URI has a parameter in it already so we don't double encode it.  [S3 has that in the botocore definition](https://github.com/boto/botocore/blob/develop/botocore/data/s3/2006-03-01/service-2.json#L565).  Supercedes https://github.com/rusoto/rusoto/pull/613 .  Will fix https://github.com/rusoto/rusoto/issues/553 once a test has been made for it.

`list_objects_v2` works:

```
DEBUG:rusoto_core::request: Full request: 
 method: GET
 final_uri: https://s3-us-west-2.amazonaws.com/rusototester?list-type=2&start-after=2016-10-07T23%3A30%3A38Z
```