### PR TITLE
Eliminate compiler warnings

### DIFF
--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -56,8 +56,8 @@ impl MockRequestDispatcher {
         self
     }
 
-    pub fn with_header<S>(mut self, key: S, value: S) -> MockRequestDispatcher
-        where S: Into<String> {
+    pub fn with_header<S1, S2>(mut self, key: S1, value: S2) -> MockRequestDispatcher
+        where S1: Into<String>, S2: Into<String> {
         self.mock_response.headers.insert(key.into(), value.into());
         self
     }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -56,8 +56,9 @@ impl MockRequestDispatcher {
         self
     }
 
-    pub fn with_header(mut self, key: String, value: String) -> MockRequestDispatcher {
-        self.mock_response.headers.insert(key, value);
+    pub fn with_header<S>(mut self, key: S, value: S) -> MockRequestDispatcher
+        where S: Into<String> {
+        self.mock_response.headers.insert(key.into(), value.into());
         self
     }
 }

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -3196,26 +3196,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Accepted => {
-                Ok(serde_json::from_str::<CancelJobResponse>(String::from_utf8_lossy(&body)
-                                                                 .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<CancelJobResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CancelJobError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(CancelJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3235,26 +3238,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Created => {
-                Ok(serde_json::from_str::<CreateJobResponse>(String::from_utf8_lossy(&body)
-                                                                 .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<CreateJobResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CreateJobError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(CreateJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3276,26 +3282,32 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Created => {
-                Ok(serde_json::from_str::<CreatePipelineResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<CreatePipelineResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CreatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(CreatePipelineError::from_body(String::from_utf8_lossy(&response.body)
+                                                       .as_ref()))
+            }
         }
     }
 
@@ -3317,26 +3329,31 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Created => {
-                Ok(serde_json::from_str::<CreatePresetResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<CreatePresetResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CreatePresetError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(CreatePresetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -3358,26 +3375,32 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Accepted => {
-                Ok(serde_json::from_str::<DeletePipelineResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<DeletePipelineResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(DeletePipelineError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(DeletePipelineError::from_body(String::from_utf8_lossy(&response.body)
+                                                       .as_ref()))
+            }
         }
     }
 
@@ -3399,26 +3422,31 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Accepted => {
-                Ok(serde_json::from_str::<DeletePresetResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<DeletePresetResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(DeletePresetError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(DeletePresetError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -3447,24 +3475,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListJobsByPipelineResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(ListJobsByPipelineError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListJobsByPipelineResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(ListJobsByPipelineError::from_body(String::from_utf8_lossy(&response.body)
+                                                           .as_ref()))
+            }
         }
     }
 
@@ -3492,26 +3525,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListJobsByStatusResponse>(String::from_utf8_lossy(&body)
-                                                                        .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListJobsByStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListJobsByStatusError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(ListJobsByStatusError::from_body(String::from_utf8_lossy(&response.body)
+                                                         .as_ref()))
+            }
         }
     }
 
@@ -3539,26 +3575,31 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListPipelinesResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListPipelinesResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListPipelinesError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(ListPipelinesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -3586,26 +3627,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListPresetsResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListPresetsResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListPresetsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(ListPresetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3624,25 +3668,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ReadJobResponse>(String::from_utf8_lossy(&body).as_ref())
-                       .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ReadJobResponse>(String::from_utf8_lossy(&body)
+                                                                .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ReadJobError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(ReadJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3663,26 +3711,31 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ReadPipelineResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ReadPipelineResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ReadPipelineError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(ReadPipelineError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -3703,26 +3756,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ReadPresetResponse>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ReadPresetResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ReadPresetError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(ReadPresetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3742,26 +3798,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<TestRoleResponse>(String::from_utf8_lossy(&body)
-                                                                .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<TestRoleResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(TestRoleError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(TestRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3782,26 +3841,32 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<UpdatePipelineResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<UpdatePipelineResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(UpdatePipelineError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(UpdatePipelineError::from_body(String::from_utf8_lossy(&response.body)
+                                                       .as_ref()))
+            }
         }
     }
 
@@ -3824,27 +3889,26 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdatePipelineNotificationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => {
-                Err(UpdatePipelineNotificationsError::from_body(String::from_utf8_lossy(&body)
-                                                                    .as_ref()))
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<UpdatePipelineNotificationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
+            _ => Err(UpdatePipelineNotificationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3867,24 +3931,29 @@ impl<P, D> Ets for EtsClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<UpdatePipelineStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(UpdatePipelineStatusError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<UpdatePipelineStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(UpdatePipelineStatusError::from_body(String::from_utf8_lossy(&response.body)
+                                                             .as_ref()))
+            }
         }
     }
 }

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -3194,9 +3194,9 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -3209,10 +3209,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<CancelJobResponse>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<CancelJobResponse>(&body).unwrap();
 
 
 
@@ -3236,9 +3233,9 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
@@ -3251,10 +3248,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<CreateJobResponse>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<CreateJobResponse>(&body).unwrap();
 
 
 
@@ -3280,9 +3274,9 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
@@ -3295,10 +3289,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<CreatePipelineResponse>(String::from_utf8_lossy(&body)
-                                                                       .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<CreatePipelineResponse>(&body).unwrap();
 
 
 
@@ -3327,9 +3318,9 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
@@ -3342,10 +3333,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<CreatePresetResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<CreatePresetResponse>(&body).unwrap();
 
 
 
@@ -3373,9 +3361,9 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -3388,10 +3376,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<DeletePipelineResponse>(String::from_utf8_lossy(&body)
-                                                                       .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<DeletePipelineResponse>(&body).unwrap();
 
 
 
@@ -3420,9 +3405,9 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -3435,10 +3420,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<DeletePresetResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<DeletePresetResponse>(&body).unwrap();
 
 
 
@@ -3473,9 +3455,9 @@ impl<P, D> Ets for EtsClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3488,7 +3470,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListJobsByPipelineResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListJobsByPipelineResponse>(&body).unwrap();
 
 
 
@@ -3523,9 +3505,9 @@ impl<P, D> Ets for EtsClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3538,7 +3520,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListJobsByStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListJobsByStatusResponse>(&body).unwrap();
 
 
 
@@ -3573,9 +3555,9 @@ impl<P, D> Ets for EtsClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3588,10 +3570,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListPipelinesResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListPipelinesResponse>(&body).unwrap();
 
 
 
@@ -3625,9 +3604,9 @@ impl<P, D> Ets for EtsClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3640,10 +3619,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListPresetsResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListPresetsResponse>(&body).unwrap();
 
 
 
@@ -3666,9 +3642,9 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3681,10 +3657,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ReadJobResponse>(String::from_utf8_lossy(&body)
-                                                                .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ReadJobResponse>(&body).unwrap();
 
 
 
@@ -3709,9 +3682,9 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3724,10 +3697,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ReadPipelineResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ReadPipelineResponse>(&body).unwrap();
 
 
 
@@ -3754,9 +3724,9 @@ impl<P, D> Ets for EtsClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3769,10 +3739,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ReadPresetResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ReadPresetResponse>(&body).unwrap();
 
 
 
@@ -3796,9 +3763,9 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3811,10 +3778,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<TestRoleResponse>(String::from_utf8_lossy(&body)
-                                                                 .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<TestRoleResponse>(&body).unwrap();
 
 
 
@@ -3839,9 +3803,9 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3854,10 +3818,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<UpdatePipelineResponse>(String::from_utf8_lossy(&body)
-                                                                       .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<UpdatePipelineResponse>(&body).unwrap();
 
 
 
@@ -3887,9 +3848,9 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3902,7 +3863,8 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<UpdatePipelineNotificationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<UpdatePipelineNotificationsResponse>(&body)
+                    .unwrap();
 
 
 
@@ -3929,9 +3891,9 @@ impl<P, D> Ets for EtsClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -3944,7 +3906,7 @@ impl<P, D> Ets for EtsClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<UpdatePipelineStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<UpdatePipelineStatusResponse>(&body).unwrap();
 
 
 

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -8242,9 +8242,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8273,9 +8273,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8308,9 +8308,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8323,7 +8323,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<AttachThingPrincipalResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<AttachThingPrincipalResponse>(&body).unwrap();
 
 
 
@@ -8352,9 +8352,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8387,9 +8387,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8402,7 +8402,8 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<CreateCertificateFromCsrResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<CreateCertificateFromCsrResponse>(&body)
+                    .unwrap();
 
 
 
@@ -8432,9 +8433,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8447,7 +8448,8 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<CreateKeysAndCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<CreateKeysAndCertificateResponse>(&body)
+                    .unwrap();
 
 
 
@@ -8472,9 +8474,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8487,10 +8489,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<CreatePolicyResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<CreatePolicyResponse>(&body).unwrap();
 
 
 
@@ -8522,9 +8521,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8537,7 +8536,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<CreatePolicyVersionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<CreatePolicyVersionResponse>(&body).unwrap();
 
 
 
@@ -8565,9 +8564,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8580,10 +8579,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<CreateThingResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<CreateThingResponse>(&body).unwrap();
 
 
 
@@ -8609,9 +8605,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8624,10 +8620,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<CreateThingTypeResponse>(String::from_utf8_lossy(&body)
-                                                                        .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<CreateThingTypeResponse>(&body).unwrap();
 
 
 
@@ -8655,9 +8648,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8689,9 +8682,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8704,7 +8697,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<DeleteCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<DeleteCACertificateResponse>(&body).unwrap();
 
 
 
@@ -8733,9 +8726,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8764,9 +8757,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8798,9 +8791,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8831,9 +8824,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8846,7 +8839,8 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<DeleteRegistrationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<DeleteRegistrationCodeResponse>(&body)
+                    .unwrap();
 
 
 
@@ -8878,9 +8872,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8893,10 +8887,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<DeleteThingResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<DeleteThingResponse>(&body).unwrap();
 
 
 
@@ -8922,9 +8913,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -8937,10 +8928,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<DeleteThingTypeResponse>(String::from_utf8_lossy(&body)
-                                                                        .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<DeleteThingTypeResponse>(&body).unwrap();
 
 
 
@@ -8968,9 +8956,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9002,9 +8990,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9017,7 +9005,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<DeprecateThingTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<DeprecateThingTypeResponse>(&body).unwrap();
 
 
 
@@ -9047,9 +9035,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9062,7 +9050,8 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<DescribeCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<DescribeCACertificateResponse>(&body)
+                    .unwrap();
 
 
 
@@ -9091,9 +9080,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9106,7 +9095,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<DescribeCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<DescribeCertificateResponse>(&body).unwrap();
 
 
 
@@ -9132,9 +9121,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9147,7 +9136,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<DescribeEndpointResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<DescribeEndpointResponse>(&body).unwrap();
 
 
 
@@ -9175,9 +9164,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9190,10 +9179,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<DescribeThingResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<DescribeThingResponse>(&body).unwrap();
 
 
 
@@ -9221,9 +9207,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9236,7 +9222,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<DescribeThingTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<DescribeThingTypeResponse>(&body).unwrap();
 
 
 
@@ -9265,9 +9251,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9300,9 +9286,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9315,7 +9301,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<DetachThingPrincipalResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<DetachThingPrincipalResponse>(&body).unwrap();
 
 
 
@@ -9343,9 +9329,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9376,9 +9362,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9407,9 +9393,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9422,7 +9408,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<GetLoggingOptionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<GetLoggingOptionsResponse>(&body).unwrap();
 
 
 
@@ -9448,9 +9434,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9463,10 +9449,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<GetPolicyResponse>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<GetPolicyResponse>(&body).unwrap();
 
 
 
@@ -9493,9 +9476,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9508,7 +9491,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<GetPolicyVersionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<GetPolicyVersionResponse>(&body).unwrap();
 
 
 
@@ -9535,9 +9518,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9550,7 +9533,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<GetRegistrationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<GetRegistrationCodeResponse>(&body).unwrap();
 
 
 
@@ -9578,9 +9561,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9593,10 +9576,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<GetTopicRuleResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<GetTopicRuleResponse>(&body).unwrap();
 
 
 
@@ -9633,9 +9613,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9648,7 +9628,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListCACertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListCACertificatesResponse>(&body).unwrap();
 
 
 
@@ -9686,9 +9666,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9701,7 +9681,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListCertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListCertificatesResponse>(&body).unwrap();
 
 
 
@@ -9741,9 +9721,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9756,7 +9736,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListCertificatesByCAResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListCertificatesByCAResponse>(&body).unwrap();
 
 
 
@@ -9795,9 +9775,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9810,7 +9790,8 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListOutgoingCertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListOutgoingCertificatesResponse>(&body)
+                    .unwrap();
 
 
 
@@ -9845,9 +9826,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9860,10 +9841,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListPoliciesResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListPoliciesResponse>(&body).unwrap();
 
 
 
@@ -9901,9 +9879,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9916,7 +9894,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListPolicyPrincipalsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListPolicyPrincipalsResponse>(&body).unwrap();
 
 
 
@@ -9945,9 +9923,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -9960,7 +9938,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListPolicyVersionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListPolicyVersionsResponse>(&body).unwrap();
 
 
 
@@ -9999,9 +9977,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10014,7 +9992,8 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListPrincipalPoliciesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListPrincipalPoliciesResponse>(&body)
+                    .unwrap();
 
 
 
@@ -10049,9 +10028,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10064,7 +10043,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListPrincipalThingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListPrincipalThingsResponse>(&body).unwrap();
 
 
 
@@ -10093,9 +10072,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10108,7 +10087,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListThingPrincipalsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListThingPrincipalsResponse>(&body).unwrap();
 
 
 
@@ -10146,9 +10125,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10161,10 +10140,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListThingTypesResponse>(String::from_utf8_lossy(&body)
-                                                                       .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListThingTypesResponse>(&body).unwrap();
 
 
 
@@ -10208,9 +10184,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10223,10 +10199,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListThingsResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListThingsResponse>(&body).unwrap();
 
 
 
@@ -10264,9 +10237,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10279,10 +10252,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListTopicRulesResponse>(String::from_utf8_lossy(&body)
-                                                                       .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListTopicRulesResponse>(&body).unwrap();
 
 
 
@@ -10318,9 +10288,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10333,7 +10303,8 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<RegisterCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<RegisterCACertificateResponse>(&body)
+                    .unwrap();
 
 
 
@@ -10361,9 +10332,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10376,7 +10347,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<RegisterCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<RegisterCertificateResponse>(&body).unwrap();
 
 
 
@@ -10405,9 +10376,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10435,9 +10406,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10470,9 +10441,9 @@ impl<P, D> Iot for IotClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10500,9 +10471,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10536,9 +10507,9 @@ impl<P, D> Iot for IotClient<P, D>
         params.put("targetAwsAccount", &input.target_aws_account);
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10551,7 +10522,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<TransferCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<TransferCertificateResponse>(&body).unwrap();
 
 
 
@@ -10587,9 +10558,9 @@ impl<P, D> Iot for IotClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10623,9 +10594,9 @@ impl<P, D> Iot for IotClient<P, D>
         params.put("newStatus", &input.new_status);
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10656,9 +10627,9 @@ impl<P, D> Iot for IotClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -10671,10 +10642,7 @@ impl<P, D> Iot for IotClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<UpdateThingResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<UpdateThingResponse>(&body).unwrap();
 
 
 

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -8244,25 +8244,16 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => {
-                Err(AcceptCertificateTransferError::from_body(String::from_utf8_lossy(&body)
-                                                                  .as_ref()))
+                Ok(result)
             }
+            _ => Err(AcceptCertificateTransferError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -8284,23 +8275,18 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
+                Ok(result)
+            }
             _ => {
-                Err(AttachPrincipalPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+                Err(AttachPrincipalPolicyError::from_body(String::from_utf8_lossy(&response.body)
+                                                              .as_ref()))
             }
         }
     }
@@ -8324,24 +8310,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<AttachThingPrincipalResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(AttachThingPrincipalError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<AttachThingPrincipalResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(AttachThingPrincipalError::from_body(String::from_utf8_lossy(&response.body)
+                                                             .as_ref()))
+            }
         }
     }
 
@@ -8363,25 +8354,16 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => {
-                Err(CancelCertificateTransferError::from_body(String::from_utf8_lossy(&body)
-                                                                  .as_ref()))
+                Ok(result)
             }
+            _ => Err(CancelCertificateTransferError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -8407,27 +8389,26 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateCertificateFromCsrResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => {
-                Err(CreateCertificateFromCsrError::from_body(String::from_utf8_lossy(&body)
-                                                                 .as_ref()))
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<CreateCertificateFromCsrResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
+            _ => Err(CreateCertificateFromCsrError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -8453,27 +8434,26 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreateKeysAndCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => {
-                Err(CreateKeysAndCertificateError::from_body(String::from_utf8_lossy(&body)
-                                                                 .as_ref()))
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<CreateKeysAndCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
+            _ => Err(CreateKeysAndCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -8494,26 +8474,31 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<CreatePolicyResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<CreatePolicyResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CreatePolicyError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(CreatePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -8539,24 +8524,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<CreatePolicyVersionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(CreatePolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<CreatePolicyVersionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(CreatePolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -8577,26 +8567,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<CreateThingResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<CreateThingResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CreateThingError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(CreateThingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -8618,26 +8611,32 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<CreateThingTypeResponse>(String::from_utf8_lossy(&body)
-                                                                       .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<CreateThingTypeResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CreateThingTypeError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(CreateThingTypeError::from_body(String::from_utf8_lossy(&response.body)
+                                                        .as_ref()))
+            }
         }
     }
 
@@ -8658,22 +8657,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(CreateTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(CreateTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
+                                                        .as_ref()))
+            }
         }
     }
 
@@ -8695,24 +8691,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(DeleteCACertificateError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<DeleteCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(DeleteCACertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -8734,22 +8735,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                          .as_ref()))
+            }
         }
     }
 
@@ -8768,22 +8766,18 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(DeletePolicyError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(DeletePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -8806,22 +8800,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(DeletePolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(DeletePolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -8842,25 +8833,28 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeleteRegistrationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<DeleteRegistrationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
             _ => {
-                Err(DeleteRegistrationCodeError::from_body(String::from_utf8_lossy(&body).as_ref()))
+                Err(DeleteRegistrationCodeError::from_body(String::from_utf8_lossy(&response.body)
+                                                               .as_ref()))
             }
         }
     }
@@ -8886,26 +8880,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DeleteThingResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<DeleteThingResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(DeleteThingError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(DeleteThingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -8927,26 +8924,32 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DeleteThingTypeResponse>(String::from_utf8_lossy(&body)
-                                                                       .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<DeleteThingTypeResponse>(String::from_utf8_lossy(&body)
+                                                                        .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(DeleteThingTypeError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(DeleteThingTypeError::from_body(String::from_utf8_lossy(&response.body)
+                                                        .as_ref()))
+            }
         }
     }
 
@@ -8967,22 +8970,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(DeleteTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(DeleteTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
+                                                        .as_ref()))
+            }
         }
     }
 
@@ -9004,24 +9004,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DeprecateThingTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(DeprecateThingTypeError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<DeprecateThingTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(DeprecateThingTypeError::from_body(String::from_utf8_lossy(&response.body)
+                                                           .as_ref()))
+            }
         }
     }
 
@@ -9044,25 +9049,28 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<DescribeCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
             _ => {
-                Err(DescribeCACertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
+                Err(DescribeCACertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                              .as_ref()))
             }
         }
     }
@@ -9085,24 +9093,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeCertificateError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<DescribeCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(DescribeCertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -9121,26 +9134,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DescribeEndpointResponse>(String::from_utf8_lossy(&body)
-                                                                        .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<DescribeEndpointResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(DescribeEndpointError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(DescribeEndpointError::from_body(String::from_utf8_lossy(&response.body)
+                                                         .as_ref()))
+            }
         }
     }
 
@@ -9161,26 +9177,31 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<DescribeThingResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<DescribeThingResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(DescribeThingError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(DescribeThingError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -9202,24 +9223,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DescribeThingTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(DescribeThingTypeError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<DescribeThingTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(DescribeThingTypeError::from_body(String::from_utf8_lossy(&response.body)
+                                                          .as_ref()))
+            }
         }
     }
 
@@ -9241,23 +9267,18 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
+                Ok(result)
+            }
             _ => {
-                Err(DetachPrincipalPolicyError::from_body(String::from_utf8_lossy(&body).as_ref()))
+                Err(DetachPrincipalPolicyError::from_body(String::from_utf8_lossy(&response.body)
+                                                              .as_ref()))
             }
         }
     }
@@ -9281,24 +9302,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<DetachThingPrincipalResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(DetachThingPrincipalError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<DetachThingPrincipalResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(DetachThingPrincipalError::from_body(String::from_utf8_lossy(&response.body)
+                                                             .as_ref()))
+            }
         }
     }
 
@@ -9319,22 +9345,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(DisableTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(DisableTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
+                                                         .as_ref()))
+            }
         }
     }
 
@@ -9355,22 +9378,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(EnableTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(EnableTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
+                                                        .as_ref()))
+            }
         }
     }
 
@@ -9389,24 +9409,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetLoggingOptionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(GetLoggingOptionsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<GetLoggingOptionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(GetLoggingOptionsError::from_body(String::from_utf8_lossy(&response.body)
+                                                          .as_ref()))
+            }
         }
     }
 
@@ -9425,26 +9450,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetPolicyResponse>(String::from_utf8_lossy(&body)
-                                                                 .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<GetPolicyResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(GetPolicyError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(GetPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -9467,26 +9495,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetPolicyVersionResponse>(String::from_utf8_lossy(&body)
-                                                                        .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<GetPolicyVersionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(GetPolicyVersionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(GetPolicyVersionError::from_body(String::from_utf8_lossy(&response.body)
+                                                         .as_ref()))
+            }
         }
     }
 
@@ -9506,24 +9537,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetRegistrationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(GetRegistrationCodeError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<GetRegistrationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(GetRegistrationCodeError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -9544,26 +9580,31 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetTopicRuleResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<GetTopicRuleResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(GetTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(GetTopicRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -9594,24 +9635,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListCACertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(ListCACertificatesError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListCACertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(ListCACertificatesError::from_body(String::from_utf8_lossy(&response.body)
+                                                           .as_ref()))
+            }
         }
     }
 
@@ -9642,26 +9688,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListCertificatesResponse>(String::from_utf8_lossy(&body)
-                                                                        .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListCertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListCertificatesError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(ListCertificatesError::from_body(String::from_utf8_lossy(&response.body)
+                                                         .as_ref()))
+            }
         }
     }
 
@@ -9694,24 +9743,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListCertificatesByCAResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(ListCertificatesByCAError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListCertificatesByCAResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(ListCertificatesByCAError::from_body(String::from_utf8_lossy(&response.body)
+                                                             .as_ref()))
+            }
         }
     }
 
@@ -9743,27 +9797,26 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListOutgoingCertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => {
-                Err(ListOutgoingCertificatesError::from_body(String::from_utf8_lossy(&body)
-                                                                 .as_ref()))
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListOutgoingCertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
+            _ => Err(ListOutgoingCertificatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -9794,26 +9847,31 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListPoliciesResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListPoliciesResponse>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(ListPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -9845,24 +9903,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPolicyPrincipalsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(ListPolicyPrincipalsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListPolicyPrincipalsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(ListPolicyPrincipalsError::from_body(String::from_utf8_lossy(&response.body)
+                                                             .as_ref()))
+            }
         }
     }
 
@@ -9884,24 +9947,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPolicyVersionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(ListPolicyVersionsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListPolicyVersionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(ListPolicyVersionsError::from_body(String::from_utf8_lossy(&response.body)
+                                                           .as_ref()))
+            }
         }
     }
 
@@ -9933,25 +10001,28 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPrincipalPoliciesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListPrincipalPoliciesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
             _ => {
-                Err(ListPrincipalPoliciesError::from_body(String::from_utf8_lossy(&body).as_ref()))
+                Err(ListPrincipalPoliciesError::from_body(String::from_utf8_lossy(&response.body)
+                                                              .as_ref()))
             }
         }
     }
@@ -9980,24 +10051,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListPrincipalThingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(ListPrincipalThingsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListPrincipalThingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(ListPrincipalThingsError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -10019,24 +10095,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListThingPrincipalsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(ListThingPrincipalsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListThingPrincipalsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(ListThingPrincipalsError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -10067,26 +10148,32 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListThingTypesResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListThingTypesResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListThingTypesError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(ListThingTypesError::from_body(String::from_utf8_lossy(&response.body)
+                                                       .as_ref()))
+            }
         }
     }
 
@@ -10123,26 +10210,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListThingsResponse>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListThingsResponse>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListThingsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(ListThingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -10176,26 +10266,32 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListTopicRulesResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListTopicRulesResponse>(String::from_utf8_lossy(&body)
+                                                                       .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListTopicRulesError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(ListTopicRulesError::from_body(String::from_utf8_lossy(&response.body)
+                                                       .as_ref()))
+            }
         }
     }
 
@@ -10224,25 +10320,28 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<RegisterCACertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
             _ => {
-                Err(RegisterCACertificateError::from_body(String::from_utf8_lossy(&body).as_ref()))
+                Err(RegisterCACertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                              .as_ref()))
             }
         }
     }
@@ -10264,24 +10363,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<RegisterCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(RegisterCertificateError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<RegisterCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(RegisterCertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -10303,25 +10407,16 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => {
-                Err(RejectCertificateTransferError::from_body(String::from_utf8_lossy(&body)
-                                                                  .as_ref()))
+                Ok(result)
             }
+            _ => Err(RejectCertificateTransferError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -10342,22 +10437,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(ReplaceTopicRuleError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(ReplaceTopicRuleError::from_body(String::from_utf8_lossy(&response.body)
+                                                         .as_ref()))
+            }
         }
     }
 
@@ -10380,25 +10472,16 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => {
-                Err(SetDefaultPolicyVersionError::from_body(String::from_utf8_lossy(&body)
-                                                                .as_ref()))
+                Ok(result)
             }
+            _ => Err(SetDefaultPolicyVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -10419,22 +10502,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(SetLoggingOptionsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(SetLoggingOptionsError::from_body(String::from_utf8_lossy(&response.body)
+                                                          .as_ref()))
+            }
         }
     }
 
@@ -10458,24 +10538,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<TransferCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(TransferCertificateError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<TransferCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(TransferCertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -10504,22 +10589,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(UpdateCACertificateError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(UpdateCACertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                            .as_ref()))
+            }
         }
     }
 
@@ -10543,22 +10625,19 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::Ok => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::Ok => Ok(()),
-            _ => Err(UpdateCertificateError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(UpdateCertificateError::from_body(String::from_utf8_lossy(&response.body)
+                                                          .as_ref()))
+            }
         }
     }
 
