### PR TITLE
Build integration tests as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,11 @@ script:
         cd .. )
   - echo "Running Rusoto tests" && cargo update && cargo test --lib --all -v
   - |
+      echo "Building integration tests" &&
+      ( cd integration_tests && \
+        cargo test --features "all" --no-run && \
+        cd .. )
+  - |
       echo "Running cargo docs on stable Rust on Linux" &&
       if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         cargo doc --all --no-deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,9 @@ build: off
 test_script:
   - cargo update
   - cargo test --all --lib -v
+  - ( cd integration_tests && \
+      cargo test --features "all" --no-run && \
+      cd .. )
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,9 +27,9 @@ build: off
 test_script:
   - cargo update
   - cargo test --all --lib -v
-  - ( cd integration_tests && \
-      cargo test --features "all" --no-run && \
-      cd .. )
+  - cd integration_tests
+  - cargo test --features "all" --no-run
+  - cd ..
 
 branches:
   only:


### PR DESCRIPTION
This builds, but does not run, the integration tests as part of the CI. Since most of the errors seen with integration tests are build-related, this should hopefully catch those issues before they hit master.