### PR TITLE
PR for Rusoto 0.26.0

### DIFF
--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["AWS", "Amazon"]
 license = "MIT"
 name = "rusoto_mock"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.24.0"
+version = "0.25.0"
 homepage = "https://www.rusoto.org/"
 
 [dependencies]
@@ -23,7 +23,7 @@ optional = true
 version = "0.0"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "> 0.25.0"
 path = "../rusoto/core"
 
 [features]

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "rusoto_core"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [badges]

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_acm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/acm/README.md
+++ b/rusoto/services/acm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_acm` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_acm = "0.25.0"
+rusoto_acm = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_appstream"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/appstream/README.md
+++ b/rusoto/services/appstream/README.md
@@ -23,7 +23,7 @@ To use `rusoto_appstream` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_appstream = "0.25.0"
+rusoto_appstream = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_autoscaling"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/autoscaling/README.md
+++ b/rusoto/services/autoscaling/README.md
@@ -23,7 +23,7 @@ To use `rusoto_autoscaling` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_autoscaling = "0.25.0"
+rusoto_autoscaling = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudformation"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cloudformation/README.md
+++ b/rusoto/services/cloudformation/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudformation` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_cloudformation = "0.25.0"
+rusoto_cloudformation = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudfront"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cloudfront/README.md
+++ b/rusoto/services/cloudfront/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudfront` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_cloudfront = "0.25.0"
+rusoto_cloudfront = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudhsm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cloudhsm/README.md
+++ b/rusoto/services/cloudhsm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudhsm` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_cloudhsm = "0.25.0"
+rusoto_cloudhsm = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudsearch"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cloudsearch/README.md
+++ b/rusoto/services/cloudsearch/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudsearch` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_cloudsearch = "0.25.0"
+rusoto_cloudsearch = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudtrail"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cloudtrail/README.md
+++ b/rusoto/services/cloudtrail/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudtrail` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_cloudtrail = "0.25.0"
+rusoto_cloudtrail = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudwatch"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cloudwatch/README.md
+++ b/rusoto/services/cloudwatch/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudwatch` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_cloudwatch = "0.25.0"
+rusoto_cloudwatch = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codebuild"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/codebuild/README.md
+++ b/rusoto/services/codebuild/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codebuild` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_codebuild = "0.25.0"
+rusoto_codebuild = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codecommit"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/codecommit/README.md
+++ b/rusoto/services/codecommit/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codecommit` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_codecommit = "0.25.0"
+rusoto_codecommit = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codedeploy"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/codedeploy/README.md
+++ b/rusoto/services/codedeploy/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codedeploy` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_codedeploy = "0.25.0"
+rusoto_codedeploy = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codepipeline"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/codepipeline/README.md
+++ b/rusoto/services/codepipeline/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codepipeline` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_codepipeline = "0.25.0"
+rusoto_codepipeline = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cognito_identity"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cognito-identity/README.md
+++ b/rusoto/services/cognito-identity/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cognito_identity` in your application, add it as a dependency in 
 
 ```toml
 [dependencies]
-rusoto_cognito_identity = "0.25.0"
+rusoto_cognito_identity = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cognito_idp"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cognito-idp/README.md
+++ b/rusoto/services/cognito-idp/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cognito_idp` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_cognito_idp = "0.25.0"
+rusoto_cognito_idp = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_config"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/config/README.md
+++ b/rusoto/services/config/README.md
@@ -23,7 +23,7 @@ To use `rusoto_config` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_config = "0.25.0"
+rusoto_config = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cur"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/cur/README.md
+++ b/rusoto/services/cur/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cur` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_cur = "0.25.0"
+rusoto_cur = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_datapipeline"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/datapipeline/README.md
+++ b/rusoto/services/datapipeline/README.md
@@ -23,7 +23,7 @@ To use `rusoto_datapipeline` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_datapipeline = "0.25.0"
+rusoto_datapipeline = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_devicefarm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/devicefarm/README.md
+++ b/rusoto/services/devicefarm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_devicefarm` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_devicefarm = "0.25.0"
+rusoto_devicefarm = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_directconnect"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/directconnect/README.md
+++ b/rusoto/services/directconnect/README.md
@@ -23,7 +23,7 @@ To use `rusoto_directconnect` in your application, add it as a dependency in you
 
 ```toml
 [dependencies]
-rusoto_directconnect = "0.25.0"
+rusoto_directconnect = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_dms"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/dms/README.md
+++ b/rusoto/services/dms/README.md
@@ -23,7 +23,7 @@ To use `rusoto_dms` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_dms = "0.25.0"
+rusoto_dms = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ds"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/ds/README.md
+++ b/rusoto/services/ds/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ds` in your application, add it as a dependency in your `Cargo.to
 
 ```toml
 [dependencies]
