### PR TITLE
Speed up AppVeyor: Part Deux

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,6 @@ install:
   - git submodule update --init --recursive
 
 # Equivalent to Travis' `script` phase
-build_script:
-  - cd service_crategen
-  - cargo run -- -c ./services.json -o ../rusoto/services
-  - cd ..
 test_script:
   - cd rusoto
   - cargo test --all --lib -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - cargo -V
   - git submodule update --init --recursive
 
-# Equivalent to Travis' `script` phase
+build: off
 test_script:
   - cd rusoto
   - cargo test --all --lib -v


### PR DESCRIPTION
AppVeyor is still significantly slower than Travis, even after removing the unnecessary build step.

We don't really need to regenerate the crates on AppVeyor as well as Travis -- one should be enough. It may cause inconsistent reporting (e.g. Travis fails, AppVeyor succeeds), but that should be rare and fairly easy to deal with (just check Travis first).

This should save ~8 minutes (~30% of the time) from each AppVeyor build (~4 per job), hopefully bringing it more in line with Travis.

@matthewkmayer There's also an option in AppVeyor apparently called "Rolling Builds" that can only be enabled via the web UI. This would also reduce the queue length when a PR is being worked on, as it cancels builds for previous commit from that PR when a new commit is pushed.