### PR TITLE
Add warning for code generation

### DIFF
--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/acm/src/lib.rs
+++ b/rusoto/services/acm/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Certificate Manager
 //!
 //! If you're using the service, you're probably looking for [AcmClient](struct.AcmClient.html) and [Acm](trait.Acm.html).

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/apigateway/src/lib.rs
+++ b/rusoto/services/apigateway/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon API Gateway
 //!
 //! If you're using the service, you're probably looking for [ApiGatewayClient](struct.ApiGatewayClient.html) and [ApiGateway](trait.ApiGateway.html).

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/appstream/src/lib.rs
+++ b/rusoto/services/appstream/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon AppStream
 //!
 //! If you're using the service, you're probably looking for [AppStreamClient](struct.AppStreamClient.html) and [AppStream](trait.AppStream.html).

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/autoscaling/src/lib.rs
+++ b/rusoto/services/autoscaling/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Auto Scaling
 //!
 //! If you're using the service, you're probably looking for [AutoscalingClient](struct.AutoscalingClient.html) and [Autoscaling](trait.Autoscaling.html).

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cloudformation/src/lib.rs
+++ b/rusoto/services/cloudformation/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS CloudFormation
 //!
 //! If you're using the service, you're probably looking for [CloudFormationClient](struct.CloudFormationClient.html) and [CloudFormation](trait.CloudFormation.html).

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cloudfront/src/lib.rs
+++ b/rusoto/services/cloudfront/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon CloudFront
 //!
 //! If you're using the service, you're probably looking for [CloudFrontClient](struct.CloudFrontClient.html) and [CloudFront](trait.CloudFront.html).

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cloudhsm/src/lib.rs
+++ b/rusoto/services/cloudhsm/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon CloudHSM
 //!
 //! If you're using the service, you're probably looking for [CloudHsmClient](struct.CloudHsmClient.html) and [CloudHsm](trait.CloudHsm.html).

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cloudsearch/src/lib.rs
+++ b/rusoto/services/cloudsearch/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon CloudSearch
 //!
 //! If you're using the service, you're probably looking for [CloudSearchClient](struct.CloudSearchClient.html) and [CloudSearch](trait.CloudSearch.html).

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cloudtrail/src/lib.rs
+++ b/rusoto/services/cloudtrail/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS CloudTrail
 //!
 //! If you're using the service, you're probably looking for [CloudTrailClient](struct.CloudTrailClient.html) and [CloudTrail](trait.CloudTrail.html).

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cloudwatch/src/lib.rs
+++ b/rusoto/services/cloudwatch/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon CloudWatch
 //!
 //! If you're using the service, you're probably looking for [CloudWatchClient](struct.CloudWatchClient.html) and [CloudWatch](trait.CloudWatch.html).

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/codebuild/src/lib.rs
+++ b/rusoto/services/codebuild/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS CodeBuild
 //!
 //! If you're using the service, you're probably looking for [CodeBuildClient](struct.CodeBuildClient.html) and [CodeBuild](trait.CodeBuild.html).

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/codecommit/src/lib.rs
+++ b/rusoto/services/codecommit/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS CodeCommit
 //!
 //! If you're using the service, you're probably looking for [CodeCommitClient](struct.CodeCommitClient.html) and [CodeCommit](trait.CodeCommit.html).

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/codedeploy/src/lib.rs
+++ b/rusoto/services/codedeploy/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS CodeDeploy
 //!
 //! If you're using the service, you're probably looking for [CodeDeployClient](struct.CodeDeployClient.html) and [CodeDeploy](trait.CodeDeploy.html).

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/codepipeline/src/lib.rs
+++ b/rusoto/services/codepipeline/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS CodePipeline
 //!
 //! If you're using the service, you're probably looking for [CodePipelineClient](struct.CodePipelineClient.html) and [CodePipeline](trait.CodePipeline.html).

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cognito-identity/src/lib.rs
+++ b/rusoto/services/cognito-identity/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Cognito Identity
 //!
 //! If you're using the service, you're probably looking for [CognitoIdentityClient](struct.CognitoIdentityClient.html) and [CognitoIdentity](trait.CognitoIdentity.html).

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cognito-idp/src/lib.rs
+++ b/rusoto/services/cognito-idp/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Cognito Identity Provider
 //!
 //! If you're using the service, you're probably looking for [CognitoIdentityProviderClient](struct.CognitoIdentityProviderClient.html) and [CognitoIdentityProvider](trait.CognitoIdentityProvider.html).

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/config/src/lib.rs
+++ b/rusoto/services/config/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Config
 //!
 //! If you're using the service, you're probably looking for [ConfigServiceClient](struct.ConfigServiceClient.html) and [ConfigService](trait.ConfigService.html).

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/cur/src/lib.rs
+++ b/rusoto/services/cur/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Cost and Usage Report Service
 //!
 //! If you're using the service, you're probably looking for [CostAndUsageReportClient](struct.CostAndUsageReportClient.html) and [CostAndUsageReport](trait.CostAndUsageReport.html).

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/datapipeline/src/lib.rs
+++ b/rusoto/services/datapipeline/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Data Pipeline
 //!
 //! If you're using the service, you're probably looking for [DataPipelineClient](struct.DataPipelineClient.html) and [DataPipeline](trait.DataPipeline.html).

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/devicefarm/src/lib.rs
+++ b/rusoto/services/devicefarm/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Device Farm
 //!
 //! If you're using the service, you're probably looking for [DeviceFarmClient](struct.DeviceFarmClient.html) and [DeviceFarm](trait.DeviceFarm.html).

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/directconnect/src/lib.rs
+++ b/rusoto/services/directconnect/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Direct Connect
 //!
 //! If you're using the service, you're probably looking for [DirectConnectClient](struct.DirectConnectClient.html) and [DirectConnect](trait.DirectConnect.html).

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/dms/src/lib.rs
+++ b/rusoto/services/dms/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Database Migration Service
 //!
 //! If you're using the service, you're probably looking for [DatabaseMigrationServiceClient](struct.DatabaseMigrationServiceClient.html) and [DatabaseMigrationService](trait.DatabaseMigrationService.html).

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/ds/src/lib.rs
+++ b/rusoto/services/ds/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Directory Service
 //!
 //! If you're using the service, you're probably looking for [DirectoryServiceClient](struct.DirectoryServiceClient.html) and [DirectoryService](trait.DirectoryService.html).

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/dynamodb/src/lib.rs
+++ b/rusoto/services/dynamodb/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon DynamoDB
 //!
 //! If you're using the service, you're probably looking for [DynamoDbClient](struct.DynamoDbClient.html) and [DynamoDb](trait.DynamoDb.html).

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/dynamodbstreams/src/lib.rs
+++ b/rusoto/services/dynamodbstreams/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon DynamoDB Streams
 //!
 //! If you're using the service, you're probably looking for [DynamoDbStreamsClient](struct.DynamoDbStreamsClient.html) and [DynamoDbStreams](trait.DynamoDbStreams.html).

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/ec2/src/lib.rs
+++ b/rusoto/services/ec2/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Elastic Compute Cloud
 //!
 //! If you're using the service, you're probably looking for [Ec2Client](struct.Ec2Client.html) and [Ec2](trait.Ec2.html).

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/ecr/src/lib.rs
+++ b/rusoto/services/ecr/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon EC2 Container Registry
 //!
 //! If you're using the service, you're probably looking for [EcrClient](struct.EcrClient.html) and [Ecr](trait.Ecr.html).

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/ecs/src/lib.rs
+++ b/rusoto/services/ecs/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon EC2 Container Service
 //!
 //! If you're using the service, you're probably looking for [EcsClient](struct.EcsClient.html) and [Ecs](trait.Ecs.html).

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/elasticache/src/lib.rs
+++ b/rusoto/services/elasticache/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon ElastiCache
 //!
 //! If you're using the service, you're probably looking for [ElastiCacheClient](struct.ElastiCacheClient.html) and [ElastiCache](trait.ElastiCache.html).

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/elasticbeanstalk/src/lib.rs
+++ b/rusoto/services/elasticbeanstalk/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Elastic Beanstalk
 //!
 //! If you're using the service, you're probably looking for [ElasticBeanstalkClient](struct.ElasticBeanstalkClient.html) and [ElasticBeanstalk](trait.ElasticBeanstalk.html).

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/elastictranscoder/src/lib.rs
+++ b/rusoto/services/elastictranscoder/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Elastic Transcoder
 //!
 //! If you're using the service, you're probably looking for [EtsClient](struct.EtsClient.html) and [Ets](trait.Ets.html).

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/elb/src/lib.rs
+++ b/rusoto/services/elb/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Elastic Load Balancing
 //!
 //! If you're using the service, you're probably looking for [ElbClient](struct.ElbClient.html) and [Elb](trait.Elb.html).

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/elbv2/src/lib.rs
+++ b/rusoto/services/elbv2/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Elastic Load Balancing
 //!
 //! If you're using the service, you're probably looking for [ElbClient](struct.ElbClient.html) and [Elb](trait.Elb.html).

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/emr/src/lib.rs
+++ b/rusoto/services/emr/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Elastic MapReduce
 //!
 //! If you're using the service, you're probably looking for [EmrClient](struct.EmrClient.html) and [Emr](trait.Emr.html).

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/events/src/lib.rs
+++ b/rusoto/services/events/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon CloudWatch Events
 //!
 //! If you're using the service, you're probably looking for [CloudWatchEventsClient](struct.CloudWatchEventsClient.html) and [CloudWatchEvents](trait.CloudWatchEvents.html).

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/firehose/src/lib.rs
+++ b/rusoto/services/firehose/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Kinesis Firehose
 //!
 //! If you're using the service, you're probably looking for [KinesisFirehoseClient](struct.KinesisFirehoseClient.html) and [KinesisFirehose](trait.KinesisFirehose.html).

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/gamelift/src/lib.rs
+++ b/rusoto/services/gamelift/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon GameLift
 //!
 //! If you're using the service, you're probably looking for [GameLiftClient](struct.GameLiftClient.html) and [GameLift](trait.GameLift.html).

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/glacier/src/lib.rs
+++ b/rusoto/services/glacier/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Glacier
 //!
 //! If you're using the service, you're probably looking for [GlacierClient](struct.GlacierClient.html) and [Glacier](trait.Glacier.html).

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/health/src/lib.rs
+++ b/rusoto/services/health/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Health APIs and Notifications
 //!
 //! If you're using the service, you're probably looking for [AWSHealthClient](struct.AWSHealthClient.html) and [AWSHealth](trait.AWSHealth.html).

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/iam/src/lib.rs
+++ b/rusoto/services/iam/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Identity and Access Management
 //!
 //! If you're using the service, you're probably looking for [IamClient](struct.IamClient.html) and [Iam](trait.Iam.html).

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/importexport/src/lib.rs
+++ b/rusoto/services/importexport/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Import/Export
 //!
 //! If you're using the service, you're probably looking for [ImportExportClient](struct.ImportExportClient.html) and [ImportExport](trait.ImportExport.html).

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/inspector/src/lib.rs
+++ b/rusoto/services/inspector/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Inspector
 //!
 //! If you're using the service, you're probably looking for [InspectorClient](struct.InspectorClient.html) and [Inspector](trait.Inspector.html).

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/iot/src/lib.rs
+++ b/rusoto/services/iot/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS IoT
 //!
 //! If you're using the service, you're probably looking for [IotClient](struct.IotClient.html) and [Iot](trait.Iot.html).

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/kinesis/src/lib.rs
+++ b/rusoto/services/kinesis/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Kinesis
 //!
 //! If you're using the service, you're probably looking for [KinesisClient](struct.KinesisClient.html) and [Kinesis](trait.Kinesis.html).

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/kinesisanalytics/src/lib.rs
+++ b/rusoto/services/kinesisanalytics/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Kinesis Analytics
 //!
 //! If you're using the service, you're probably looking for [KinesisAnalyticsClient](struct.KinesisAnalyticsClient.html) and [KinesisAnalytics](trait.KinesisAnalytics.html).

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/kms/src/lib.rs
+++ b/rusoto/services/kms/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Key Management Service
 //!
 //! If you're using the service, you're probably looking for [KmsClient](struct.KmsClient.html) and [Kms](trait.Kms.html).

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/lambda/src/lib.rs
+++ b/rusoto/services/lambda/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Lambda
 //!
 //! If you're using the service, you're probably looking for [LambdaClient](struct.LambdaClient.html) and [Lambda](trait.Lambda.html).

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/lightsail/src/lib.rs
+++ b/rusoto/services/lightsail/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Lightsail
 //!
 //! If you're using the service, you're probably looking for [LightsailClient](struct.LightsailClient.html) and [Lightsail](trait.Lightsail.html).

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/logs/src/lib.rs
+++ b/rusoto/services/logs/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon CloudWatch Logs
 //!
 //! If you're using the service, you're probably looking for [CloudWatchLogsClient](struct.CloudWatchLogsClient.html) and [CloudWatchLogs](trait.CloudWatchLogs.html).

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/machinelearning/src/lib.rs
+++ b/rusoto/services/machinelearning/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Machine Learning
 //!
 //! If you're using the service, you're probably looking for [MachineLearningClient](struct.MachineLearningClient.html) and [MachineLearning](trait.MachineLearning.html).

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/marketplacecommerceanalytics/src/lib.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Marketplace Commerce Analytics
 //!
 //! If you're using the service, you're probably looking for [MarketplaceCommerceAnalyticsClient](struct.MarketplaceCommerceAnalyticsClient.html) and [MarketplaceCommerceAnalytics](trait.MarketplaceCommerceAnalytics.html).

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/meteringmarketplace/src/lib.rs
+++ b/rusoto/services/meteringmarketplace/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWSMarketplace Metering
 //!
 //! If you're using the service, you're probably looking for [MarketplaceMeteringClient](struct.MarketplaceMeteringClient.html) and [MarketplaceMetering](trait.MarketplaceMetering.html).

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/mturk/src/lib.rs
+++ b/rusoto/services/mturk/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Mechanical Turk
 //!
 //! If you're using the service, you're probably looking for [MechanicalTurkClient](struct.MechanicalTurkClient.html) and [MechanicalTurk](trait.MechanicalTurk.html).

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/opsworks/src/lib.rs
+++ b/rusoto/services/opsworks/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS OpsWorks
 //!
 //! If you're using the service, you're probably looking for [OpsWorksClient](struct.OpsWorksClient.html) and [OpsWorks](trait.OpsWorks.html).

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/opsworkscm/src/lib.rs
+++ b/rusoto/services/opsworkscm/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS OpsWorks for Chef Automate
 //!
 //! If you're using the service, you're probably looking for [OpsWorksCMClient](struct.OpsWorksCMClient.html) and [OpsWorksCM](trait.OpsWorksCM.html).

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/organizations/src/lib.rs
+++ b/rusoto/services/organizations/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Organizations
 //!
 //! If you're using the service, you're probably looking for [OrganizationsClient](struct.OrganizationsClient.html) and [Organizations](trait.Organizations.html).

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/polly/src/lib.rs
+++ b/rusoto/services/polly/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Polly
 //!
 //! If you're using the service, you're probably looking for [PollyClient](struct.PollyClient.html) and [Polly](trait.Polly.html).

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/rds/src/lib.rs
+++ b/rusoto/services/rds/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Relational Database Service
 //!
 //! If you're using the service, you're probably looking for [RdsClient](struct.RdsClient.html) and [Rds](trait.Rds.html).

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/redshift/src/lib.rs
+++ b/rusoto/services/redshift/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Redshift
 //!
 //! If you're using the service, you're probably looking for [RedshiftClient](struct.RedshiftClient.html) and [Redshift](trait.Redshift.html).

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/rekognition/src/lib.rs
+++ b/rusoto/services/rekognition/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Rekognition
 //!
 //! If you're using the service, you're probably looking for [RekognitionClient](struct.RekognitionClient.html) and [Rekognition](trait.Rekognition.html).

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/route53/src/lib.rs
+++ b/rusoto/services/route53/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Route 53
 //!
 //! If you're using the service, you're probably looking for [Route53Client](struct.Route53Client.html) and [Route53](trait.Route53.html).

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/route53domains/src/lib.rs
+++ b/rusoto/services/route53domains/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Route 53 Domains
 //!
 //! If you're using the service, you're probably looking for [Route53DomainsClient](struct.Route53DomainsClient.html) and [Route53Domains](trait.Route53Domains.html).

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/s3/src/lib.rs
+++ b/rusoto/services/s3/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Simple Storage Service
 //!
 //! If you're using the service, you're probably looking for [S3Client](struct.S3Client.html) and [S3](trait.S3.html).

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/sdb/src/lib.rs
+++ b/rusoto/services/sdb/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon SimpleDB
 //!
 //! If you're using the service, you're probably looking for [SimpleDbClient](struct.SimpleDbClient.html) and [SimpleDb](trait.SimpleDb.html).

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/servicecatalog/src/lib.rs
+++ b/rusoto/services/servicecatalog/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Service Catalog
 //!
 //! If you're using the service, you're probably looking for [ServiceCatalogClient](struct.ServiceCatalogClient.html) and [ServiceCatalog](trait.ServiceCatalog.html).

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/ses/src/lib.rs
+++ b/rusoto/services/ses/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Simple Email Service
 //!
 //! If you're using the service, you're probably looking for [SesClient](struct.SesClient.html) and [Ses](trait.Ses.html).

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/sms/src/lib.rs
+++ b/rusoto/services/sms/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Server Migration Service
 //!
 //! If you're using the service, you're probably looking for [ServerMigrationServiceClient](struct.ServerMigrationServiceClient.html) and [ServerMigrationService](trait.ServerMigrationService.html).

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/snowball/src/lib.rs
+++ b/rusoto/services/snowball/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Import/Export Snowball
 //!
 //! If you're using the service, you're probably looking for [SnowballClient](struct.SnowballClient.html) and [Snowball](trait.Snowball.html).

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/sns/src/lib.rs
+++ b/rusoto/services/sns/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Simple Notification Service
 //!
 //! If you're using the service, you're probably looking for [SnsClient](struct.SnsClient.html) and [Sns](trait.Sns.html).

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/sqs/src/lib.rs
+++ b/rusoto/services/sqs/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Simple Queue Service
 //!
 //! If you're using the service, you're probably looking for [SqsClient](struct.SqsClient.html) and [Sqs](trait.Sqs.html).

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/ssm/src/lib.rs
+++ b/rusoto/services/ssm/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Simple Systems Manager (SSM)
 //!
 //! If you're using the service, you're probably looking for [SsmClient](struct.SsmClient.html) and [Ssm](trait.Ssm.html).

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/stepfunctions/src/lib.rs
+++ b/rusoto/services/stepfunctions/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Step Functions
 //!
 //! If you're using the service, you're probably looking for [StepFunctionsClient](struct.StepFunctionsClient.html) and [StepFunctions](trait.StepFunctions.html).

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/storagegateway/src/lib.rs
+++ b/rusoto/services/storagegateway/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Storage Gateway
 //!
 //! If you're using the service, you're probably looking for [StorageGatewayClient](struct.StorageGatewayClient.html) and [StorageGateway](trait.StorageGateway.html).

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/sts/src/lib.rs
+++ b/rusoto/services/sts/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Security Token Service
 //!
 //! If you're using the service, you're probably looking for [StsClient](struct.StsClient.html) and [Sts](trait.Sts.html).

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/support/src/lib.rs
+++ b/rusoto/services/support/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS Support
 //!
 //! If you're using the service, you're probably looking for [AWSSupportClient](struct.AWSSupportClient.html) and [AWSSupport](trait.AWSSupport.html).

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/swf/src/lib.rs
+++ b/rusoto/services/swf/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon Simple Workflow Service
 //!
 //! If you're using the service, you're probably looking for [SwfClient](struct.SwfClient.html) and [Swf](trait.Swf.html).

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/waf-regional/src/lib.rs
+++ b/rusoto/services/waf-regional/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS WAF Regional
 //!
 //! If you're using the service, you're probably looking for [WAFRegionalClient](struct.WAFRegionalClient.html) and [WAFRegional](trait.WAFRegional.html).

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/waf/src/lib.rs
+++ b/rusoto/services/waf/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! AWS WAF
 //!
 //! If you're using the service, you're probably looking for [WafClient](struct.WafClient.html) and [Waf](trait.Waf.html).

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -1,3 +1,16 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 #[allow(warnings)]
 use hyper::Client;
 use hyper::status::StatusCode;