-rusoto_ds = "0.25.0"
+rusoto_ds = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_dynamodb"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/dynamodb/README.md
+++ b/rusoto/services/dynamodb/README.md
@@ -23,7 +23,7 @@ To use `rusoto_dynamodb` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_dynamodb = "0.25.0"
+rusoto_dynamodb = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_dynamodbstreams"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/dynamodbstreams/README.md
+++ b/rusoto/services/dynamodbstreams/README.md
@@ -23,7 +23,7 @@ To use `rusoto_dynamodbstreams` in your application, add it as a dependency in y
 
 ```toml
 [dependencies]
-rusoto_dynamodbstreams = "0.25.0"
+rusoto_dynamodbstreams = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ec2"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/ec2/README.md
+++ b/rusoto/services/ec2/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ec2` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ec2 = "0.25.0"
+rusoto_ec2 = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ecr"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/ecr/README.md
+++ b/rusoto/services/ecr/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ecr` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ecr = "0.25.0"
+rusoto_ecr = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ecs"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/ecs/README.md
+++ b/rusoto/services/ecs/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ecs` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ecs = "0.25.0"
+rusoto_ecs = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elasticache"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/elasticache/README.md
+++ b/rusoto/services/elasticache/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elasticache` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_elasticache = "0.25.0"
+rusoto_elasticache = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elasticbeanstalk"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/elasticbeanstalk/README.md
+++ b/rusoto/services/elasticbeanstalk/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elasticbeanstalk` in your application, add it as a dependency in 
 
 ```toml
 [dependencies]
-rusoto_elasticbeanstalk = "0.25.0"
+rusoto_elasticbeanstalk = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elastictranscoder"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -20,7 +20,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/elastictranscoder/README.md
+++ b/rusoto/services/elastictranscoder/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elastictranscoder` in your application, add it as a dependency in
 
 ```toml
 [dependencies]
-rusoto_elastictranscoder = "0.25.0"
+rusoto_elastictranscoder = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elb"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/elb/README.md
+++ b/rusoto/services/elb/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elb` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_elb = "0.25.0"
+rusoto_elb = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elbv2"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/elbv2/README.md
+++ b/rusoto/services/elbv2/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elbv2` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_elbv2 = "0.25.0"
+rusoto_elbv2 = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_emr"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/emr/README.md
+++ b/rusoto/services/emr/README.md
@@ -23,7 +23,7 @@ To use `rusoto_emr` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_emr = "0.25.0"
+rusoto_emr = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_events"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/events/README.md
+++ b/rusoto/services/events/README.md
@@ -23,7 +23,7 @@ To use `rusoto_events` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_events = "0.25.0"
+rusoto_events = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_firehose"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/firehose/README.md
+++ b/rusoto/services/firehose/README.md
@@ -23,7 +23,7 @@ To use `rusoto_firehose` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_firehose = "0.25.0"
+rusoto_firehose = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_gamelift"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/gamelift/README.md
+++ b/rusoto/services/gamelift/README.md
@@ -23,7 +23,7 @@ To use `rusoto_gamelift` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_gamelift = "0.25.0"
+rusoto_gamelift = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_health"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/health/README.md
+++ b/rusoto/services/health/README.md
@@ -23,7 +23,7 @@ To use `rusoto_health` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_health = "0.25.0"
+rusoto_health = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iam"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/iam/README.md
+++ b/rusoto/services/iam/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iam` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_iam = "0.25.0"
+rusoto_iam = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_importexport"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/importexport/README.md
+++ b/rusoto/services/importexport/README.md
@@ -23,7 +23,7 @@ To use `rusoto_importexport` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_importexport = "0.25.0"
+rusoto_importexport = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_inspector"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/inspector/README.md
+++ b/rusoto/services/inspector/README.md
@@ -23,7 +23,7 @@ To use `rusoto_inspector` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_inspector = "0.25.0"
+rusoto_inspector = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iot"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -20,7 +20,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/iot/README.md
+++ b/rusoto/services/iot/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iot` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_iot = "0.25.0"
+rusoto_iot = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kinesis"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/kinesis/README.md
+++ b/rusoto/services/kinesis/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kinesis` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_kinesis = "0.25.0"
+rusoto_kinesis = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kinesisanalytics"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/kinesisanalytics/README.md
+++ b/rusoto/services/kinesisanalytics/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kinesisanalytics` in your application, add it as a dependency in 
 
 ```toml
 [dependencies]
