### PR TITLE
Fix cfg macro use for SMS integration test.

### DIFF
--- a/integration_tests/tests/sms.rs
+++ b/integration_tests/tests/sms.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "sms")]
+#![cfg(feature = "sms")]
 
 extern crate rusoto_core;
 extern crate rusoto_sms;


### PR DESCRIPTION
Little typo when SMS was added.  Before this PR:

```bash
$ cargo test --features sqs
   Compiling rusoto_tests v0.25.0 (file:///Users/matthew/Documents/rusoto/integration_tests)
error[E0463]: can't find crate for `rusoto_sms`
 --> tests/sms.rs:4:1
  |
4 | extern crate rusoto_sms;
  | ^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate
```

Afterwards it works as expected. 😁 