### PR TITLE
Force test response sorting to ensure stable generation

### DIFF
--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -13386,6 +13386,30 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_autoscaling_describe_auto_scaling_groups() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "autoscaling-describe-auto-scaling-groups.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = AutoScalingGroupNamesType::default();
+        let result = client.describe_auto_scaling_groups(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_autoscaling_describe_auto_scaling_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "autoscaling-describe-auto-scaling-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeAutoScalingInstancesType::default();
+        let result = client.describe_auto_scaling_instances(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_autoscaling_describe_auto_scaling_notification_types() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "autoscaling-describe-auto-scaling-notification-types.xml");
@@ -13398,25 +13422,37 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_autoscaling_describe_scheduled_actions() {
+    fn test_parse_valid_autoscaling_describe_launch_configurations() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "autoscaling-describe-scheduled-actions.xml");
+                                                              "autoscaling-describe-launch-configurations.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeScheduledActionsType::default();
-        let result = client.describe_scheduled_actions(&request);
+        let request = LaunchConfigurationNamesType::default();
+        let result = client.describe_launch_configurations(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_autoscaling_describe_scaling_process_types() {
+    fn test_parse_valid_autoscaling_describe_metric_collection_types() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "autoscaling-describe-scaling-process-types.xml");
+                                                              "autoscaling-describe-metric-collection-types.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
 
-        let result = client.describe_scaling_process_types();
+        let result = client.describe_metric_collection_types();
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_autoscaling_describe_notification_configurations() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "autoscaling-describe-notification-configurations.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeNotificationConfigurationsType::default();
+        let result = client.describe_notification_configurations(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -13446,73 +13482,25 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_autoscaling_describe_metric_collection_types() {
+    fn test_parse_valid_autoscaling_describe_scaling_process_types() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "autoscaling-describe-metric-collection-types.xml");
+                                                              "autoscaling-describe-scaling-process-types.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
 
-        let result = client.describe_metric_collection_types();
+        let result = client.describe_scaling_process_types();
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_autoscaling_describe_termination_policy_types() {
+    fn test_parse_valid_autoscaling_describe_scheduled_actions() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "autoscaling-describe-termination-policy-types.xml");
+                                                              "autoscaling-describe-scheduled-actions.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-
-        let result = client.describe_termination_policy_types();
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_autoscaling_describe_auto_scaling_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "autoscaling-describe-auto-scaling-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeAutoScalingInstancesType::default();
-        let result = client.describe_auto_scaling_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_autoscaling_describe_auto_scaling_groups() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "autoscaling-describe-auto-scaling-groups.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AutoScalingGroupNamesType::default();
-        let result = client.describe_auto_scaling_groups(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_autoscaling_describe_launch_configurations() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "autoscaling-describe-launch-configurations.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = LaunchConfigurationNamesType::default();
-        let result = client.describe_launch_configurations(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_autoscaling_describe_notification_configurations() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "autoscaling-describe-notification-configurations.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeNotificationConfigurationsType::default();
-        let result = client.describe_notification_configurations(&request);
+        let request = DescribeScheduledActionsType::default();
+        let result = client.describe_scheduled_actions(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -13525,6 +13513,18 @@ mod protocol_tests {
         let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = DescribeTagsType::default();
         let result = client.describe_tags(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_autoscaling_describe_termination_policy_types() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "autoscaling-describe-termination-policy-types.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = AutoscalingClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+
+        let result = client.describe_termination_policy_types();
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -8702,19 +8702,6 @@ mod protocol_tests {
     }
 
     #[test]
-    fn test_parse_valid_cloudformation_list_stacks() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "cloudformation-list-stacks.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            CloudFormationClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListStacksInput::default();
-        let result = client.list_stacks(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_valid_cloudformation_describe_stacks() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "cloudformation-describe-stacks.xml");
@@ -8736,6 +8723,19 @@ mod protocol_tests {
             CloudFormationClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = GetTemplateInput::default();
         let result = client.get_template(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_cloudformation_list_stacks() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "cloudformation-list-stacks.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            CloudFormationClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListStacksInput::default();
+        let result = client.list_stacks(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -11538,6 +11538,18 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_cloudfront_get_cloud_front_origin_access_identity() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "cloudfront-get-cloud-front-origin-access-identity.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = CloudFrontClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetCloudFrontOriginAccessIdentityRequest::default();
+        let result = client.get_cloud_front_origin_access_identity(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_cloudfront_get_distribution() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "cloudfront-get-distribution.xml");
@@ -11562,30 +11574,6 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_cloudfront_get_cloud_front_origin_access_identity() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "cloudfront-get-cloud-front-origin-access-identity.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = CloudFrontClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetCloudFrontOriginAccessIdentityRequest::default();
-        let result = client.get_cloud_front_origin_access_identity(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_cloudfront_list_streaming_distributions() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "cloudfront-list-streaming-distributions.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = CloudFrontClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListStreamingDistributionsRequest::default();
-        let result = client.list_streaming_distributions(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_valid_cloudfront_get_streaming_distribution() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "cloudfront-get-streaming-distribution.xml");
@@ -11593,18 +11581,6 @@ mod protocol_tests {
         let client = CloudFrontClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = GetStreamingDistributionRequest::default();
         let result = client.get_streaming_distribution(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_cloudfront_list_distributions() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "cloudfront-list-distributions.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = CloudFrontClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListDistributionsRequest::default();
-        let result = client.list_distributions(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -11622,6 +11598,18 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_cloudfront_list_distributions() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "cloudfront-list-distributions.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = CloudFrontClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListDistributionsRequest::default();
+        let result = client.list_distributions(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_cloudfront_list_invalidations() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "cloudfront-list-invalidations.xml");
@@ -11629,6 +11617,18 @@ mod protocol_tests {
         let client = CloudFrontClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = ListInvalidationsRequest::default();
         let result = client.list_invalidations(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_cloudfront_list_streaming_distributions() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "cloudfront-list-streaming-distributions.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = CloudFrontClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListStreamingDistributionsRequest::default();
+        let result = client.list_streaming_distributions(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -63779,25 +63779,109 @@ mod protocol_tests {
     }
 
     #[test]
-    fn test_parse_valid_ec_2_describe_tags() {
+    fn test_parse_valid_ec_2_allocate_address() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-tags.xml");
+                                                              "ec2-allocate-address.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeTagsRequest::default();
-        let result = client.describe_tags(&request);
+        let request = AllocateAddressRequest::default();
+        let result = client.allocate_address(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_ec_2_import_key_pair() {
+    fn test_parse_valid_ec_2_assign_private_ip_addresses() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-import-key-pair.xml");
+                                                              "ec2-assign-private-ip-addresses.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ImportKeyPairRequest::default();
-        let result = client.import_key_pair(&request);
+        let request = AssignPrivateIpAddressesRequest::default();
+        let result = client.assign_private_ip_addresses(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_associate_address() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-associate-address.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = AssociateAddressRequest::default();
+        let result = client.associate_address(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_associate_route_table() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-associate-route-table.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = AssociateRouteTableRequest::default();
+        let result = client.associate_route_table(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_attach_volume() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-attach-volume.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = AttachVolumeRequest::default();
+        let result = client.attach_volume(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_attach_vpn_gateway() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-attach-vpn-gateway.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = AttachVpnGatewayRequest::default();
+        let result = client.attach_vpn_gateway(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_bundle_instance() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-bundle-instance.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = BundleInstanceRequest::default();
+        let result = client.bundle_instance(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_cancel_bundle_task() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-cancel-bundle-task.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CancelBundleTaskRequest::default();
+        let result = client.cancel_bundle_task(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_cancel_reserved_instances_listing() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-cancel-reserved-instances-listing.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CancelReservedInstancesListingRequest::default();
+        let result = client.cancel_reserved_instances_listing(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -63815,133 +63899,25 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_ec_2_create_key_pair() {
+    fn test_parse_valid_ec_2_confirm_product_instance() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-key-pair.xml");
+                                                              "ec2-confirm-product-instance.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateKeyPairRequest::default();
-        let result = client.create_key_pair(&request);
+        let request = ConfirmProductInstanceRequest::default();
+        let result = client.confirm_product_instance(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_ec_2_create_volume() {
+    fn test_parse_valid_ec_2_copy_snapshot() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-volume.xml");
+                                                              "ec2-copy-snapshot.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateVolumeRequest::default();
-        let result = client.create_volume(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_route_tables() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-route-tables.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeRouteTablesRequest::default();
-        let result = client.describe_route_tables(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_import_instance() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-import-instance.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ImportInstanceRequest::default();
-        let result = client.import_instance(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_run_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-run-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = RunInstancesRequest::default();
-        let result = client.run_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_account_attributes() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-account-attributes.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeAccountAttributesRequest::default();
-        let result = client.describe_account_attributes(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeInstancesRequest::default();
-        let result = client.describe_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_start_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-start-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = StartInstancesRequest::default();
-        let result = client.start_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_network_interfaces() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-network-interfaces.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeNetworkInterfacesRequest::default();
-        let result = client.describe_network_interfaces(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_create_vpn_gateway() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-vpn-gateway.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateVpnGatewayRequest::default();
-        let result = client.create_vpn_gateway(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_detach_volume() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-detach-volume.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DetachVolumeRequest::default();
-        let result = client.detach_volume(&request);
+        let request = CopySnapshotRequest::default();
+        let result = client.copy_snapshot(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -63971,186 +63947,6 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_ec_2_create_network_acl() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-network-acl.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateNetworkAclRequest::default();
-        let result = client.create_network_acl(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_vpcs() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-vpcs.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeVpcsRequest::default();
-        let result = client.describe_vpcs(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_get_password_data() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-get-password-data.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetPasswordDataRequest::default();
-        let result = client.get_password_data(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_addresses() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-addresses.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeAddressesRequest::default();
-        let result = client.describe_addresses(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_placement_groups() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-placement-groups.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribePlacementGroupsRequest::default();
-        let result = client.describe_placement_groups(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_cancel_reserved_instances_listing() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-cancel-reserved-instances-listing.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CancelReservedInstancesListingRequest::default();
-        let result = client.cancel_reserved_instances_listing(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_volume_status() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-volume-status.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeVolumeStatusRequest::default();
-        let result = client.describe_volume_status(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_snapshots() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-snapshots.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeSnapshotsRequest::default();
-        let result = client.describe_snapshots(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_key_pairs() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-key-pairs.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeKeyPairsRequest::default();
-        let result = client.describe_key_pairs(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_bundle_instance() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-bundle-instance.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = BundleInstanceRequest::default();
-        let result = client.bundle_instance(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_import_volume() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-import-volume.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ImportVolumeRequest::default();
-        let result = client.import_volume(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_replace_network_acl_association() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-replace-network-acl-association.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ReplaceNetworkAclAssociationRequest::default();
-        let result = client.replace_network_acl_association(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_assign_private_ip_addresses() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-assign-private-ip-addresses.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AssignPrivateIpAddressesRequest::default();
-        let result = client.assign_private_ip_addresses(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_confirm_product_instance() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-confirm-product-instance.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ConfirmProductInstanceRequest::default();
-        let result = client.confirm_product_instance(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_subnets() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-subnets.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeSubnetsRequest::default();
-        let result = client.describe_subnets(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_valid_ec_2_create_instance_export_task() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "ec2-create-instance-export-task.xml");
@@ -64163,409 +63959,25 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_ec_2_describe_vpn_gateways() {
+    fn test_parse_valid_ec_2_create_key_pair() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-vpn-gateways.xml");
+                                                              "ec2-create-key-pair.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeVpnGatewaysRequest::default();
-        let result = client.describe_vpn_gateways(&request);
+        let request = CreateKeyPairRequest::default();
+        let result = client.create_key_pair(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_ec_2_attach_volume() {
+    fn test_parse_valid_ec_2_create_network_acl() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-attach-volume.xml");
+                                                              "ec2-create-network-acl.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AttachVolumeRequest::default();
-        let result = client.attach_volume(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_create_reserved_instances_listing() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-reserved-instances-listing.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateReservedInstancesListingRequest::default();
-        let result = client.create_reserved_instances_listing(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_create_spot_datafeed_subscription() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-spot-datafeed-subscription.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateSpotDatafeedSubscriptionRequest::default();
-        let result = client.create_spot_datafeed_subscription(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_monitor_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-monitor-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = MonitorInstancesRequest::default();
-        let result = client.monitor_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_create_subnet() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-subnet.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateSubnetRequest::default();
-        let result = client.create_subnet(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_associate_route_table() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-associate-route-table.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AssociateRouteTableRequest::default();
-        let result = client.associate_route_table(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_customer_gateways() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-customer-gateways.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeCustomerGatewaysRequest::default();
-        let result = client.describe_customer_gateways(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_volumes() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-volumes.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeVolumesRequest::default();
-        let result = client.describe_volumes(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_request_spot_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-request-spot-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = RequestSpotInstancesRequest::default();
-        let result = client.request_spot_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_modify_snapshot_attribute() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-modify-snapshot-attribute.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ModifySnapshotAttributeRequest::default();
-        let result = client.modify_snapshot_attribute(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_security_groups() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-security-groups.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeSecurityGroupsRequest::default();
-        let result = client.describe_security_groups(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_unmonitor_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-unmonitor-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = UnmonitorInstancesRequest::default();
-        let result = client.unmonitor_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_cancel_bundle_task() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-cancel-bundle-task.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CancelBundleTaskRequest::default();
-        let result = client.cancel_bundle_task(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_detach_network_interface() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-detach-network-interface.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DetachNetworkInterfaceRequest::default();
-        let result = client.detach_network_interface(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_create_snapshot() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-snapshot.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateSnapshotRequest::default();
-        let result = client.create_snapshot(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_availability_zones() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-availability-zones.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeAvailabilityZonesRequest::default();
-        let result = client.describe_availability_zones(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_create_route_table() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-route-table.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateRouteTableRequest::default();
-        let result = client.create_route_table(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_spot_price_history() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-spot-price-history.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeSpotPriceHistoryRequest::default();
-        let result = client.describe_spot_price_history(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_vpn_connections() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-vpn-connections.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeVpnConnectionsRequest::default();
-        let result = client.describe_vpn_connections(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_stop_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-stop-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = StopInstancesRequest::default();
-        let result = client.stop_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_allocate_address() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-allocate-address.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AllocateAddressRequest::default();
-        let result = client.allocate_address(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_bundle_tasks() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-bundle-tasks.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeBundleTasksRequest::default();
-        let result = client.describe_bundle_tasks(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_reserved_instances_offerings() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-reserved-instances-offerings.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeReservedInstancesOfferingsRequest::default();
-        let result = client.describe_reserved_instances_offerings(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_network_acls() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-network-acls.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeNetworkAclsRequest::default();
-        let result = client.describe_network_acls(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_reserved_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-reserved-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeReservedInstancesRequest::default();
-        let result = client.describe_reserved_instances(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_register_image() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-register-image.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = RegisterImageRequest::default();
-        let result = client.register_image(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_delete_internet_gateway() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-delete-internet-gateway.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DeleteInternetGatewayRequest::default();
-        let result = client.delete_internet_gateway(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_instance_status() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-instance-status.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeInstanceStatusRequest::default();
-        let result = client.describe_instance_status(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_instance_attribute() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-instance-attribute.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeInstanceAttributeRequest::default();
-        let result = client.describe_instance_attribute(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_internet_gateways() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-internet-gateways.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeInternetGatewaysRequest::default();
-        let result = client.describe_internet_gateways(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_attach_vpn_gateway() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-attach-vpn-gateway.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AttachVpnGatewayRequest::default();
-        let result = client.attach_vpn_gateway(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_create_vpc() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-create-vpc.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateVpcRequest::default();
-        let result = client.create_vpc(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ec_2_describe_export_tasks() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-export-tasks.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeExportTasksRequest::default();
-        let result = client.describe_export_tasks(&request);
+        let request = CreateNetworkAclRequest::default();
+        let result = client.create_network_acl(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -64583,37 +63995,169 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_ec_2_associate_address() {
+    fn test_parse_valid_ec_2_create_reserved_instances_listing() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-associate-address.xml");
+                                                              "ec2-create-reserved-instances-listing.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AssociateAddressRequest::default();
-        let result = client.associate_address(&request);
+        let request = CreateReservedInstancesListingRequest::default();
+        let result = client.create_reserved_instances_listing(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_ec_2_describe_spot_instance_requests() {
+    fn test_parse_valid_ec_2_create_route_table() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-spot-instance-requests.xml");
+                                                              "ec2-create-route-table.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeSpotInstanceRequestsRequest::default();
-        let result = client.describe_spot_instance_requests(&request);
+        let request = CreateRouteTableRequest::default();
+        let result = client.create_route_table(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_ec_2_describe_regions() {
+    fn test_parse_valid_ec_2_create_snapshot() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-describe-regions.xml");
+                                                              "ec2-create-snapshot.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeRegionsRequest::default();
-        let result = client.describe_regions(&request);
+        let request = CreateSnapshotRequest::default();
+        let result = client.create_snapshot(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_create_spot_datafeed_subscription() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-create-spot-datafeed-subscription.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CreateSpotDatafeedSubscriptionRequest::default();
+        let result = client.create_spot_datafeed_subscription(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_create_subnet() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-create-subnet.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CreateSubnetRequest::default();
+        let result = client.create_subnet(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_create_volume() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-create-volume.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CreateVolumeRequest::default();
+        let result = client.create_volume(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_create_vpc() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-create-vpc.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CreateVpcRequest::default();
+        let result = client.create_vpc(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_create_vpn_gateway() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-create-vpn-gateway.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CreateVpnGatewayRequest::default();
+        let result = client.create_vpn_gateway(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_delete_internet_gateway() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-delete-internet-gateway.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DeleteInternetGatewayRequest::default();
+        let result = client.delete_internet_gateway(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_account_attributes() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-account-attributes.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeAccountAttributesRequest::default();
+        let result = client.describe_account_attributes(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_addresses() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-addresses.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeAddressesRequest::default();
+        let result = client.describe_addresses(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_availability_zones() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-availability-zones.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeAvailabilityZonesRequest::default();
+        let result = client.describe_availability_zones(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_bundle_tasks() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-bundle-tasks.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeBundleTasksRequest::default();
+        let result = client.describe_bundle_tasks(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_customer_gateways() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-customer-gateways.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeCustomerGatewaysRequest::default();
+        let result = client.describe_customer_gateways(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -64631,13 +64175,469 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_ec_2_copy_snapshot() {
+    fn test_parse_valid_ec_2_describe_export_tasks() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ec2-copy-snapshot.xml");
+                                                              "ec2-describe-export-tasks.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CopySnapshotRequest::default();
-        let result = client.copy_snapshot(&request);
+        let request = DescribeExportTasksRequest::default();
+        let result = client.describe_export_tasks(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_instance_attribute() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-instance-attribute.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeInstanceAttributeRequest::default();
+        let result = client.describe_instance_attribute(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_instance_status() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-instance-status.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeInstanceStatusRequest::default();
+        let result = client.describe_instance_status(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeInstancesRequest::default();
+        let result = client.describe_instances(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_internet_gateways() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-internet-gateways.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeInternetGatewaysRequest::default();
+        let result = client.describe_internet_gateways(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_key_pairs() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-key-pairs.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeKeyPairsRequest::default();
+        let result = client.describe_key_pairs(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_network_acls() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-network-acls.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeNetworkAclsRequest::default();
+        let result = client.describe_network_acls(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_network_interfaces() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-network-interfaces.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeNetworkInterfacesRequest::default();
+        let result = client.describe_network_interfaces(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_placement_groups() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-placement-groups.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribePlacementGroupsRequest::default();
+        let result = client.describe_placement_groups(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_regions() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-regions.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeRegionsRequest::default();
+        let result = client.describe_regions(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_reserved_instances_offerings() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-reserved-instances-offerings.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeReservedInstancesOfferingsRequest::default();
+        let result = client.describe_reserved_instances_offerings(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_reserved_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-reserved-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeReservedInstancesRequest::default();
+        let result = client.describe_reserved_instances(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_route_tables() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-route-tables.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeRouteTablesRequest::default();
+        let result = client.describe_route_tables(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_security_groups() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-security-groups.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeSecurityGroupsRequest::default();
+        let result = client.describe_security_groups(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_snapshots() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-snapshots.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeSnapshotsRequest::default();
+        let result = client.describe_snapshots(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_spot_instance_requests() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-spot-instance-requests.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeSpotInstanceRequestsRequest::default();
+        let result = client.describe_spot_instance_requests(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_spot_price_history() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-spot-price-history.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeSpotPriceHistoryRequest::default();
+        let result = client.describe_spot_price_history(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_subnets() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-subnets.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeSubnetsRequest::default();
+        let result = client.describe_subnets(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_tags() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-tags.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeTagsRequest::default();
+        let result = client.describe_tags(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_volume_status() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-volume-status.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeVolumeStatusRequest::default();
+        let result = client.describe_volume_status(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_volumes() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-volumes.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeVolumesRequest::default();
+        let result = client.describe_volumes(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_vpcs() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-vpcs.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeVpcsRequest::default();
+        let result = client.describe_vpcs(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_vpn_connections() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-vpn-connections.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeVpnConnectionsRequest::default();
+        let result = client.describe_vpn_connections(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_describe_vpn_gateways() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-describe-vpn-gateways.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeVpnGatewaysRequest::default();
+        let result = client.describe_vpn_gateways(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_detach_network_interface() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-detach-network-interface.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DetachNetworkInterfaceRequest::default();
+        let result = client.detach_network_interface(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_detach_volume() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-detach-volume.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DetachVolumeRequest::default();
+        let result = client.detach_volume(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_get_password_data() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-get-password-data.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetPasswordDataRequest::default();
+        let result = client.get_password_data(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_import_instance() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-import-instance.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ImportInstanceRequest::default();
+        let result = client.import_instance(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_import_key_pair() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-import-key-pair.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ImportKeyPairRequest::default();
+        let result = client.import_key_pair(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_import_volume() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-import-volume.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ImportVolumeRequest::default();
+        let result = client.import_volume(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_modify_snapshot_attribute() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-modify-snapshot-attribute.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ModifySnapshotAttributeRequest::default();
+        let result = client.modify_snapshot_attribute(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_monitor_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-monitor-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = MonitorInstancesRequest::default();
+        let result = client.monitor_instances(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_register_image() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-register-image.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = RegisterImageRequest::default();
+        let result = client.register_image(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_replace_network_acl_association() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-replace-network-acl-association.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ReplaceNetworkAclAssociationRequest::default();
+        let result = client.replace_network_acl_association(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_request_spot_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-request-spot-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = RequestSpotInstancesRequest::default();
+        let result = client.request_spot_instances(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_run_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-run-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = RunInstancesRequest::default();
+        let result = client.run_instances(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_start_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-start-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = StartInstancesRequest::default();
+        let result = client.start_instances(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_stop_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-stop-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = StopInstancesRequest::default();
+        let result = client.stop_instances(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ec_2_unmonitor_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ec2-unmonitor-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = Ec2Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = UnmonitorInstancesRequest::default();
+        let result = client.unmonitor_instances(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -12354,97 +12354,6 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_elasticbeanstalk_describe_applications() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-describe-applications.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeApplicationsMessage::default();
-        let result = client.describe_applications(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_update_application_version() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-update-application-version.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = UpdateApplicationVersionMessage::default();
-        let result = client.update_application_version(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_describe_events() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-describe-events.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeEventsMessage::default();
-        let result = client.describe_events(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_create_application() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-create-application.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateApplicationMessage::default();
-        let result = client.create_application(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_terminate_environment() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-terminate-environment.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = TerminateEnvironmentMessage::default();
-        let result = client.terminate_environment(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_delete_application() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-delete-application.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DeleteApplicationMessage::default();
-        let result = client.delete_application(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_list_available_solution_stacks() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-list-available-solution-stacks.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-
-        let result = client.list_available_solution_stacks();
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_valid_elasticbeanstalk_check_dns_availability() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "elasticbeanstalk-check-dns-availability.xml");
@@ -12453,32 +12362,6 @@ mod protocol_tests {
             ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = CheckDNSAvailabilityMessage::default();
         let result = client.check_dns_availability(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_describe_configuration_options() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-describe-configuration-options.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeConfigurationOptionsMessage::default();
-        let result = client.describe_configuration_options(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_create_configuration_template() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-create-configuration-template.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateConfigurationTemplateMessage::default();
-        let result = client.create_configuration_template(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -12497,40 +12380,27 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_elasticbeanstalk_update_application() {
+    fn test_parse_valid_elasticbeanstalk_create_application() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-update-application.xml");
+                                                              "elasticbeanstalk-create-application.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client =
             ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = UpdateApplicationMessage::default();
-        let result = client.update_application(&request);
+        let request = CreateApplicationMessage::default();
+        let result = client.create_application(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_elasticbeanstalk_retrieve_environment_info() {
+    fn test_parse_valid_elasticbeanstalk_create_configuration_template() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-retrieve-environment-info.xml");
+                                                              "elasticbeanstalk-create-configuration-template.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client =
             ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = RetrieveEnvironmentInfoMessage::default();
-        let result = client.retrieve_environment_info(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_elasticbeanstalk_create_storage_location() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elasticbeanstalk-create-storage-location.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client =
-            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-
-        let result = client.create_storage_location();
+        let request = CreateConfigurationTemplateMessage::default();
+        let result = client.create_configuration_template(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -12549,6 +12419,32 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_elasticbeanstalk_create_storage_location() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-create-storage-location.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+
+        let result = client.create_storage_location();
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elasticbeanstalk_delete_application() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-delete-application.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DeleteApplicationMessage::default();
+        let result = client.delete_application(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_elasticbeanstalk_describe_application_versions() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "elasticbeanstalk-describe-application-versions.xml");
@@ -12562,6 +12458,32 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_elasticbeanstalk_describe_applications() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-describe-applications.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeApplicationsMessage::default();
+        let result = client.describe_applications(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elasticbeanstalk_describe_configuration_options() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-describe-configuration-options.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeConfigurationOptionsMessage::default();
+        let result = client.describe_configuration_options(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_elasticbeanstalk_describe_environments() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "elasticbeanstalk-describe-environments.xml");
@@ -12570,6 +12492,84 @@ mod protocol_tests {
             ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = DescribeEnvironmentsMessage::default();
         let result = client.describe_environments(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elasticbeanstalk_describe_events() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-describe-events.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeEventsMessage::default();
+        let result = client.describe_events(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elasticbeanstalk_list_available_solution_stacks() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-list-available-solution-stacks.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+
+        let result = client.list_available_solution_stacks();
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elasticbeanstalk_retrieve_environment_info() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-retrieve-environment-info.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = RetrieveEnvironmentInfoMessage::default();
+        let result = client.retrieve_environment_info(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elasticbeanstalk_terminate_environment() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-terminate-environment.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = TerminateEnvironmentMessage::default();
+        let result = client.terminate_environment(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elasticbeanstalk_update_application_version() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-update-application-version.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = UpdateApplicationVersionMessage::default();
+        let result = client.update_application_version(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elasticbeanstalk_update_application() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elasticbeanstalk-update-application.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client =
+            ElasticBeanstalkClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = UpdateApplicationMessage::default();
+        let result = client.update_application(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -8854,18 +8854,6 @@ mod protocol_tests {
     }
 
     #[test]
-    fn test_parse_valid_elb_describe_load_balancers() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "elb-describe-load-balancers.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = ElbClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeAccessPointsInput::default();
-        let result = client.describe_load_balancers(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_valid_elb_describe_load_balancer_policies() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "elb-describe-load-balancer-policies.xml");
@@ -8885,6 +8873,18 @@ mod protocol_tests {
         let client = ElbClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = DescribeLoadBalancerPolicyTypesInput::default();
         let result = client.describe_load_balancer_policy_types(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_elb_describe_load_balancers() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "elb-describe-load-balancers.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = ElbClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeAccessPointsInput::default();
+        let result = client.describe_load_balancers(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -26215,6 +26215,66 @@ mod protocol_tests {
     }
 
     #[test]
+    fn test_parse_valid_iam_create_virtual_mfa_device() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "iam-create-virtual-mfa-device.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CreateVirtualMFADeviceRequest::default();
+        let result = client.create_virtual_mfa_device(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_iam_get_account_summary() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "iam-get-account-summary.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+
+        let result = client.get_account_summary();
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_iam_get_group() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "iam-get-group.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetGroupRequest::default();
+        let result = client.get_group(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_iam_get_user_policy() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "iam-get-user-policy.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetUserPolicyRequest::default();
+        let result = client.get_user_policy(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_iam_get_user() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "iam-get-user.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetUserRequest::default();
+        let result = client.get_user(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_iam_list_access_keys() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "iam-list-access-keys.xml");
@@ -26227,13 +26287,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_iam_list_virtual_mfa_devices() {
+    fn test_parse_valid_iam_list_account_aliases() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-list-virtual-mfa-devices.xml");
+                                                              "iam-list-account-aliases.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListVirtualMFADevicesRequest::default();
-        let result = client.list_virtual_mfa_devices(&request);
+        let request = ListAccountAliasesRequest::default();
+        let result = client.list_account_aliases(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -26246,6 +26306,30 @@ mod protocol_tests {
         let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = ListGroupsRequest::default();
         let result = client.list_groups(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_iam_list_instance_profiles() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "iam-list-instance-profiles.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListInstanceProfilesRequest::default();
+        let result = client.list_instance_profiles(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_iam_list_mfa_devices() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "iam-list-mfa-devices.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListMFADevicesRequest::default();
+        let result = client.list_mfa_devices(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -26275,13 +26359,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_iam_list_account_aliases() {
+    fn test_parse_valid_iam_list_signing_certificates() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-list-account-aliases.xml");
+                                                              "iam-list-signing-certificates.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListAccountAliasesRequest::default();
-        let result = client.list_account_aliases(&request);
+        let request = ListSigningCertificatesRequest::default();
+        let result = client.list_signing_certificates(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -26299,97 +26383,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_iam_get_user_policy() {
+    fn test_parse_valid_iam_list_virtual_mfa_devices() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-get-user-policy.xml");
+                                                              "iam-list-virtual-mfa-devices.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetUserPolicyRequest::default();
-        let result = client.get_user_policy(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_iam_get_account_summary() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-get-account-summary.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-
-        let result = client.get_account_summary();
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_iam_list_signing_certificates() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-list-signing-certificates.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListSigningCertificatesRequest::default();
-        let result = client.list_signing_certificates(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_iam_get_group() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-get-group.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetGroupRequest::default();
-        let result = client.get_group(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_iam_list_mfa_devices() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-list-mfa-devices.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListMFADevicesRequest::default();
-        let result = client.list_mfa_devices(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_iam_get_user() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-get-user.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetUserRequest::default();
-        let result = client.get_user(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_iam_list_instance_profiles() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-list-instance-profiles.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListInstanceProfilesRequest::default();
-        let result = client.list_instance_profiles(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_iam_create_virtual_mfa_device() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "iam-create-virtual-mfa-device.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = IamClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateVirtualMFADeviceRequest::default();
-        let result = client.create_virtual_mfa_device(&request);
+        let request = ListVirtualMFADevicesRequest::default();
+        let result = client.list_virtual_mfa_devices(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -26555,49 +26555,13 @@ mod protocol_tests {
     }
 
     #[test]
-    fn test_parse_valid_rds_describe_event_subscriptions() {
+    fn test_parse_valid_rds_describe_db_engine_versions() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-event-subscriptions.xml");
+                                                              "rds-describe-db-engine-versions.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeEventSubscriptionsMessage::default();
-        let result = client.describe_event_subscriptions(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_rds_describe_option_groups() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-option-groups.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeOptionGroupsMessage::default();
-        let result = client.describe_option_groups(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_rds_describe_events() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-events.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeEventsMessage::default();
-        let result = client.describe_events(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_rds_describe_reserved_db_instances() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-reserved-db-instances.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeReservedDBInstancesMessage::default();
-        let result = client.describe_reserved_db_instances(&request);
+        let request = DescribeDBEngineVersionsMessage::default();
+        let result = client.describe_db_engine_versions(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -26615,25 +26579,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_rds_describe_db_subnet_groups() {
+    fn test_parse_valid_rds_describe_db_parameter_groups() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-db-subnet-groups.xml");
+                                                              "rds-describe-db-parameter-groups.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeDBSubnetGroupsMessage::default();
-        let result = client.describe_db_subnet_groups(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_rds_describe_reserved_db_instances_offerings() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-reserved-db-instances-offerings.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeReservedDBInstancesOfferingsMessage::default();
-        let result = client.describe_reserved_db_instances_offerings(&request);
+        let request = DescribeDBParameterGroupsMessage::default();
+        let result = client.describe_db_parameter_groups(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -26651,30 +26603,6 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_rds_describe_event_categories() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-event-categories.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeEventCategoriesMessage::default();
-        let result = client.describe_event_categories(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_rds_describe_db_engine_versions() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-db-engine-versions.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeDBEngineVersionsMessage::default();
-        let result = client.describe_db_engine_versions(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_valid_rds_describe_db_snapshots() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "rds-describe-db-snapshots.xml");
@@ -26687,13 +26615,85 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_rds_describe_db_parameter_groups() {
+    fn test_parse_valid_rds_describe_db_subnet_groups() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "rds-describe-db-parameter-groups.xml");
+                                                              "rds-describe-db-subnet-groups.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeDBParameterGroupsMessage::default();
-        let result = client.describe_db_parameter_groups(&request);
+        let request = DescribeDBSubnetGroupsMessage::default();
+        let result = client.describe_db_subnet_groups(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_rds_describe_event_categories() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "rds-describe-event-categories.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeEventCategoriesMessage::default();
+        let result = client.describe_event_categories(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_rds_describe_event_subscriptions() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "rds-describe-event-subscriptions.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeEventSubscriptionsMessage::default();
+        let result = client.describe_event_subscriptions(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_rds_describe_events() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "rds-describe-events.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeEventsMessage::default();
+        let result = client.describe_events(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_rds_describe_option_groups() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "rds-describe-option-groups.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeOptionGroupsMessage::default();
+        let result = client.describe_option_groups(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_rds_describe_reserved_db_instances_offerings() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "rds-describe-reserved-db-instances-offerings.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeReservedDBInstancesOfferingsMessage::default();
+        let result = client.describe_reserved_db_instances_offerings(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_rds_describe_reserved_db_instances() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "rds-describe-reserved-db-instances.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RdsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeReservedDBInstancesMessage::default();
+        let result = client.describe_reserved_db_instances(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -18323,49 +18323,61 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_redshift_describe_cluster_snapshots() {
+    fn test_parse_valid_redshift_authorize_cluster_security_group_ingress() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-describe-cluster-snapshots.xml");
+                                                              "redshift-authorize-cluster-security-group-ingress.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeClusterSnapshotsMessage::default();
-        let result = client.describe_cluster_snapshots(&request);
+        let request = AuthorizeClusterSecurityGroupIngressMessage::default();
+        let result = client.authorize_cluster_security_group_ingress(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_redshift_describe_events() {
+    fn test_parse_valid_redshift_copy_cluster_snapshot() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-describe-events.xml");
+                                                              "redshift-copy-cluster-snapshot.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeEventsMessage::default();
-        let result = client.describe_events(&request);
+        let request = CopyClusterSnapshotMessage::default();
+        let result = client.copy_cluster_snapshot(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_redshift_describe_reserved_nodes() {
+    fn test_parse_valid_redshift_create_cluster_parameter_group() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-describe-reserved-nodes.xml");
+                                                              "redshift-create-cluster-parameter-group.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeReservedNodesMessage::default();
-        let result = client.describe_reserved_nodes(&request);
+        let request = CreateClusterParameterGroupMessage::default();
+        let result = client.create_cluster_parameter_group(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_redshift_revoke_cluster_security_group_ingress() {
+    fn test_parse_valid_redshift_create_cluster_security_group() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-revoke-cluster-security-group-ingress.xml");
+                                                              "redshift-create-cluster-security-group.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = RevokeClusterSecurityGroupIngressMessage::default();
-        let result = client.revoke_cluster_security_group_ingress(&request);
+        let request = CreateClusterSecurityGroupMessage::default();
+        let result = client.create_cluster_security_group(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_redshift_create_cluster_snapshot() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "redshift-create-cluster-snapshot.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = CreateClusterSnapshotMessage::default();
+        let result = client.create_cluster_snapshot(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -18383,49 +18395,37 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_redshift_describe_cluster_subnet_groups() {
+    fn test_parse_valid_redshift_create_cluster() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-describe-cluster-subnet-groups.xml");
+                                                              "redshift-create-cluster.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeClusterSubnetGroupsMessage::default();
-        let result = client.describe_cluster_subnet_groups(&request);
+        let request = CreateClusterMessage::default();
+        let result = client.create_cluster(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_redshift_describe_reserved_node_offerings() {
+    fn test_parse_valid_redshift_delete_cluster_parameter_group() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-describe-reserved-node-offerings.xml");
+                                                              "redshift-delete-cluster-parameter-group.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeReservedNodeOfferingsMessage::default();
-        let result = client.describe_reserved_node_offerings(&request);
+        let request = DeleteClusterParameterGroupMessage::default();
+        let result = client.delete_cluster_parameter_group(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_redshift_reset_cluster_parameter_group() {
+    fn test_parse_valid_redshift_delete_cluster_snapshot() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-reset-cluster-parameter-group.xml");
+                                                              "redshift-delete-cluster-snapshot.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ResetClusterParameterGroupMessage::default();
-        let result = client.reset_cluster_parameter_group(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_redshift_create_cluster_security_group() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-create-cluster-security-group.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateClusterSecurityGroupMessage::default();
-        let result = client.create_cluster_security_group(&request);
+        let request = DeleteClusterSnapshotMessage::default();
+        let result = client.delete_cluster_snapshot(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -18455,6 +18455,18 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_redshift_describe_cluster_parameters() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "redshift-describe-cluster-parameters.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeClusterParametersMessage::default();
+        let result = client.describe_cluster_parameters(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_redshift_describe_cluster_security_groups() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "redshift-describe-cluster-security-groups.xml");
@@ -18462,6 +18474,30 @@ mod protocol_tests {
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = DescribeClusterSecurityGroupsMessage::default();
         let result = client.describe_cluster_security_groups(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_redshift_describe_cluster_snapshots() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "redshift-describe-cluster-snapshots.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeClusterSnapshotsMessage::default();
+        let result = client.describe_cluster_snapshots(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_redshift_describe_cluster_subnet_groups() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "redshift-describe-cluster-subnet-groups.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DescribeClusterSubnetGroupsMessage::default();
+        let result = client.describe_cluster_subnet_groups(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -18479,42 +18515,6 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_redshift_create_cluster() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-create-cluster.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateClusterMessage::default();
-        let result = client.create_cluster(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_redshift_create_cluster_snapshot() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-create-cluster-snapshot.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateClusterSnapshotMessage::default();
-        let result = client.create_cluster_snapshot(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_redshift_modify_cluster_parameter_group() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-modify-cluster-parameter-group.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ModifyClusterParameterGroupMessage::default();
-        let result = client.modify_cluster_parameter_group(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_valid_redshift_describe_clusters() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "redshift-describe-clusters.xml");
@@ -18527,49 +18527,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_redshift_purchase_reserved_node_offering() {
+    fn test_parse_valid_redshift_describe_events() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-purchase-reserved-node-offering.xml");
+                                                              "redshift-describe-events.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = PurchaseReservedNodeOfferingMessage::default();
-        let result = client.purchase_reserved_node_offering(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_redshift_create_cluster_parameter_group() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-create-cluster-parameter-group.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateClusterParameterGroupMessage::default();
-        let result = client.create_cluster_parameter_group(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_redshift_delete_cluster_parameter_group() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-delete-cluster-parameter-group.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DeleteClusterParameterGroupMessage::default();
-        let result = client.delete_cluster_parameter_group(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_redshift_reboot_cluster() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-reboot-cluster.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = RebootClusterMessage::default();
-        let result = client.reboot_cluster(&request);
+        let request = DescribeEventsMessage::default();
+        let result = client.describe_events(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -18587,25 +18551,25 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_redshift_authorize_cluster_security_group_ingress() {
+    fn test_parse_valid_redshift_describe_reserved_node_offerings() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-authorize-cluster-security-group-ingress.xml");
+                                                              "redshift-describe-reserved-node-offerings.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AuthorizeClusterSecurityGroupIngressMessage::default();
-        let result = client.authorize_cluster_security_group_ingress(&request);
+        let request = DescribeReservedNodeOfferingsMessage::default();
+        let result = client.describe_reserved_node_offerings(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_redshift_copy_cluster_snapshot() {
+    fn test_parse_valid_redshift_describe_reserved_nodes() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-copy-cluster-snapshot.xml");
+                                                              "redshift-describe-reserved-nodes.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CopyClusterSnapshotMessage::default();
-        let result = client.copy_cluster_snapshot(&request);
+        let request = DescribeReservedNodesMessage::default();
+        let result = client.describe_reserved_nodes(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -18623,25 +18587,49 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_redshift_describe_cluster_parameters() {
+    fn test_parse_valid_redshift_modify_cluster_parameter_group() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-describe-cluster-parameters.xml");
+                                                              "redshift-modify-cluster-parameter-group.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DescribeClusterParametersMessage::default();
-        let result = client.describe_cluster_parameters(&request);
+        let request = ModifyClusterParameterGroupMessage::default();
+        let result = client.modify_cluster_parameter_group(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_redshift_delete_cluster_snapshot() {
+    fn test_parse_valid_redshift_purchase_reserved_node_offering() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "redshift-delete-cluster-snapshot.xml");
+                                                              "redshift-purchase-reserved-node-offering.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DeleteClusterSnapshotMessage::default();
-        let result = client.delete_cluster_snapshot(&request);
+        let request = PurchaseReservedNodeOfferingMessage::default();
+        let result = client.purchase_reserved_node_offering(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_redshift_reboot_cluster() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "redshift-reboot-cluster.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = RebootClusterMessage::default();
+        let result = client.reboot_cluster(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_redshift_reset_cluster_parameter_group() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "redshift-reset-cluster-parameter-group.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ResetClusterParameterGroupMessage::default();
+        let result = client.reset_cluster_parameter_group(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -18654,6 +18642,18 @@ mod protocol_tests {
         let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = RestoreFromClusterSnapshotMessage::default();
         let result = client.restore_from_cluster_snapshot(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_redshift_revoke_cluster_security_group_ingress() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "redshift-revoke-cluster-security-group-ingress.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = RedshiftClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = RevokeClusterSecurityGroupIngressMessage::default();
+        let result = client.revoke_cluster_security_group_ingress(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -21990,18 +21990,6 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_error_s3_list_objects() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/error",
-                                                              "s3-list-objects.xml");
-        let mock = MockRequestDispatcher::with_status(400).with_body(&mock_response);
-        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListObjectsRequest::default();
-        let result = client.list_objects(&request);
-        assert!(!result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_error_s3_create_bucket() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/error",
                                                               "s3-create-bucket.xml");
@@ -22012,65 +22000,17 @@ mod protocol_tests {
         assert!(!result.is_ok(), "parse error: {:?}", result);
     }
 
-    #[test]
-    fn test_parse_valid_s3_list_multipart_uploads() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "s3-list-multipart-uploads.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListMultipartUploadsRequest::default();
-        let result = client.list_multipart_uploads(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
 
     #[test]
-    fn test_parse_valid_s3_get_bucket_policy() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "s3-get-bucket-policy.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetBucketPolicyRequest::default();
-        let result = client.get_bucket_policy(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_s3_list_objects() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+    fn test_parse_error_s3_list_objects() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/error",
                                                               "s3-list-objects.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let mock = MockRequestDispatcher::with_status(400).with_body(&mock_response);
         let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = ListObjectsRequest::default();
         let result = client.list_objects(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
+        assert!(!result.is_ok(), "parse error: {:?}", result);
     }
-
-
-    #[test]
-    fn test_parse_valid_s3_list_object_versions() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "s3-list-object-versions.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListObjectVersionsRequest::default();
-        let result = client.list_object_versions(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_s3_get_bucket_logging() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "s3-get-bucket-logging.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetBucketLoggingRequest::default();
-        let result = client.get_bucket_logging(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
 
     #[test]
     fn test_parse_valid_s3_get_bucket_acl() {
@@ -22097,6 +22037,30 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_s3_get_bucket_logging() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "s3-get-bucket-logging.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetBucketLoggingRequest::default();
+        let result = client.get_bucket_logging(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_s3_get_bucket_policy() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "s3-get-bucket-policy.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetBucketPolicyRequest::default();
+        let result = client.get_bucket_policy(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_s3_list_buckets() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "s3-list-buckets.xml");
@@ -22104,6 +22068,42 @@ mod protocol_tests {
         let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
 
         let result = client.list_buckets();
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_s3_list_multipart_uploads() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "s3-list-multipart-uploads.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListMultipartUploadsRequest::default();
+        let result = client.list_multipart_uploads(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_s3_list_object_versions() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "s3-list-object-versions.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListObjectVersionsRequest::default();
+        let result = client.list_object_versions(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_s3_list_objects() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "s3-list-objects.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = S3Client::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListObjectsRequest::default();
+        let result = client.list_objects(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -12419,6 +12419,30 @@ mod protocol_tests {
     }
 
     #[test]
+    fn test_parse_valid_ses_delete_identity() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ses-delete-identity.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = DeleteIdentityRequest::default();
+        let result = client.delete_identity(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ses_get_identity_dkim_attributes() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ses-get-identity-dkim-attributes.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetIdentityDkimAttributesRequest::default();
+        let result = client.get_identity_dkim_attributes(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_ses_get_identity_notification_attributes() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "ses-get-identity-notification-attributes.xml");
@@ -12431,25 +12455,37 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_ses_set_identity_dkim_enabled() {
+    fn test_parse_valid_ses_get_identity_verification_attributes() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ses-set-identity-dkim-enabled.xml");
+                                                              "ses-get-identity-verification-attributes.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = SetIdentityDkimEnabledRequest::default();
-        let result = client.set_identity_dkim_enabled(&request);
+        let request = GetIdentityVerificationAttributesRequest::default();
+        let result = client.get_identity_verification_attributes(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_ses_delete_identity() {
+    fn test_parse_valid_ses_get_send_quota() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ses-delete-identity.xml");
+                                                              "ses-get-send-quota.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DeleteIdentityRequest::default();
-        let result = client.delete_identity(&request);
+
+        let result = client.get_send_quota();
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_ses_get_send_statistics() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "ses-get-send-statistics.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+
+        let result = client.get_send_statistics();
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -12491,37 +12527,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_ses_verify_domain_identity() {
+    fn test_parse_valid_ses_set_identity_dkim_enabled() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ses-verify-domain-identity.xml");
+                                                              "ses-set-identity-dkim-enabled.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = VerifyDomainIdentityRequest::default();
-        let result = client.verify_domain_identity(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ses_get_identity_dkim_attributes() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ses-get-identity-dkim-attributes.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetIdentityDkimAttributesRequest::default();
-        let result = client.get_identity_dkim_attributes(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ses_get_identity_verification_attributes() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ses-get-identity-verification-attributes.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetIdentityVerificationAttributesRequest::default();
-        let result = client.get_identity_verification_attributes(&request);
+        let request = SetIdentityDkimEnabledRequest::default();
+        let result = client.set_identity_dkim_enabled(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -12539,25 +12551,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_ses_get_send_statistics() {
+    fn test_parse_valid_ses_verify_domain_identity() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ses-get-send-statistics.xml");
+                                                              "ses-verify-domain-identity.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-
-        let result = client.get_send_statistics();
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_ses_get_send_quota() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "ses-get-send-quota.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SesClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-
-        let result = client.get_send_quota();
+        let request = VerifyDomainIdentityRequest::default();
+        let result = client.verify_domain_identity(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -6388,18 +6388,6 @@ mod protocol_tests {
     }
 
     #[test]
-    fn test_parse_valid_sns_subscribe() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sns-subscribe.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = SubscribeInput::default();
-        let result = client.subscribe(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
     fn test_parse_valid_sns_add_permission() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "sns-add-permission.xml");
@@ -6407,42 +6395,6 @@ mod protocol_tests {
         let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = AddPermissionInput::default();
         let result = client.add_permission(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_sns_create_topic() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sns-create-topic.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = CreateTopicInput::default();
-        let result = client.create_topic(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_sns_get_topic_attributes() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sns-get-topic-attributes.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = GetTopicAttributesInput::default();
-        let result = client.get_topic_attributes(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_sns_list_subscriptions() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sns-list-subscriptions.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListSubscriptionsInput::default();
-        let result = client.list_subscriptions(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -6460,13 +6412,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_sns_list_topics() {
+    fn test_parse_valid_sns_create_topic() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sns-list-topics.xml");
+                                                              "sns-create-topic.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListTopicsInput::default();
-        let result = client.list_topics(&request);
+        let request = CreateTopicInput::default();
+        let result = client.create_topic(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -6484,6 +6436,18 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_sns_get_topic_attributes() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "sns-get-topic-attributes.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = GetTopicAttributesInput::default();
+        let result = client.get_topic_attributes(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_sns_list_subscriptions_by_topic() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "sns-list-subscriptions-by-topic.xml");
@@ -6496,6 +6460,30 @@ mod protocol_tests {
 
 
     #[test]
+    fn test_parse_valid_sns_list_subscriptions() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "sns-list-subscriptions.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListSubscriptionsInput::default();
+        let result = client.list_subscriptions(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_sns_list_topics() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "sns-list-topics.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = ListTopicsInput::default();
+        let result = client.list_topics(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
     fn test_parse_valid_sns_publish() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
                                                               "sns-publish.xml");
@@ -6503,6 +6491,18 @@ mod protocol_tests {
         let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = PublishInput::default();
         let result = client.publish(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_sns_subscribe() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "sns-subscribe.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SnsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = SubscribeInput::default();
+        let result = client.subscribe(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -4109,37 +4109,25 @@ mod protocol_tests {
     }
 
     #[test]
-    fn test_parse_valid_sqs_list_queues() {
+    fn test_parse_valid_sqs_add_permission() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sqs-list-queues.xml");
+                                                              "sqs-add-permission.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ListQueuesRequest::default();
-        let result = client.list_queues(&request);
+        let request = AddPermissionRequest::default();
+        let result = client.add_permission(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
 
     #[test]
-    fn test_parse_valid_sqs_send_message_batch() {
+    fn test_parse_valid_sqs_change_message_visibility_batch() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sqs-send-message-batch.xml");
+                                                              "sqs-change-message-visibility-batch.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = SendMessageBatchRequest::default();
-        let result = client.send_message_batch(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_sqs_send_message() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sqs-send-message.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = SendMessageRequest::default();
-        let result = client.send_message(&request);
+        let request = ChangeMessageVisibilityBatchRequest::default();
+        let result = client.change_message_visibility_batch(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -4157,13 +4145,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_sqs_change_message_visibility_batch() {
+    fn test_parse_valid_sqs_delete_message_batch() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sqs-change-message-visibility-batch.xml");
+                                                              "sqs-delete-message-batch.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = ChangeMessageVisibilityBatchRequest::default();
-        let result = client.change_message_visibility_batch(&request);
+        let request = DeleteMessageBatchRequest::default();
+        let result = client.delete_message_batch(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -4193,25 +4181,13 @@ mod protocol_tests {
 
 
     #[test]
-    fn test_parse_valid_sqs_add_permission() {
+    fn test_parse_valid_sqs_list_queues() {
         let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sqs-add-permission.xml");
+                                                              "sqs-list-queues.xml");
         let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
         let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = AddPermissionRequest::default();
-        let result = client.add_permission(&request);
-        assert!(result.is_ok(), "parse error: {:?}", result);
-    }
-
-
-    #[test]
-    fn test_parse_valid_sqs_delete_message_batch() {
-        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
-                                                              "sqs-delete-message-batch.xml");
-        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
-        let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
-        let request = DeleteMessageBatchRequest::default();
-        let result = client.delete_message_batch(&request);
+        let request = ListQueuesRequest::default();
+        let result = client.list_queues(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 
@@ -4224,6 +4200,30 @@ mod protocol_tests {
         let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
         let request = ReceiveMessageRequest::default();
         let result = client.receive_message(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_sqs_send_message_batch() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "sqs-send-message-batch.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = SendMessageBatchRequest::default();
+        let result = client.send_message_batch(&request);
+        assert!(result.is_ok(), "parse error: {:?}", result);
+    }
+
+
+    #[test]
+    fn test_parse_valid_sqs_send_message() {
+        let mock_response = MockResponseReader::read_response("test_resources/generated/valid",
+                                                              "sqs-send-message.xml");
+        let mock = MockRequestDispatcher::with_status(200).with_body(&mock_response);
+        let client = SqsClient::new(mock, MockCredentialsProvider, rusoto_region::UsEast1);
+        let request = SendMessageRequest::default();
+        let result = client.send_message(&request);
         assert!(result.is_ok(), "parse error: {:?}", result);
     }
 }

--- a/service_crategen/codegen/src/generator/tests.rs
+++ b/service_crategen/codegen/src/generator/tests.rs
@@ -166,10 +166,15 @@ impl Response {
 pub fn find_responses_in_dir(dir_path: &Path) -> Vec<Response> {
     let dir = fs::read_dir(dir_path).expect("read_dir");
 
-    dir.filter_map(|e| e.ok())
+    let mut responses = dir
+        .filter_map(|e| e.ok())
         .filter(|d| d.path().extension().map(|ex| ex == "xml").unwrap_or(false))
         .filter_map(|d| Response::from_response_path(&d.path()))
-        .collect()
+        .collect::<Vec<_>>();
+    
+    responses.sort_by_key(|e| e.full_path.clone());
+
+    responses
 }
 
 pub fn find_error_responses_for_service(service: &Service) -> Vec<Response> {


### PR DESCRIPTION
This PR changes the test generation code to force the responses read from the botocore directory to be sorted by path. This guarantees that, no matter what order `fs::read_dir` returns files in, the resulting generation will always have the same output.

Fixes #659 