-rusoto_kinesisanalytics = "0.25.0"
+rusoto_kinesisanalytics = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kms"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/kms/README.md
+++ b/rusoto/services/kms/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kms` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_kms = "0.25.0"
+rusoto_kms = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_lambda"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -20,7 +20,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/lambda/README.md
+++ b/rusoto/services/lambda/README.md
@@ -23,7 +23,7 @@ To use `rusoto_lambda` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_lambda = "0.25.0"
+rusoto_lambda = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_lightsail"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/lightsail/README.md
+++ b/rusoto/services/lightsail/README.md
@@ -23,7 +23,7 @@ To use `rusoto_lightsail` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_lightsail = "0.25.0"
+rusoto_lightsail = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_logs"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/logs/README.md
+++ b/rusoto/services/logs/README.md
@@ -23,7 +23,7 @@ To use `rusoto_logs` in your application, add it as a dependency in your `Cargo.
 
 ```toml
 [dependencies]
-rusoto_logs = "0.25.0"
+rusoto_logs = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_machinelearning"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/machinelearning/README.md
+++ b/rusoto/services/machinelearning/README.md
@@ -23,7 +23,7 @@ To use `rusoto_machinelearning` in your application, add it as a dependency in y
 
 ```toml
 [dependencies]
-rusoto_machinelearning = "0.25.0"
+rusoto_machinelearning = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_marketplacecommerceanalytics"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/marketplacecommerceanalytics/README.md
+++ b/rusoto/services/marketplacecommerceanalytics/README.md
@@ -23,7 +23,7 @@ To use `rusoto_marketplacecommerceanalytics` in your application, add it as a de
 
 ```toml
 [dependencies]
-rusoto_marketplacecommerceanalytics = "0.25.0"
+rusoto_marketplacecommerceanalytics = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_meteringmarketplace"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/meteringmarketplace/README.md
+++ b/rusoto/services/meteringmarketplace/README.md
@@ -23,7 +23,7 @@ To use `rusoto_meteringmarketplace` in your application, add it as a dependency 
 
 ```toml
 [dependencies]
-rusoto_meteringmarketplace = "0.25.0"
+rusoto_meteringmarketplace = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_opsworks"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/opsworks/README.md
+++ b/rusoto/services/opsworks/README.md
@@ -23,7 +23,7 @@ To use `rusoto_opsworks` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_opsworks = "0.25.0"
+rusoto_opsworks = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_opsworkscm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/opsworkscm/README.md
+++ b/rusoto/services/opsworkscm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_opsworkscm` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_opsworkscm = "0.25.0"
+rusoto_opsworkscm = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_organizations"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/organizations/README.md
+++ b/rusoto/services/organizations/README.md
@@ -23,7 +23,7 @@ To use `rusoto_organizations` in your application, add it as a dependency in you
 
 ```toml
 [dependencies]