--- a/rusoto/services/workspaces/src/lib.rs
+++ b/rusoto/services/workspaces/src/lib.rs
@@ -1,4 +1,16 @@
 
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! Amazon WorkSpaces
 //!
 //! If you're using the service, you're probably looking for [WorkspacesClient](struct.WorkspacesClient.html) and [Workspaces](trait.Workspaces.html).

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -89,7 +89,20 @@ fn generate<P, E>(writer: &mut FileWriter, service: &Service, protocol_generator
     where P: GenerateProtocol,
           E: GenerateErrorTypes {
 
-    writeln!(writer, "#[allow(warnings)]
+    writeln!(writer, "
+        // =================================================================
+        //
+        //                           * WARNING *
+        //
+        //                    This file is generated!
+        //
+        //  Changes made to this file will be overwritten. If changes are
+        //  required to the generated code, the service_crategen project
+        //  must be updated to generate the changes.
+        //
+        // =================================================================
+
+        #[allow(warnings)]
         use hyper::Client;
         use hyper::status::StatusCode;
         use rusoto_core::request::DispatchSignedRequest;

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -170,6 +170,18 @@ See [LICENSE][license] for details.
                 .expect("Unable to write lib.rs");
 
             let lib_file_contents = format!(r#"
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
 //! {service_full_name}
 //!
 //! If you're using the service, you're probably looking for [{client_name}](struct.{client_name}.html) and [{trait_name}](trait.{trait_name}.html).


### PR DESCRIPTION
This resolves #673. The first commit adds it to the template and the second commit are the generated changes. Please let me know if the comment wasn't final and should be changed to something else. :)