### PR TITLE
Remove travis-cargo from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 sudo: required
 dist: trusty
-# necessary for `travis-cargo coveralls --no-sudo`
-addons:
-  apt:
-    packages:
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
-      - binutils-dev # optional: only required for the --verify flag of coveralls
 language: rust
 # cache dependencies: https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
 cache: cargo
@@ -22,17 +14,6 @@ os:
 cache:
   directories:
     - $HOME/.cargo
-before_script:
-  # load travis-cargo
-  - |
-      pip install 'travis-cargo<0.2' --user &&
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        export PATH=$HOME/.local/bin/:$PATH
-      else
-        export PATH=$HOME/Library/Python/2.7/bin:$PATH
-      fi
-
-# the main build
 script:
   - |
       echo "Generating service crates..." &&
@@ -54,14 +35,6 @@ after_success:
         && sudo pip install ghp-import && ghp-import -n target/doc \
         && git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages \
         && cd ..
-      fi
-  # measure code coverage and upload to coveralls.io (the verify argument
-  # mitigates kcov crashes due to malformed debuginfo, at the cost of some
-  # speed. <https://github.com/huonw/travis-cargo/issues/12>)
-  # Don't run on OSX.
-  - |
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        travis-cargo coveralls --no-sudo --verify -- --lib
       fi
 env:
   global:


### PR DESCRIPTION
`travis-cargo` is only used in the coveralls upload currently, which to my knowledge is not actually being used, as that step was also being removed as part of the original [adding of JSON services PR](https://github.com/rusoto/rusoto/pull/576/files#diff-354f30a63fb0907d4ad57269548329e3).

Hopefully removing these dependencies can speed up the CI a little bit. 😄 