-rusoto_organizations = "0.25.0"
+rusoto_organizations = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_rds"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/rds/README.md
+++ b/rusoto/services/rds/README.md
@@ -23,7 +23,7 @@ To use `rusoto_rds` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_rds = "0.25.0"
+rusoto_rds = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_redshift"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/redshift/README.md
+++ b/rusoto/services/redshift/README.md
@@ -23,7 +23,7 @@ To use `rusoto_redshift` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_redshift = "0.25.0"
+rusoto_redshift = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_rekognition"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/rekognition/README.md
+++ b/rusoto/services/rekognition/README.md
@@ -23,7 +23,7 @@ To use `rusoto_rekognition` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_rekognition = "0.25.0"
+rusoto_rekognition = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_route53"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/route53/README.md
+++ b/rusoto/services/route53/README.md
@@ -23,7 +23,7 @@ To use `rusoto_route53` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_route53 = "0.25.0"
+rusoto_route53 = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_route53domains"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/route53domains/README.md
+++ b/rusoto/services/route53domains/README.md
@@ -23,7 +23,7 @@ To use `rusoto_route53domains` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_route53domains = "0.25.0"
+rusoto_route53domains = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_s3"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ rustc-serialize = "0.3.19"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/s3/README.md
+++ b/rusoto/services/s3/README.md
@@ -23,7 +23,7 @@ To use `rusoto_s3` in your application, add it as a dependency in your `Cargo.to
 
 ```toml
 [dependencies]
-rusoto_s3 = "0.25.0"
+rusoto_s3 = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sdb"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/sdb/README.md
+++ b/rusoto/services/sdb/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sdb` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sdb = "0.25.0"
+rusoto_sdb = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_servicecatalog"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/servicecatalog/README.md
+++ b/rusoto/services/servicecatalog/README.md
@@ -23,7 +23,7 @@ To use `rusoto_servicecatalog` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_servicecatalog = "0.25.0"
+rusoto_servicecatalog = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ses"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/ses/README.md
+++ b/rusoto/services/ses/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ses` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ses = "0.25.0"
+rusoto_ses = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sms"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/sms/README.md
+++ b/rusoto/services/sms/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sms` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sms = "0.25.0"
+rusoto_sms = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_snowball"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/snowball/README.md
+++ b/rusoto/services/snowball/README.md
@@ -23,7 +23,7 @@ To use `rusoto_snowball` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_snowball = "0.25.0"
+rusoto_snowball = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sns"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/sns/README.md
+++ b/rusoto/services/sns/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sns` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sns = "0.25.0"
+rusoto_sns = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sqs"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -17,7 +17,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/sqs/README.md
+++ b/rusoto/services/sqs/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sqs` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sqs = "0.25.0"
+rusoto_sqs = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ssm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/ssm/README.md
+++ b/rusoto/services/ssm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ssm` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ssm = "0.25.0"
+rusoto_ssm = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_stepfunctions"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/stepfunctions/README.md
+++ b/rusoto/services/stepfunctions/README.md
@@ -23,7 +23,7 @@ To use `rusoto_stepfunctions` in your application, add it as a dependency in you
 
 ```toml
 [dependencies]
-rusoto_stepfunctions = "0.25.0"
+rusoto_stepfunctions = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_storagegateway"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/storagegateway/README.md
+++ b/rusoto/services/storagegateway/README.md
@@ -23,7 +23,7 @@ To use `rusoto_storagegateway` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_storagegateway = "0.25.0"
+rusoto_storagegateway = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sts"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -18,7 +18,7 @@ hyper = "0.10.0"
 xml-rs = "0.6"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/sts/README.md
+++ b/rusoto/services/sts/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sts` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sts = "0.25.0"
+rusoto_sts = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_support"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/support/README.md
+++ b/rusoto/services/support/README.md
@@ -23,7 +23,7 @@ To use `rusoto_support` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_support = "0.25.0"
+rusoto_support = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_swf"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/swf/README.md
+++ b/rusoto/services/swf/README.md
@@ -23,7 +23,7 @@ To use `rusoto_swf` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_swf = "0.25.0"
+rusoto_swf = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_waf_regional"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/waf-regional/README.md
+++ b/rusoto/services/waf-regional/README.md
@@ -23,7 +23,7 @@ To use `rusoto_waf_regional` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_waf_regional = "0.25.0"
+rusoto_waf_regional = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_waf"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/waf/README.md
+++ b/rusoto/services/waf/README.md
@@ -23,7 +23,7 @@ To use `rusoto_waf` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_waf = "0.25.0"
+rusoto_waf = "0.26.0"
 ```
 
 ## Contributing

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_workspaces"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.25.0"
+version = "0.26.0"
 homepage = "https://www.rusoto.org/"
 
 [build-dependencies]
@@ -19,7 +19,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.25.0"
+version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
 version = "0.24.0"

--- a/rusoto/services/workspaces/README.md
+++ b/rusoto/services/workspaces/README.md
@@ -23,7 +23,7 @@ To use `rusoto_workspaces` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_workspaces = "0.25.0"
+rusoto_workspaces = "0.26.0"
 ```
 
 ## Contributing

