### PR TITLE
Fix rusoto_mock dependency version

### DIFF
--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -23,5 +23,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -23,5 +23,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -23,5 +23,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -22,5 +22,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -20,5 +20,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -21,5 +21,5 @@ xml-rs = "0.6"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0.1"
 version = "0.26.0"
 path = "../../core"
 [dev-dependencies.rusoto_mock]
-version = "0.24.0"
+version = "0.25.0"
 path = "../../../mock"

--- a/service_crategen/src/main.rs
+++ b/service_crategen/src/main.rs
@@ -124,7 +124,7 @@ fn main() {
             dev_dependencies: vec![
                 ("rusoto_mock".to_owned(), cargo::Dependency::Extended {
                     path: Some("../../../mock".into()),
-                    version: Some("0.24.0".into()),
+                    version: Some("0.25.0".into()),
                     optional: None,
                     default_features: None,
                     features: None


### PR DESCRIPTION
Our build is broken since the publication of the 0.26.0 release.  All the generated service crates reference `rusoto_mock` version `0.24.0` via a local path in the filesystem with syntax that prevents them from using the `0.25.0` version of `rusoto_mock` that actually exists in the filesystem when you clone the repository.

This PR updates `service_crategen` to generate `Cargo.toml` files for the generated services with that version bumped to `0.25.0`, and fixes the build.

There shouldn't be any need to re-publish to crates.io since the published version of `rusoto_mock` is still `0.24.0`, and the dependency that this PR fixes is a dev dependency.