### PR TITLE
run generated code through rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,0 @@
-format_strings = false
-fn_brace_style = "PreferSameLine"
-item_brace_style = "PreferSameLine"
-max_width = 140 # allow longer lines to run through rustfmt

--- a/service_crategen/Cargo.toml
+++ b/service_crategen/Cargo.toml
@@ -11,6 +11,7 @@ serde = "1.0.0"
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 toml = "0.4.0"
+rustfmt = "0.8.4"
 
 [dependencies.rusoto_codegen]
 path = "codegen"


### PR DESCRIPTION
This just passes the `generated.rs` files output by the codegen/crategen process through rustfmt.

It was complaining a LOT about not being able to fit certain lines into the default line length, and a closer look showed this to be caused by all the documentation we're including from botocore.  There didn't seem to be a rustfmt option for splitting up long strings like that, so I just squelched the error message.