--- a/service_crategen/services.json
+++ b/service_crategen/services.json
@@ -1,355 +1,355 @@
 {
   "acm": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-12-08",
     "baseTypeName": "Acm"
   },
   "appstream": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-12-01",
     "baseTypeName": "AppStream"
   },
   "autoscaling": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2011-01-01",
     "baseTypeName": "Autoscaling"
   },
   "cloudformation": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2010-05-15",
     "baseTypeName": "CloudFormation"
   },
   "cloudfront": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-11-25",
     "baseTypeName": "CloudFront"
   },
   "cloudhsm": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-05-30",
     "baseTypeName": "CloudHsm"
   },
   "cloudsearch": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2013-01-01",
     "baseTypeName": "CloudSearch"
   },
   "cloudtrail": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2013-11-01",
     "baseTypeName": "CloudTrail"
   },
   "cloudwatch": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2010-08-01",
     "baseTypeName": "CloudWatch"
   },
   "codebuild": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-10-06",
     "baseTypeName": "CodeBuild"
   },
   "codecommit": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-04-13",
     "baseTypeName": "CodeCommit"
   },
   "codedeploy": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-10-06",
     "baseTypeName": "CodeDeploy"
   },
   "codepipeline": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-07-09",
     "baseTypeName": "CodePipeline"
   },
   "cognito-identity": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-06-30",
     "baseTypeName": "CognitoIdentity"
   },
   "cognito-idp": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-04-18",
     "baseTypeName": "CognitoIdentityProvider"
   },
   "config": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-11-12",
     "baseTypeName": "ConfigService"
   },
   "cur": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2017-01-06",
     "baseTypeName": "CostAndUsageReport"
   },
   "datapipeline": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-10-29",
     "baseTypeName": "DataPipeline"
   },
   "devicefarm": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-06-23",
     "baseTypeName": "DeviceFarm"
   },
   "directconnect": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-10-25",
     "baseTypeName": "DirectConnect"
   },
   "dms": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-01-01",
     "baseTypeName": "DatabaseMigrationService"
   },
   "ds": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-04-16",
     "baseTypeName": "DirectoryService"
   },
   "dynamodb": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-08-10",
     "baseTypeName": "DynamoDb"
   },
   "dynamodbstreams": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-08-10",
     "baseTypeName": "DynamoDbStreams"
   },
   "ec2": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-11-15",
     "baseTypeName": "Ec2"
   },
   "ecr": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-09-21",
     "baseTypeName": "Ecr"
   },
   "ecs": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-11-13",
     "baseTypeName": "Ecs"
   },
   "elasticache": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-02-02",
     "baseTypeName": "ElastiCache"
   },
   "elasticbeanstalk": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2010-12-01",
     "baseTypeName": "ElasticBeanstalk"
   },
   "elastictranscoder": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-09-25",
     "baseTypeName": "Ets"
   },
   "elb": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-06-01",
     "baseTypeName": "Elb"
   },
   "elbv2": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-12-01",
     "baseTypeName": "Elb"
   },
   "emr": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2009-03-31",
     "baseTypeName": "Emr"
   },
   "events": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-10-07",
     "baseTypeName": "CloudWatchEvents"
   },
   "firehose": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-08-04",
     "baseTypeName": "KinesisFirehose"
   },
   "gamelift": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-10-01",
     "baseTypeName": "GameLift"
   },
   "health": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-08-04",
     "baseTypeName": "AWSHealth"
   },
   "iam": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2010-05-08",
     "baseTypeName": "Iam"
   },
   "importexport": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2010-06-01",
     "baseTypeName": "ImportExport"
   },
   "inspector": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-02-16",
     "baseTypeName": "Inspector"
   },
   "iot": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-05-28",
     "baseTypeName": "Iot"
   },
   "kinesis": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2013-12-02",
     "baseTypeName": "Kinesis"
   },
   "kinesisanalytics": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-08-14",
     "baseTypeName": "KinesisAnalytics"
   },
   "kms": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-11-01",
     "baseTypeName": "Kms"
   },
   "lambda": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-03-31",
     "baseTypeName": "Lambda"
   },
   "lightsail": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "Lightsail"
   },
   "logs": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-03-28",
     "baseTypeName": "CloudWatchLogs"
   },
   "machinelearning": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-12-12",
     "baseTypeName": "MachineLearning"
   },
   "marketplacecommerceanalytics": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-07-01",
     "baseTypeName": "MarketplaceCommerceAnalytics"
   },
   "meteringmarketplace": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-01-14",
     "baseTypeName": "MarketplaceMetering"
   },
   "opsworks": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2013-02-18",
     "baseTypeName": "OpsWorks"
   },
   "opsworkscm": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-11-01",
     "baseTypeName": "OpsWorksCM"
   },
   "organizations": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "Organizations"
   },
   "rds": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-10-31",
     "baseTypeName": "Rds"
   },
   "redshift": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-12-01",
     "baseTypeName": "Redshift"
   },
   "rekognition": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-06-27",
     "baseTypeName": "Rekognition"
   },
   "route53": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2013-04-01",
     "baseTypeName": "Route53"
   },
   "route53domains": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-05-15",
     "baseTypeName": "Route53Domains"
   },
   "s3": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2006-03-01",
     "customDependencies": {
       "md5": "0.3.2",
@@ -358,68 +358,68 @@
     "baseTypeName": "S3"
   },
   "sdb": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2009-04-15",
     "baseTypeName": "SimpleDb"
   },
   "servicecatalog": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-12-10",
     "baseTypeName": "ServiceCatalog"
   },
   "ses": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2010-12-01",
     "baseTypeName": "Ses"
   },
   "sms": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-10-24",
     "baseTypeName": "ServerMigrationService"
   },
   "snowball": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-06-30",
     "baseTypeName": "Snowball"
   },
   "sns": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2010-03-31",
     "baseTypeName": "Sns"
   },
   "sqs": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-11-05",
     "baseTypeName": "Sqs"
   },
   "ssm": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2014-11-06",
     "baseTypeName": "Ssm"
   },
   "stepfunctions": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-11-23",
     "baseTypeName": "StepFunctions"
   },
   "storagegateway": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2013-06-30",
     "baseTypeName": "StorageGateway"
   },
   "sts": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2011-06-15",
     "customDependencies": {
       "chrono": "0.2.25"
@@ -427,32 +427,32 @@
     "baseTypeName": "Sts"
   },
   "support": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2013-04-15",
     "baseTypeName": "AWSSupport"
   },
   "swf": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2012-01-25",
     "baseTypeName": "Swf"
   },
   "waf": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-08-24",
     "baseTypeName": "Waf"
   },
   "waf-regional": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "WAFRegional"
   },
   "workspaces": {
-    "version": "0.25.0",
-    "coreVersion": "0.25.0",
+    "version": "0.26.0",
+    "coreVersion": "0.26.0",
     "protocolVersion": "2015-04-08",
     "baseTypeName": "Workspaces"
   }


### PR DESCRIPTION
I checked the services we changed since the previous release with this command and translated the changes into services.json:

```bash
git diff --name-only HEAD rusoto-v0.25.0 | grep "rusoto/services" | sort
```

We touched every service.  Credentials was untouched so it didn't need to be updated in `rusoto_core`. 😄 

HEAD was tip of `master`, `d5f547b9d`.

This will break on publish without https://github.com/rusoto/rusoto/pull/712 merged first.