### PR TITLE
Add `encode_key` helper to encode keys on S3 copy

### DIFF
--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -376,7 +376,8 @@ impl EncodeSet for StrictPathEncodeSet {
 }
 
 #[inline]
-fn encode_uri_path(uri: &str) -> String {
+#[doc(hidden)]
+pub fn encode_uri_path(uri: &str) -> String {
     utf8_percent_encode(uri, StrictPathEncodeSet).collect::<String>()
 }
 

--- a/rusoto/services/s3/src/custom/mod.rs
+++ b/rusoto/services/s3/src/custom/mod.rs
@@ -1,2 +1,5 @@
+/// Utility helpers for working with S3
+pub mod util;
+
 #[cfg(test)]
 mod custom_tests;

--- a/rusoto/services/s3/src/custom/util.rs
+++ b/rusoto/services/s3/src/custom/util.rs
@@ -14,6 +14,7 @@ use rusoto_core::signature;
 ///     copy_source: rusoto_s3::util::encode_key("other-buckét/key-to-cöpy"),
 ///     ..Default::default()
 /// };
+/// ```
 pub fn encode_key<T: AsRef<str>>(key: T) -> String {
     signature::encode_uri_path(key.as_ref())
 }

--- a/rusoto/services/s3/src/custom/util.rs
+++ b/rusoto/services/s3/src/custom/util.rs
@@ -1,22 +1,19 @@
 use rusoto_core::signature;
 
 /// URL encodes an S3 object key. This is necessary for `copy_object` and `upload_part_copy`,
-/// which require the `copy_source` field to be URL encoded to be used properly.
+/// which require the `copy_source` field to be URL encoded.
 ///
 /// # Examples
 ///
 /// ```
-/// # use rusoto_s3::{S3, CopyObjectRequest};
-/// # fn test_fn<T: S3>(s3_client: T) {
-///
-/// let response = s3_client.copy_object(&CopyObjectRequest {
+/// use rusoto_s3::CopyObjectRequest;
+/// 
+/// let request = CopyObjectRequest {
 ///     bucket: "my-bucket".to_owned(),
 ///     key: "my-key".to_owned(),
 ///     copy_source: rusoto_s3::util::encode_key("other-buckét/key-to-cöpy"),
 ///     ..Default::default()
-/// }).unwrap();
-///
-/// # }
+/// };
 pub fn encode_key<T: AsRef<str>>(key: T) -> String {
     signature::encode_uri_path(key.as_ref())
 }

--- a/rusoto/services/s3/src/custom/util.rs
+++ b/rusoto/services/s3/src/custom/util.rs
@@ -1,0 +1,22 @@
+use rusoto_core::signature;
+
+/// URL encodes an S3 object key. This is necessary for `copy_object` and `upload_part_copy`,
+/// which require the `copy_source` field to be URL encoded to be used properly.
+///
+/// # Examples
+///
+/// ```
+/// # use rusoto_s3::{S3, CopyObjectRequest};
+/// # fn test_fn<T: S3>(s3_client: T) {
+///
+/// let response = s3_client.copy_object(&CopyObjectRequest {
+///     bucket: "my-bucket".to_owned(),
+///     key: "my-key".to_owned(),
+///     copy_source: rusoto_s3::util::encode_key("other-buckét/key-to-cöpy"),
+///     ..Default::default()
+/// }).unwrap();
+///
+/// # }
+pub fn encode_key<T: AsRef<str>>(key: T) -> String {
+    signature::encode_uri_path(key.as_ref())
+}


### PR DESCRIPTION
Fixes #630 