@@ -10579,26 +10658,29 @@ impl<P, D> Iot for IotClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<UpdateThingResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<UpdateThingResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(UpdateThingError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(UpdateThingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 }

--- a/rusoto/services/lambda/src/custom/custom_tests.rs
+++ b/rusoto/services/lambda/src/custom/custom_tests.rs
@@ -1,0 +1,30 @@
+extern crate rusoto_mock;
+
+use ::{Lambda, LambdaClient, InvocationRequest};
+
+use rusoto_core::Region;
+use self::rusoto_mock::*;
+
+/// Ensures that rest-json codegen handles the response body,
+/// headers, and status code properly
+#[test]
+fn should_parse_invocation_response() {
+    let mock = MockRequestDispatcher::with_status(200)
+        .with_body(r#"{"arbitrary":"json"}"#)
+        .with_header("X-Amz-Function-Error", "Handled")
+        .with_header("X-Amz-Log-Result", "foo bar baz");
+
+    let request = InvocationRequest {
+        function_name: "foo".to_owned(),
+        ..Default::default()
+    };
+
+    let client = LambdaClient::new(mock, MockCredentialsProvider, Region::UsEast1);
+    let result = client.invoke(&request).unwrap();
+
+    assert_eq!(Some(r#"{"arbitrary":"json"}"#.to_owned().into_bytes()), result.payload);
+    assert_eq!(Some("foo bar baz".to_owned()), result.log_result);
+    assert_eq!(Some("Handled".to_owned()), result.function_error);
+    assert_eq!(Some(200), result.status_code);
+
+}

--- a/rusoto/services/lambda/src/custom/mod.rs
+++ b/rusoto/services/lambda/src/custom/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod custom_tests;

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -581,27 +581,15 @@ pub struct InvocationRequest {
 }
 
 #[doc="<p>Upon success, returns an empty response. Otherwise, throws an exception.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone)]
 pub struct InvocationResponse {
     #[doc="<p>Indicates whether an error occurred while executing the Lambda function. If an error occurred this field will have one of two values; <code>Handled</code> or <code>Unhandled</code>. <code>Handled</code> errors are errors that are reported by the function while the <code>Unhandled</code> errors are those detected and reported by AWS Lambda. Unhandled errors include out of memory errors and function timeouts. For information about how to report an <code>Handled</code> error, see <a href=\"http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html\">Programming Model</a>. </p>"]
-    #[serde(rename="FunctionError")]
-    #[serde(skip_serializing_if="Option::is_none")]
     pub function_error: Option<String>,
     #[doc="<p> It is the base64-encoded logs for the Lambda function invocation. This is present only if the invocation type is <code>RequestResponse</code> and the logs were requested. </p>"]
-    #[serde(rename="LogResult")]
-    #[serde(skip_serializing_if="Option::is_none")]
     pub log_result: Option<String>,
     #[doc="<p> It is the JSON representation of the object returned by the Lambda function. This is present only if the invocation type is <code>RequestResponse</code>. </p> <p>In the event of a function error this field contains a message describing the error. For the <code>Handled</code> errors the Lambda function will report this message. For <code>Unhandled</code> errors AWS Lambda reports the message. </p>"]
-    #[serde(rename="Payload")]
-    #[serde(
-                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
-                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
-                            default,
-                        )]
     pub payload: Option<Blob>,
     #[doc="<p>The HTTP status code will be in the 200 range for successful request. For the <code>RequestResonse</code> invocation type this status code will be 200. For the <code>Event</code> invocation type this status code will be 202. For the <code>DryRun</code> invocation type the status code will be 204. </p>"]
-    #[serde(rename="StatusCode")]
-    #[serde(skip_serializing_if="Option::is_none")]
     pub status_code: Option<Integer>,
 }
 

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -3869,9 +3869,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
@@ -3884,10 +3884,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<AddPermissionResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<AddPermissionResponse>(&body).unwrap();
 
 
 
@@ -3915,9 +3912,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
@@ -3930,10 +3927,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<AliasConfiguration>(&body).unwrap();
 
 
 
@@ -3959,9 +3953,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -3974,7 +3968,8 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<EventSourceMappingConfiguration>(&body)
+                    .unwrap();
 
 
 
@@ -3999,9 +3994,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
@@ -4014,10 +4009,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<FunctionConfiguration>(&body).unwrap();
 
 
 
@@ -4045,9 +4037,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4077,9 +4069,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -4092,7 +4084,8 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<EventSourceMappingConfiguration>(&body)
+                    .unwrap();
 
 
 
@@ -4120,9 +4113,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4151,9 +4144,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4166,7 +4159,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<GetAccountSettingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<GetAccountSettingsResponse>(&body).unwrap();
 
 
 
@@ -4194,9 +4187,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4209,10 +4202,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<AliasConfiguration>(&body).unwrap();
 
 
 
@@ -4239,9 +4229,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4254,7 +4244,8 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<EventSourceMappingConfiguration>(&body)
+                    .unwrap();
 
 
 
@@ -4287,9 +4278,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4302,10 +4293,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<GetFunctionResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<GetFunctionResponse>(&body).unwrap();
 
 
 
@@ -4336,9 +4324,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4351,10 +4339,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<FunctionConfiguration>(&body).unwrap();
 
 
 
@@ -4382,9 +4367,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4397,10 +4382,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<GetPolicyResponse>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<GetPolicyResponse>(&body).unwrap();
 
 
 
@@ -4428,9 +4410,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4469,9 +4451,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -4484,10 +4466,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let mut result =
-                    serde_json::from_str::<InvokeAsyncResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                            .unwrap();
+                let mut result = serde_json::from_slice::<InvokeAsyncResponse>(&body).unwrap();
 
 
                 result.status = Some(StatusCode::to_u16(&response.status) as i64);
@@ -4523,9 +4502,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4538,10 +4517,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListAliasesResponse>(String::from_utf8_lossy(&body)
-                                                                    .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListAliasesResponse>(&body).unwrap();
 
 
 
@@ -4580,9 +4556,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4595,7 +4571,8 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListEventSourceMappingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListEventSourceMappingsResponse>(&body)
+                    .unwrap();
 
 
 
@@ -4627,9 +4604,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4642,10 +4619,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListFunctionsResponse>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListFunctionsResponse>(&body).unwrap();
 
 
 
@@ -4670,9 +4644,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4685,10 +4659,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<ListTagsResponse>(String::from_utf8_lossy(&body)
-                                                                 .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<ListTagsResponse>(&body).unwrap();
 
 
 
@@ -4722,9 +4693,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4737,7 +4708,8 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<ListVersionsByFunctionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<ListVersionsByFunctionResponse>(&body)
+                    .unwrap();
 
 
 
@@ -4766,9 +4738,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Created => {
@@ -4781,10 +4753,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<FunctionConfiguration>(&body).unwrap();
 
 
 
@@ -4818,9 +4787,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4849,9 +4818,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4881,9 +4850,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         }
         request.set_params(params);
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::NoContent => {
@@ -4915,9 +4884,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -4930,10 +4899,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<AliasConfiguration>(&body).unwrap();
 
 
 
@@ -4960,9 +4926,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Accepted => {
@@ -4975,7 +4941,8 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let  result = serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+                let result = serde_json::from_slice::<EventSourceMappingConfiguration>(&body)
+                    .unwrap();
 
 
 
@@ -5001,9 +4968,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -5016,10 +4983,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<FunctionConfiguration>(&body).unwrap();
 
 
 
@@ -5049,9 +5013,9 @@ impl<P, D> Lambda for LambdaClient<P, D>
         request.set_payload(Some(encoded.into_bytes()));
 
 
-        request.sign(&try!(self.credentials_provider.credentials()));
+        request.sign(&self.credentials_provider.credentials()?);
 
-        let response = try!(self.dispatcher.dispatch(&request));
+        let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
             StatusCode::Ok => {
@@ -5064,10 +5028,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
                 debug!("Response body: {:?}", body);
                 debug!("Response status: {}", response.status);
-                let result =
-                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                      .as_ref())
-                            .unwrap();
+                let result = serde_json::from_slice::<FunctionConfiguration>(&body).unwrap();
 
 
 

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -3871,26 +3871,31 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Created => {
-                Ok(serde_json::from_str::<AddPermissionResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<AddPermissionResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(AddPermissionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(AddPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -3912,26 +3917,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Created => {
-                Ok(serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3953,27 +3961,26 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Accepted => {
-                            Ok(serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => {
-                Err(CreateEventSourceMappingError::from_body(String::from_utf8_lossy(&body)
-                                                                 .as_ref()))
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
+            _ => Err(CreateEventSourceMappingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -3994,26 +4001,32 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Created => {
-                Ok(serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(CreateFunctionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(CreateFunctionError::from_body(String::from_utf8_lossy(&response.body)
+                                                       .as_ref()))
+            }
         }
     }
 
@@ -4034,22 +4047,16 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::NoContent => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::NoContent => Ok(()),
-            _ => Err(DeleteAliasError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => Err(DeleteAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4072,27 +4079,26 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Accepted => {
-                            Ok(serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => {
-                Err(DeleteEventSourceMappingError::from_body(String::from_utf8_lossy(&body)
-                                                                 .as_ref()))
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
+            _ => Err(DeleteEventSourceMappingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4116,22 +4122,19 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::NoContent => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::NoContent => Ok(()),
-            _ => Err(DeleteFunctionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(DeleteFunctionError::from_body(String::from_utf8_lossy(&response.body)
+                                                       .as_ref()))
+            }
         }
     }
 
@@ -4150,24 +4153,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<GetAccountSettingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => Err(GetAccountSettingsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<GetAccountSettingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
+            _ => {
+                Err(GetAccountSettingsError::from_body(String::from_utf8_lossy(&response.body)
+                                                           .as_ref()))
+            }
         }
     }
 
@@ -4188,26 +4196,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(GetAliasError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(GetAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4230,25 +4241,28 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
             _ => {
-                Err(GetEventSourceMappingError::from_body(String::from_utf8_lossy(&body).as_ref()))
+                Err(GetEventSourceMappingError::from_body(String::from_utf8_lossy(&response.body)
+                                                              .as_ref()))
             }
         }
     }
@@ -4275,26 +4289,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetFunctionResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<GetFunctionResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(GetFunctionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(GetFunctionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4321,29 +4338,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => {
-                Err(GetFunctionConfigurationError::from_body(String::from_utf8_lossy(&body)
-                                                                 .as_ref()))
-            }
+            _ => Err(GetFunctionConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4367,26 +4384,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<GetPolicyResponse>(String::from_utf8_lossy(&body)
-                                                                 .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<GetPolicyResponse>(String::from_utf8_lossy(&body)
+                                                                  .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(GetPolicyError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(GetPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4410,26 +4430,26 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<InvocationResponse>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                           .unwrap())
+
+                let mut result = InvocationResponse::default();
+                result.payload = Some(response.body);
+
+                if let Some(function_error) = response.headers.get("X-Amz-Function-Error") {
+                    let value = function_error.to_owned();
+                    result.function_error = Some(value)
+                };
+                if let Some(log_result) = response.headers.get("X-Amz-Log-Result") {
+                    let value = log_result.to_owned();
+                    result.log_result = Some(value)
+                };
+                result.status_code = Some(StatusCode::to_u16(&response.status) as i64);
+                Ok(result)
             }
-            _ => Err(InvokeError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(InvokeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4451,26 +4471,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Accepted => {
-                Ok(serde_json::from_str::<InvokeAsyncResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let mut result =
+                    serde_json::from_str::<InvokeAsyncResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                            .unwrap();
+
+
+                result.status = Some(StatusCode::to_u16(&response.status) as i64);
+                Ok(result)
             }
-            _ => Err(InvokeAsyncError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(InvokeAsyncError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4502,26 +4525,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListAliasesResponse>(String::from_utf8_lossy(&body)
-                                                                   .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListAliasesResponse>(String::from_utf8_lossy(&body)
+                                                                    .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListAliasesError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(ListAliasesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4556,27 +4582,26 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListEventSourceMappingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => {
-                Err(ListEventSourceMappingsError::from_body(String::from_utf8_lossy(&body)
-                                                                .as_ref()))
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListEventSourceMappingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
+            _ => Err(ListEventSourceMappingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4604,26 +4629,31 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListFunctionsResponse>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListFunctionsResponse>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListFunctionsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(ListFunctionsError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -4642,26 +4672,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<ListTagsResponse>(String::from_utf8_lossy(&body)
-                                                                .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<ListTagsResponse>(String::from_utf8_lossy(&body)
+                                                                 .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(ListTagsError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(ListTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4691,25 +4724,28 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                            Ok(serde_json::from_str::<ListVersionsByFunctionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<ListVersionsByFunctionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
+            }
             _ => {
-                Err(ListVersionsByFunctionError::from_body(String::from_utf8_lossy(&body).as_ref()))
+                Err(ListVersionsByFunctionError::from_body(String::from_utf8_lossy(&response.body)
+                                                               .as_ref()))
             }
         }
     }
@@ -4732,26 +4768,32 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Created => {
-                Ok(serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(PublishVersionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(PublishVersionError::from_body(String::from_utf8_lossy(&response.body)
+                                                       .as_ref()))
+            }
         }
     }
 
@@ -4778,22 +4820,19 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::NoContent => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::NoContent => Ok(()),
-            _ => Err(RemovePermissionError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(RemovePermissionError::from_body(String::from_utf8_lossy(&response.body)
+                                                         .as_ref()))
+            }
         }
     }
 
@@ -4812,22 +4851,16 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::NoContent => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::NoContent => Ok(()),
-            _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4850,22 +4883,18 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
+        match response.status {
+            StatusCode::NoContent => {
+                let result = ();
 
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
 
-        match result.status {
-            StatusCode::NoContent => Ok(()),
-            _ => Err(UntagResourceError::from_body(String::from_utf8_lossy(&body).as_ref())),
+                Ok(result)
+            }
+            _ => {
+                Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
+            }
         }
     }
 
@@ -4888,26 +4917,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
-                                                                  .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<AliasConfiguration>(String::from_utf8_lossy(&body)
+                                                                   .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(UpdateAliasError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => Err(UpdateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4930,27 +4962,26 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Accepted => {
-                            Ok(serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap())
-                        }
-            _ => {
-                Err(UpdateEventSourceMappingError::from_body(String::from_utf8_lossy(&body)
-                                                                 .as_ref()))
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let  result = serde_json::from_str::<EventSourceMappingConfiguration>(String::from_utf8_lossy(&body).as_ref()).unwrap();
+
+
+
+                Ok(result)
             }
+            _ => Err(UpdateEventSourceMappingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 
@@ -4972,26 +5003,32 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => Err(UpdateFunctionCodeError::from_body(String::from_utf8_lossy(&body).as_ref())),
+            _ => {
+                Err(UpdateFunctionCodeError::from_body(String::from_utf8_lossy(&response.body)
+                                                           .as_ref()))
+            }
         }
     }
 
@@ -5014,29 +5051,29 @@ impl<P, D> Lambda for LambdaClient<P, D>
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
-        let result = try!(self.dispatcher.dispatch(&request));
-        let mut body = result.body;
+        let response = try!(self.dispatcher.dispatch(&request));
 
-        // `serde-json` serializes field-less structs as "null", but AWS returns
-        // "{}" for a field-less response, so we must check for this result
-        // and convert it if necessary.
-        if body == b"{}" {
-            body = b"null".to_vec();
-        }
-
-        debug!("Response body: {:?}", body);
-        debug!("Response status: {}", result.status);
-
-        match result.status {
+        match response.status {
             StatusCode::Ok => {
-                Ok(serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
-                                                                     .as_ref())
-                           .unwrap())
+
+                let mut body = response.body;
+
+                if body == b"{}" {
+                    body = b"null".to_vec();
+                }
+
+                debug!("Response body: {:?}", body);
+                debug!("Response status: {}", response.status);
+                let result =
+                    serde_json::from_str::<FunctionConfiguration>(String::from_utf8_lossy(&body)
+                                                                      .as_ref())
+                            .unwrap();
+
+
+
+                Ok(result)
             }
-            _ => {
-                Err(UpdateFunctionConfigurationError::from_body(String::from_utf8_lossy(&body)
-                                                                    .as_ref()))
-            }
+            _ => Err(UpdateFunctionConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
 }

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Marketplace Commerce Analytics @ 2015-07-01"
 documentation = "https://rusoto.github.io/rusoto/rusoto_core/index.html"
-keywords = ["AWS", "Amazon", "marketplacecommerceanalytics"]
+keywords = ["AWS", "Amazon", "marketplacecommercea"]
 license = "MIT"
 name = "rusoto_marketplacecommerceanalytics"
 readme = "README.md"

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -856,20 +856,6 @@ impl AnalyticsS3ExportFileFormatSerializer {
 }
 
 pub type Body = Vec<u8>;
-struct BodyDeserializer;
-impl BodyDeserializer {
-    #[allow(unused_variables)]
-    fn deserialize<'a, T: Peek + Next>(tag_name: &str,
-                                       stack: &mut T)
-                                       -> Result<Body, XmlParseError> {
-        try!(start_element(tag_name, stack));
-        let obj = try!(characters(stack)).into_bytes();
-        try!(end_element(tag_name, stack));
-
-        Ok(obj)
-
-    }
-}
 
 pub struct BodySerializer;
 impl BodySerializer {
@@ -4355,47 +4341,6 @@ pub struct GetObjectOutput {
     pub website_redirect_location: Option<WebsiteRedirectLocation>,
 }
 
-struct GetObjectOutputDeserializer;
-impl GetObjectOutputDeserializer {
-    #[allow(unused_variables)]
-    fn deserialize<'a, T: Peek + Next>(tag_name: &str,
-                                       stack: &mut T)
-                                       -> Result<GetObjectOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
-        let mut obj = GetObjectOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    match &name[..] {
-                        "Body" => {
-                            obj.body = Some(try!(BodyDeserializer::deserialize("Body", stack)));
-                        }
-                        _ => skip_tree(stack),
-                    }
-                }
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
-
-        Ok(obj)
-
-    }
-}
 #[derive(Default,Clone,Debug)]
 pub struct GetObjectRequest {
     pub bucket: BucketName,
@@ -4495,47 +4440,6 @@ pub struct GetObjectTorrentOutput {
     pub request_charged: Option<RequestCharged>,
 }
 
-struct GetObjectTorrentOutputDeserializer;
-impl GetObjectTorrentOutputDeserializer {
-    #[allow(unused_variables)]
-    fn deserialize<'a, T: Peek + Next>(tag_name: &str,
-                                       stack: &mut T)
-                                       -> Result<GetObjectTorrentOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
-        let mut obj = GetObjectTorrentOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    match &name[..] {
-                        "Body" => {
-                            obj.body = Some(try!(BodyDeserializer::deserialize("Body", stack)));
-                        }
-                        _ => skip_tree(stack),
-                    }
-                }
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
-
-        Ok(obj)
-
-    }
-}
 #[derive(Default,Clone,Debug)]
 pub struct GetObjectTorrentRequest {
     pub bucket: BucketName,

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -1442,8 +1442,7 @@ pub trait ServerMigrationService {
 
 
     #[doc="The DeleteServerCatalog API clears all servers from your server catalog. This means that these servers will no longer be accessible to the Server Migration Service."]
-    fn delete_server_catalog(&self,
-                             input: &DeleteServerCatalogRequest)
+    fn delete_server_catalog(&self)
                              -> Result<DeleteServerCatalogResponse, DeleteServerCatalogError>;
 
 
@@ -1479,8 +1478,7 @@ pub trait ServerMigrationService {
 
 
     #[doc="The ImportServerCatalog API is used to gather the complete list of on-premises servers on your premises. This API call requires connectors to be installed and monitoring all servers you would like imported. This API call returns immediately, but may take some time to retrieve all of the servers."]
-    fn import_server_catalog(&self,
-                             input: &ImportServerCatalogRequest)
+    fn import_server_catalog(&self)
                              -> Result<ImportServerCatalogResponse, ImportServerCatalogError>;
 
 
@@ -1583,16 +1581,14 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
 
     #[doc="The DeleteServerCatalog API clears all servers from your server catalog. This means that these servers will no longer be accessible to the Server Migration Service."]
-    fn delete_server_catalog(&self,
-                             input: &DeleteServerCatalogRequest)
+    fn delete_server_catalog(&self)
                              -> Result<DeleteServerCatalogResponse, DeleteServerCatalogError> {
         let mut request = SignedRequest::new("POST", "sms", self.region, "/");
 
         request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target",
                            "AWSServerMigrationService_V2016_10_24.DeleteServerCatalog");
-        let encoded = serde_json::to_string(input).unwrap();
-        request.set_payload(Some(encoded.into_bytes()));
+        request.set_payload(Some(b"{}".to_vec()));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -1748,16 +1744,14 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
 
 
     #[doc="The ImportServerCatalog API is used to gather the complete list of on-premises servers on your premises. This API call requires connectors to be installed and monitoring all servers you would like imported. This API call returns immediately, but may take some time to retrieve all of the servers."]
-    fn import_server_catalog(&self,
-                             input: &ImportServerCatalogRequest)
+    fn import_server_catalog(&self)
                              -> Result<ImportServerCatalogResponse, ImportServerCatalogError> {
         let mut request = SignedRequest::new("POST", "sms", self.region, "/");
 
         request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target",
                            "AWSServerMigrationService_V2016_10_24.ImportServerCatalog");
-        let encoded = serde_json::to_string(input).unwrap();
-        request.set_payload(Some(encoded.into_bytes()));
+        request.set_payload(Some(b"{}".to_vec()));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 

--- a/service_crategen/src/codegen/generator/rest_response_parser.rs
+++ b/service_crategen/src/codegen/generator/rest_response_parser.rs
@@ -3,6 +3,10 @@ use inflector::Inflector;
 use ::Service;
 use codegen::botocore::{Operation, Shape, ShapeType, Member};
 
+// Rest Response Parser
+//
+// Used by rest-json and rest-xml protocol codegen to generate
+// code to parse headers from the http response.
 pub fn generate_response_headers_parser(service: &Service,
                                         operation: &Operation)
                                         -> Option<String> {

--- a/service_crategen/src/codegen/generator/type_filter.rs
+++ b/service_crategen/src/codegen/generator/type_filter.rs
@@ -63,6 +63,7 @@ fn can_skip_deserializer(service: &Service, output_shape: &Shape) -> bool {
 
             let has_streaming_payload = payload_shape.shape_type == ShapeType::Blob ||
                                         payload_shape.shape_type == ShapeType::String;
+
             let mut has_other_members = false;
 
             for member in output_shape.members.as_ref().unwrap().values() {


### PR DESCRIPTION
Our build was spitting out some warnings about unused code.  This PR makes our `type_filter` a little smarter about what types don't need deserializers generated, and the warnings go away.

It's branched off of #717 so that one will need to go first.