### PR TITLE
Generate enums

### DIFF
--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -125,6 +121,56 @@ pub struct CertificateDetail {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CertificateStatus {
+    Expired,
+    Failed,
+    Inactive,
+    Issued,
+    PendingValidation,
+    Revoked,
+    ValidationTimedOut,
+}
+
+impl Into<String> for CertificateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CertificateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CertificateStatus::Expired => "EXPIRED",
+            CertificateStatus::Failed => "FAILED",
+            CertificateStatus::Inactive => "INACTIVE",
+            CertificateStatus::Issued => "ISSUED",
+            CertificateStatus::PendingValidation => "PENDING_VALIDATION",
+            CertificateStatus::Revoked => "REVOKED",
+            CertificateStatus::ValidationTimedOut => "VALIDATION_TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CertificateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EXPIRED" => Ok(CertificateStatus::Expired),
+            "FAILED" => Ok(CertificateStatus::Failed),
+            "INACTIVE" => Ok(CertificateStatus::Inactive),
+            "ISSUED" => Ok(CertificateStatus::Issued),
+            "PENDING_VALIDATION" => Ok(CertificateStatus::PendingValidation),
+            "REVOKED" => Ok(CertificateStatus::Revoked),
+            "VALIDATION_TIMED_OUT" => Ok(CertificateStatus::ValidationTimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>This structure is returned in the response object of <a>ListCertificates</a> action.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CertificateSummary {
@@ -136,6 +182,41 @@ pub struct CertificateSummary {
     #[serde(rename="DomainName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub domain_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CertificateType {
+    AmazonIssued,
+    Imported,
+}
+
+impl Into<String> for CertificateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CertificateType {
+    fn into(self) -> &'static str {
+        match self {
+            CertificateType::AmazonIssued => "AMAZON_ISSUED",
+            CertificateType::Imported => "IMPORTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CertificateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AMAZON_ISSUED" => Ok(CertificateType::AmazonIssued),
+            "IMPORTED" => Ok(CertificateType::Imported),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -158,6 +239,44 @@ pub struct DescribeCertificateResponse {
     #[serde(rename="Certificate")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub certificate: Option<CertificateDetail>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainStatus {
+    Failed,
+    PendingValidation,
+    Success,
+}
+
+impl Into<String> for DomainStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DomainStatus::Failed => "FAILED",
+            DomainStatus::PendingValidation => "PENDING_VALIDATION",
+            DomainStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(DomainStatus::Failed),
+            "PENDING_VALIDATION" => Ok(DomainStatus::PendingValidation),
+            "SUCCESS" => Ok(DomainStatus::Success),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains information about the validation of each domain name in the certificate.</p>"]
@@ -189,6 +308,50 @@ pub struct DomainValidationOption {
     #[doc="<p>The domain name that you want ACM to use to send you validation emails. This domain name is the suffix of the email addresses that you want ACM to use. This must be the same as the <code>DomainName</code> value or a superdomain of the <code>DomainName</code> value. For example, if you request a certificate for <code>testing.example.com</code>, you can specify <code>example.com</code> for this value. In that case, ACM sends domain validation emails to the following five addresses:</p> <ul> <li> <p>admin@example.com</p> </li> <li> <p>administrator@example.com</p> </li> <li> <p>hostmaster@example.com</p> </li> <li> <p>postmaster@example.com</p> </li> <li> <p>webmaster@example.com</p> </li> </ul>"]
     #[serde(rename="ValidationDomain")]
     pub validation_domain: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailureReason {
+    AdditionalVerificationRequired,
+    DomainNotAllowed,
+    InvalidPublicDomain,
+    NoAvailableContacts,
+    Other,
+}
+
+impl Into<String> for FailureReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailureReason {
+    fn into(self) -> &'static str {
+        match self {
+            FailureReason::AdditionalVerificationRequired => "ADDITIONAL_VERIFICATION_REQUIRED",
+            FailureReason::DomainNotAllowed => "DOMAIN_NOT_ALLOWED",
+            FailureReason::InvalidPublicDomain => "INVALID_PUBLIC_DOMAIN",
+            FailureReason::NoAvailableContacts => "NO_AVAILABLE_CONTACTS",
+            FailureReason::Other => "OTHER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailureReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADDITIONAL_VERIFICATION_REQUIRED" => Ok(FailureReason::AdditionalVerificationRequired),
+            "DOMAIN_NOT_ALLOWED" => Ok(FailureReason::DomainNotAllowed),
+            "INVALID_PUBLIC_DOMAIN" => Ok(FailureReason::InvalidPublicDomain),
+            "NO_AVAILABLE_CONTACTS" => Ok(FailureReason::NoAvailableContacts),
+            "OTHER" => Ok(FailureReason::Other),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -250,6 +413,44 @@ pub struct ImportCertificateResponse {
     pub certificate_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyAlgorithm {
+    EcPrime256V1,
+    Rsa1024,
+    Rsa2048,
+}
+
+impl Into<String> for KeyAlgorithm {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyAlgorithm {
+    fn into(self) -> &'static str {
+        match self {
+            KeyAlgorithm::EcPrime256V1 => "EC_prime256v1",
+            KeyAlgorithm::Rsa1024 => "RSA_1024",
+            KeyAlgorithm::Rsa2048 => "RSA_2048",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyAlgorithm {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EC_prime256v1" => Ok(KeyAlgorithm::EcPrime256V1),
+            "RSA_1024" => Ok(KeyAlgorithm::Rsa1024),
+            "RSA_2048" => Ok(KeyAlgorithm::Rsa2048),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListCertificatesRequest {
     #[doc="<p>The status or statuses on which to filter the list of ACM Certificates.</p>"]
@@ -303,6 +504,47 @@ pub struct RemoveTagsFromCertificateRequest {
     pub tags: Vec<Tag>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RenewalStatus {
+    Failed,
+    PendingAutoRenewal,
+    PendingValidation,
+    Success,
+}
+
+impl Into<String> for RenewalStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RenewalStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RenewalStatus::Failed => "FAILED",
+            RenewalStatus::PendingAutoRenewal => "PENDING_AUTO_RENEWAL",
+            RenewalStatus::PendingValidation => "PENDING_VALIDATION",
+            RenewalStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RenewalStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(RenewalStatus::Failed),
+            "PENDING_AUTO_RENEWAL" => Ok(RenewalStatus::PendingAutoRenewal),
+            "PENDING_VALIDATION" => Ok(RenewalStatus::PendingValidation),
+            "SUCCESS" => Ok(RenewalStatus::Success),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about the status of ACM's <a href=\"http://docs.aws.amazon.com/acm/latest/userguide/acm-renewal.html\">managed renewal</a> for the certificate. This structure exists only when the certificate type is <code>AMAZON_ISSUED</code>.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RenewalSummary {
@@ -352,6 +594,65 @@ pub struct ResendValidationEmailRequest {
     #[doc="<p>The base validation domain that will act as the suffix of the email addresses that are used to send the emails. This must be the same as the <code>Domain</code> value or a superdomain of the <code>Domain</code> value. For example, if you requested a certificate for <code>site.subdomain.example.com</code> and specify a <b>ValidationDomain</b> of <code>subdomain.example.com</code>, ACM sends email to the domain registrant, technical contact, and administrative contact in WHOIS and the following five addresses:</p> <ul> <li> <p>admin@subdomain.example.com</p> </li> <li> <p>administrator@subdomain.example.com</p> </li> <li> <p>hostmaster@subdomain.example.com</p> </li> <li> <p>postmaster@subdomain.example.com</p> </li> <li> <p>webmaster@subdomain.example.com</p> </li> </ul>"]
     #[serde(rename="ValidationDomain")]
     pub validation_domain: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RevocationReason {
+    AffiliationChanged,
+    AACompromise,
+    CaCompromise,
+    CertificateHold,
+    CessationOfOperation,
+    KeyCompromise,
+    PrivilegeWithdrawn,
+    RemoveFromCrl,
+    Superceded,
+    Unspecified,
+}
+
+impl Into<String> for RevocationReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RevocationReason {
+    fn into(self) -> &'static str {
+        match self {
+            RevocationReason::AffiliationChanged => "AFFILIATION_CHANGED",
+            RevocationReason::AACompromise => "A_A_COMPROMISE",
+            RevocationReason::CaCompromise => "CA_COMPROMISE",
+            RevocationReason::CertificateHold => "CERTIFICATE_HOLD",
+            RevocationReason::CessationOfOperation => "CESSATION_OF_OPERATION",
+            RevocationReason::KeyCompromise => "KEY_COMPROMISE",
+            RevocationReason::PrivilegeWithdrawn => "PRIVILEGE_WITHDRAWN",
+            RevocationReason::RemoveFromCrl => "REMOVE_FROM_CRL",
+            RevocationReason::Superceded => "SUPERCEDED",
+            RevocationReason::Unspecified => "UNSPECIFIED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RevocationReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AFFILIATION_CHANGED" => Ok(RevocationReason::AffiliationChanged),
+            "A_A_COMPROMISE" => Ok(RevocationReason::AACompromise),
+            "CA_COMPROMISE" => Ok(RevocationReason::CaCompromise),
+            "CERTIFICATE_HOLD" => Ok(RevocationReason::CertificateHold),
+            "CESSATION_OF_OPERATION" => Ok(RevocationReason::CessationOfOperation),
+            "KEY_COMPROMISE" => Ok(RevocationReason::KeyCompromise),
+            "PRIVILEGE_WITHDRAWN" => Ok(RevocationReason::PrivilegeWithdrawn),
+            "REMOVE_FROM_CRL" => Ok(RevocationReason::RemoveFromCrl),
+            "SUPERCEDED" => Ok(RevocationReason::Superceded),
+            "UNSPECIFIED" => Ok(RevocationReason::Unspecified),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A key-value pair that identifies or specifies metadata about an ACM resource.</p>"]
@@ -1311,7 +1612,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AddTagsToCertificateError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -1336,7 +1637,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteCertificateError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -1361,7 +1662,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1388,7 +1689,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1415,7 +1716,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ImportCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1442,7 +1743,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListCertificatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1470,7 +1771,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1498,7 +1799,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RemoveTagsFromCertificateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -1520,7 +1821,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RequestCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1547,7 +1848,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(ResendValidationEmailError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -118,6 +114,38 @@ pub struct ApiKeys {
     pub warnings: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApiKeysFormat {
+    Csv,
+}
+
+impl Into<String> for ApiKeysFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApiKeysFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ApiKeysFormat::Csv => "csv",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApiKeysFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "csv" => Ok(ApiKeysFormat::Csv),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>API stage name of the associated API stage in a usage plan.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApiStage {
@@ -176,6 +204,41 @@ pub struct Authorizer {
     pub type_: Option<String>,
 }
 
+#[doc="<p>The authorizer type. the current value is <code>TOKEN</code> for a Lambda function or <code>COGNITO_USER_POOLS</code> for an Amazon Cognito Your User Pool.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthorizerType {
+    CognitoUserPools,
+    Token,
+}
+
+impl Into<String> for AuthorizerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthorizerType {
+    fn into(self) -> &'static str {
+        match self {
+            AuthorizerType::CognitoUserPools => "COGNITO_USER_POOLS",
+            AuthorizerType::Token => "TOKEN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthorizerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COGNITO_USER_POOLS" => Ok(AuthorizerType::CognitoUserPools),
+            "TOKEN" => Ok(AuthorizerType::Token),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a collection of <a>Authorizer</a> resources.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html\">Enable custom authorization</a> </div>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Authorizers {
@@ -217,6 +280,103 @@ pub struct BasePathMappings {
     pub position: Option<String>,
 }
 
+#[doc="<p>Returns the size of the <b>CacheCluster</b>.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CacheClusterSize {
+    _0_5,
+    _1_6,
+    _118,
+    _13_5,
+    _237,
+    _28_4,
+    _58_2,
+    _6_1,
+}
+
+impl Into<String> for CacheClusterSize {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CacheClusterSize {
+    fn into(self) -> &'static str {
+        match self {
+            CacheClusterSize::_0_5 => "0.5",
+            CacheClusterSize::_1_6 => "1.6",
+            CacheClusterSize::_118 => "118",
+            CacheClusterSize::_13_5 => "13.5",
+            CacheClusterSize::_237 => "237",
+            CacheClusterSize::_28_4 => "28.4",
+            CacheClusterSize::_58_2 => "58.2",
+            CacheClusterSize::_6_1 => "6.1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CacheClusterSize {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "0.5" => Ok(CacheClusterSize::_0_5),
+            "1.6" => Ok(CacheClusterSize::_1_6),
+            "118" => Ok(CacheClusterSize::_118),
+            "13.5" => Ok(CacheClusterSize::_13_5),
+            "237" => Ok(CacheClusterSize::_237),
+            "28.4" => Ok(CacheClusterSize::_28_4),
+            "58.2" => Ok(CacheClusterSize::_58_2),
+            "6.1" => Ok(CacheClusterSize::_6_1),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>Returns the status of the <b>CacheCluster</b>.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CacheClusterStatus {
+    Available,
+    CreateInProgress,
+    DeleteInProgress,
+    FlushInProgress,
+    NotAvailable,
+}
+
+impl Into<String> for CacheClusterStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CacheClusterStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CacheClusterStatus::Available => "AVAILABLE",
+            CacheClusterStatus::CreateInProgress => "CREATE_IN_PROGRESS",
+            CacheClusterStatus::DeleteInProgress => "DELETE_IN_PROGRESS",
+            CacheClusterStatus::FlushInProgress => "FLUSH_IN_PROGRESS",
+            CacheClusterStatus::NotAvailable => "NOT_AVAILABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CacheClusterStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(CacheClusterStatus::Available),
+            "CREATE_IN_PROGRESS" => Ok(CacheClusterStatus::CreateInProgress),
+            "DELETE_IN_PROGRESS" => Ok(CacheClusterStatus::DeleteInProgress),
+            "FLUSH_IN_PROGRESS" => Ok(CacheClusterStatus::FlushInProgress),
+            "NOT_AVAILABLE" => Ok(CacheClusterStatus::NotAvailable),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a client certificate used to configure client-side SSL authentication while sending requests to the integration endpoint.</p> <div class=\"remarks\">Client certificates are used authenticate an API by the back-end server. To authenticate an API client (or user), use a custom <a>Authorizer</a>.</div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html\">Use Client-Side Certificate</a> </div>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ClientCertificate {
@@ -252,6 +412,41 @@ pub struct ClientCertificates {
     #[serde(rename="position")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub position: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContentHandlingStrategy {
+    ConvertToBinary,
+    ConvertToText,
+}
+
+impl Into<String> for ContentHandlingStrategy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContentHandlingStrategy {
+    fn into(self) -> &'static str {
+        match self {
+            ContentHandlingStrategy::ConvertToBinary => "CONVERT_TO_BINARY",
+            ContentHandlingStrategy::ConvertToText => "CONVERT_TO_TEXT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContentHandlingStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONVERT_TO_BINARY" => Ok(ContentHandlingStrategy::ConvertToBinary),
+            "CONVERT_TO_TEXT" => Ok(ContentHandlingStrategy::ConvertToText),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Request to create an <a>ApiKey</a> resource.</p>"]
@@ -891,6 +1086,71 @@ pub struct DocumentationPartLocation {
     #[doc="<p>The type of API entity to which the documentation content applies. It is a valid and required field for API entity types of <code>API</code>, <code>AUTHORIZER</code>, <code>MODEL</code>, <code>RESOURCE</code>, <code>METHOD</code>, <code>PATH_PARAMETER</code>, <code>QUERY_PARAMETER</code>, <code>REQUEST_HEADER</code>, <code>REQUEST_BODY</code>, <code>RESPONSE</code>, <code>RESPONSE_HEADER</code>, and <code>RESPONSE_BODY</code>. Content inheritance does not apply to any entity of the <code>API</code>, <code>AUTHROZER</code>, <code>METHOD</code>, <code>MODEL</code>, <code>REQUEST_BODY</code>, or <code>RESOURCE</code> type.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentationPartType {
+    Api,
+    Authorizer,
+    Method,
+    Model,
+    PathParameter,
+    QueryParameter,
+    RequestBody,
+    RequestHeader,
+    Resource,
+    Response,
+    ResponseBody,
+    ResponseHeader,
+}
+
+impl Into<String> for DocumentationPartType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentationPartType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentationPartType::Api => "API",
+            DocumentationPartType::Authorizer => "AUTHORIZER",
+            DocumentationPartType::Method => "METHOD",
+            DocumentationPartType::Model => "MODEL",
+            DocumentationPartType::PathParameter => "PATH_PARAMETER",
+            DocumentationPartType::QueryParameter => "QUERY_PARAMETER",
+            DocumentationPartType::RequestBody => "REQUEST_BODY",
+            DocumentationPartType::RequestHeader => "REQUEST_HEADER",
+            DocumentationPartType::Resource => "RESOURCE",
+            DocumentationPartType::Response => "RESPONSE",
+            DocumentationPartType::ResponseBody => "RESPONSE_BODY",
+            DocumentationPartType::ResponseHeader => "RESPONSE_HEADER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentationPartType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "API" => Ok(DocumentationPartType::Api),
+            "AUTHORIZER" => Ok(DocumentationPartType::Authorizer),
+            "METHOD" => Ok(DocumentationPartType::Method),
+            "MODEL" => Ok(DocumentationPartType::Model),
+            "PATH_PARAMETER" => Ok(DocumentationPartType::PathParameter),
+            "QUERY_PARAMETER" => Ok(DocumentationPartType::QueryParameter),
+            "REQUEST_BODY" => Ok(DocumentationPartType::RequestBody),
+            "REQUEST_HEADER" => Ok(DocumentationPartType::RequestHeader),
+            "RESOURCE" => Ok(DocumentationPartType::Resource),
+            "RESPONSE" => Ok(DocumentationPartType::Response),
+            "RESPONSE_BODY" => Ok(DocumentationPartType::ResponseBody),
+            "RESPONSE_HEADER" => Ok(DocumentationPartType::ResponseHeader),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The collection of documentation parts of an API.</p> <div class=\"remarks\"/> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html\">Documenting an API</a>, <a>DocumentationPart</a> </div>"]
@@ -1739,6 +1999,50 @@ pub struct IntegrationResponse {
     pub status_code: Option<String>,
 }
 
+#[doc="<p>The integration type. The valid value is <code>HTTP</code> for integrating with an HTTP back end, <code>AWS</code> for any AWS service endpoints, <code>MOCK</code> for testing without actually invoking the back end, <code>HTTP_PROXY</code> for integrating with the HTTP proxy integration, or <code>AWS_PROXY</code> for integrating with the Lambda proxy integration type.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IntegrationType {
+    Aws,
+    AwsProxy,
+    Http,
+    HttpProxy,
+    Mock,
+}
+
+impl Into<String> for IntegrationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IntegrationType {
+    fn into(self) -> &'static str {
+        match self {
+            IntegrationType::Aws => "AWS",
+            IntegrationType::AwsProxy => "AWS_PROXY",
+            IntegrationType::Http => "HTTP",
+            IntegrationType::HttpProxy => "HTTP_PROXY",
+            IntegrationType::Mock => "MOCK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IntegrationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(IntegrationType::Aws),
+            "AWS_PROXY" => Ok(IntegrationType::AwsProxy),
+            "HTTP" => Ok(IntegrationType::Http),
+            "HTTP_PROXY" => Ok(IntegrationType::HttpProxy),
+            "MOCK" => Ok(IntegrationType::Mock),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> Represents a client-facing interface by which the client calls the API to access back-end resources. A <b>Method</b> resource is integrated with an <a>Integration</a> resource. Both consist of a request and one or more responses. The method request takes the client input that is passed to the back end through the integration request. A method response returns the output from the back end to the client through an integration response. A method request is embodied in a <b>Method</b> resource, whereas an integration request is embodied in an <a>Integration</a> resource. On the other hand, a method response is represented by a <a>MethodResponse</a> resource, whereas an integration response is represented by an <a>IntegrationResponse</a> resource. </p> <div class=\"remarks\"> <p/> <h4>Example: Retrive the GET method on a specified resource</h4> <h5>Request</h5> <p>The following example request retrieves the information about the GET method on an API resource (<code>3kzxbg5sa2</code>) of an API (<code>fugvjdxtri</code>). </p> <pre><code>GET /restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160603T210259Z Authorization: AWS4-HMAC-SHA256 Credential={access_key_ID}/20160603/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4_hash}</code></pre> <h5>Response</h5> <p>The successful response returns a <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ \"_links\": { \"curies\": [ { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-{rel}.html\", \"name\": \"integration\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-response-{rel}.html\", \"name\": \"integrationresponse\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-{rel}.html\", \"name\": \"method\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-response-{rel}.html\", \"name\": \"methodresponse\", \"templated\": true } ], \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\", \"name\": \"GET\", \"title\": \"GET\" }, \"integration:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"method:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\" }, \"method:integration\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"method:responses\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"method:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\" }, \"methodresponse:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/{status_code}\", \"templated\": true } }, \"apiKeyRequired\": true, \"authorizationType\": \"NONE\", \"httpMethod\": \"GET\", \"_embedded\": { \"method:integration\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integration:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integration:responses\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"integration:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integrationresponse:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/{status_code}\", \"templated\": true } }, \"cacheKeyParameters\": [], \"cacheNamespace\": \"3kzxbg5sa2\", \"credentials\": \"arn:aws:iam::123456789012:role/apigAwsProxyRole\", \"httpMethod\": \"POST\", \"passthroughBehavior\": \"WHEN_NO_MATCH\", \"requestParameters\": { \"integration.request.header.Content-Type\": \"'application/x-amz-json-1.1'\" }, \"requestTemplates\": { \"application/json\": \"{\\n}\" }, \"type\": \"AWS\", \"uri\": \"arn:aws:apigateway:us-east-1:kinesis:action/ListStreams\", \"_embedded\": { \"integration:responses\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"integrationresponse:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\" }, \"integrationresponse:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\" } }, \"responseParameters\": { \"method.response.header.Content-Type\": \"'application/xml'\" }, \"responseTemplates\": { \"application/json\": \"$util.urlDecode(\\\"%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E\\\")\" }, \"statusCode\": \"200\" } } }, \"method:responses\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"methodresponse:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\" }, \"methodresponse:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\" } }, \"responseModels\": { \"application/json\": \"Empty\" }, \"responseParameters\": { \"method.response.header.Content-Type\": false }, \"statusCode\": \"200\" } } }</code></pre> <p>In the example above, the response template for the <code>200 OK</code> response maps the JSON output from the <code>ListStreams</code> action in the back end to an XML output. The mapping template is URL-encoded as <code>%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E</code> and the output is decoded using the <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-templat-reference\">$util.urlDecode()</a> helper function.</p> </div> <div class=\"seeAlso\"> <a>MethodResponse</a>, <a>Integration</a>, <a>IntegrationResponse</a>, <a>Resource</a>, <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-method-settings.html\">Set up an API's method</a> </div>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Method {
@@ -1894,6 +2198,53 @@ pub struct Models {
     #[serde(rename="position")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub position: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Op {
+    Add,
+    Copy,
+    Move,
+    Remove,
+    Replace,
+    Test,
+}
+
+impl Into<String> for Op {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Op {
+    fn into(self) -> &'static str {
+        match self {
+            Op::Add => "add",
+            Op::Copy => "copy",
+            Op::Move => "move",
+            Op::Remove => "remove",
+            Op::Replace => "replace",
+            Op::Test => "test",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Op {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "add" => Ok(Op::Add),
+            "copy" => Ok(Op::Copy),
+            "move" => Ok(Op::Move),
+            "remove" => Ok(Op::Remove),
+            "replace" => Ok(Op::Replace),
+            "test" => Ok(Op::Test),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="A single patch operation to apply to the specified resource. Please refer to http://tools.ietf.org/html/rfc6902#section-4 for an explanation of how each operation is used."]
@@ -2069,6 +2420,41 @@ pub struct PutMethodResponseRequest {
     pub status_code: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PutMode {
+    Merge,
+    Overwrite,
+}
+
+impl Into<String> for PutMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PutMode {
+    fn into(self) -> &'static str {
+        match self {
+            PutMode::Merge => "merge",
+            PutMode::Overwrite => "overwrite",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PutMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "merge" => Ok(PutMode::Merge),
+            "overwrite" => Ok(PutMode::Overwrite),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A PUT request to update an existing API, with external API definitions specified as the request body.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutRestApiRequest {
@@ -2095,6 +2481,44 @@ pub struct PutRestApiRequest {
     #[doc="<p>The identifier of the <a>RestApi</a> to be updated. </p>"]
     #[serde(rename="restApiId")]
     pub rest_api_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QuotaPeriodType {
+    Day,
+    Month,
+    Week,
+}
+
+impl Into<String> for QuotaPeriodType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QuotaPeriodType {
+    fn into(self) -> &'static str {
+        match self {
+            QuotaPeriodType::Day => "DAY",
+            QuotaPeriodType::Month => "MONTH",
+            QuotaPeriodType::Week => "WEEK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QuotaPeriodType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DAY" => Ok(QuotaPeriodType::Day),
+            "MONTH" => Ok(QuotaPeriodType::Month),
+            "WEEK" => Ok(QuotaPeriodType::Week),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Quotas configured for a usage plan.</p>"]
@@ -2515,6 +2939,52 @@ pub struct ThrottleSettings {
     #[serde(rename="rateLimit")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub rate_limit: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UnauthorizedCacheControlHeaderStrategy {
+    FailWith403,
+    SucceedWithoutResponseHeader,
+    SucceedWithResponseHeader,
+}
+
+impl Into<String> for UnauthorizedCacheControlHeaderStrategy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UnauthorizedCacheControlHeaderStrategy {
+    fn into(self) -> &'static str {
+        match self {
+            UnauthorizedCacheControlHeaderStrategy::FailWith403 => "FAIL_WITH_403",
+            UnauthorizedCacheControlHeaderStrategy::SucceedWithoutResponseHeader => {
+                "SUCCEED_WITHOUT_RESPONSE_HEADER"
+            }
+            UnauthorizedCacheControlHeaderStrategy::SucceedWithResponseHeader => {
+                "SUCCEED_WITH_RESPONSE_HEADER"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for UnauthorizedCacheControlHeaderStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAIL_WITH_403" => Ok(UnauthorizedCacheControlHeaderStrategy::FailWith403),
+            "SUCCEED_WITHOUT_RESPONSE_HEADER" => {
+                Ok(UnauthorizedCacheControlHeaderStrategy::SucceedWithoutResponseHeader)
+            }
+            "SUCCEED_WITH_RESPONSE_HEADER" => {
+                Ok(UnauthorizedCacheControlHeaderStrategy::SucceedWithResponseHeader)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Requests Amazon API Gateway to change information about the current <a>Account</a> resource.</p>"]
@@ -13528,7 +13998,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13572,7 +14042,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13617,7 +14087,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13662,7 +14132,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13707,7 +14177,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13750,7 +14220,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13791,7 +14261,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13834,7 +14304,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13876,7 +14346,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13922,7 +14392,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -13964,7 +14434,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -14006,7 +14476,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -14047,7 +14517,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -14092,7 +14562,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -14134,7 +14604,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14169,7 +14639,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14205,7 +14675,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14240,7 +14710,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14273,7 +14743,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14309,7 +14779,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14342,7 +14812,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14374,7 +14844,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14411,7 +14881,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -14449,7 +14919,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -14481,7 +14951,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -14518,7 +14988,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -14552,7 +15022,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14585,7 +15055,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14619,7 +15089,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14651,7 +15121,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14684,7 +15154,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14716,7 +15186,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14752,7 +15222,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14788,7 +15258,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14821,7 +15291,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -14855,7 +15325,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -14894,7 +15364,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -14937,7 +15407,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -14992,7 +15462,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15035,7 +15505,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15086,7 +15556,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15132,7 +15602,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15184,7 +15654,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15229,7 +15699,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15280,7 +15750,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15332,7 +15802,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15383,7 +15853,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15429,7 +15899,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15490,7 +15960,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15536,7 +16006,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15586,7 +16056,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15628,7 +16098,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15678,7 +16148,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15729,7 +16199,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = ExportResponse::default();
                 result.body = Some(response.body);
@@ -15773,7 +16243,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15821,7 +16291,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15866,7 +16336,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15911,7 +16381,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -15959,7 +16429,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16002,7 +16472,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16052,7 +16522,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16095,7 +16565,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16147,7 +16617,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16197,7 +16667,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16249,7 +16719,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16290,7 +16760,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16336,7 +16806,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16384,7 +16854,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = SdkResponse::default();
                 result.body = Some(response.body);
@@ -16423,7 +16893,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16469,7 +16939,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16510,7 +16980,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16554,7 +17024,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16606,7 +17076,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16646,7 +17116,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16691,7 +17161,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16746,7 +17216,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16800,7 +17270,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16848,7 +17318,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -16900,7 +17370,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -16948,7 +17418,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -16994,7 +17464,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -17042,7 +17512,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -17087,7 +17557,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -17132,7 +17602,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -17186,7 +17656,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17230,7 +17700,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17277,7 +17747,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17319,7 +17789,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17360,7 +17830,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17405,7 +17875,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17451,7 +17921,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17496,7 +17966,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17539,7 +18009,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17585,7 +18055,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17629,7 +18099,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17671,7 +18141,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17718,7 +18188,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17767,7 +18237,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17809,7 +18279,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17856,7 +18326,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -17900,7 +18370,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17943,7 +18413,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -17989,7 +18459,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -18031,7 +18501,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -18074,7 +18544,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -18115,7 +18585,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -18157,7 +18627,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -71,6 +67,44 @@ pub struct AssociateFleetRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AssociateFleetResult;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthenticationType {
+    Api,
+    Saml,
+    Userpool,
+}
+
+impl Into<String> for AuthenticationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthenticationType {
+    fn into(self) -> &'static str {
+        match self {
+            AuthenticationType::Api => "API",
+            AuthenticationType::Saml => "SAML",
+            AuthenticationType::Userpool => "USERPOOL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthenticationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "API" => Ok(AuthenticationType::Api),
+            "SAML" => Ok(AuthenticationType::Saml),
+            "USERPOOL" => Ok(AuthenticationType::Userpool),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p>The capacity configuration for the fleet.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
@@ -413,6 +447,45 @@ pub struct Fleet {
     pub vpc_config: Option<VpcConfig>,
 }
 
+#[doc="<p>Fleet attribute.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetAttribute {
+    VpcConfiguration,
+    VpcConfigurationSecurityGroupIds,
+}
+
+impl Into<String> for FleetAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            FleetAttribute::VpcConfiguration => "VPC_CONFIGURATION",
+            FleetAttribute::VpcConfigurationSecurityGroupIds => {
+                "VPC_CONFIGURATION_SECURITY_GROUP_IDS"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "VPC_CONFIGURATION" => Ok(FleetAttribute::VpcConfiguration),
+            "VPC_CONFIGURATION_SECURITY_GROUP_IDS" => {
+                Ok(FleetAttribute::VpcConfigurationSecurityGroupIds)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The details of the fleet error.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct FleetError {
@@ -424,6 +497,129 @@ pub struct FleetError {
     #[serde(rename="ErrorMessage")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub error_message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetErrorCode {
+    IamServiceRoleIsMissing,
+    IamServiceRoleMissingDescribeSubnetAction,
+    IamServiceRoleMissingEniCreateAction,
+    IamServiceRoleMissingEniDeleteAction,
+    IamServiceRoleMissingEniDescribeAction,
+    ImageNotFound,
+    InternalServiceError,
+    InvalidSubnetConfiguration,
+    NetworkInterfaceLimitExceeded,
+    SubnetHasInsufficientIpAddresses,
+    SubnetNotFound,
+}
+
+impl Into<String> for FleetErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            FleetErrorCode::IamServiceRoleIsMissing => "IAM_SERVICE_ROLE_IS_MISSING",
+            FleetErrorCode::IamServiceRoleMissingDescribeSubnetAction => {
+                "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION"
+            }
+            FleetErrorCode::IamServiceRoleMissingEniCreateAction => {
+                "IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION"
+            }
+            FleetErrorCode::IamServiceRoleMissingEniDeleteAction => {
+                "IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION"
+            }
+            FleetErrorCode::IamServiceRoleMissingEniDescribeAction => {
+                "IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION"
+            }
+            FleetErrorCode::ImageNotFound => "IMAGE_NOT_FOUND",
+            FleetErrorCode::InternalServiceError => "INTERNAL_SERVICE_ERROR",
+            FleetErrorCode::InvalidSubnetConfiguration => "INVALID_SUBNET_CONFIGURATION",
+            FleetErrorCode::NetworkInterfaceLimitExceeded => "NETWORK_INTERFACE_LIMIT_EXCEEDED",
+            FleetErrorCode::SubnetHasInsufficientIpAddresses => {
+                "SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES"
+            }
+            FleetErrorCode::SubnetNotFound => "SUBNET_NOT_FOUND",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IAM_SERVICE_ROLE_IS_MISSING" => Ok(FleetErrorCode::IamServiceRoleIsMissing),
+            "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingDescribeSubnetAction)
+            }
+            "IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingEniCreateAction)
+            }
+            "IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingEniDeleteAction)
+            }
+            "IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingEniDescribeAction)
+            }
+            "IMAGE_NOT_FOUND" => Ok(FleetErrorCode::ImageNotFound),
+            "INTERNAL_SERVICE_ERROR" => Ok(FleetErrorCode::InternalServiceError),
+            "INVALID_SUBNET_CONFIGURATION" => Ok(FleetErrorCode::InvalidSubnetConfiguration),
+            "NETWORK_INTERFACE_LIMIT_EXCEEDED" => Ok(FleetErrorCode::NetworkInterfaceLimitExceeded),
+            "SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES" => {
+                Ok(FleetErrorCode::SubnetHasInsufficientIpAddresses)
+            }
+            "SUBNET_NOT_FOUND" => Ok(FleetErrorCode::SubnetNotFound),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetState {
+    Running,
+    Starting,
+    Stopped,
+    Stopping,
+}
+
+impl Into<String> for FleetState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetState {
+    fn into(self) -> &'static str {
+        match self {
+            FleetState::Running => "RUNNING",
+            FleetState::Starting => "STARTING",
+            FleetState::Stopped => "STOPPED",
+            FleetState::Stopping => "STOPPING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RUNNING" => Ok(FleetState::Running),
+            "STARTING" => Ok(FleetState::Starting),
+            "STOPPED" => Ok(FleetState::Stopped),
+            "STOPPING" => Ok(FleetState::Stopping),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>New streaming instances are booted from images. The image stores the application catalog and is connected to fleets.</p>"]
@@ -482,6 +678,47 @@ pub struct Image {
     pub visibility: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageState {
+    Available,
+    Deleting,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for ImageState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageState {
+    fn into(self) -> &'static str {
+        match self {
+            ImageState::Available => "AVAILABLE",
+            ImageState::Deleting => "DELETING",
+            ImageState::Failed => "FAILED",
+            ImageState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(ImageState::Available),
+            "DELETING" => Ok(ImageState::Deleting),
+            "FAILED" => Ok(ImageState::Failed),
+            "PENDING" => Ok(ImageState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The reason why the last state change occurred.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ImageStateChangeReason {
@@ -493,6 +730,43 @@ pub struct ImageStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageStateChangeReasonCode {
+    ImageBuilderNotAvailable,
+    InternalError,
+}
+
+impl Into<String> for ImageStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            ImageStateChangeReasonCode::ImageBuilderNotAvailable => "IMAGE_BUILDER_NOT_AVAILABLE",
+            ImageStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IMAGE_BUILDER_NOT_AVAILABLE" => {
+                Ok(ImageStateChangeReasonCode::ImageBuilderNotAvailable)
+            }
+            "INTERNAL_ERROR" => Ok(ImageStateChangeReasonCode::InternalError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -543,6 +817,38 @@ pub struct ListAssociatedStacksResult {
     pub next_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformType {
+    Windows,
+}
+
+impl Into<String> for PlatformType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformType {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformType::Windows => "WINDOWS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "WINDOWS" => Ok(PlatformType::Windows),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the parameters for a streaming session.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Session {
@@ -565,6 +871,44 @@ pub struct Session {
     #[doc="<p>The identifier of the user for whom the session was created.</p>"]
     #[serde(rename="UserId")]
     pub user_id: String,
+}
+
+#[doc="<p>Possible values for the state of a streaming session.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SessionState {
+    Active,
+    Expired,
+    Pending,
+}
+
+impl Into<String> for SessionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SessionState {
+    fn into(self) -> &'static str {
+        match self {
+            SessionState::Active => "ACTIVE",
+            SessionState::Expired => "EXPIRED",
+            SessionState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SessionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(SessionState::Active),
+            "EXPIRED" => Ok(SessionState::Expired),
+            "PENDING" => Ok(SessionState::Pending),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Details about a stack.</p>"]
@@ -612,6 +956,41 @@ pub struct StackError {
     pub error_message: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackErrorCode {
+    InternalServiceError,
+    StorageConnectorError,
+}
+
+impl Into<String> for StackErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            StackErrorCode::InternalServiceError => "INTERNAL_SERVICE_ERROR",
+            StackErrorCode::StorageConnectorError => "STORAGE_CONNECTOR_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INTERNAL_SERVICE_ERROR" => Ok(StackErrorCode::InternalServiceError),
+            "STORAGE_CONNECTOR_ERROR" => Ok(StackErrorCode::StorageConnectorError),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartFleetRequest {
     #[doc="<p>The name of the fleet to start.</p>"]
@@ -642,6 +1021,38 @@ pub struct StorageConnector {
     #[serde(rename="ResourceIdentifier")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub resource_identifier: Option<String>,
+}
+
+#[doc="<p>The type of storage connector. The possible values include: HOMEFOLDERS.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StorageConnectorType {
+    Homefolders,
+}
+
+impl Into<String> for StorageConnectorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StorageConnectorType {
+    fn into(self) -> &'static str {
+        match self {
+            StorageConnectorType::Homefolders => "HOMEFOLDERS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StorageConnectorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HOMEFOLDERS" => Ok(StorageConnectorType::Homefolders),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -728,6 +1139,41 @@ pub struct UpdateStackResult {
     #[serde(rename="Stack")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stack: Option<Stack>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VisibilityType {
+    Private,
+    Public,
+}
+
+impl Into<String> for VisibilityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VisibilityType {
+    fn into(self) -> &'static str {
+        match self {
+            VisibilityType::Private => "PRIVATE",
+            VisibilityType::Public => "PUBLIC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VisibilityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PRIVATE" => Ok(VisibilityType::Private),
+            "PUBLIC" => Ok(VisibilityType::Public),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>VPC configuration information.</p>"]
@@ -2433,7 +2879,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AssociateFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2460,7 +2906,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2484,7 +2930,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2508,7 +2954,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateStreamingURLResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2535,7 +2981,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2559,7 +3005,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2583,7 +3029,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeFleetsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2610,7 +3056,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeImagesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2637,7 +3083,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeSessionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2664,7 +3110,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStacksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2691,7 +3137,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisassociateFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2718,7 +3164,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ExpireSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2745,7 +3191,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAssociatedFleetsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2773,7 +3219,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAssociatedStacksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2798,7 +3244,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StartFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2820,7 +3266,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<StopFleetResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -2846,7 +3292,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateFleetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2870,7 +3316,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -509,7 +504,7 @@ impl AssociatePublicIpAddressDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -837,7 +832,7 @@ impl AutoScalingGroupDesiredCapacityDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -851,7 +846,7 @@ impl AutoScalingGroupMaxSizeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -865,7 +860,7 @@ impl AutoScalingGroupMinSizeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1323,7 +1318,7 @@ impl BlockDeviceEbsDeleteOnTerminationDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1337,7 +1332,7 @@ impl BlockDeviceEbsEncryptedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1351,7 +1346,7 @@ impl BlockDeviceEbsIopsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1365,7 +1360,7 @@ impl BlockDeviceEbsVolumeSizeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1654,7 +1649,7 @@ impl CooldownDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3288,7 +3283,7 @@ impl EbsOptimizedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3511,7 +3506,7 @@ impl EstimatedInstanceWarmupDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3688,7 +3683,7 @@ impl GlobalTimeoutDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3702,7 +3697,7 @@ impl HealthCheckGracePeriodDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3716,7 +3711,7 @@ impl HeartbeatTimeoutDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3895,7 +3890,7 @@ impl InstanceProtectedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4453,6 +4448,74 @@ impl LifecycleHooksDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LifecycleState {
+    Detached,
+    Detaching,
+    EnteringStandby,
+    InService,
+    Pending,
+    PendingProceed,
+    PendingWait,
+    Quarantined,
+    Standby,
+    Terminated,
+    Terminating,
+    TerminatingProceed,
+    TerminatingWait,
+}
+
+impl Into<String> for LifecycleState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LifecycleState {
+    fn into(self) -> &'static str {
+        match self {
+            LifecycleState::Detached => "Detached",
+            LifecycleState::Detaching => "Detaching",
+            LifecycleState::EnteringStandby => "EnteringStandby",
+            LifecycleState::InService => "InService",
+            LifecycleState::Pending => "Pending",
+            LifecycleState::PendingProceed => "Pending:Proceed",
+            LifecycleState::PendingWait => "Pending:Wait",
+            LifecycleState::Quarantined => "Quarantined",
+            LifecycleState::Standby => "Standby",
+            LifecycleState::Terminated => "Terminated",
+            LifecycleState::Terminating => "Terminating",
+            LifecycleState::TerminatingProceed => "Terminating:Proceed",
+            LifecycleState::TerminatingWait => "Terminating:Wait",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LifecycleState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Detached" => Ok(LifecycleState::Detached),
+            "Detaching" => Ok(LifecycleState::Detaching),
+            "EnteringStandby" => Ok(LifecycleState::EnteringStandby),
+            "InService" => Ok(LifecycleState::InService),
+            "Pending" => Ok(LifecycleState::Pending),
+            "Pending:Proceed" => Ok(LifecycleState::PendingProceed),
+            "Pending:Wait" => Ok(LifecycleState::PendingWait),
+            "Quarantined" => Ok(LifecycleState::Quarantined),
+            "Standby" => Ok(LifecycleState::Standby),
+            "Terminated" => Ok(LifecycleState::Terminated),
+            "Terminating" => Ok(LifecycleState::Terminating),
+            "Terminating:Proceed" => Ok(LifecycleState::TerminatingProceed),
+            "Terminating:Wait" => Ok(LifecycleState::TerminatingWait),
+            _ => Err(()),
+        }
+    }
+}
+
 struct LifecycleStateDeserializer;
 impl LifecycleStateDeserializer {
     #[allow(unused_variables)]
@@ -4739,7 +4802,7 @@ impl MaxNumberOfAutoScalingGroupsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4753,7 +4816,7 @@ impl MaxNumberOfLaunchConfigurationsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4951,7 +5014,7 @@ impl MetricScaleDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4977,7 +5040,7 @@ impl MinAdjustmentMagnitudeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4991,7 +5054,7 @@ impl MinAdjustmentStepDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5005,7 +5068,7 @@ impl MonitoringEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5019,7 +5082,7 @@ impl NoDeviceDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5139,7 +5202,7 @@ impl NumberOfAutoScalingGroupsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5153,7 +5216,7 @@ impl NumberOfLaunchConfigurationsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5271,7 +5334,7 @@ impl PolicyIncrementDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5460,7 +5523,7 @@ impl ProgressDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5474,7 +5537,7 @@ impl PropagateAtLaunchDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5804,6 +5867,79 @@ impl ResourceNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingActivityStatusCode {
+    Cancelled,
+    Failed,
+    InProgress,
+    MidLifecycleAction,
+    PendingSpotBidPlacement,
+    PreInService,
+    Successful,
+    WaitingForELBConnectionDraining,
+    WaitingForInstanceId,
+    WaitingForInstanceWarmup,
+    WaitingForSpotInstanceId,
+    WaitingForSpotInstanceRequestId,
+}
+
+impl Into<String> for ScalingActivityStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingActivityStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingActivityStatusCode::Cancelled => "Cancelled",
+            ScalingActivityStatusCode::Failed => "Failed",
+            ScalingActivityStatusCode::InProgress => "InProgress",
+            ScalingActivityStatusCode::MidLifecycleAction => "MidLifecycleAction",
+            ScalingActivityStatusCode::PendingSpotBidPlacement => "PendingSpotBidPlacement",
+            ScalingActivityStatusCode::PreInService => "PreInService",
+            ScalingActivityStatusCode::Successful => "Successful",
+            ScalingActivityStatusCode::WaitingForELBConnectionDraining => {
+                "WaitingForELBConnectionDraining"
+            }
+            ScalingActivityStatusCode::WaitingForInstanceId => "WaitingForInstanceId",
+            ScalingActivityStatusCode::WaitingForInstanceWarmup => "WaitingForInstanceWarmup",
+            ScalingActivityStatusCode::WaitingForSpotInstanceId => "WaitingForSpotInstanceId",
+            ScalingActivityStatusCode::WaitingForSpotInstanceRequestId => {
+                "WaitingForSpotInstanceRequestId"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingActivityStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(ScalingActivityStatusCode::Cancelled),
+            "Failed" => Ok(ScalingActivityStatusCode::Failed),
+            "InProgress" => Ok(ScalingActivityStatusCode::InProgress),
+            "MidLifecycleAction" => Ok(ScalingActivityStatusCode::MidLifecycleAction),
+            "PendingSpotBidPlacement" => Ok(ScalingActivityStatusCode::PendingSpotBidPlacement),
+            "PreInService" => Ok(ScalingActivityStatusCode::PreInService),
+            "Successful" => Ok(ScalingActivityStatusCode::Successful),
+            "WaitingForELBConnectionDraining" => {
+                Ok(ScalingActivityStatusCode::WaitingForELBConnectionDraining)
+            }
+            "WaitingForInstanceId" => Ok(ScalingActivityStatusCode::WaitingForInstanceId),
+            "WaitingForInstanceWarmup" => Ok(ScalingActivityStatusCode::WaitingForInstanceWarmup),
+            "WaitingForSpotInstanceId" => Ok(ScalingActivityStatusCode::WaitingForSpotInstanceId),
+            "WaitingForSpotInstanceRequestId" => {
+                Ok(ScalingActivityStatusCode::WaitingForSpotInstanceRequestId)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 struct ScalingActivityStatusCodeDeserializer;
 impl ScalingActivityStatusCodeDeserializer {
     #[allow(unused_variables)]
@@ -11294,7 +11430,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11322,7 +11458,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11364,7 +11500,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11410,7 +11546,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11454,7 +11590,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11481,7 +11617,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11507,7 +11643,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11534,7 +11670,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11561,7 +11697,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11587,7 +11723,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11631,7 +11767,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11655,7 +11791,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11681,7 +11817,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11706,7 +11842,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11730,7 +11866,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11774,7 +11910,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11819,7 +11955,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11863,7 +11999,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11907,7 +12043,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11950,7 +12086,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11993,7 +12129,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12038,7 +12174,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12084,7 +12220,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12127,7 +12263,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12172,7 +12308,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12216,7 +12352,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12258,7 +12394,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12302,7 +12438,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12345,7 +12481,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12389,7 +12525,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12430,7 +12566,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12473,7 +12609,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12515,7 +12651,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12560,7 +12696,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12602,7 +12738,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12647,7 +12783,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12673,7 +12809,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12699,7 +12835,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12740,7 +12876,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12766,7 +12902,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12807,7 +12943,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12851,7 +12987,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12877,7 +13013,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12921,7 +13057,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12948,7 +13084,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12988,7 +13124,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13015,7 +13151,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13042,7 +13178,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13070,7 +13206,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13112,7 +13248,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13140,7 +13276,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13183,7 +13319,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -66,6 +62,158 @@ pub struct AttemptDetail {
     #[serde(rename="stoppedAt")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stopped_at: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CEState {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for CEState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CEState {
+    fn into(self) -> &'static str {
+        match self {
+            CEState::Disabled => "DISABLED",
+            CEState::Enabled => "ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CEState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(CEState::Disabled),
+            "ENABLED" => Ok(CEState::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CEStatus {
+    Creating,
+    Deleted,
+    Deleting,
+    Invalid,
+    Updating,
+    Valid,
+}
+
+impl Into<String> for CEStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CEStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CEStatus::Creating => "CREATING",
+            CEStatus::Deleted => "DELETED",
+            CEStatus::Deleting => "DELETING",
+            CEStatus::Invalid => "INVALID",
+            CEStatus::Updating => "UPDATING",
+            CEStatus::Valid => "VALID",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CEStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATING" => Ok(CEStatus::Creating),
+            "DELETED" => Ok(CEStatus::Deleted),
+            "DELETING" => Ok(CEStatus::Deleting),
+            "INVALID" => Ok(CEStatus::Invalid),
+            "UPDATING" => Ok(CEStatus::Updating),
+            "VALID" => Ok(CEStatus::Valid),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CEType {
+    Managed,
+    Unmanaged,
+}
+
+impl Into<String> for CEType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CEType {
+    fn into(self) -> &'static str {
+        match self {
+            CEType::Managed => "MANAGED",
+            CEType::Unmanaged => "UNMANAGED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CEType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MANAGED" => Ok(CEType::Managed),
+            "UNMANAGED" => Ok(CEType::Unmanaged),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CRType {
+    Ec2,
+    Spot,
+}
+
+impl Into<String> for CRType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CRType {
+    fn into(self) -> &'static str {
+        match self {
+            CRType::Ec2 => "EC2",
+            CRType::Spot => "SPOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CRType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EC2" => Ok(CRType::Ec2),
+            "SPOT" => Ok(CRType::Spot),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -543,6 +691,88 @@ pub struct Host {
     pub source_path: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JQState {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for JQState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JQState {
+    fn into(self) -> &'static str {
+        match self {
+            JQState::Disabled => "DISABLED",
+            JQState::Enabled => "ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JQState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(JQState::Disabled),
+            "ENABLED" => Ok(JQState::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JQStatus {
+    Creating,
+    Deleted,
+    Deleting,
+    Invalid,
+    Updating,
+    Valid,
+}
+
+impl Into<String> for JQStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JQStatus {
+    fn into(self) -> &'static str {
+        match self {
+            JQStatus::Creating => "CREATING",
+            JQStatus::Deleted => "DELETED",
+            JQStatus::Deleting => "DELETING",
+            JQStatus::Invalid => "INVALID",
+            JQStatus::Updating => "UPDATING",
+            JQStatus::Valid => "VALID",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JQStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATING" => Ok(JQStatus::Creating),
+            "DELETED" => Ok(JQStatus::Deleted),
+            "DELETING" => Ok(JQStatus::Deleting),
+            "INVALID" => Ok(JQStatus::Invalid),
+            "UPDATING" => Ok(JQStatus::Updating),
+            "VALID" => Ok(JQStatus::Valid),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object representing an AWS Batch job definition.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct JobDefinition {
@@ -574,6 +804,38 @@ pub struct JobDefinition {
     #[doc="<p>The type of job definition.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobDefinitionType {
+    Container,
+}
+
+impl Into<String> for JobDefinitionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobDefinitionType {
+    fn into(self) -> &'static str {
+        match self {
+            JobDefinitionType::Container => "container",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobDefinitionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "container" => Ok(JobDefinitionType::Container),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An object representing an AWS Batch job dependency.</p>"]
@@ -666,6 +928,56 @@ pub struct JobQueueDetail {
     #[serde(rename="statusReason")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status_reason: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobStatus {
+    Failed,
+    Pending,
+    Runnable,
+    Running,
+    Starting,
+    Submitted,
+    Succeeded,
+}
+
+impl Into<String> for JobStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobStatus {
+    fn into(self) -> &'static str {
+        match self {
+            JobStatus::Failed => "FAILED",
+            JobStatus::Pending => "PENDING",
+            JobStatus::Runnable => "RUNNABLE",
+            JobStatus::Running => "RUNNING",
+            JobStatus::Starting => "STARTING",
+            JobStatus::Submitted => "SUBMITTED",
+            JobStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(JobStatus::Failed),
+            "PENDING" => Ok(JobStatus::Pending),
+            "RUNNABLE" => Ok(JobStatus::Runnable),
+            "RUNNING" => Ok(JobStatus::Running),
+            "STARTING" => Ok(JobStatus::Starting),
+            "SUBMITTED" => Ok(JobStatus::Submitted),
+            "SUCCEEDED" => Ok(JobStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An object representing summary details of a job.</p>"]
@@ -2325,7 +2637,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2367,7 +2679,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2409,7 +2721,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2454,7 +2766,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2496,7 +2808,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2541,7 +2853,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2584,7 +2896,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2627,7 +2939,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2672,7 +2984,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2716,7 +3028,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2757,7 +3069,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2799,7 +3111,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2842,7 +3154,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2883,7 +3195,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2927,7 +3239,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -2969,7 +3281,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -282,6 +277,41 @@ impl CapabilitiesReasonDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Capability {
+    CapabilityIam,
+    CapabilityNamedIam,
+}
+
+impl Into<String> for Capability {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Capability {
+    fn into(self) -> &'static str {
+        match self {
+            Capability::CapabilityIam => "CAPABILITY_IAM",
+            Capability::CapabilityNamedIam => "CAPABILITY_NAMED_IAM",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Capability {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CAPABILITY_IAM" => Ok(Capability::CapabilityIam),
+            "CAPABILITY_NAMED_IAM" => Ok(Capability::CapabilityNamedIam),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CapabilityDeserializer;
 impl CapabilityDeserializer {
     #[allow(unused_variables)]
@@ -366,6 +396,44 @@ impl ChangeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeAction {
+    Add,
+    Modify,
+    Remove,
+}
+
+impl Into<String> for ChangeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeAction {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeAction::Add => "Add",
+            ChangeAction::Modify => "Modify",
+            ChangeAction::Remove => "Remove",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Add" => Ok(ChangeAction::Add),
+            "Modify" => Ok(ChangeAction::Modify),
+            "Remove" => Ok(ChangeAction::Remove),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeActionDeserializer;
 impl ChangeActionDeserializer {
     #[allow(unused_variables)]
@@ -408,6 +476,50 @@ impl ChangeSetNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeSetStatus {
+    CreateComplete,
+    CreateInProgress,
+    CreatePending,
+    DeleteComplete,
+    Failed,
+}
+
+impl Into<String> for ChangeSetStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeSetStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeSetStatus::CreateComplete => "CREATE_COMPLETE",
+            ChangeSetStatus::CreateInProgress => "CREATE_IN_PROGRESS",
+            ChangeSetStatus::CreatePending => "CREATE_PENDING",
+            ChangeSetStatus::DeleteComplete => "DELETE_COMPLETE",
+            ChangeSetStatus::Failed => "FAILED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeSetStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE_COMPLETE" => Ok(ChangeSetStatus::CreateComplete),
+            "CREATE_IN_PROGRESS" => Ok(ChangeSetStatus::CreateInProgress),
+            "CREATE_PENDING" => Ok(ChangeSetStatus::CreatePending),
+            "DELETE_COMPLETE" => Ok(ChangeSetStatus::DeleteComplete),
+            "FAILED" => Ok(ChangeSetStatus::Failed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeSetStatusDeserializer;
 impl ChangeSetStatusDeserializer {
     #[allow(unused_variables)]
@@ -581,6 +693,85 @@ impl ChangeSetSummaryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeSetType {
+    Create,
+    Update,
+}
+
+impl Into<String> for ChangeSetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeSetType {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeSetType::Create => "CREATE",
+            ChangeSetType::Update => "UPDATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeSetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE" => Ok(ChangeSetType::Create),
+            "UPDATE" => Ok(ChangeSetType::Update),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeSource {
+    Automatic,
+    DirectModification,
+    ParameterReference,
+    ResourceAttribute,
+    ResourceReference,
+}
+
+impl Into<String> for ChangeSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeSource {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeSource::Automatic => "Automatic",
+            ChangeSource::DirectModification => "DirectModification",
+            ChangeSource::ParameterReference => "ParameterReference",
+            ChangeSource::ResourceAttribute => "ResourceAttribute",
+            ChangeSource::ResourceReference => "ResourceReference",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Automatic" => Ok(ChangeSource::Automatic),
+            "DirectModification" => Ok(ChangeSource::DirectModification),
+            "ParameterReference" => Ok(ChangeSource::ParameterReference),
+            "ResourceAttribute" => Ok(ChangeSource::ResourceAttribute),
+            "ResourceReference" => Ok(ChangeSource::ResourceReference),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeSourceDeserializer;
 impl ChangeSourceDeserializer {
     #[allow(unused_variables)]
@@ -595,6 +786,38 @@ impl ChangeSourceDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeType {
+    Resource,
+}
+
+impl Into<String> for ChangeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeType {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeType::Resource => "Resource",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Resource" => Ok(ChangeType::Resource),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeTypeDeserializer;
 impl ChangeTypeDeserializer {
     #[allow(unused_variables)]
@@ -1742,7 +1965,7 @@ impl DisableRollbackDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1833,6 +2056,41 @@ impl EstimateTemplateCostOutputDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EvaluationType {
+    Dynamic,
+    Static,
+}
+
+impl Into<String> for EvaluationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EvaluationType {
+    fn into(self) -> &'static str {
+        match self {
+            EvaluationType::Dynamic => "Dynamic",
+            EvaluationType::Static => "Static",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EvaluationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Dynamic" => Ok(EvaluationType::Dynamic),
+            "Static" => Ok(EvaluationType::Static),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EvaluationTypeDeserializer;
 impl EvaluationTypeDeserializer {
     #[allow(unused_variables)]
@@ -1914,6 +2172,53 @@ impl ExecuteChangeSetOutputDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionStatus {
+    Available,
+    ExecuteComplete,
+    ExecuteFailed,
+    ExecuteInProgress,
+    Obsolete,
+    Unavailable,
+}
+
+impl Into<String> for ExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionStatus::Available => "AVAILABLE",
+            ExecutionStatus::ExecuteComplete => "EXECUTE_COMPLETE",
+            ExecutionStatus::ExecuteFailed => "EXECUTE_FAILED",
+            ExecutionStatus::ExecuteInProgress => "EXECUTE_IN_PROGRESS",
+            ExecutionStatus::Obsolete => "OBSOLETE",
+            ExecutionStatus::Unavailable => "UNAVAILABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(ExecutionStatus::Available),
+            "EXECUTE_COMPLETE" => Ok(ExecutionStatus::ExecuteComplete),
+            "EXECUTE_FAILED" => Ok(ExecutionStatus::ExecuteFailed),
+            "EXECUTE_IN_PROGRESS" => Ok(ExecutionStatus::ExecuteInProgress),
+            "OBSOLETE" => Ok(ExecutionStatus::Obsolete),
+            "UNAVAILABLE" => Ok(ExecutionStatus::Unavailable),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ExecutionStatusDeserializer;
 impl ExecutionStatusDeserializer {
     #[allow(unused_variables)]
@@ -2429,7 +2734,7 @@ impl LimitValueDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2895,7 +3200,7 @@ impl NoEchoDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2965,6 +3270,44 @@ impl NotificationARNsSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OnFailure {
+    Delete,
+    DoNothing,
+    Rollback,
+}
+
+impl Into<String> for OnFailure {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OnFailure {
+    fn into(self) -> &'static str {
+        match self {
+            OnFailure::Delete => "DELETE",
+            OnFailure::DoNothing => "DO_NOTHING",
+            OnFailure::Rollback => "ROLLBACK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OnFailure {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE" => Ok(OnFailure::Delete),
+            "DO_NOTHING" => Ok(OnFailure::DoNothing),
+            "ROLLBACK" => Ok(OnFailure::Rollback),
+            _ => Err(()),
         }
     }
 }
@@ -3488,6 +3831,44 @@ impl PropertyNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Replacement {
+    Conditional,
+    False,
+    True,
+}
+
+impl Into<String> for Replacement {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Replacement {
+    fn into(self) -> &'static str {
+        match self {
+            Replacement::Conditional => "Conditional",
+            Replacement::False => "False",
+            Replacement::True => "True",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Replacement {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Conditional" => Ok(Replacement::Conditional),
+            "False" => Ok(Replacement::False),
+            "True" => Ok(Replacement::True),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReplacementDeserializer;
 impl ReplacementDeserializer {
     #[allow(unused_variables)]
@@ -3502,6 +3883,44 @@ impl ReplacementDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequiresRecreation {
+    Always,
+    Conditionally,
+    Never,
+}
+
+impl Into<String> for RequiresRecreation {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequiresRecreation {
+    fn into(self) -> &'static str {
+        match self {
+            RequiresRecreation::Always => "Always",
+            RequiresRecreation::Conditionally => "Conditionally",
+            RequiresRecreation::Never => "Never",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequiresRecreation {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Always" => Ok(RequiresRecreation::Always),
+            "Conditionally" => Ok(RequiresRecreation::Conditionally),
+            "Never" => Ok(RequiresRecreation::Never),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RequiresRecreationDeserializer;
 impl RequiresRecreationDeserializer {
     #[allow(unused_variables)]
@@ -3516,6 +3935,53 @@ impl RequiresRecreationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceAttribute {
+    CreationPolicy,
+    DeletionPolicy,
+    Metadata,
+    Properties,
+    Tags,
+    UpdatePolicy,
+}
+
+impl Into<String> for ResourceAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceAttribute::CreationPolicy => "CreationPolicy",
+            ResourceAttribute::DeletionPolicy => "DeletionPolicy",
+            ResourceAttribute::Metadata => "Metadata",
+            ResourceAttribute::Properties => "Properties",
+            ResourceAttribute::Tags => "Tags",
+            ResourceAttribute::UpdatePolicy => "UpdatePolicy",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreationPolicy" => Ok(ResourceAttribute::CreationPolicy),
+            "DeletionPolicy" => Ok(ResourceAttribute::DeletionPolicy),
+            "Metadata" => Ok(ResourceAttribute::Metadata),
+            "Properties" => Ok(ResourceAttribute::Properties),
+            "Tags" => Ok(ResourceAttribute::Tags),
+            "UpdatePolicy" => Ok(ResourceAttribute::UpdatePolicy),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ResourceAttributeDeserializer;
 impl ResourceAttributeDeserializer {
     #[allow(unused_variables)]
@@ -3744,6 +4210,100 @@ impl ResourcePropertiesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceSignalStatus {
+    Failure,
+    Success,
+}
+
+impl Into<String> for ResourceSignalStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceSignalStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceSignalStatus::Failure => "FAILURE",
+            ResourceSignalStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceSignalStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILURE" => Ok(ResourceSignalStatus::Failure),
+            "SUCCESS" => Ok(ResourceSignalStatus::Success),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceStatus {
+    CreateComplete,
+    CreateFailed,
+    CreateInProgress,
+    DeleteComplete,
+    DeleteFailed,
+    DeleteInProgress,
+    DeleteSkipped,
+    UpdateComplete,
+    UpdateFailed,
+    UpdateInProgress,
+}
+
+impl Into<String> for ResourceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceStatus::CreateComplete => "CREATE_COMPLETE",
+            ResourceStatus::CreateFailed => "CREATE_FAILED",
+            ResourceStatus::CreateInProgress => "CREATE_IN_PROGRESS",
+            ResourceStatus::DeleteComplete => "DELETE_COMPLETE",
+            ResourceStatus::DeleteFailed => "DELETE_FAILED",
+            ResourceStatus::DeleteInProgress => "DELETE_IN_PROGRESS",
+            ResourceStatus::DeleteSkipped => "DELETE_SKIPPED",
+            ResourceStatus::UpdateComplete => "UPDATE_COMPLETE",
+            ResourceStatus::UpdateFailed => "UPDATE_FAILED",
+            ResourceStatus::UpdateInProgress => "UPDATE_IN_PROGRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE_COMPLETE" => Ok(ResourceStatus::CreateComplete),
+            "CREATE_FAILED" => Ok(ResourceStatus::CreateFailed),
+            "CREATE_IN_PROGRESS" => Ok(ResourceStatus::CreateInProgress),
+            "DELETE_COMPLETE" => Ok(ResourceStatus::DeleteComplete),
+            "DELETE_FAILED" => Ok(ResourceStatus::DeleteFailed),
+            "DELETE_IN_PROGRESS" => Ok(ResourceStatus::DeleteInProgress),
+            "DELETE_SKIPPED" => Ok(ResourceStatus::DeleteSkipped),
+            "UPDATE_COMPLETE" => Ok(ResourceStatus::UpdateComplete),
+            "UPDATE_FAILED" => Ok(ResourceStatus::UpdateFailed),
+            "UPDATE_IN_PROGRESS" => Ok(ResourceStatus::UpdateInProgress),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ResourceStatusDeserializer;
 impl ResourceStatusDeserializer {
     #[allow(unused_variables)]
@@ -4766,6 +5326,92 @@ impl StackResourcesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackStatus {
+    CreateComplete,
+    CreateFailed,
+    CreateInProgress,
+    DeleteComplete,
+    DeleteFailed,
+    DeleteInProgress,
+    ReviewInProgress,
+    RollbackComplete,
+    RollbackFailed,
+    RollbackInProgress,
+    UpdateComplete,
+    UpdateCompleteCleanupInProgress,
+    UpdateInProgress,
+    UpdateRollbackComplete,
+    UpdateRollbackCompleteCleanupInProgress,
+    UpdateRollbackFailed,
+    UpdateRollbackInProgress,
+}
+
+impl Into<String> for StackStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StackStatus::CreateComplete => "CREATE_COMPLETE",
+            StackStatus::CreateFailed => "CREATE_FAILED",
+            StackStatus::CreateInProgress => "CREATE_IN_PROGRESS",
+            StackStatus::DeleteComplete => "DELETE_COMPLETE",
+            StackStatus::DeleteFailed => "DELETE_FAILED",
+            StackStatus::DeleteInProgress => "DELETE_IN_PROGRESS",
+            StackStatus::ReviewInProgress => "REVIEW_IN_PROGRESS",
+            StackStatus::RollbackComplete => "ROLLBACK_COMPLETE",
+            StackStatus::RollbackFailed => "ROLLBACK_FAILED",
+            StackStatus::RollbackInProgress => "ROLLBACK_IN_PROGRESS",
+            StackStatus::UpdateComplete => "UPDATE_COMPLETE",
+            StackStatus::UpdateCompleteCleanupInProgress => "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            StackStatus::UpdateInProgress => "UPDATE_IN_PROGRESS",
+            StackStatus::UpdateRollbackComplete => "UPDATE_ROLLBACK_COMPLETE",
+            StackStatus::UpdateRollbackCompleteCleanupInProgress => {
+                "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS"
+            }
+            StackStatus::UpdateRollbackFailed => "UPDATE_ROLLBACK_FAILED",
+            StackStatus::UpdateRollbackInProgress => "UPDATE_ROLLBACK_IN_PROGRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE_COMPLETE" => Ok(StackStatus::CreateComplete),
+            "CREATE_FAILED" => Ok(StackStatus::CreateFailed),
+            "CREATE_IN_PROGRESS" => Ok(StackStatus::CreateInProgress),
+            "DELETE_COMPLETE" => Ok(StackStatus::DeleteComplete),
+            "DELETE_FAILED" => Ok(StackStatus::DeleteFailed),
+            "DELETE_IN_PROGRESS" => Ok(StackStatus::DeleteInProgress),
+            "REVIEW_IN_PROGRESS" => Ok(StackStatus::ReviewInProgress),
+            "ROLLBACK_COMPLETE" => Ok(StackStatus::RollbackComplete),
+            "ROLLBACK_FAILED" => Ok(StackStatus::RollbackFailed),
+            "ROLLBACK_IN_PROGRESS" => Ok(StackStatus::RollbackInProgress),
+            "UPDATE_COMPLETE" => Ok(StackStatus::UpdateComplete),
+            "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS" => {
+                Ok(StackStatus::UpdateCompleteCleanupInProgress)
+            }
+            "UPDATE_IN_PROGRESS" => Ok(StackStatus::UpdateInProgress),
+            "UPDATE_ROLLBACK_COMPLETE" => Ok(StackStatus::UpdateRollbackComplete),
+            "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS" => {
+                Ok(StackStatus::UpdateRollbackCompleteCleanupInProgress)
+            }
+            "UPDATE_ROLLBACK_FAILED" => Ok(StackStatus::UpdateRollbackFailed),
+            "UPDATE_ROLLBACK_IN_PROGRESS" => Ok(StackStatus::UpdateRollbackInProgress),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StackStatusDeserializer;
 impl StackStatusDeserializer {
     #[allow(unused_variables)]
@@ -5318,6 +5964,41 @@ impl TemplateParametersDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TemplateStage {
+    Original,
+    Processed,
+}
+
+impl Into<String> for TemplateStage {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TemplateStage {
+    fn into(self) -> &'static str {
+        match self {
+            TemplateStage::Original => "Original",
+            TemplateStage::Processed => "Processed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TemplateStage {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Original" => Ok(TemplateStage::Original),
+            "Processed" => Ok(TemplateStage::Processed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TemplateStageDeserializer;
 impl TemplateStageDeserializer {
     #[allow(unused_variables)]
@@ -5339,7 +6020,7 @@ impl TimeoutMinutesDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5588,7 +6269,7 @@ impl UsePreviousValueDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7637,7 +8318,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -7665,7 +8346,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7710,7 +8391,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7754,7 +8435,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7795,7 +8476,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7837,7 +8518,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -7862,7 +8543,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7906,7 +8587,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7950,7 +8631,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7995,7 +8676,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8040,7 +8721,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8085,7 +8766,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8129,7 +8810,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8173,7 +8854,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8217,7 +8898,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8261,7 +8942,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8302,7 +8983,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8346,7 +9027,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8390,7 +9071,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8431,7 +9112,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8472,7 +9153,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8514,7 +9195,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8553,7 +9234,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -8578,7 +9259,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -8605,7 +9286,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8646,7 +9327,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -11,19 +11,14 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 
-use std::str::FromStr;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
@@ -362,7 +357,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -729,6 +724,44 @@ impl CachedMethodsSerializer {
         serialized += &format!("<Quantity>{value}</Quantity>", value = obj.quantity);
         serialized += &format!("</{name}>", name = name);
         serialized
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CertificateSource {
+    Acm,
+    Cloudfront,
+    Iam,
+}
+
+impl Into<String> for CertificateSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CertificateSource {
+    fn into(self) -> &'static str {
+        match self {
+            CertificateSource::Acm => "acm",
+            CertificateSource::Cloudfront => "cloudfront",
+            CertificateSource::Iam => "iam",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CertificateSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "acm" => Ok(CertificateSource::Acm),
+            "cloudfront" => Ok(CertificateSource::Cloudfront),
+            "iam" => Ok(CertificateSource::Iam),
+            _ => Err(()),
+        }
     }
 }
 
@@ -2752,6 +2785,47 @@ impl DistributionSummaryListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    OriginRequest,
+    OriginResponse,
+    ViewerRequest,
+    ViewerResponse,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::OriginRequest => "origin-request",
+            EventType::OriginResponse => "origin-response",
+            EventType::ViewerRequest => "viewer-request",
+            EventType::ViewerResponse => "viewer-response",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "origin-request" => Ok(EventType::OriginRequest),
+            "origin-response" => Ok(EventType::OriginResponse),
+            "viewer-request" => Ok(EventType::ViewerRequest),
+            "viewer-response" => Ok(EventType::ViewerResponse),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventTypeDeserializer;
 impl EventTypeDeserializer {
     #[allow(unused_variables)]
@@ -2941,6 +3015,44 @@ impl GeoRestrictionSerializer {
                 value = obj.restriction_type);
         serialized += &format!("</{name}>", name = name);
         serialized
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GeoRestrictionType {
+    Blacklist,
+    None,
+    Whitelist,
+}
+
+impl Into<String> for GeoRestrictionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GeoRestrictionType {
+    fn into(self) -> &'static str {
+        match self {
+            GeoRestrictionType::Blacklist => "blacklist",
+            GeoRestrictionType::None => "none",
+            GeoRestrictionType::Whitelist => "whitelist",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GeoRestrictionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "blacklist" => Ok(GeoRestrictionType::Blacklist),
+            "none" => Ok(GeoRestrictionType::None),
+            "whitelist" => Ok(GeoRestrictionType::Whitelist),
+            _ => Err(()),
+        }
     }
 }
 
@@ -3505,6 +3617,41 @@ impl HeadersSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HttpVersion {
+    Http11,
+    Http2,
+}
+
+impl Into<String> for HttpVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HttpVersion {
+    fn into(self) -> &'static str {
+        match self {
+            HttpVersion::Http11 => "http1.1",
+            HttpVersion::Http2 => "http2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HttpVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http1.1" => Ok(HttpVersion::Http11),
+            "http2" => Ok(HttpVersion::Http2),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HttpVersionDeserializer;
 impl HttpVersionDeserializer {
     #[allow(unused_variables)]
@@ -3537,7 +3684,7 @@ impl IntegerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3867,6 +4014,44 @@ impl InvalidationSummaryListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ItemSelection {
+    All,
+    None,
+    Whitelist,
+}
+
+impl Into<String> for ItemSelection {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ItemSelection {
+    fn into(self) -> &'static str {
+        match self {
+            ItemSelection::All => "all",
+            ItemSelection::None => "none",
+            ItemSelection::Whitelist => "whitelist",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ItemSelection {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(ItemSelection::All),
+            "none" => Ok(ItemSelection::None),
+            "whitelist" => Ok(ItemSelection::Whitelist),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ItemSelectionDeserializer;
 impl ItemSelectionDeserializer {
     #[allow(unused_variables)]
@@ -4683,7 +4868,7 @@ impl LongDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4698,6 +4883,56 @@ impl LongSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Method {
+    Delete,
+    Get,
+    Head,
+    Options,
+    Patch,
+    Post,
+    Put,
+}
+
+impl Into<String> for Method {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Method {
+    fn into(self) -> &'static str {
+        match self {
+            Method::Delete => "DELETE",
+            Method::Get => "GET",
+            Method::Head => "HEAD",
+            Method::Options => "OPTIONS",
+            Method::Patch => "PATCH",
+            Method::Post => "POST",
+            Method::Put => "PUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Method {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE" => Ok(Method::Delete),
+            "GET" => Ok(Method::Get),
+            "HEAD" => Ok(Method::Head),
+            "OPTIONS" => Ok(Method::Options),
+            "PATCH" => Ok(Method::Patch),
+            "POST" => Ok(Method::Post),
+            "PUT" => Ok(Method::Put),
+            _ => Err(()),
+        }
     }
 }
 
@@ -4779,6 +5014,41 @@ impl MethodsListSerializer {
         }
         parts.push(format!("</{}>", name));
         parts.join("")
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MinimumProtocolVersion {
+    Sslv3,
+    Tlsv1,
+}
+
+impl Into<String> for MinimumProtocolVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MinimumProtocolVersion {
+    fn into(self) -> &'static str {
+        match self {
+            MinimumProtocolVersion::Sslv3 => "SSLv3",
+            MinimumProtocolVersion::Tlsv1 => "TLSv1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MinimumProtocolVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SSLv3" => Ok(MinimumProtocolVersion::Sslv3),
+            "TLSv1" => Ok(MinimumProtocolVersion::Tlsv1),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5094,6 +5364,44 @@ impl OriginListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OriginProtocolPolicy {
+    HttpOnly,
+    HttpsOnly,
+    MatchViewer,
+}
+
+impl Into<String> for OriginProtocolPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OriginProtocolPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            OriginProtocolPolicy::HttpOnly => "http-only",
+            OriginProtocolPolicy::HttpsOnly => "https-only",
+            OriginProtocolPolicy::MatchViewer => "match-viewer",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OriginProtocolPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http-only" => Ok(OriginProtocolPolicy::HttpOnly),
+            "https-only" => Ok(OriginProtocolPolicy::HttpsOnly),
+            "match-viewer" => Ok(OriginProtocolPolicy::MatchViewer),
+            _ => Err(()),
+        }
+    }
+}
+
 struct OriginProtocolPolicyDeserializer;
 impl OriginProtocolPolicyDeserializer {
     #[allow(unused_variables)]
@@ -5380,6 +5688,44 @@ impl PathsSerializer {
         serialized += &format!("<Quantity>{value}</Quantity>", value = obj.quantity);
         serialized += &format!("</{name}>", name = name);
         serialized
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PriceClass {
+    PriceClass100,
+    PriceClass200,
+    PriceClassAll,
+}
+
+impl Into<String> for PriceClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PriceClass {
+    fn into(self) -> &'static str {
+        match self {
+            PriceClass::PriceClass100 => "PriceClass_100",
+            PriceClass::PriceClass200 => "PriceClass_200",
+            PriceClass::PriceClassAll => "PriceClass_All",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PriceClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PriceClass_100" => Ok(PriceClass::PriceClass100),
+            "PriceClass_200" => Ok(PriceClass::PriceClass200),
+            "PriceClass_All" => Ok(PriceClass::PriceClassAll),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5737,6 +6083,41 @@ impl S3OriginConfigSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SSLSupportMethod {
+    SniOnly,
+    Vip,
+}
+
+impl Into<String> for SSLSupportMethod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SSLSupportMethod {
+    fn into(self) -> &'static str {
+        match self {
+            SSLSupportMethod::SniOnly => "sni-only",
+            SSLSupportMethod::Vip => "vip",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SSLSupportMethod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "sni-only" => Ok(SSLSupportMethod::SniOnly),
+            "vip" => Ok(SSLSupportMethod::Vip),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SSLSupportMethodDeserializer;
 impl SSLSupportMethodDeserializer {
     #[allow(unused_variables)]
@@ -5860,6 +6241,47 @@ impl SignerListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SslProtocol {
+    Sslv3,
+    Tlsv1,
+    Tlsv11,
+    Tlsv12,
+}
+
+impl Into<String> for SslProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SslProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            SslProtocol::Sslv3 => "SSLv3",
+            SslProtocol::Tlsv1 => "TLSv1",
+            SslProtocol::Tlsv11 => "TLSv1.1",
+            SslProtocol::Tlsv12 => "TLSv1.2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SslProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SSLv3" => Ok(SslProtocol::Sslv3),
+            "TLSv1" => Ok(SslProtocol::Tlsv1),
+            "TLSv1.1" => Ok(SslProtocol::Tlsv11),
+            "TLSv1.2" => Ok(SslProtocol::Tlsv12),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SslProtocolDeserializer;
 impl SslProtocolDeserializer {
     #[allow(unused_variables)]
@@ -7161,6 +7583,44 @@ impl ViewerCertificateSerializer {
         }
         serialized += &format!("</{name}>", name = name);
         serialized
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ViewerProtocolPolicy {
+    AllowAll,
+    HttpsOnly,
+    RedirectToHttps,
+}
+
+impl Into<String> for ViewerProtocolPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ViewerProtocolPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ViewerProtocolPolicy::AllowAll => "allow-all",
+            ViewerProtocolPolicy::HttpsOnly => "https-only",
+            ViewerProtocolPolicy::RedirectToHttps => "redirect-to-https",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ViewerProtocolPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow-all" => Ok(ViewerProtocolPolicy::AllowAll),
+            "https-only" => Ok(ViewerProtocolPolicy::HttpsOnly),
+            "redirect-to-https" => Ok(ViewerProtocolPolicy::RedirectToHttps),
+            _ => Err(()),
+        }
     }
 }
 
@@ -10147,9 +10607,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10206,9 +10666,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10269,9 +10729,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10328,9 +10788,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10387,9 +10847,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10446,9 +10906,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10504,9 +10964,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -10541,9 +11001,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -10581,9 +11041,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -10616,9 +11076,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10665,9 +11125,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10715,9 +11175,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10770,9 +11230,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10825,9 +11285,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10877,9 +11337,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10928,9 +11388,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -10987,9 +11447,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11041,9 +11501,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11101,9 +11561,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11155,9 +11615,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11215,9 +11675,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11262,9 +11722,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11315,9 +11775,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -11350,9 +11810,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -11395,9 +11855,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11453,9 +11913,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11515,9 +11975,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -41,6 +37,79 @@ pub struct AddTagsToResourceResponse {
     #[doc="<p>The status of the operation.</p>"]
     #[serde(rename="Status")]
     pub status: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClientVersion {
+    _5_1,
+    _5_3,
+}
+
+impl Into<String> for ClientVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClientVersion {
+    fn into(self) -> &'static str {
+        match self {
+            ClientVersion::_5_1 => "5.1",
+            ClientVersion::_5_3 => "5.3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClientVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "5.1" => Ok(ClientVersion::_5_1),
+            "5.3" => Ok(ClientVersion::_5_3),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudHsmObjectState {
+    Degraded,
+    Ready,
+    Updating,
+}
+
+impl Into<String> for CloudHsmObjectState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudHsmObjectState {
+    fn into(self) -> &'static str {
+        match self {
+            CloudHsmObjectState::Degraded => "DEGRADED",
+            CloudHsmObjectState::Ready => "READY",
+            CloudHsmObjectState::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudHsmObjectState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEGRADED" => Ok(CloudHsmObjectState::Degraded),
+            "READY" => Ok(CloudHsmObjectState::Ready),
+            "UPDATING" => Ok(CloudHsmObjectState::Updating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the inputs for the <a>CreateHapgRequest</a> action.</p>"]
@@ -380,6 +449,56 @@ pub struct GetConfigResponse {
     pub config_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HsmStatus {
+    Degraded,
+    Pending,
+    Running,
+    Suspended,
+    Terminated,
+    Terminating,
+    Updating,
+}
+
+impl Into<String> for HsmStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HsmStatus {
+    fn into(self) -> &'static str {
+        match self {
+            HsmStatus::Degraded => "DEGRADED",
+            HsmStatus::Pending => "PENDING",
+            HsmStatus::Running => "RUNNING",
+            HsmStatus::Suspended => "SUSPENDED",
+            HsmStatus::Terminated => "TERMINATED",
+            HsmStatus::Terminating => "TERMINATING",
+            HsmStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HsmStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEGRADED" => Ok(HsmStatus::Degraded),
+            "PENDING" => Ok(HsmStatus::Pending),
+            "RUNNING" => Ok(HsmStatus::Running),
+            "SUSPENDED" => Ok(HsmStatus::Suspended),
+            "TERMINATED" => Ok(HsmStatus::Terminated),
+            "TERMINATING" => Ok(HsmStatus::Terminating),
+            "UPDATING" => Ok(HsmStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the inputs for the <a>ListAvailableZones</a> action.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListAvailableZonesRequest;
@@ -558,6 +677,38 @@ pub struct RemoveTagsFromResourceResponse {
     #[doc="<p>The status of the operation.</p>"]
     #[serde(rename="Status")]
     pub status: String,
+}
+
+#[doc="<p>Specifies the type of subscription for the HSM.</p> <ul> <li><b>PRODUCTION</b> - The HSM is being used in a production environment.</li> <li><b>TRIAL</b> - The HSM is being used in a product trial.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubscriptionType {
+    Production,
+}
+
+impl Into<String> for SubscriptionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubscriptionType {
+    fn into(self) -> &'static str {
+        match self {
+            SubscriptionType::Production => "PRODUCTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubscriptionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PRODUCTION" => Ok(SubscriptionType::Production),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A key-value pair that identifies or specifies metadata about an AWS CloudHSM resource.</p>"]
@@ -2422,7 +2573,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddTagsToResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2449,7 +2600,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateHapgResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateHapgError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2471,7 +2622,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateHsmResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateHsmError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2495,7 +2646,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateLunaClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2522,7 +2673,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteHapgResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteHapgError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2544,7 +2695,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteHsmResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteHsmError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2568,7 +2719,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteLunaClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2595,7 +2746,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeHapgResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2621,7 +2772,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeHsmResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeHsmError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2645,7 +2796,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeLunaClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2670,7 +2821,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetConfigResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetConfigError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2691,7 +2842,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAvailableZonesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2716,7 +2867,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListHapgsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListHapgsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2738,7 +2889,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListHsmsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListHsmsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2762,7 +2913,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListLunaClientsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2790,7 +2941,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2817,7 +2968,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyHapgResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ModifyHapgError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2839,7 +2990,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyHsmResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ModifyHsmError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2863,7 +3014,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyLunaClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2892,7 +3043,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTagsFromResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -118,6 +113,47 @@ impl AccessPoliciesStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AlgorithmicStemming {
+    Full,
+    Light,
+    Minimal,
+    None,
+}
+
+impl Into<String> for AlgorithmicStemming {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AlgorithmicStemming {
+    fn into(self) -> &'static str {
+        match self {
+            AlgorithmicStemming::Full => "full",
+            AlgorithmicStemming::Light => "light",
+            AlgorithmicStemming::Minimal => "minimal",
+            AlgorithmicStemming::None => "none",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AlgorithmicStemming {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "full" => Ok(AlgorithmicStemming::Full),
+            "light" => Ok(AlgorithmicStemming::Light),
+            "minimal" => Ok(AlgorithmicStemming::Minimal),
+            "none" => Ok(AlgorithmicStemming::None),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AlgorithmicStemmingDeserializer;
 impl AlgorithmicStemmingDeserializer {
     #[allow(unused_variables)]
@@ -323,6 +359,140 @@ impl AnalysisSchemeSerializer {
     }
 }
 
+#[doc="<p>An <a href=\"http://tools.ietf.org/html/rfc4646\" target=\"_blank\">IETF RFC 4646</a> language code or <code>mul</code> for multiple languages.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AnalysisSchemeLanguage {
+    Ar,
+    Bg,
+    Ca,
+    Cs,
+    Da,
+    De,
+    El,
+    En,
+    Es,
+    Eu,
+    Fa,
+    Fi,
+    Fr,
+    Ga,
+    Gl,
+    He,
+    Hi,
+    Hu,
+    Hy,
+    Id,
+    It,
+    Ja,
+    Ko,
+    Lv,
+    Mul,
+    Nl,
+    No,
+    Pt,
+    Ro,
+    Ru,
+    Sv,
+    Th,
+    Tr,
+    ZhHans,
+    ZhHant,
+}
+
+impl Into<String> for AnalysisSchemeLanguage {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AnalysisSchemeLanguage {
+    fn into(self) -> &'static str {
+        match self {
+            AnalysisSchemeLanguage::Ar => "ar",
+            AnalysisSchemeLanguage::Bg => "bg",
+            AnalysisSchemeLanguage::Ca => "ca",
+            AnalysisSchemeLanguage::Cs => "cs",
+            AnalysisSchemeLanguage::Da => "da",
+            AnalysisSchemeLanguage::De => "de",
+            AnalysisSchemeLanguage::El => "el",
+            AnalysisSchemeLanguage::En => "en",
+            AnalysisSchemeLanguage::Es => "es",
+            AnalysisSchemeLanguage::Eu => "eu",
+            AnalysisSchemeLanguage::Fa => "fa",
+            AnalysisSchemeLanguage::Fi => "fi",
+            AnalysisSchemeLanguage::Fr => "fr",
+            AnalysisSchemeLanguage::Ga => "ga",
+            AnalysisSchemeLanguage::Gl => "gl",
+            AnalysisSchemeLanguage::He => "he",
+            AnalysisSchemeLanguage::Hi => "hi",
+            AnalysisSchemeLanguage::Hu => "hu",
+            AnalysisSchemeLanguage::Hy => "hy",
+            AnalysisSchemeLanguage::Id => "id",
+            AnalysisSchemeLanguage::It => "it",
+            AnalysisSchemeLanguage::Ja => "ja",
+            AnalysisSchemeLanguage::Ko => "ko",
+            AnalysisSchemeLanguage::Lv => "lv",
+            AnalysisSchemeLanguage::Mul => "mul",
+            AnalysisSchemeLanguage::Nl => "nl",
+            AnalysisSchemeLanguage::No => "no",
+            AnalysisSchemeLanguage::Pt => "pt",
+            AnalysisSchemeLanguage::Ro => "ro",
+            AnalysisSchemeLanguage::Ru => "ru",
+            AnalysisSchemeLanguage::Sv => "sv",
+            AnalysisSchemeLanguage::Th => "th",
+            AnalysisSchemeLanguage::Tr => "tr",
+            AnalysisSchemeLanguage::ZhHans => "zh-Hans",
+            AnalysisSchemeLanguage::ZhHant => "zh-Hant",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AnalysisSchemeLanguage {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ar" => Ok(AnalysisSchemeLanguage::Ar),
+            "bg" => Ok(AnalysisSchemeLanguage::Bg),
+            "ca" => Ok(AnalysisSchemeLanguage::Ca),
+            "cs" => Ok(AnalysisSchemeLanguage::Cs),
+            "da" => Ok(AnalysisSchemeLanguage::Da),
+            "de" => Ok(AnalysisSchemeLanguage::De),
+            "el" => Ok(AnalysisSchemeLanguage::El),
+            "en" => Ok(AnalysisSchemeLanguage::En),
+            "es" => Ok(AnalysisSchemeLanguage::Es),
+            "eu" => Ok(AnalysisSchemeLanguage::Eu),
+            "fa" => Ok(AnalysisSchemeLanguage::Fa),
+            "fi" => Ok(AnalysisSchemeLanguage::Fi),
+            "fr" => Ok(AnalysisSchemeLanguage::Fr),
+            "ga" => Ok(AnalysisSchemeLanguage::Ga),
+            "gl" => Ok(AnalysisSchemeLanguage::Gl),
+            "he" => Ok(AnalysisSchemeLanguage::He),
+            "hi" => Ok(AnalysisSchemeLanguage::Hi),
+            "hu" => Ok(AnalysisSchemeLanguage::Hu),
+            "hy" => Ok(AnalysisSchemeLanguage::Hy),
+            "id" => Ok(AnalysisSchemeLanguage::Id),
+            "it" => Ok(AnalysisSchemeLanguage::It),
+            "ja" => Ok(AnalysisSchemeLanguage::Ja),
+            "ko" => Ok(AnalysisSchemeLanguage::Ko),
+            "lv" => Ok(AnalysisSchemeLanguage::Lv),
+            "mul" => Ok(AnalysisSchemeLanguage::Mul),
+            "nl" => Ok(AnalysisSchemeLanguage::Nl),
+            "no" => Ok(AnalysisSchemeLanguage::No),
+            "pt" => Ok(AnalysisSchemeLanguage::Pt),
+            "ro" => Ok(AnalysisSchemeLanguage::Ro),
+            "ru" => Ok(AnalysisSchemeLanguage::Ru),
+            "sv" => Ok(AnalysisSchemeLanguage::Sv),
+            "th" => Ok(AnalysisSchemeLanguage::Th),
+            "tr" => Ok(AnalysisSchemeLanguage::Tr),
+            "zh-Hans" => Ok(AnalysisSchemeLanguage::ZhHans),
+            "zh-Hant" => Ok(AnalysisSchemeLanguage::ZhHant),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AnalysisSchemeLanguageDeserializer;
 impl AnalysisSchemeLanguageDeserializer {
     #[allow(unused_variables)]
@@ -492,7 +662,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2492,7 +2662,7 @@ impl DoubleDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3380,6 +3550,68 @@ impl IndexFieldStatusListDeserializer {
 
     }
 }
+#[doc="<p>The type of field. The valid options for a field depend on the field type. For more information about the supported field types, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-index-fields.html\" target=\"_blank\">Configuring Index Fields</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IndexFieldType {
+    Date,
+    DateArray,
+    Double,
+    DoubleArray,
+    Int,
+    IntArray,
+    Latlon,
+    Literal,
+    LiteralArray,
+    Text,
+    TextArray,
+}
+
+impl Into<String> for IndexFieldType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IndexFieldType {
+    fn into(self) -> &'static str {
+        match self {
+            IndexFieldType::Date => "date",
+            IndexFieldType::DateArray => "date-array",
+            IndexFieldType::Double => "double",
+            IndexFieldType::DoubleArray => "double-array",
+            IndexFieldType::Int => "int",
+            IndexFieldType::IntArray => "int-array",
+            IndexFieldType::Latlon => "latlon",
+            IndexFieldType::Literal => "literal",
+            IndexFieldType::LiteralArray => "literal-array",
+            IndexFieldType::Text => "text",
+            IndexFieldType::TextArray => "text-array",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IndexFieldType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "date" => Ok(IndexFieldType::Date),
+            "date-array" => Ok(IndexFieldType::DateArray),
+            "double" => Ok(IndexFieldType::Double),
+            "double-array" => Ok(IndexFieldType::DoubleArray),
+            "int" => Ok(IndexFieldType::Int),
+            "int-array" => Ok(IndexFieldType::IntArray),
+            "latlon" => Ok(IndexFieldType::Latlon),
+            "literal" => Ok(IndexFieldType::Literal),
+            "literal-array" => Ok(IndexFieldType::LiteralArray),
+            "text" => Ok(IndexFieldType::Text),
+            "text-array" => Ok(IndexFieldType::TextArray),
+            _ => Err(()),
+        }
+    }
+}
+
 struct IndexFieldTypeDeserializer;
 impl IndexFieldTypeDeserializer {
     #[allow(unused_variables)]
@@ -3401,7 +3633,7 @@ impl InstanceCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4092,7 +4324,7 @@ impl LongDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4106,7 +4338,7 @@ impl MaximumPartitionCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4120,7 +4352,7 @@ impl MaximumReplicationCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4134,13 +4366,54 @@ impl MultiAZDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
 
     }
 }
+#[doc="<p>The state of processing a change to an option. One of:</p> <ul> <li>RequiresIndexDocuments: The option's latest value will not be deployed until <a>IndexDocuments</a> has been called and indexing is complete.</li> <li>Processing: The option's latest value is in the process of being activated.</li> <li>Active: The option's latest value is fully deployed. </li> <li>FailedToValidate: The option value is not compatible with the domain's data and cannot be used to index the data. You must either modify the option value or update or remove the incompatible documents.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OptionState {
+    Active,
+    FailedToValidate,
+    Processing,
+    RequiresIndexDocuments,
+}
+
+impl Into<String> for OptionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OptionState {
+    fn into(self) -> &'static str {
+        match self {
+            OptionState::Active => "Active",
+            OptionState::FailedToValidate => "FailedToValidate",
+            OptionState::Processing => "Processing",
+            OptionState::RequiresIndexDocuments => "RequiresIndexDocuments",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OptionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(OptionState::Active),
+            "FailedToValidate" => Ok(OptionState::FailedToValidate),
+            "Processing" => Ok(OptionState::Processing),
+            "RequiresIndexDocuments" => Ok(OptionState::RequiresIndexDocuments),
+            _ => Err(()),
+        }
+    }
+}
+
 struct OptionStateDeserializer;
 impl OptionStateDeserializer {
     #[allow(unused_variables)]
@@ -4237,13 +4510,66 @@ impl PartitionCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
 
     }
 }
+#[doc="<p>The instance type (such as <code>search.m1.small</code>) on which an index partition is hosted.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PartitionInstanceType {
+    SearchM1Large,
+    SearchM1Small,
+    SearchM22Xlarge,
+    SearchM2Xlarge,
+    SearchM32Xlarge,
+    SearchM3Large,
+    SearchM3Medium,
+    SearchM3Xlarge,
+}
+
+impl Into<String> for PartitionInstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PartitionInstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            PartitionInstanceType::SearchM1Large => "search.m1.large",
+            PartitionInstanceType::SearchM1Small => "search.m1.small",
+            PartitionInstanceType::SearchM22Xlarge => "search.m2.2xlarge",
+            PartitionInstanceType::SearchM2Xlarge => "search.m2.xlarge",
+            PartitionInstanceType::SearchM32Xlarge => "search.m3.2xlarge",
+            PartitionInstanceType::SearchM3Large => "search.m3.large",
+            PartitionInstanceType::SearchM3Medium => "search.m3.medium",
+            PartitionInstanceType::SearchM3Xlarge => "search.m3.xlarge",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PartitionInstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "search.m1.large" => Ok(PartitionInstanceType::SearchM1Large),
+            "search.m1.small" => Ok(PartitionInstanceType::SearchM1Small),
+            "search.m2.2xlarge" => Ok(PartitionInstanceType::SearchM22Xlarge),
+            "search.m2.xlarge" => Ok(PartitionInstanceType::SearchM2Xlarge),
+            "search.m3.2xlarge" => Ok(PartitionInstanceType::SearchM32Xlarge),
+            "search.m3.large" => Ok(PartitionInstanceType::SearchM3Large),
+            "search.m3.medium" => Ok(PartitionInstanceType::SearchM3Medium),
+            "search.m3.xlarge" => Ok(PartitionInstanceType::SearchM3Xlarge),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PartitionInstanceTypeDeserializer;
 impl PartitionInstanceTypeDeserializer {
     #[allow(unused_variables)]
@@ -4606,6 +4932,44 @@ impl SuggesterSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SuggesterFuzzyMatching {
+    High,
+    Low,
+    None,
+}
+
+impl Into<String> for SuggesterFuzzyMatching {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SuggesterFuzzyMatching {
+    fn into(self) -> &'static str {
+        match self {
+            SuggesterFuzzyMatching::High => "high",
+            SuggesterFuzzyMatching::Low => "low",
+            SuggesterFuzzyMatching::None => "none",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SuggesterFuzzyMatching {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "high" => Ok(SuggesterFuzzyMatching::High),
+            "low" => Ok(SuggesterFuzzyMatching::Low),
+            "none" => Ok(SuggesterFuzzyMatching::None),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SuggesterFuzzyMatchingDeserializer;
 impl SuggesterFuzzyMatchingDeserializer {
     #[allow(unused_variables)]
@@ -4946,7 +5310,7 @@ impl UIntValueDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7398,7 +7762,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7442,7 +7806,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7486,7 +7850,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7531,7 +7895,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7575,7 +7939,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7619,7 +7983,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7664,7 +8028,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7709,7 +8073,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7752,7 +8116,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7796,7 +8160,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7840,7 +8204,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7885,7 +8249,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7930,7 +8294,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7972,7 +8336,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8016,7 +8380,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8060,7 +8424,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8105,7 +8469,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8148,7 +8512,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8190,7 +8554,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8234,7 +8598,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8276,7 +8640,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8321,7 +8685,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8364,7 +8728,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8409,7 +8773,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -397,6 +393,53 @@ pub struct LookupAttribute {
     pub attribute_value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LookupAttributeKey {
+    EventId,
+    EventName,
+    EventSource,
+    ResourceName,
+    ResourceType,
+    Username,
+}
+
+impl Into<String> for LookupAttributeKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LookupAttributeKey {
+    fn into(self) -> &'static str {
+        match self {
+            LookupAttributeKey::EventId => "EventId",
+            LookupAttributeKey::EventName => "EventName",
+            LookupAttributeKey::EventSource => "EventSource",
+            LookupAttributeKey::ResourceName => "ResourceName",
+            LookupAttributeKey::ResourceType => "ResourceType",
+            LookupAttributeKey::Username => "Username",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LookupAttributeKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EventId" => Ok(LookupAttributeKey::EventId),
+            "EventName" => Ok(LookupAttributeKey::EventName),
+            "EventSource" => Ok(LookupAttributeKey::EventSource),
+            "ResourceName" => Ok(LookupAttributeKey::ResourceName),
+            "ResourceType" => Ok(LookupAttributeKey::ResourceType),
+            "Username" => Ok(LookupAttributeKey::Username),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains a request for LookupEvents.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct LookupEventsRequest {
@@ -480,6 +523,44 @@ pub struct PutEventSelectorsResponse {
     #[serde(rename="TrailARN")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub trail_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReadWriteType {
+    All,
+    ReadOnly,
+    WriteOnly,
+}
+
+impl Into<String> for ReadWriteType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReadWriteType {
+    fn into(self) -> &'static str {
+        match self {
+            ReadWriteType::All => "All",
+            ReadWriteType::ReadOnly => "ReadOnly",
+            ReadWriteType::WriteOnly => "WriteOnly",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReadWriteType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(ReadWriteType::All),
+            "ReadOnly" => Ok(ReadWriteType::ReadOnly),
+            "WriteOnly" => Ok(ReadWriteType::WriteOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Specifies the tags to remove from a trail.</p>"]
@@ -2341,7 +2422,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<AddTagsResponse>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -2368,7 +2449,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateTrailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateTrailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2393,7 +2474,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteTrailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteTrailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2418,7 +2499,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTrailsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2445,7 +2526,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetEventSelectorsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2473,7 +2554,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetTrailStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2501,7 +2582,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPublicKeysResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2527,7 +2608,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2552,7 +2633,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<LookupEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2578,7 +2659,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutEventSelectorsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2606,7 +2687,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTagsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RemoveTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2631,7 +2712,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartLoggingResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2658,7 +2739,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopLoggingResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StopLoggingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2683,7 +2764,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateTrailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateTrailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -44,7 +39,7 @@ impl ActionsEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -222,6 +217,49 @@ impl AlarmNamesSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    GreaterThanOrEqualToThreshold,
+    GreaterThanThreshold,
+    LessThanOrEqualToThreshold,
+    LessThanThreshold,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::GreaterThanOrEqualToThreshold => "GreaterThanOrEqualToThreshold",
+            ComparisonOperator::GreaterThanThreshold => "GreaterThanThreshold",
+            ComparisonOperator::LessThanOrEqualToThreshold => "LessThanOrEqualToThreshold",
+            ComparisonOperator::LessThanThreshold => "LessThanThreshold",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GreaterThanOrEqualToThreshold" => {
+                Ok(ComparisonOperator::GreaterThanOrEqualToThreshold)
+            }
+            "GreaterThanThreshold" => Ok(ComparisonOperator::GreaterThanThreshold),
+            "LessThanOrEqualToThreshold" => Ok(ComparisonOperator::LessThanOrEqualToThreshold),
+            "LessThanThreshold" => Ok(ComparisonOperator::LessThanThreshold),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ComparisonOperatorDeserializer;
 impl ComparisonOperatorDeserializer {
     #[allow(unused_variables)]
@@ -339,7 +377,7 @@ impl DatapointValueDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1001,7 +1039,7 @@ impl EvaluationPeriodsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1161,6 +1199,44 @@ impl HistoryDataDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HistoryItemType {
+    Action,
+    ConfigurationUpdate,
+    StateUpdate,
+}
+
+impl Into<String> for HistoryItemType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HistoryItemType {
+    fn into(self) -> &'static str {
+        match self {
+            HistoryItemType::Action => "Action",
+            HistoryItemType::ConfigurationUpdate => "ConfigurationUpdate",
+            HistoryItemType::StateUpdate => "StateUpdate",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HistoryItemType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Action" => Ok(HistoryItemType::Action),
+            "ConfigurationUpdate" => Ok(HistoryItemType::ConfigurationUpdate),
+            "StateUpdate" => Ok(HistoryItemType::StateUpdate),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HistoryItemTypeDeserializer;
 impl HistoryItemTypeDeserializer {
     #[allow(unused_variables)]
@@ -1752,7 +1828,7 @@ impl PeriodDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1991,6 +2067,116 @@ impl SetAlarmStateInputSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StandardUnit {
+    Bits,
+    BitsSecond,
+    Bytes,
+    BytesSecond,
+    Count,
+    CountSecond,
+    Gigabits,
+    GigabitsSecond,
+    Gigabytes,
+    GigabytesSecond,
+    Kilobits,
+    KilobitsSecond,
+    Kilobytes,
+    KilobytesSecond,
+    Megabits,
+    MegabitsSecond,
+    Megabytes,
+    MegabytesSecond,
+    Microseconds,
+    Milliseconds,
+    None,
+    Percent,
+    Seconds,
+    Terabits,
+    TerabitsSecond,
+    Terabytes,
+    TerabytesSecond,
+}
+
+impl Into<String> for StandardUnit {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StandardUnit {
+    fn into(self) -> &'static str {
+        match self {
+            StandardUnit::Bits => "Bits",
+            StandardUnit::BitsSecond => "Bits/Second",
+            StandardUnit::Bytes => "Bytes",
+            StandardUnit::BytesSecond => "Bytes/Second",
+            StandardUnit::Count => "Count",
+            StandardUnit::CountSecond => "Count/Second",
+            StandardUnit::Gigabits => "Gigabits",
+            StandardUnit::GigabitsSecond => "Gigabits/Second",
+            StandardUnit::Gigabytes => "Gigabytes",
+            StandardUnit::GigabytesSecond => "Gigabytes/Second",
+            StandardUnit::Kilobits => "Kilobits",
+            StandardUnit::KilobitsSecond => "Kilobits/Second",
+            StandardUnit::Kilobytes => "Kilobytes",
+            StandardUnit::KilobytesSecond => "Kilobytes/Second",
+            StandardUnit::Megabits => "Megabits",
+            StandardUnit::MegabitsSecond => "Megabits/Second",
+            StandardUnit::Megabytes => "Megabytes",
+            StandardUnit::MegabytesSecond => "Megabytes/Second",
+            StandardUnit::Microseconds => "Microseconds",
+            StandardUnit::Milliseconds => "Milliseconds",
+            StandardUnit::None => "None",
+            StandardUnit::Percent => "Percent",
+            StandardUnit::Seconds => "Seconds",
+            StandardUnit::Terabits => "Terabits",
+            StandardUnit::TerabitsSecond => "Terabits/Second",
+            StandardUnit::Terabytes => "Terabytes",
+            StandardUnit::TerabytesSecond => "Terabytes/Second",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StandardUnit {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bits" => Ok(StandardUnit::Bits),
+            "Bits/Second" => Ok(StandardUnit::BitsSecond),
+            "Bytes" => Ok(StandardUnit::Bytes),
+            "Bytes/Second" => Ok(StandardUnit::BytesSecond),
+            "Count" => Ok(StandardUnit::Count),
+            "Count/Second" => Ok(StandardUnit::CountSecond),
+            "Gigabits" => Ok(StandardUnit::Gigabits),
+            "Gigabits/Second" => Ok(StandardUnit::GigabitsSecond),
+            "Gigabytes" => Ok(StandardUnit::Gigabytes),
+            "Gigabytes/Second" => Ok(StandardUnit::GigabytesSecond),
+            "Kilobits" => Ok(StandardUnit::Kilobits),
+            "Kilobits/Second" => Ok(StandardUnit::KilobitsSecond),
+            "Kilobytes" => Ok(StandardUnit::Kilobytes),
+            "Kilobytes/Second" => Ok(StandardUnit::KilobytesSecond),
+            "Megabits" => Ok(StandardUnit::Megabits),
+            "Megabits/Second" => Ok(StandardUnit::MegabitsSecond),
+            "Megabytes" => Ok(StandardUnit::Megabytes),
+            "Megabytes/Second" => Ok(StandardUnit::MegabytesSecond),
+            "Microseconds" => Ok(StandardUnit::Microseconds),
+            "Milliseconds" => Ok(StandardUnit::Milliseconds),
+            "None" => Ok(StandardUnit::None),
+            "Percent" => Ok(StandardUnit::Percent),
+            "Seconds" => Ok(StandardUnit::Seconds),
+            "Terabits" => Ok(StandardUnit::Terabits),
+            "Terabits/Second" => Ok(StandardUnit::TerabitsSecond),
+            "Terabytes" => Ok(StandardUnit::Terabytes),
+            "Terabytes/Second" => Ok(StandardUnit::TerabytesSecond),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StandardUnitDeserializer;
 impl StandardUnitDeserializer {
     #[allow(unused_variables)]
@@ -2033,6 +2219,44 @@ impl StateReasonDataDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StateValue {
+    Alarm,
+    InsufficientData,
+    Ok,
+}
+
+impl Into<String> for StateValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StateValue {
+    fn into(self) -> &'static str {
+        match self {
+            StateValue::Alarm => "ALARM",
+            StateValue::InsufficientData => "INSUFFICIENT_DATA",
+            StateValue::Ok => "OK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StateValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALARM" => Ok(StateValue::Alarm),
+            "INSUFFICIENT_DATA" => Ok(StateValue::InsufficientData),
+            "OK" => Ok(StateValue::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StateValueDeserializer;
 impl StateValueDeserializer {
     #[allow(unused_variables)]
@@ -2047,6 +2271,50 @@ impl StateValueDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Statistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for Statistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Statistic {
+    fn into(self) -> &'static str {
+        match self {
+            Statistic::Average => "Average",
+            Statistic::Maximum => "Maximum",
+            Statistic::Minimum => "Minimum",
+            Statistic::SampleCount => "SampleCount",
+            Statistic::Sum => "Sum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Statistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(Statistic::Average),
+            "Maximum" => Ok(Statistic::Maximum),
+            "Minimum" => Ok(Statistic::Minimum),
+            "SampleCount" => Ok(Statistic::SampleCount),
+            "Sum" => Ok(Statistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatisticDeserializer;
 impl StatisticDeserializer {
     #[allow(unused_variables)]
@@ -2114,7 +2382,7 @@ impl ThresholdDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3021,7 +3289,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3047,7 +3315,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3091,7 +3359,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3136,7 +3404,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3180,7 +3448,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3207,7 +3475,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3234,7 +3502,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3278,7 +3546,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3317,7 +3585,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3342,7 +3610,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3366,7 +3634,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -11,21 +11,125 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactNamespace {
+    BuildId,
+    None,
+}
+
+impl Into<String> for ArtifactNamespace {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactNamespace {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactNamespace::BuildId => "BUILD_ID",
+            ArtifactNamespace::None => "NONE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactNamespace {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BUILD_ID" => Ok(ArtifactNamespace::BuildId),
+            "NONE" => Ok(ArtifactNamespace::None),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactPackaging {
+    None,
+    Zip,
+}
+
+impl Into<String> for ArtifactPackaging {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactPackaging {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactPackaging::None => "NONE",
+            ArtifactPackaging::Zip => "ZIP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactPackaging {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NONE" => Ok(ArtifactPackaging::None),
+            "ZIP" => Ok(ArtifactPackaging::Zip),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactsType {
+    Codepipeline,
+    NoArtifacts,
+    S3,
+}
+
+impl Into<String> for ArtifactsType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactsType {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactsType::Codepipeline => "CODEPIPELINE",
+            ArtifactsType::NoArtifacts => "NO_ARTIFACTS",
+            ArtifactsType::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactsType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CODEPIPELINE" => Ok(ArtifactsType::Codepipeline),
+            "NO_ARTIFACTS" => Ok(ArtifactsType::NoArtifacts),
+            "S3" => Ok(ArtifactsType::S3),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct BatchGetBuildsInput {
     #[doc="<p>The IDs of the builds.</p>"]
@@ -179,6 +283,103 @@ pub struct BuildPhase {
     pub start_time: Option<f64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BuildPhaseType {
+    Build,
+    Completed,
+    DownloadSource,
+    Finalizing,
+    Install,
+    PostBuild,
+    PreBuild,
+    Provisioning,
+    Submitted,
+    UploadArtifacts,
+}
+
+impl Into<String> for BuildPhaseType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BuildPhaseType {
+    fn into(self) -> &'static str {
+        match self {
+            BuildPhaseType::Build => "BUILD",
+            BuildPhaseType::Completed => "COMPLETED",
+            BuildPhaseType::DownloadSource => "DOWNLOAD_SOURCE",
+            BuildPhaseType::Finalizing => "FINALIZING",
+            BuildPhaseType::Install => "INSTALL",
+            BuildPhaseType::PostBuild => "POST_BUILD",
+            BuildPhaseType::PreBuild => "PRE_BUILD",
+            BuildPhaseType::Provisioning => "PROVISIONING",
+            BuildPhaseType::Submitted => "SUBMITTED",
+            BuildPhaseType::UploadArtifacts => "UPLOAD_ARTIFACTS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BuildPhaseType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BUILD" => Ok(BuildPhaseType::Build),
+            "COMPLETED" => Ok(BuildPhaseType::Completed),
+            "DOWNLOAD_SOURCE" => Ok(BuildPhaseType::DownloadSource),
+            "FINALIZING" => Ok(BuildPhaseType::Finalizing),
+            "INSTALL" => Ok(BuildPhaseType::Install),
+            "POST_BUILD" => Ok(BuildPhaseType::PostBuild),
+            "PRE_BUILD" => Ok(BuildPhaseType::PreBuild),
+            "PROVISIONING" => Ok(BuildPhaseType::Provisioning),
+            "SUBMITTED" => Ok(BuildPhaseType::Submitted),
+            "UPLOAD_ARTIFACTS" => Ok(BuildPhaseType::UploadArtifacts),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComputeType {
+    BuildGeneral1Large,
+    BuildGeneral1Medium,
+    BuildGeneral1Small,
+}
+
+impl Into<String> for ComputeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComputeType {
+    fn into(self) -> &'static str {
+        match self {
+            ComputeType::BuildGeneral1Large => "BUILD_GENERAL1_LARGE",
+            ComputeType::BuildGeneral1Medium => "BUILD_GENERAL1_MEDIUM",
+            ComputeType::BuildGeneral1Small => "BUILD_GENERAL1_SMALL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComputeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BUILD_GENERAL1_LARGE" => Ok(ComputeType::BuildGeneral1Large),
+            "BUILD_GENERAL1_MEDIUM" => Ok(ComputeType::BuildGeneral1Medium),
+            "BUILD_GENERAL1_SMALL" => Ok(ComputeType::BuildGeneral1Small),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct CreateProjectInput {
     #[doc="<p>Information about the build output artifacts for the build project.</p>"]
@@ -272,6 +473,38 @@ pub struct EnvironmentPlatform {
     pub platform: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentType {
+    LinuxContainer,
+}
+
+impl Into<String> for EnvironmentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentType {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentType::LinuxContainer => "LINUX_CONTAINER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LINUX_CONTAINER" => Ok(EnvironmentType::LinuxContainer),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about an environment variable for a build project or a build.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentVariable {
@@ -281,6 +514,59 @@ pub struct EnvironmentVariable {
     #[doc="<p>The value of the environment variable.</p> <important> <p>We strongly discourage using environment variables to store sensitive values, especially AWS secret key IDs and secret access keys. Environment variables can be displayed in plain text using tools such as the AWS CodeBuild console and the AWS Command Line Interface (AWS CLI).</p> </important>"]
     #[serde(rename="value")]
     pub value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LanguageType {
+    Android,
+    Base,
+    Docker,
+    Golang,
+    Java,
+    NodeJs,
+    Python,
+    Ruby,
+}
+
+impl Into<String> for LanguageType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LanguageType {
+    fn into(self) -> &'static str {
+        match self {
+            LanguageType::Android => "ANDROID",
+            LanguageType::Base => "BASE",
+            LanguageType::Docker => "DOCKER",
+            LanguageType::Golang => "GOLANG",
+            LanguageType::Java => "JAVA",
+            LanguageType::NodeJs => "NODE_JS",
+            LanguageType::Python => "PYTHON",
+            LanguageType::Ruby => "RUBY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LanguageType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ANDROID" => Ok(LanguageType::Android),
+            "BASE" => Ok(LanguageType::Base),
+            "DOCKER" => Ok(LanguageType::Docker),
+            "GOLANG" => Ok(LanguageType::Golang),
+            "JAVA" => Ok(LanguageType::Java),
+            "NODE_JS" => Ok(LanguageType::NodeJs),
+            "PYTHON" => Ok(LanguageType::Python),
+            "RUBY" => Ok(LanguageType::Ruby),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -403,6 +689,44 @@ pub struct PhaseContext {
     pub status_code: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformType {
+    AmazonLinux,
+    Debian,
+    Ubuntu,
+}
+
+impl Into<String> for PlatformType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformType {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformType::AmazonLinux => "AMAZON_LINUX",
+            PlatformType::Debian => "DEBIAN",
+            PlatformType::Ubuntu => "UBUNTU",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AMAZON_LINUX" => Ok(PlatformType::AmazonLinux),
+            "DEBIAN" => Ok(PlatformType::Debian),
+            "UBUNTU" => Ok(PlatformType::Ubuntu),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a build project.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Project {
@@ -506,6 +830,44 @@ pub struct ProjectEnvironment {
     pub type_: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProjectSortByType {
+    CreatedTime,
+    LastModifiedTime,
+    Name,
+}
+
+impl Into<String> for ProjectSortByType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProjectSortByType {
+    fn into(self) -> &'static str {
+        match self {
+            ProjectSortByType::CreatedTime => "CREATED_TIME",
+            ProjectSortByType::LastModifiedTime => "LAST_MODIFIED_TIME",
+            ProjectSortByType::Name => "NAME",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProjectSortByType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATED_TIME" => Ok(ProjectSortByType::CreatedTime),
+            "LAST_MODIFIED_TIME" => Ok(ProjectSortByType::LastModifiedTime),
+            "NAME" => Ok(ProjectSortByType::Name),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the build input source code for the build project.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProjectSource {
@@ -526,6 +888,41 @@ pub struct ProjectSource {
     pub type_: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrderType {
+    Ascending,
+    Descending,
+}
+
+impl Into<String> for SortOrderType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrderType {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrderType::Ascending => "ASCENDING",
+            SortOrderType::Descending => "DESCENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrderType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASCENDING" => Ok(SortOrderType::Ascending),
+            "DESCENDING" => Ok(SortOrderType::Descending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the authorization settings for AWS CodeBuild to access the source code to be built.</p> <p>This information is for the AWS CodeBuild console's use only. Your code should not get or set this information directly (unless the build project's source <code>type</code> value is <code>GITHUB</code>).</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SourceAuth {
@@ -536,6 +933,79 @@ pub struct SourceAuth {
     #[doc="<p>The authorization type to use. The only valid value is <code>OAUTH</code>, which represents the OAuth authorization type.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceAuthType {
+    Oauth,
+}
+
+impl Into<String> for SourceAuthType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceAuthType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceAuthType::Oauth => "OAUTH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceAuthType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OAUTH" => Ok(SourceAuthType::Oauth),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    Codecommit,
+    Codepipeline,
+    Github,
+    S3,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::Codecommit => "CODECOMMIT",
+            SourceType::Codepipeline => "CODEPIPELINE",
+            SourceType::Github => "GITHUB",
+            SourceType::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CODECOMMIT" => Ok(SourceType::Codecommit),
+            "CODEPIPELINE" => Ok(SourceType::Codepipeline),
+            "GITHUB" => Ok(SourceType::Github),
+            "S3" => Ok(SourceType::S3),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -571,6 +1041,53 @@ pub struct StartBuildOutput {
     #[serde(rename="build")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub build: Option<Build>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusType {
+    Failed,
+    Fault,
+    InProgress,
+    Stopped,
+    Succeeded,
+    TimedOut,
+}
+
+impl Into<String> for StatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusType {
+    fn into(self) -> &'static str {
+        match self {
+            StatusType::Failed => "FAILED",
+            StatusType::Fault => "FAULT",
+            StatusType::InProgress => "IN_PROGRESS",
+            StatusType::Stopped => "STOPPED",
+            StatusType::Succeeded => "SUCCEEDED",
+            StatusType::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(StatusType::Failed),
+            "FAULT" => Ok(StatusType::Fault),
+            "IN_PROGRESS" => Ok(StatusType::InProgress),
+            "STOPPED" => Ok(StatusType::Stopped),
+            "SUCCEEDED" => Ok(StatusType::Succeeded),
+            "TIMED_OUT" => Ok(StatusType::TimedOut),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1600,7 +2117,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetBuildsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1627,7 +2144,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetProjectsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1654,7 +2171,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateProjectOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1680,7 +2197,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteProjectOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1704,7 +2221,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListBuildsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListBuildsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1728,7 +2245,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListBuildsForProjectOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1755,7 +2272,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListCuratedEnvironmentImagesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListCuratedEnvironmentImagesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1779,7 +2296,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListProjectsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1803,7 +2320,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartBuildOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StartBuildError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1825,7 +2342,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<StopBuildOutput>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -1851,7 +2368,7 @@ impl<P, D> CodeBuild for CodeBuildClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateProjectOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -75,6 +71,44 @@ pub struct BranchInfo {
     #[serde(rename="commitId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub commit_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeTypeEnum {
+    A,
+    D,
+    M,
+}
+
+impl Into<String> for ChangeTypeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeTypeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeTypeEnum::A => "A",
+            ChangeTypeEnum::D => "D",
+            ChangeTypeEnum::M => "M",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeTypeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "A" => Ok(ChangeTypeEnum::A),
+            "D" => Ok(ChangeTypeEnum::D),
+            "M" => Ok(ChangeTypeEnum::M),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Returns information about a specific commit.</p>"]
@@ -375,6 +409,41 @@ pub struct ListRepositoriesOutput {
     pub repositories: Option<Vec<RepositoryNameIdPair>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrderEnum {
+    Ascending,
+    Descending,
+}
+
+impl Into<String> for OrderEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrderEnum {
+    fn into(self) -> &'static str {
+        match self {
+            OrderEnum::Ascending => "ascending",
+            OrderEnum::Descending => "descending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrderEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ascending" => Ok(OrderEnum::Ascending),
+            "descending" => Ok(OrderEnum::Descending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input ofa put repository triggers operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutRepositoryTriggersInput {
@@ -475,6 +544,47 @@ pub struct RepositoryTrigger {
     pub name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RepositoryTriggerEventEnum {
+    All,
+    CreateReference,
+    DeleteReference,
+    UpdateReference,
+}
+
+impl Into<String> for RepositoryTriggerEventEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RepositoryTriggerEventEnum {
+    fn into(self) -> &'static str {
+        match self {
+            RepositoryTriggerEventEnum::All => "all",
+            RepositoryTriggerEventEnum::CreateReference => "createReference",
+            RepositoryTriggerEventEnum::DeleteReference => "deleteReference",
+            RepositoryTriggerEventEnum::UpdateReference => "updateReference",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RepositoryTriggerEventEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(RepositoryTriggerEventEnum::All),
+            "createReference" => Ok(RepositoryTriggerEventEnum::CreateReference),
+            "deleteReference" => Ok(RepositoryTriggerEventEnum::DeleteReference),
+            "updateReference" => Ok(RepositoryTriggerEventEnum::UpdateReference),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A trigger failed to run.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RepositoryTriggerExecutionFailure {
@@ -486,6 +596,41 @@ pub struct RepositoryTriggerExecutionFailure {
     #[serde(rename="trigger")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub trigger: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortByEnum {
+    LastModifiedDate,
+    RepositoryName,
+}
+
+impl Into<String> for SortByEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortByEnum {
+    fn into(self) -> &'static str {
+        match self {
+            SortByEnum::LastModifiedDate => "lastModifiedDate",
+            SortByEnum::RepositoryName => "repositoryName",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortByEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "lastModifiedDate" => Ok(SortByEnum::LastModifiedDate),
+            "repositoryName" => Ok(SortByEnum::RepositoryName),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a test repository triggers operation.</p>"]
@@ -2802,7 +2947,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetRepositoriesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2827,7 +2972,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(CreateBranchError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -2851,7 +2996,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateRepositoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2878,7 +3023,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRepositoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2903,7 +3048,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetBlobOutput>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -2927,7 +3072,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetBranchOutput>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -2951,7 +3096,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetCommitOutput>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -2977,7 +3122,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDifferencesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3004,7 +3149,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRepositoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3031,7 +3176,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRepositoryTriggersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3058,7 +3203,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListBranchesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3084,7 +3229,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRepositoriesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3112,7 +3257,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutRepositoryTriggersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3140,7 +3285,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<TestRepositoryTriggersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3167,7 +3312,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateDefaultBranchError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -3193,7 +3338,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(UpdateRepositoryDescriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -3215,7 +3360,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateRepositoryNameError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -88,6 +84,44 @@ pub struct ApplicationInfo {
     pub linked_to_git_hub: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApplicationRevisionSortBy {
+    FirstUsedTime,
+    LastUsedTime,
+    RegisterTime,
+}
+
+impl Into<String> for ApplicationRevisionSortBy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApplicationRevisionSortBy {
+    fn into(self) -> &'static str {
+        match self {
+            ApplicationRevisionSortBy::FirstUsedTime => "firstUsedTime",
+            ApplicationRevisionSortBy::LastUsedTime => "lastUsedTime",
+            ApplicationRevisionSortBy::RegisterTime => "registerTime",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApplicationRevisionSortBy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "firstUsedTime" => Ok(ApplicationRevisionSortBy::FirstUsedTime),
+            "lastUsedTime" => Ok(ApplicationRevisionSortBy::LastUsedTime),
+            "registerTime" => Ok(ApplicationRevisionSortBy::RegisterTime),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a configuration for automatically rolling back to a previous version of an application revision when a deployment doesn't complete successfully.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoRollbackConfiguration {
@@ -99,6 +133,44 @@ pub struct AutoRollbackConfiguration {
     #[serde(rename="events")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<String>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoRollbackEvent {
+    DeploymentFailure,
+    DeploymentStopOnAlarm,
+    DeploymentStopOnRequest,
+}
+
+impl Into<String> for AutoRollbackEvent {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoRollbackEvent {
+    fn into(self) -> &'static str {
+        match self {
+            AutoRollbackEvent::DeploymentFailure => "DEPLOYMENT_FAILURE",
+            AutoRollbackEvent::DeploymentStopOnAlarm => "DEPLOYMENT_STOP_ON_ALARM",
+            AutoRollbackEvent::DeploymentStopOnRequest => "DEPLOYMENT_STOP_ON_REQUEST",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoRollbackEvent {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEPLOYMENT_FAILURE" => Ok(AutoRollbackEvent::DeploymentFailure),
+            "DEPLOYMENT_STOP_ON_ALARM" => Ok(AutoRollbackEvent::DeploymentStopOnAlarm),
+            "DEPLOYMENT_STOP_ON_REQUEST" => Ok(AutoRollbackEvent::DeploymentStopOnRequest),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about an Auto Scaling group.</p>"]
@@ -272,6 +344,44 @@ pub struct BlueInstanceTerminationOption {
     #[serde(rename="terminationWaitTimeInMinutes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub termination_wait_time_in_minutes: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BundleType {
+    Tar,
+    Tgz,
+    Zip,
+}
+
+impl Into<String> for BundleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BundleType {
+    fn into(self) -> &'static str {
+        match self {
+            BundleType::Tar => "tar",
+            BundleType::Tgz => "tgz",
+            BundleType::Zip => "zip",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BundleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tar" => Ok(BundleType::Tar),
+            "tgz" => Ok(BundleType::Tgz),
+            "zip" => Ok(BundleType::Zip),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -493,6 +603,44 @@ pub struct DeploymentConfigInfo {
     pub minimum_healthy_hosts: Option<MinimumHealthyHosts>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentCreator {
+    Autoscaling,
+    CodeDeployRollback,
+    User,
+}
+
+impl Into<String> for DeploymentCreator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentCreator {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentCreator::Autoscaling => "autoscaling",
+            DeploymentCreator::CodeDeployRollback => "codeDeployRollback",
+            DeploymentCreator::User => "user",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentCreator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "autoscaling" => Ok(DeploymentCreator::Autoscaling),
+            "codeDeployRollback" => Ok(DeploymentCreator::CodeDeployRollback),
+            "user" => Ok(DeploymentCreator::User),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a deployment group.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DeploymentGroupInfo {
@@ -671,6 +819,41 @@ pub struct DeploymentInfo {
     pub update_outdated_instances_only: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentOption {
+    WithoutTrafficControl,
+    WithTrafficControl,
+}
+
+impl Into<String> for DeploymentOption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentOption {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentOption::WithoutTrafficControl => "WITHOUT_TRAFFIC_CONTROL",
+            DeploymentOption::WithTrafficControl => "WITH_TRAFFIC_CONTROL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentOption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "WITHOUT_TRAFFIC_CONTROL" => Ok(DeploymentOption::WithoutTrafficControl),
+            "WITH_TRAFFIC_CONTROL" => Ok(DeploymentOption::WithTrafficControl),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the deployment status of the instances in the deployment.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DeploymentOverview {
@@ -700,6 +883,41 @@ pub struct DeploymentOverview {
     pub succeeded: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentReadyAction {
+    ContinueDeployment,
+    StopDeployment,
+}
+
+impl Into<String> for DeploymentReadyAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentReadyAction {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentReadyAction::ContinueDeployment => "CONTINUE_DEPLOYMENT",
+            DeploymentReadyAction::StopDeployment => "STOP_DEPLOYMENT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentReadyAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTINUE_DEPLOYMENT" => Ok(DeploymentReadyAction::ContinueDeployment),
+            "STOP_DEPLOYMENT" => Ok(DeploymentReadyAction::StopDeployment),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about how traffic is rerouted to instances in a replacement environment in a blue/green deployment.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeploymentReadyOption {
@@ -713,6 +931,56 @@ pub struct DeploymentReadyOption {
     pub wait_time_in_minutes: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentStatus {
+    Created,
+    Failed,
+    InProgress,
+    Queued,
+    Ready,
+    Stopped,
+    Succeeded,
+}
+
+impl Into<String> for DeploymentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentStatus::Created => "Created",
+            DeploymentStatus::Failed => "Failed",
+            DeploymentStatus::InProgress => "InProgress",
+            DeploymentStatus::Queued => "Queued",
+            DeploymentStatus::Ready => "Ready",
+            DeploymentStatus::Stopped => "Stopped",
+            DeploymentStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(DeploymentStatus::Created),
+            "Failed" => Ok(DeploymentStatus::Failed),
+            "InProgress" => Ok(DeploymentStatus::InProgress),
+            "Queued" => Ok(DeploymentStatus::Queued),
+            "Ready" => Ok(DeploymentStatus::Ready),
+            "Stopped" => Ok(DeploymentStatus::Stopped),
+            "Succeeded" => Ok(DeploymentStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeploymentStyle {
@@ -724,6 +992,41 @@ pub struct DeploymentStyle {
     #[serde(rename="deploymentType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub deployment_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentType {
+    BlueGreen,
+    InPlace,
+}
+
+impl Into<String> for DeploymentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentType {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentType::BlueGreen => "BLUE_GREEN",
+            DeploymentType::InPlace => "IN_PLACE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BLUE_GREEN" => Ok(DeploymentType::BlueGreen),
+            "IN_PLACE" => Ok(DeploymentType::InPlace),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a DeregisterOnPremisesInstance operation.</p>"]
@@ -772,6 +1075,44 @@ pub struct EC2TagFilter {
     pub value: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EC2TagFilterType {
+    KeyAndValue,
+    KeyOnly,
+    ValueOnly,
+}
+
+impl Into<String> for EC2TagFilterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EC2TagFilterType {
+    fn into(self) -> &'static str {
+        match self {
+            EC2TagFilterType::KeyAndValue => "KEY_AND_VALUE",
+            EC2TagFilterType::KeyOnly => "KEY_ONLY",
+            EC2TagFilterType::ValueOnly => "VALUE_ONLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EC2TagFilterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEY_AND_VALUE" => Ok(EC2TagFilterType::KeyAndValue),
+            "KEY_ONLY" => Ok(EC2TagFilterType::KeyOnly),
+            "VALUE_ONLY" => Ok(EC2TagFilterType::ValueOnly),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a load balancer in Elastic Load Balancing to use in a deployment.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ELBInfo {
@@ -779,6 +1120,89 @@ pub struct ELBInfo {
     #[serde(rename="name")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ErrorCode {
+    AgentIssue,
+    AlarmActive,
+    ApplicationMissing,
+    AutoScalingConfiguration,
+    AutoScalingIamRolePermissions,
+    DeploymentGroupMissing,
+    HealthConstraints,
+    HealthConstraintsInvalid,
+    IamRoleMissing,
+    IamRolePermissions,
+    InternalError,
+    ManualStop,
+    NoEc2Subscription,
+    NoInstances,
+    OverMaxInstances,
+    RevisionMissing,
+    Throttled,
+    Timeout,
+}
+
+impl Into<String> for ErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            ErrorCode::AgentIssue => "AGENT_ISSUE",
+            ErrorCode::AlarmActive => "ALARM_ACTIVE",
+            ErrorCode::ApplicationMissing => "APPLICATION_MISSING",
+            ErrorCode::AutoScalingConfiguration => "AUTO_SCALING_CONFIGURATION",
+            ErrorCode::AutoScalingIamRolePermissions => "AUTO_SCALING_IAM_ROLE_PERMISSIONS",
+            ErrorCode::DeploymentGroupMissing => "DEPLOYMENT_GROUP_MISSING",
+            ErrorCode::HealthConstraints => "HEALTH_CONSTRAINTS",
+            ErrorCode::HealthConstraintsInvalid => "HEALTH_CONSTRAINTS_INVALID",
+            ErrorCode::IamRoleMissing => "IAM_ROLE_MISSING",
+            ErrorCode::IamRolePermissions => "IAM_ROLE_PERMISSIONS",
+            ErrorCode::InternalError => "INTERNAL_ERROR",
+            ErrorCode::ManualStop => "MANUAL_STOP",
+            ErrorCode::NoEc2Subscription => "NO_EC2_SUBSCRIPTION",
+            ErrorCode::NoInstances => "NO_INSTANCES",
+            ErrorCode::OverMaxInstances => "OVER_MAX_INSTANCES",
+            ErrorCode::RevisionMissing => "REVISION_MISSING",
+            ErrorCode::Throttled => "THROTTLED",
+            ErrorCode::Timeout => "TIMEOUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AGENT_ISSUE" => Ok(ErrorCode::AgentIssue),
+            "ALARM_ACTIVE" => Ok(ErrorCode::AlarmActive),
+            "APPLICATION_MISSING" => Ok(ErrorCode::ApplicationMissing),
+            "AUTO_SCALING_CONFIGURATION" => Ok(ErrorCode::AutoScalingConfiguration),
+            "AUTO_SCALING_IAM_ROLE_PERMISSIONS" => Ok(ErrorCode::AutoScalingIamRolePermissions),
+            "DEPLOYMENT_GROUP_MISSING" => Ok(ErrorCode::DeploymentGroupMissing),
+            "HEALTH_CONSTRAINTS" => Ok(ErrorCode::HealthConstraints),
+            "HEALTH_CONSTRAINTS_INVALID" => Ok(ErrorCode::HealthConstraintsInvalid),
+            "IAM_ROLE_MISSING" => Ok(ErrorCode::IamRoleMissing),
+            "IAM_ROLE_PERMISSIONS" => Ok(ErrorCode::IamRolePermissions),
+            "INTERNAL_ERROR" => Ok(ErrorCode::InternalError),
+            "MANUAL_STOP" => Ok(ErrorCode::ManualStop),
+            "NO_EC2_SUBSCRIPTION" => Ok(ErrorCode::NoEc2Subscription),
+            "NO_INSTANCES" => Ok(ErrorCode::NoInstances),
+            "OVER_MAX_INSTANCES" => Ok(ErrorCode::OverMaxInstances),
+            "REVISION_MISSING" => Ok(ErrorCode::RevisionMissing),
+            "THROTTLED" => Ok(ErrorCode::Throttled),
+            "TIMEOUT" => Ok(ErrorCode::Timeout),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a deployment error.</p>"]
@@ -792,6 +1216,44 @@ pub struct ErrorInformation {
     #[serde(rename="message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FileExistsBehavior {
+    Disallow,
+    Overwrite,
+    Retain,
+}
+
+impl Into<String> for FileExistsBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FileExistsBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            FileExistsBehavior::Disallow => "DISALLOW",
+            FileExistsBehavior::Overwrite => "OVERWRITE",
+            FileExistsBehavior::Retain => "RETAIN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FileExistsBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISALLOW" => Ok(FileExistsBehavior::Disallow),
+            "OVERWRITE" => Ok(FileExistsBehavior::Overwrite),
+            "RETAIN" => Ok(FileExistsBehavior::Retain),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about an application revision.</p>"]
@@ -968,6 +1430,41 @@ pub struct GitHubLocation {
     pub repository: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GreenFleetProvisioningAction {
+    CopyAutoScalingGroup,
+    DiscoverExisting,
+}
+
+impl Into<String> for GreenFleetProvisioningAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GreenFleetProvisioningAction {
+    fn into(self) -> &'static str {
+        match self {
+            GreenFleetProvisioningAction::CopyAutoScalingGroup => "COPY_AUTO_SCALING_GROUP",
+            GreenFleetProvisioningAction::DiscoverExisting => "DISCOVER_EXISTING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GreenFleetProvisioningAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COPY_AUTO_SCALING_GROUP" => Ok(GreenFleetProvisioningAction::CopyAutoScalingGroup),
+            "DISCOVER_EXISTING" => Ok(GreenFleetProvisioningAction::DiscoverExisting),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the instances that belong to the replacement environment in a blue/green deployment.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GreenFleetProvisioningOption {
@@ -975,6 +1472,41 @@ pub struct GreenFleetProvisioningOption {
     #[serde(rename="action")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub action: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceAction {
+    KeepAlive,
+    Terminate,
+}
+
+impl Into<String> for InstanceAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceAction {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceAction::KeepAlive => "KEEP_ALIVE",
+            InstanceAction::Terminate => "TERMINATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEEP_ALIVE" => Ok(InstanceAction::KeepAlive),
+            "TERMINATE" => Ok(InstanceAction::Terminate),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about an on-premises instance.</p>"]
@@ -1010,6 +1542,56 @@ pub struct InstanceInfo {
     pub tags: Option<Vec<Tag>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceStatus {
+    Failed,
+    InProgress,
+    Pending,
+    Ready,
+    Skipped,
+    Succeeded,
+    Unknown,
+}
+
+impl Into<String> for InstanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceStatus::Failed => "Failed",
+            InstanceStatus::InProgress => "InProgress",
+            InstanceStatus::Pending => "Pending",
+            InstanceStatus::Ready => "Ready",
+            InstanceStatus::Skipped => "Skipped",
+            InstanceStatus::Succeeded => "Succeeded",
+            InstanceStatus::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(InstanceStatus::Failed),
+            "InProgress" => Ok(InstanceStatus::InProgress),
+            "Pending" => Ok(InstanceStatus::Pending),
+            "Ready" => Ok(InstanceStatus::Ready),
+            "Skipped" => Ok(InstanceStatus::Skipped),
+            "Succeeded" => Ok(InstanceStatus::Succeeded),
+            "Unknown" => Ok(InstanceStatus::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about an instance in a deployment.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceSummary {
@@ -1039,6 +1621,41 @@ pub struct InstanceSummary {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceType {
+    Blue,
+    Green,
+}
+
+impl Into<String> for InstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceType::Blue => "Blue",
+            InstanceType::Green => "Green",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Blue" => Ok(InstanceType::Blue),
+            "Green" => Ok(InstanceType::Green),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the most recent attempted or successful deployment to a deployment group.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct LastDeploymentInfo {
@@ -1058,6 +1675,53 @@ pub struct LastDeploymentInfo {
     #[serde(rename="status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LifecycleErrorCode {
+    ScriptFailed,
+    ScriptMissing,
+    ScriptNotExecutable,
+    ScriptTimedOut,
+    Success,
+    UnknownError,
+}
+
+impl Into<String> for LifecycleErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LifecycleErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            LifecycleErrorCode::ScriptFailed => "ScriptFailed",
+            LifecycleErrorCode::ScriptMissing => "ScriptMissing",
+            LifecycleErrorCode::ScriptNotExecutable => "ScriptNotExecutable",
+            LifecycleErrorCode::ScriptTimedOut => "ScriptTimedOut",
+            LifecycleErrorCode::Success => "Success",
+            LifecycleErrorCode::UnknownError => "UnknownError",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LifecycleErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ScriptFailed" => Ok(LifecycleErrorCode::ScriptFailed),
+            "ScriptMissing" => Ok(LifecycleErrorCode::ScriptMissing),
+            "ScriptNotExecutable" => Ok(LifecycleErrorCode::ScriptNotExecutable),
+            "ScriptTimedOut" => Ok(LifecycleErrorCode::ScriptTimedOut),
+            "Success" => Ok(LifecycleErrorCode::Success),
+            "UnknownError" => Ok(LifecycleErrorCode::UnknownError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a deployment lifecycle event.</p>"]
@@ -1083,6 +1747,53 @@ pub struct LifecycleEvent {
     #[serde(rename="status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LifecycleEventStatus {
+    Failed,
+    InProgress,
+    Pending,
+    Skipped,
+    Succeeded,
+    Unknown,
+}
+
+impl Into<String> for LifecycleEventStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LifecycleEventStatus {
+    fn into(self) -> &'static str {
+        match self {
+            LifecycleEventStatus::Failed => "Failed",
+            LifecycleEventStatus::InProgress => "InProgress",
+            LifecycleEventStatus::Pending => "Pending",
+            LifecycleEventStatus::Skipped => "Skipped",
+            LifecycleEventStatus::Succeeded => "Succeeded",
+            LifecycleEventStatus::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LifecycleEventStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(LifecycleEventStatus::Failed),
+            "InProgress" => Ok(LifecycleEventStatus::InProgress),
+            "Pending" => Ok(LifecycleEventStatus::Pending),
+            "Skipped" => Ok(LifecycleEventStatus::Skipped),
+            "Succeeded" => Ok(LifecycleEventStatus::Succeeded),
+            "Unknown" => Ok(LifecycleEventStatus::Unknown),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a ListApplicationRevisions operation.</p>"]
@@ -1326,6 +2037,44 @@ pub struct ListOnPremisesInstancesOutput {
     pub next_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ListStateFilterAction {
+    Exclude,
+    Ignore,
+    Include,
+}
+
+impl Into<String> for ListStateFilterAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ListStateFilterAction {
+    fn into(self) -> &'static str {
+        match self {
+            ListStateFilterAction::Exclude => "exclude",
+            ListStateFilterAction::Ignore => "ignore",
+            ListStateFilterAction::Include => "include",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ListStateFilterAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "exclude" => Ok(ListStateFilterAction::Exclude),
+            "ignore" => Ok(ListStateFilterAction::Ignore),
+            "include" => Ok(ListStateFilterAction::Include),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the load balancer used in a deployment.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerInfo {
@@ -1346,6 +2095,41 @@ pub struct MinimumHealthyHosts {
     #[serde(rename="value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MinimumHealthyHostsType {
+    FleetPercent,
+    HostCount,
+}
+
+impl Into<String> for MinimumHealthyHostsType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MinimumHealthyHostsType {
+    fn into(self) -> &'static str {
+        match self {
+            MinimumHealthyHostsType::FleetPercent => "FLEET_PERCENT",
+            MinimumHealthyHostsType::HostCount => "HOST_COUNT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MinimumHealthyHostsType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FLEET_PERCENT" => Ok(MinimumHealthyHostsType::FleetPercent),
+            "HOST_COUNT" => Ok(MinimumHealthyHostsType::HostCount),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a RegisterApplicationRevision operation.</p>"]
@@ -1377,6 +2161,41 @@ pub struct RegisterOnPremisesInstanceInput {
     #[doc="<p>The name of the on-premises instance to register.</p>"]
     #[serde(rename="instanceName")]
     pub instance_name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RegistrationStatus {
+    Deregistered,
+    Registered,
+}
+
+impl Into<String> for RegistrationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RegistrationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RegistrationStatus::Deregistered => "Deregistered",
+            RegistrationStatus::Registered => "Registered",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RegistrationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Deregistered" => Ok(RegistrationStatus::Deregistered),
+            "Registered" => Ok(RegistrationStatus::Registered),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a RemoveTagsFromOnPremisesInstances operation.</p>"]
@@ -1418,6 +2237,41 @@ pub struct RevisionLocation {
     #[serde(rename="s3Location")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub s_3_location: Option<S3Location>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RevisionLocationType {
+    GitHub,
+    S3,
+}
+
+impl Into<String> for RevisionLocationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RevisionLocationType {
+    fn into(self) -> &'static str {
+        match self {
+            RevisionLocationType::GitHub => "GitHub",
+            RevisionLocationType::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RevisionLocationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GitHub" => Ok(RevisionLocationType::GitHub),
+            "S3" => Ok(RevisionLocationType::S3),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a deployment rollback.</p>"]
@@ -1470,6 +2324,41 @@ pub struct SkipWaitTimeForInstanceTerminationInput {
     pub deployment_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+impl Into<String> for SortOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrder {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrder::Ascending => "ascending",
+            SortOrder::Descending => "descending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ascending" => Ok(SortOrder::Ascending),
+            "descending" => Ok(SortOrder::Descending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of a StopDeployment operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StopDeploymentInput {
@@ -1493,6 +2382,41 @@ pub struct StopDeploymentOutput {
     #[serde(rename="statusMessage")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StopStatus {
+    Pending,
+    Succeeded,
+}
+
+impl Into<String> for StopStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StopStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StopStatus::Pending => "Pending",
+            StopStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StopStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(StopStatus::Pending),
+            "Succeeded" => Ok(StopStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a tag.</p>"]
@@ -1523,6 +2447,44 @@ pub struct TagFilter {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TagFilterType {
+    KeyAndValue,
+    KeyOnly,
+    ValueOnly,
+}
+
+impl Into<String> for TagFilterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TagFilterType {
+    fn into(self) -> &'static str {
+        match self {
+            TagFilterType::KeyAndValue => "KEY_AND_VALUE",
+            TagFilterType::KeyOnly => "KEY_ONLY",
+            TagFilterType::ValueOnly => "VALUE_ONLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TagFilterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEY_AND_VALUE" => Ok(TagFilterType::KeyAndValue),
+            "KEY_ONLY" => Ok(TagFilterType::KeyOnly),
+            "VALUE_ONLY" => Ok(TagFilterType::ValueOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about the instances to be used in the replacement environment in a blue/green deployment.</p>"]
@@ -1566,6 +2528,65 @@ pub struct TriggerConfig {
     #[serde(rename="triggerTargetArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub trigger_target_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TriggerEventType {
+    DeploymentFailure,
+    DeploymentReady,
+    DeploymentRollback,
+    DeploymentStart,
+    DeploymentStop,
+    DeploymentSuccess,
+    InstanceFailure,
+    InstanceReady,
+    InstanceStart,
+    InstanceSuccess,
+}
+
+impl Into<String> for TriggerEventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TriggerEventType {
+    fn into(self) -> &'static str {
+        match self {
+            TriggerEventType::DeploymentFailure => "DeploymentFailure",
+            TriggerEventType::DeploymentReady => "DeploymentReady",
+            TriggerEventType::DeploymentRollback => "DeploymentRollback",
+            TriggerEventType::DeploymentStart => "DeploymentStart",
+            TriggerEventType::DeploymentStop => "DeploymentStop",
+            TriggerEventType::DeploymentSuccess => "DeploymentSuccess",
+            TriggerEventType::InstanceFailure => "InstanceFailure",
+            TriggerEventType::InstanceReady => "InstanceReady",
+            TriggerEventType::InstanceStart => "InstanceStart",
+            TriggerEventType::InstanceSuccess => "InstanceSuccess",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TriggerEventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DeploymentFailure" => Ok(TriggerEventType::DeploymentFailure),
+            "DeploymentReady" => Ok(TriggerEventType::DeploymentReady),
+            "DeploymentRollback" => Ok(TriggerEventType::DeploymentRollback),
+            "DeploymentStart" => Ok(TriggerEventType::DeploymentStart),
+            "DeploymentStop" => Ok(TriggerEventType::DeploymentStop),
+            "DeploymentSuccess" => Ok(TriggerEventType::DeploymentSuccess),
+            "InstanceFailure" => Ok(TriggerEventType::InstanceFailure),
+            "InstanceReady" => Ok(TriggerEventType::InstanceReady),
+            "InstanceStart" => Ok(TriggerEventType::InstanceStart),
+            "InstanceSuccess" => Ok(TriggerEventType::InstanceSuccess),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of an UpdateApplication operation.</p>"]
@@ -5646,7 +6667,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(AddTagsToOnPremisesInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -5670,7 +6691,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetApplicationRevisionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(BatchGetApplicationRevisionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5694,7 +6715,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetApplicationsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5723,7 +6744,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetDeploymentGroupsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(BatchGetDeploymentGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5749,7 +6770,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetDeploymentInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(BatchGetDeploymentInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5773,7 +6794,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetDeploymentsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5802,7 +6823,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetOnPremisesInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(BatchGetOnPremisesInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5826,7 +6847,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(ContinueDeploymentError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -5851,7 +6872,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateApplicationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5878,7 +6899,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDeploymentOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5906,7 +6927,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDeploymentConfigOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5934,7 +6955,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDeploymentGroupOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5961,7 +6982,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteApplicationError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -5986,7 +7007,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteDeploymentConfigError::from_body(String::from_utf8_lossy(&response.body)
                                                                .as_ref()))
@@ -6012,7 +7033,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteDeploymentGroupOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6040,7 +7061,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeregisterOnPremisesInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6062,7 +7083,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetApplicationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6090,7 +7111,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetApplicationRevisionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6117,7 +7138,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDeploymentOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6143,7 +7164,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDeploymentConfigOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6170,7 +7191,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDeploymentGroupOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6198,7 +7219,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDeploymentInstanceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6226,7 +7247,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetOnPremisesInstanceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6255,7 +7276,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListApplicationRevisionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListApplicationRevisionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6279,7 +7300,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListApplicationsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6307,7 +7328,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDeploymentConfigsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6334,7 +7355,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDeploymentGroupsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6363,7 +7384,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDeploymentInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListDeploymentInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6387,7 +7408,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDeploymentsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6416,7 +7437,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListGitHubAccountTokenNamesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListGitHubAccountTokenNamesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6442,7 +7463,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListOnPremisesInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListOnPremisesInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6467,7 +7488,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RegisterApplicationRevisionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6490,7 +7511,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RegisterOnPremisesInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6514,7 +7535,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RemoveTagsFromOnPremisesInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6538,7 +7559,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(SkipWaitTimeForInstanceTerminationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6560,7 +7581,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopDeploymentOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6587,7 +7608,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateApplicationError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -6613,7 +7634,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDeploymentGroupOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -83,6 +79,53 @@ pub struct AcknowledgeThirdPartyJobOutput {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionCategory {
+    Approval,
+    Build,
+    Deploy,
+    Invoke,
+    Source,
+    Test,
+}
+
+impl Into<String> for ActionCategory {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionCategory {
+    fn into(self) -> &'static str {
+        match self {
+            ActionCategory::Approval => "Approval",
+            ActionCategory::Build => "Build",
+            ActionCategory::Deploy => "Deploy",
+            ActionCategory::Invoke => "Invoke",
+            ActionCategory::Source => "Source",
+            ActionCategory::Test => "Test",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionCategory {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Approval" => Ok(ActionCategory::Approval),
+            "Build" => Ok(ActionCategory::Build),
+            "Deploy" => Ok(ActionCategory::Deploy),
+            "Invoke" => Ok(ActionCategory::Invoke),
+            "Source" => Ok(ActionCategory::Source),
+            "Test" => Ok(ActionCategory::Test),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about an action configuration.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ActionConfiguration {
@@ -119,6 +162,44 @@ pub struct ActionConfigurationProperty {
     #[serde(rename="type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionConfigurationPropertyType {
+    Boolean,
+    Number,
+    String,
+}
+
+impl Into<String> for ActionConfigurationPropertyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionConfigurationPropertyType {
+    fn into(self) -> &'static str {
+        match self {
+            ActionConfigurationPropertyType::Boolean => "Boolean",
+            ActionConfigurationPropertyType::Number => "Number",
+            ActionConfigurationPropertyType::String => "String",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionConfigurationPropertyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Boolean" => Ok(ActionConfigurationPropertyType::Boolean),
+            "Number" => Ok(ActionConfigurationPropertyType::Number),
+            "String" => Ok(ActionConfigurationPropertyType::String),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the context of an action within the stage of a pipeline to a job worker.</p>"]
@@ -200,6 +281,82 @@ pub struct ActionExecution {
     #[serde(rename="token")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub token: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionExecutionStatus {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for ActionExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ActionExecutionStatus::Failed => "Failed",
+            ActionExecutionStatus::InProgress => "InProgress",
+            ActionExecutionStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(ActionExecutionStatus::Failed),
+            "InProgress" => Ok(ActionExecutionStatus::InProgress),
+            "Succeeded" => Ok(ActionExecutionStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionOwner {
+    Aws,
+    Custom,
+    ThirdParty,
+}
+
+impl Into<String> for ActionOwner {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionOwner {
+    fn into(self) -> &'static str {
+        match self {
+            ActionOwner::Aws => "AWS",
+            ActionOwner::Custom => "Custom",
+            ActionOwner::ThirdParty => "ThirdParty",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionOwner {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(ActionOwner::Aws),
+            "Custom" => Ok(ActionOwner::Custom),
+            "ThirdParty" => Ok(ActionOwner::ThirdParty),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents information about the version (or revision) of an action.</p>"]
@@ -312,6 +469,41 @@ pub struct ApprovalResult {
     pub summary: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApprovalStatus {
+    Approved,
+    Rejected,
+}
+
+impl Into<String> for ApprovalStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApprovalStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ApprovalStatus::Approved => "Approved",
+            ApprovalStatus::Rejected => "Rejected",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApprovalStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Approved" => Ok(ApprovalStatus::Approved),
+            "Rejected" => Ok(ApprovalStatus::Rejected),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about an artifact that will be worked upon by actions in the pipeline.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Artifact {
@@ -351,6 +543,38 @@ pub struct ArtifactLocation {
     #[serde(rename="type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactLocationType {
+    S3,
+}
+
+impl Into<String> for ArtifactLocationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactLocationType {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactLocationType::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactLocationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "S3" => Ok(ArtifactLocationType::S3),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents revision details of an artifact. </p>"]
@@ -397,6 +621,38 @@ pub struct ArtifactStore {
     pub type_: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactStoreType {
+    S3,
+}
+
+impl Into<String> for ArtifactStoreType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactStoreType {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactStoreType::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactStoreType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "S3" => Ok(ArtifactStoreType::S3),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Reserved for future use.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BlockerDeclaration {
@@ -406,6 +662,38 @@ pub struct BlockerDeclaration {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BlockerType {
+    Schedule,
+}
+
+impl Into<String> for BlockerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BlockerType {
+    fn into(self) -> &'static str {
+        match self {
+            BlockerType::Schedule => "Schedule",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BlockerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Schedule" => Ok(BlockerType::Schedule),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a create custom action operation.</p>"]
@@ -544,6 +832,38 @@ pub struct EncryptionKey {
     pub type_: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EncryptionKeyType {
+    Kms,
+}
+
+impl Into<String> for EncryptionKeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EncryptionKeyType {
+    fn into(self) -> &'static str {
+        match self {
+            EncryptionKeyType::Kms => "KMS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EncryptionKeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KMS" => Ok(EncryptionKeyType::Kms),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about an error in AWS CodePipeline.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ErrorDetails {
@@ -587,6 +907,53 @@ pub struct FailureDetails {
     #[doc="<p>The type of the failure.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailureType {
+    ConfigurationError,
+    JobFailed,
+    PermissionError,
+    RevisionOutOfSync,
+    RevisionUnavailable,
+    SystemUnavailable,
+}
+
+impl Into<String> for FailureType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailureType {
+    fn into(self) -> &'static str {
+        match self {
+            FailureType::ConfigurationError => "ConfigurationError",
+            FailureType::JobFailed => "JobFailed",
+            FailureType::PermissionError => "PermissionError",
+            FailureType::RevisionOutOfSync => "RevisionOutOfSync",
+            FailureType::RevisionUnavailable => "RevisionUnavailable",
+            FailureType::SystemUnavailable => "SystemUnavailable",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailureType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ConfigurationError" => Ok(FailureType::ConfigurationError),
+            "JobFailed" => Ok(FailureType::JobFailed),
+            "PermissionError" => Ok(FailureType::PermissionError),
+            "RevisionOutOfSync" => Ok(FailureType::RevisionOutOfSync),
+            "RevisionUnavailable" => Ok(FailureType::RevisionUnavailable),
+            "SystemUnavailable" => Ok(FailureType::SystemUnavailable),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a get job details action.</p>"]
@@ -783,6 +1150,56 @@ pub struct JobDetails {
     pub id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobStatus {
+    Created,
+    Dispatched,
+    Failed,
+    InProgress,
+    Queued,
+    Succeeded,
+    TimedOut,
+}
+
+impl Into<String> for JobStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobStatus {
+    fn into(self) -> &'static str {
+        match self {
+            JobStatus::Created => "Created",
+            JobStatus::Dispatched => "Dispatched",
+            JobStatus::Failed => "Failed",
+            JobStatus::InProgress => "InProgress",
+            JobStatus::Queued => "Queued",
+            JobStatus::Succeeded => "Succeeded",
+            JobStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(JobStatus::Created),
+            "Dispatched" => Ok(JobStatus::Dispatched),
+            "Failed" => Ok(JobStatus::Failed),
+            "InProgress" => Ok(JobStatus::InProgress),
+            "Queued" => Ok(JobStatus::Queued),
+            "Succeeded" => Ok(JobStatus::Succeeded),
+            "TimedOut" => Ok(JobStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of a list action types action.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListActionTypesInput {
@@ -928,6 +1345,47 @@ pub struct PipelineExecution {
     #[serde(rename="status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PipelineExecutionStatus {
+    Failed,
+    InProgress,
+    Succeeded,
+    Superseded,
+}
+
+impl Into<String> for PipelineExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PipelineExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PipelineExecutionStatus::Failed => "Failed",
+            PipelineExecutionStatus::InProgress => "InProgress",
+            PipelineExecutionStatus::Succeeded => "Succeeded",
+            PipelineExecutionStatus::Superseded => "Superseded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PipelineExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(PipelineExecutionStatus::Failed),
+            "InProgress" => Ok(PipelineExecutionStatus::InProgress),
+            "Succeeded" => Ok(PipelineExecutionStatus::Succeeded),
+            "Superseded" => Ok(PipelineExecutionStatus::Superseded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Summary information about a pipeline execution.</p>"]
@@ -1217,6 +1675,76 @@ pub struct StageExecution {
     pub status: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StageExecutionStatus {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for StageExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StageExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StageExecutionStatus::Failed => "Failed",
+            StageExecutionStatus::InProgress => "InProgress",
+            StageExecutionStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StageExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(StageExecutionStatus::Failed),
+            "InProgress" => Ok(StageExecutionStatus::InProgress),
+            "Succeeded" => Ok(StageExecutionStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StageRetryMode {
+    FailedActions,
+}
+
+impl Into<String> for StageRetryMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StageRetryMode {
+    fn into(self) -> &'static str {
+        match self {
+            StageRetryMode::FailedActions => "FAILED_ACTIONS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StageRetryMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED_ACTIONS" => Ok(StageRetryMode::FailedActions),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about the state of the stage.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StageState {
@@ -1236,6 +1764,41 @@ pub struct StageState {
     #[serde(rename="stageName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stage_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StageTransitionType {
+    Inbound,
+    Outbound,
+}
+
+impl Into<String> for StageTransitionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StageTransitionType {
+    fn into(self) -> &'static str {
+        match self {
+            StageTransitionType::Inbound => "Inbound",
+            StageTransitionType::Outbound => "Outbound",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StageTransitionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Inbound" => Ok(StageTransitionType::Inbound),
+            "Outbound" => Ok(StageTransitionType::Outbound),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a start pipeline execution action.</p>"]
@@ -3770,7 +4333,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AcknowledgeJobOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3799,7 +4362,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AcknowledgeThirdPartyJobOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AcknowledgeThirdPartyJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3825,7 +4388,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateCustomActionTypeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3852,7 +4415,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3880,7 +4443,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteCustomActionTypeError::from_body(String::from_utf8_lossy(&response.body)
                                                                .as_ref()))
@@ -3903,7 +4466,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeletePipelineError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -3929,7 +4492,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DisableStageTransitionError::from_body(String::from_utf8_lossy(&response.body)
                                                                .as_ref()))
@@ -3955,7 +4518,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(EnableStageTransitionError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))
@@ -3980,7 +4543,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetJobDetailsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4006,7 +4569,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetPipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetPipelineError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4030,7 +4593,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetPipelineExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4057,7 +4620,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetPipelineStateOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4086,7 +4649,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetThirdPartyJobDetailsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetThirdPartyJobDetailsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4110,7 +4673,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListActionTypesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4139,7 +4702,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPipelineExecutionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4166,7 +4729,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPipelinesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4192,7 +4755,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PollForJobsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(PollForJobsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4218,7 +4781,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PollForThirdPartyJobsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4245,7 +4808,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutActionRevisionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4272,7 +4835,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutApprovalResultOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4299,7 +4862,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutJobFailureResultError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -4324,7 +4887,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutJobSuccessResultError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -4350,7 +4913,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(PutThirdPartyJobFailureResultError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4373,7 +4936,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(PutThirdPartyJobSuccessResultError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4395,7 +4958,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RetryStageExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4424,7 +4987,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartPipelineExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4451,7 +5014,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -11,21 +11,52 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AmbiguousRoleResolutionType {
+    AuthenticatedRole,
+    Deny,
+}
+
+impl Into<String> for AmbiguousRoleResolutionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AmbiguousRoleResolutionType {
+    fn into(self) -> &'static str {
+        match self {
+            AmbiguousRoleResolutionType::AuthenticatedRole => "AuthenticatedRole",
+            AmbiguousRoleResolutionType::Deny => "Deny",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AmbiguousRoleResolutionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AuthenticatedRole" => Ok(AmbiguousRoleResolutionType::AuthenticatedRole),
+            "Deny" => Ok(AmbiguousRoleResolutionType::Deny),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A provider representing an Amazon Cognito Identity User Pool and its client ID.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CognitoIdentityProvider {
@@ -134,6 +165,41 @@ pub struct DescribeIdentityPoolInput {
     #[doc="<p>An identity pool ID in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityPoolId")]
     pub identity_pool_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ErrorCode {
+    AccessDenied,
+    InternalServerError,
+}
+
+impl Into<String> for ErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            ErrorCode::AccessDenied => "AccessDenied",
+            ErrorCode::InternalServerError => "InternalServerError",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AccessDenied" => Ok(ErrorCode::AccessDenied),
+            "InternalServerError" => Ok(ErrorCode::InternalServerError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Input to the <code>GetCredentialsForIdentity</code> action.</p>"]
@@ -459,6 +525,47 @@ pub struct MappingRule {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MappingRuleMatchType {
+    Contains,
+    Equals,
+    NotEqual,
+    StartsWith,
+}
+
+impl Into<String> for MappingRuleMatchType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MappingRuleMatchType {
+    fn into(self) -> &'static str {
+        match self {
+            MappingRuleMatchType::Contains => "Contains",
+            MappingRuleMatchType::Equals => "Equals",
+            MappingRuleMatchType::NotEqual => "NotEqual",
+            MappingRuleMatchType::StartsWith => "StartsWith",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MappingRuleMatchType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Contains" => Ok(MappingRuleMatchType::Contains),
+            "Equals" => Ok(MappingRuleMatchType::Equals),
+            "NotEqual" => Ok(MappingRuleMatchType::NotEqual),
+            "StartsWith" => Ok(MappingRuleMatchType::StartsWith),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Input to the <code>MergeDeveloperIdentities</code> action.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct MergeDeveloperIdentitiesInput {
@@ -499,6 +606,41 @@ pub struct RoleMapping {
     #[doc="<p>The role mapping type. Token will use <code>cognito:roles</code> and <code>cognito:preferred_role</code> claims from the Cognito identity provider token to map groups to roles. Rules will attempt to match claims from the token to map to a role.</p>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RoleMappingType {
+    Rules,
+    Token,
+}
+
+impl Into<String> for RoleMappingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RoleMappingType {
+    fn into(self) -> &'static str {
+        match self {
+            RoleMappingType::Rules => "Rules",
+            RoleMappingType::Token => "Token",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RoleMappingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Rules" => Ok(RoleMappingType::Rules),
+            "Token" => Ok(RoleMappingType::Token),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A container for rules.</p>"]
@@ -2602,7 +2744,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())
@@ -2631,7 +2773,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteIdentitiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2659,7 +2801,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteIdentityPoolError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -2684,7 +2826,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<IdentityDescription>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2712,7 +2854,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())
@@ -2743,7 +2885,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetCredentialsForIdentityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetCredentialsForIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2765,7 +2907,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetIdResponse>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -2793,7 +2935,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetIdentityPoolRolesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2820,7 +2962,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetOpenIdTokenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2850,7 +2992,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetOpenIdTokenForDeveloperIdentityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetOpenIdTokenForDeveloperIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2874,7 +3016,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListIdentitiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2902,7 +3044,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListIdentityPoolsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2931,7 +3073,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<LookupDeveloperIdentityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(LookupDeveloperIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2957,7 +3099,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<MergeDeveloperIdentitiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(MergeDeveloperIdentitiesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2982,7 +3124,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(SetIdentityPoolRolesError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -3008,7 +3150,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(UnlinkDeveloperIdentityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -3028,7 +3170,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UnlinkIdentityError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -3054,7 +3196,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -517,6 +513,85 @@ pub struct AdminUserGlobalSignOutRequest {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AdminUserGlobalSignOutResponse;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AliasAttributeType {
+    Email,
+    PhoneNumber,
+    PreferredUsername,
+}
+
+impl Into<String> for AliasAttributeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AliasAttributeType {
+    fn into(self) -> &'static str {
+        match self {
+            AliasAttributeType::Email => "email",
+            AliasAttributeType::PhoneNumber => "phone_number",
+            AliasAttributeType::PreferredUsername => "preferred_username",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AliasAttributeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "email" => Ok(AliasAttributeType::Email),
+            "phone_number" => Ok(AliasAttributeType::PhoneNumber),
+            "preferred_username" => Ok(AliasAttributeType::PreferredUsername),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AttributeDataType {
+    Boolean,
+    DateTime,
+    Number,
+    String,
+}
+
+impl Into<String> for AttributeDataType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AttributeDataType {
+    fn into(self) -> &'static str {
+        match self {
+            AttributeDataType::Boolean => "Boolean",
+            AttributeDataType::DateTime => "DateTime",
+            AttributeDataType::Number => "Number",
+            AttributeDataType::String => "String",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AttributeDataType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Boolean" => Ok(AttributeDataType::Boolean),
+            "DateTime" => Ok(AttributeDataType::DateTime),
+            "Number" => Ok(AttributeDataType::Number),
+            "String" => Ok(AttributeDataType::String),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies whether the attribute is standard or custom.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttributeType {
@@ -527,6 +602,50 @@ pub struct AttributeType {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthFlowType {
+    AdminNoSrpAuth,
+    CustomAuth,
+    RefreshToken,
+    RefreshTokenAuth,
+    UserSrpAuth,
+}
+
+impl Into<String> for AuthFlowType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthFlowType {
+    fn into(self) -> &'static str {
+        match self {
+            AuthFlowType::AdminNoSrpAuth => "ADMIN_NO_SRP_AUTH",
+            AuthFlowType::CustomAuth => "CUSTOM_AUTH",
+            AuthFlowType::RefreshToken => "REFRESH_TOKEN",
+            AuthFlowType::RefreshTokenAuth => "REFRESH_TOKEN_AUTH",
+            AuthFlowType::UserSrpAuth => "USER_SRP_AUTH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthFlowType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADMIN_NO_SRP_AUTH" => Ok(AuthFlowType::AdminNoSrpAuth),
+            "CUSTOM_AUTH" => Ok(AuthFlowType::CustomAuth),
+            "REFRESH_TOKEN" => Ok(AuthFlowType::RefreshToken),
+            "REFRESH_TOKEN_AUTH" => Ok(AuthFlowType::RefreshTokenAuth),
+            "USER_SRP_AUTH" => Ok(AuthFlowType::UserSrpAuth),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The result type of the authentication result.</p>"]
@@ -556,6 +675,56 @@ pub struct AuthenticationResultType {
     #[serde(rename="TokenType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub token_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChallengeNameType {
+    AdminNoSrpAuth,
+    CustomChallenge,
+    DevicePasswordVerifier,
+    DeviceSrpAuth,
+    NewPasswordRequired,
+    PasswordVerifier,
+    SmsMfa,
+}
+
+impl Into<String> for ChallengeNameType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChallengeNameType {
+    fn into(self) -> &'static str {
+        match self {
+            ChallengeNameType::AdminNoSrpAuth => "ADMIN_NO_SRP_AUTH",
+            ChallengeNameType::CustomChallenge => "CUSTOM_CHALLENGE",
+            ChallengeNameType::DevicePasswordVerifier => "DEVICE_PASSWORD_VERIFIER",
+            ChallengeNameType::DeviceSrpAuth => "DEVICE_SRP_AUTH",
+            ChallengeNameType::NewPasswordRequired => "NEW_PASSWORD_REQUIRED",
+            ChallengeNameType::PasswordVerifier => "PASSWORD_VERIFIER",
+            ChallengeNameType::SmsMfa => "SMS_MFA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChallengeNameType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADMIN_NO_SRP_AUTH" => Ok(ChallengeNameType::AdminNoSrpAuth),
+            "CUSTOM_CHALLENGE" => Ok(ChallengeNameType::CustomChallenge),
+            "DEVICE_PASSWORD_VERIFIER" => Ok(ChallengeNameType::DevicePasswordVerifier),
+            "DEVICE_SRP_AUTH" => Ok(ChallengeNameType::DeviceSrpAuth),
+            "NEW_PASSWORD_REQUIRED" => Ok(ChallengeNameType::NewPasswordRequired),
+            "PASSWORD_VERIFIER" => Ok(ChallengeNameType::PasswordVerifier),
+            "SMS_MFA" => Ok(ChallengeNameType::SmsMfa),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request to change a user password.</p>"]
@@ -989,6 +1158,41 @@ pub struct DeleteUserRequest {
     pub access_token: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeliveryMediumType {
+    Email,
+    Sms,
+}
+
+impl Into<String> for DeliveryMediumType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeliveryMediumType {
+    fn into(self) -> &'static str {
+        match self {
+            DeliveryMediumType::Email => "EMAIL",
+            DeliveryMediumType::Sms => "SMS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeliveryMediumType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EMAIL" => Ok(DeliveryMediumType::Email),
+            "SMS" => Ok(DeliveryMediumType::Sms),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DescribeIdentityProviderRequest {
     #[doc="<p>The identity provider name.</p>"]
@@ -1091,6 +1295,41 @@ pub struct DeviceConfigurationType {
     pub device_only_remembered_on_user_prompt: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeviceRememberedStatusType {
+    NotRemembered,
+    Remembered,
+}
+
+impl Into<String> for DeviceRememberedStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeviceRememberedStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            DeviceRememberedStatusType::NotRemembered => "not_remembered",
+            DeviceRememberedStatusType::Remembered => "remembered",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeviceRememberedStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "not_remembered" => Ok(DeviceRememberedStatusType::NotRemembered),
+            "remembered" => Ok(DeviceRememberedStatusType::Remembered),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The device verifier against which it will be authenticated.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeviceSecretVerifierConfigType {
@@ -1162,6 +1401,47 @@ pub struct DomainDescriptionType {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainStatusType {
+    Active,
+    Creating,
+    Deleting,
+    Updating,
+}
+
+impl Into<String> for DomainStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            DomainStatusType::Active => "ACTIVE",
+            DomainStatusType::Creating => "CREATING",
+            DomainStatusType::Deleting => "DELETING",
+            DomainStatusType::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(DomainStatusType::Active),
+            "CREATING" => Ok(DomainStatusType::Creating),
+            "DELETING" => Ok(DomainStatusType::Deleting),
+            "UPDATING" => Ok(DomainStatusType::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The email configuration type.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EmailConfigurationType {
@@ -1173,6 +1453,41 @@ pub struct EmailConfigurationType {
     #[serde(rename="SourceArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub source_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExplicitAuthFlowsType {
+    AdminNoSrpAuth,
+    CustomAuthFlowOnly,
+}
+
+impl Into<String> for ExplicitAuthFlowsType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExplicitAuthFlowsType {
+    fn into(self) -> &'static str {
+        match self {
+            ExplicitAuthFlowsType::AdminNoSrpAuth => "ADMIN_NO_SRP_AUTH",
+            ExplicitAuthFlowsType::CustomAuthFlowOnly => "CUSTOM_AUTH_FLOW_ONLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExplicitAuthFlowsType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADMIN_NO_SRP_AUTH" => Ok(ExplicitAuthFlowsType::AdminNoSrpAuth),
+            "CUSTOM_AUTH_FLOW_ONLY" => Ok(ExplicitAuthFlowsType::CustomAuthFlowOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request to forget the device.</p>"]
@@ -1410,6 +1725,38 @@ pub struct IdentityProviderType {
     #[serde(rename="UserPoolId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub user_pool_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IdentityProviderTypeType {
+    Saml,
+}
+
+impl Into<String> for IdentityProviderTypeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IdentityProviderTypeType {
+    fn into(self) -> &'static str {
+        match self {
+            IdentityProviderTypeType::Saml => "SAML",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IdentityProviderTypeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SAML" => Ok(IdentityProviderTypeType::Saml),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Initiates the authentication request.</p>"]
@@ -1733,6 +2080,41 @@ pub struct MFAOptionType {
     pub delivery_medium: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MessageActionType {
+    Resend,
+    Suppress,
+}
+
+impl Into<String> for MessageActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MessageActionType {
+    fn into(self) -> &'static str {
+        match self {
+            MessageActionType::Resend => "RESEND",
+            MessageActionType::Suppress => "SUPPRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MessageActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RESEND" => Ok(MessageActionType::Resend),
+            "SUPPRESS" => Ok(MessageActionType::Suppress),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The message template structure.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MessageTemplateType {
@@ -1774,6 +2156,44 @@ pub struct NumberAttributeConstraintsType {
     #[serde(rename="MinValue")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub min_value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OAuthFlowType {
+    ClientCredentials,
+    Code,
+    Implicit,
+}
+
+impl Into<String> for OAuthFlowType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OAuthFlowType {
+    fn into(self) -> &'static str {
+        match self {
+            OAuthFlowType::ClientCredentials => "client_credentials",
+            OAuthFlowType::Code => "code",
+            OAuthFlowType::Implicit => "implicit",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OAuthFlowType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "client_credentials" => Ok(OAuthFlowType::ClientCredentials),
+            "code" => Ok(OAuthFlowType::Code),
+            "implicit" => Ok(OAuthFlowType::Implicit),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The password policy type.</p>"]
@@ -2005,6 +2425,41 @@ pub struct StartUserImportJobResponse {
     #[serde(rename="UserImportJob")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub user_import_job: Option<UserImportJobType>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusType {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for StatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusType {
+    fn into(self) -> &'static str {
+        match self {
+            StatusType::Disabled => "Disabled",
+            StatusType::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(StatusType::Disabled),
+            "Enabled" => Ok(StatusType::Enabled),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request to stop the user import job.</p>"]
@@ -2270,6 +2725,59 @@ pub struct UpdateUserPoolRequest {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UpdateUserPoolResponse;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserImportJobStatusType {
+    Created,
+    Expired,
+    Failed,
+    InProgress,
+    Pending,
+    Stopped,
+    Stopping,
+    Succeeded,
+}
+
+impl Into<String> for UserImportJobStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserImportJobStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            UserImportJobStatusType::Created => "Created",
+            UserImportJobStatusType::Expired => "Expired",
+            UserImportJobStatusType::Failed => "Failed",
+            UserImportJobStatusType::InProgress => "InProgress",
+            UserImportJobStatusType::Pending => "Pending",
+            UserImportJobStatusType::Stopped => "Stopped",
+            UserImportJobStatusType::Stopping => "Stopping",
+            UserImportJobStatusType::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserImportJobStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(UserImportJobStatusType::Created),
+            "Expired" => Ok(UserImportJobStatusType::Expired),
+            "Failed" => Ok(UserImportJobStatusType::Failed),
+            "InProgress" => Ok(UserImportJobStatusType::InProgress),
+            "Pending" => Ok(UserImportJobStatusType::Pending),
+            "Stopped" => Ok(UserImportJobStatusType::Stopped),
+            "Stopping" => Ok(UserImportJobStatusType::Stopping),
+            "Succeeded" => Ok(UserImportJobStatusType::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The user import job type.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UserImportJobType {
@@ -2446,6 +2954,44 @@ pub struct UserPoolDescriptionType {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserPoolMfaType {
+    Off,
+    On,
+    Optional,
+}
+
+impl Into<String> for UserPoolMfaType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserPoolMfaType {
+    fn into(self) -> &'static str {
+        match self {
+            UserPoolMfaType::Off => "OFF",
+            UserPoolMfaType::On => "ON",
+            UserPoolMfaType::Optional => "OPTIONAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserPoolMfaType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OFF" => Ok(UserPoolMfaType::Off),
+            "ON" => Ok(UserPoolMfaType::On),
+            "OPTIONAL" => Ok(UserPoolMfaType::Optional),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The type of policy in a user pool.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserPoolPolicyType {
@@ -2552,6 +3098,56 @@ pub struct UserPoolType {
     pub user_pool_tags: Option<::std::collections::HashMap<String, String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserStatusType {
+    Archived,
+    Compromised,
+    Confirmed,
+    ForceChangePassword,
+    ResetRequired,
+    Unconfirmed,
+    Unknown,
+}
+
+impl Into<String> for UserStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            UserStatusType::Archived => "ARCHIVED",
+            UserStatusType::Compromised => "COMPROMISED",
+            UserStatusType::Confirmed => "CONFIRMED",
+            UserStatusType::ForceChangePassword => "FORCE_CHANGE_PASSWORD",
+            UserStatusType::ResetRequired => "RESET_REQUIRED",
+            UserStatusType::Unconfirmed => "UNCONFIRMED",
+            UserStatusType::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ARCHIVED" => Ok(UserStatusType::Archived),
+            "COMPROMISED" => Ok(UserStatusType::Compromised),
+            "CONFIRMED" => Ok(UserStatusType::Confirmed),
+            "FORCE_CHANGE_PASSWORD" => Ok(UserStatusType::ForceChangePassword),
+            "RESET_REQUIRED" => Ok(UserStatusType::ResetRequired),
+            "UNCONFIRMED" => Ok(UserStatusType::Unconfirmed),
+            "UNKNOWN" => Ok(UserStatusType::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The user type.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UserType {
@@ -2583,6 +3179,41 @@ pub struct UserType {
     #[serde(rename="Username")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub username: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VerifiedAttributeType {
+    Email,
+    PhoneNumber,
+}
+
+impl Into<String> for VerifiedAttributeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VerifiedAttributeType {
+    fn into(self) -> &'static str {
+        match self {
+            VerifiedAttributeType::Email => "email",
+            VerifiedAttributeType::PhoneNumber => "phone_number",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VerifiedAttributeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "email" => Ok(VerifiedAttributeType::Email),
+            "phone_number" => Ok(VerifiedAttributeType::PhoneNumber),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request to verify user attributes.</p>"]
@@ -11630,7 +12261,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddCustomAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11658,7 +12289,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AdminAddUserToGroupError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -11684,7 +12315,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminConfirmSignUpResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11712,7 +12343,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminCreateUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11740,7 +12371,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AdminDeleteUserError::from_body(String::from_utf8_lossy(&response.body)
                                                         .as_ref()))
@@ -11767,7 +12398,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminDeleteUserAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AdminDeleteUserAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -11792,7 +12423,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminDisableUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11820,7 +12451,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminEnableUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11848,7 +12479,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AdminForgetDeviceError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -11874,7 +12505,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminGetDeviceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11902,7 +12533,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminGetUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11929,7 +12560,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminInitiateAuthResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11957,7 +12588,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminListDevicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -11986,7 +12617,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminListGroupsForUserResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12014,7 +12645,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(AdminRemoveUserFromGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -12038,7 +12669,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminResetUserPasswordResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12067,7 +12698,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminRespondToAuthChallengeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AdminRespondToAuthChallengeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12093,7 +12724,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminSetUserSettingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12122,7 +12753,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminUpdateDeviceStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AdminUpdateDeviceStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12148,7 +12779,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminUpdateUserAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AdminUpdateUserAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12174,7 +12805,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AdminUserGlobalSignOutResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12202,7 +12833,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ChangePasswordResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12230,7 +12861,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ConfirmDeviceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12258,7 +12889,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ConfirmForgotPasswordResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12286,7 +12917,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ConfirmSignUpResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12313,7 +12944,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12339,7 +12970,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateIdentityProviderResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12367,7 +12998,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateUserImportJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12395,7 +13026,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateUserPoolResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12424,7 +13055,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateUserPoolClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12453,7 +13084,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateUserPoolDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12479,7 +13110,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -12502,7 +13133,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteIdentityProviderError::from_body(String::from_utf8_lossy(&response.body)
                                                                .as_ref()))
@@ -12526,7 +13157,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteUserError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -12550,7 +13181,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteUserAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12576,7 +13207,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteUserPoolError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -12602,7 +13233,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteUserPoolClientError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -12629,7 +13260,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteUserPoolDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12658,7 +13289,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeIdentityProviderResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeIdentityProviderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12684,7 +13315,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeUserImportJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12712,7 +13343,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeUserPoolResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12741,7 +13372,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeUserPoolClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12770,7 +13401,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeUserPoolDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12796,7 +13427,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(ForgetDeviceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -12821,7 +13452,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ForgotPasswordResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12849,7 +13480,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetCSVHeaderResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12874,7 +13505,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDeviceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetDeviceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12896,7 +13527,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12922,7 +13553,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetIdentityProviderByIdentifierResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetIdentityProviderByIdentifierError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12944,7 +13575,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetUserResponse>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -12972,7 +13603,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetUserAttributeVerificationCodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetUserAttributeVerificationCodeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12997,7 +13628,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GlobalSignOutResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13024,7 +13655,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<InitiateAuthResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13051,7 +13682,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDevicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListDevicesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13076,7 +13707,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListGroupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13102,7 +13733,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListIdentityProvidersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13130,7 +13761,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListUserImportJobsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13158,7 +13789,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListUserPoolClientsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13186,7 +13817,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListUserPoolsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13211,7 +13842,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListUsersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListUsersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13236,7 +13867,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListUsersInGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13265,7 +13896,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ResendConfirmationCodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13294,7 +13925,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RespondToAuthChallengeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13322,7 +13953,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SetUserSettingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13347,7 +13978,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<SignUpResponse>(String::from_utf8_lossy(&response.body)
                                                               .as_ref())
                            .unwrap())
@@ -13374,7 +14005,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartUserImportJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13402,7 +14033,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopUserImportJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13430,7 +14061,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDeviceStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13458,7 +14089,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13484,7 +14115,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateIdentityProviderResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13513,7 +14144,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateUserAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13541,7 +14172,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateUserPoolResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13570,7 +14201,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateUserPoolClientResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13598,7 +14229,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<VerifyUserAttributeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -11,21 +11,52 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChronologicalOrder {
+    Forward,
+    Reverse,
+}
+
+impl Into<String> for ChronologicalOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChronologicalOrder {
+    fn into(self) -> &'static str {
+        match self {
+            ChronologicalOrder::Forward => "Forward",
+            ChronologicalOrder::Reverse => "Reverse",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChronologicalOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Forward" => Ok(ChronologicalOrder::Forward),
+            "Reverse" => Ok(ChronologicalOrder::Reverse),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Indicates whether an AWS resource or AWS Config rule is compliant and provides the number of contributors that affect the compliance.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Compliance {
@@ -110,6 +141,47 @@ pub struct ComplianceSummaryByResourceType {
     #[serde(rename="ResourceType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComplianceType {
+    Compliant,
+    InsufficientData,
+    NonCompliant,
+    NotApplicable,
+}
+
+impl Into<String> for ComplianceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComplianceType {
+    fn into(self) -> &'static str {
+        match self {
+            ComplianceType::Compliant => "COMPLIANT",
+            ComplianceType::InsufficientData => "INSUFFICIENT_DATA",
+            ComplianceType::NonCompliant => "NON_COMPLIANT",
+            ComplianceType::NotApplicable => "NOT_APPLICABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComplianceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLIANT" => Ok(ComplianceType::Compliant),
+            "INSUFFICIENT_DATA" => Ok(ComplianceType::InsufficientData),
+            "NON_COMPLIANT" => Ok(ComplianceType::NonCompliant),
+            "NOT_APPLICABLE" => Ok(ComplianceType::NotApplicable),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A list that contains the status of the delivery of either the snapshot or the configuration history to the specified Amazon S3 bucket.</p>"]
@@ -230,6 +302,47 @@ pub struct ConfigRuleEvaluationStatus {
     pub last_successful_invocation_time: Option<f64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigRuleState {
+    Active,
+    Deleting,
+    DeletingResults,
+    Evaluating,
+}
+
+impl Into<String> for ConfigRuleState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigRuleState {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigRuleState::Active => "ACTIVE",
+            ConfigRuleState::Deleting => "DELETING",
+            ConfigRuleState::DeletingResults => "DELETING_RESULTS",
+            ConfigRuleState::Evaluating => "EVALUATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigRuleState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ConfigRuleState::Active),
+            "DELETING" => Ok(ConfigRuleState::Deleting),
+            "DELETING_RESULTS" => Ok(ConfigRuleState::DeletingResults),
+            "EVALUATING" => Ok(ConfigRuleState::Evaluating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides options for how often AWS Config delivers configuration snapshots to the Amazon S3 bucket in your delivery channel.</p> <note> <p>If you want to create a rule that triggers evaluations for your resources when AWS Config delivers the configuration snapshot, see the following:</p> </note> <p>The frequency for a rule that triggers evaluations for your resources when AWS Config delivers the configuration snapshot is set by one of two values, depending on which is less frequent:</p> <ul> <li> <p>The value for the <code>deliveryFrequency</code> parameter within the delivery channel configuration, which sets how often AWS Config delivers configuration snapshots. This value also sets how often AWS Config invokes evaluations for Config rules.</p> </li> <li> <p>The value for the <code>MaximumExecutionFrequency</code> parameter, which sets the maximum frequency with which AWS Config invokes evaluations for the rule. For more information, see <a>ConfigRule</a>.</p> </li> </ul> <p>If the <code>deliveryFrequency</code> value is less frequent than the <code>MaximumExecutionFrequency</code> value for a rule, AWS Config invokes the rule only as often as the <code>deliveryFrequency</code> value.</p> <ol> <li> <p>For example, you want your rule to run evaluations when AWS Config delivers the configuration snapshot.</p> </li> <li> <p>You specify the <code>MaximumExecutionFrequency</code> value for <code>Six_Hours</code>. </p> </li> <li> <p>You then specify the delivery channel <code>deliveryFrequency</code> value for <code>TwentyFour_Hours</code>.</p> </li> <li> <p>Because the value for <code>deliveryFrequency</code> is less frequent than <code>MaximumExecutionFrequency</code>, AWS Config invokes evaluations for the rule every 24 hours. </p> </li> </ol> <p>You should set the <code>MaximumExecutionFrequency</code> value to be at least as frequent as the <code>deliveryFrequency</code> value. You can view the <code>deliveryFrequency</code> value by using the <code>DescribeDeliveryChannnels</code> action.</p> <p>To update the <code>deliveryFrequency</code> with which AWS Config delivers your configuration snapshots, use the <code>PutDeliveryChannel</code> action.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigSnapshotDeliveryProperties {
@@ -335,6 +448,47 @@ pub struct ConfigurationItem {
     #[serde(rename="version")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigurationItemStatus {
+    Deleted,
+    Discovered,
+    Failed,
+    Ok,
+}
+
+impl Into<String> for ConfigurationItemStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigurationItemStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigurationItemStatus::Deleted => "Deleted",
+            ConfigurationItemStatus::Discovered => "Discovered",
+            ConfigurationItemStatus::Failed => "Failed",
+            ConfigurationItemStatus::Ok => "Ok",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigurationItemStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Deleted" => Ok(ConfigurationItemStatus::Deleted),
+            "Discovered" => Ok(ConfigurationItemStatus::Discovered),
+            "Failed" => Ok(ConfigurationItemStatus::Failed),
+            "Ok" => Ok(ConfigurationItemStatus::Ok),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An object that represents the recording of configuration changes of an AWS resource.</p>"]
@@ -488,6 +642,44 @@ pub struct DeliveryChannelStatus {
     #[serde(rename="name")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeliveryStatus {
+    Failure,
+    NotApplicable,
+    Success,
+}
+
+impl Into<String> for DeliveryStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeliveryStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DeliveryStatus::Failure => "Failure",
+            DeliveryStatus::NotApplicable => "Not_Applicable",
+            DeliveryStatus::Success => "Success",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeliveryStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failure" => Ok(DeliveryStatus::Failure),
+            "Not_Applicable" => Ok(DeliveryStatus::NotApplicable),
+            "Success" => Ok(DeliveryStatus::Success),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -766,6 +958,38 @@ pub struct EvaluationResultQualifier {
     pub resource_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventSource {
+    AwsConfig,
+}
+
+impl Into<String> for EventSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventSource {
+    fn into(self) -> &'static str {
+        match self {
+            EventSource::AwsConfig => "aws.config",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "aws.config" => Ok(EventSource::AwsConfig),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GetComplianceDetailsByConfigRuleRequest {
@@ -943,6 +1167,138 @@ pub struct ListDiscoveredResourcesResponse {
     pub resource_identifiers: Option<Vec<ResourceIdentifier>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaximumExecutionFrequency {
+    OneHour,
+    SixHours,
+    ThreeHours,
+    TwelveHours,
+    TwentyFourHours,
+}
+
+impl Into<String> for MaximumExecutionFrequency {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaximumExecutionFrequency {
+    fn into(self) -> &'static str {
+        match self {
+            MaximumExecutionFrequency::OneHour => "One_Hour",
+            MaximumExecutionFrequency::SixHours => "Six_Hours",
+            MaximumExecutionFrequency::ThreeHours => "Three_Hours",
+            MaximumExecutionFrequency::TwelveHours => "Twelve_Hours",
+            MaximumExecutionFrequency::TwentyFourHours => "TwentyFour_Hours",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaximumExecutionFrequency {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "One_Hour" => Ok(MaximumExecutionFrequency::OneHour),
+            "Six_Hours" => Ok(MaximumExecutionFrequency::SixHours),
+            "Three_Hours" => Ok(MaximumExecutionFrequency::ThreeHours),
+            "Twelve_Hours" => Ok(MaximumExecutionFrequency::TwelveHours),
+            "TwentyFour_Hours" => Ok(MaximumExecutionFrequency::TwentyFourHours),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MessageType {
+    ConfigurationItemChangeNotification,
+    ConfigurationSnapshotDeliveryCompleted,
+    OversizedConfigurationItemChangeNotification,
+    ScheduledNotification,
+}
+
+impl Into<String> for MessageType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MessageType {
+    fn into(self) -> &'static str {
+        match self {
+            MessageType::ConfigurationItemChangeNotification => {
+                "ConfigurationItemChangeNotification"
+            }
+            MessageType::ConfigurationSnapshotDeliveryCompleted => {
+                "ConfigurationSnapshotDeliveryCompleted"
+            }
+            MessageType::OversizedConfigurationItemChangeNotification => {
+                "OversizedConfigurationItemChangeNotification"
+            }
+            MessageType::ScheduledNotification => "ScheduledNotification",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MessageType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ConfigurationItemChangeNotification" => {
+                Ok(MessageType::ConfigurationItemChangeNotification)
+            }
+            "ConfigurationSnapshotDeliveryCompleted" => {
+                Ok(MessageType::ConfigurationSnapshotDeliveryCompleted)
+            }
+            "OversizedConfigurationItemChangeNotification" => {
+                Ok(MessageType::OversizedConfigurationItemChangeNotification)
+            }
+            "ScheduledNotification" => Ok(MessageType::ScheduledNotification),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Owner {
+    Aws,
+    CustomLambda,
+}
+
+impl Into<String> for Owner {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Owner {
+    fn into(self) -> &'static str {
+        match self {
+            Owner::Aws => "AWS",
+            Owner::CustomLambda => "CUSTOM_LAMBDA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Owner {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(Owner::Aws),
+            "CUSTOM_LAMBDA" => Ok(Owner::CustomLambda),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutConfigRuleRequest {
     #[doc="<p>The rule that you want to add to your account.</p>"]
@@ -989,6 +1345,44 @@ pub struct PutEvaluationsResponse {
     #[serde(rename="FailedEvaluations")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub failed_evaluations: Option<Vec<Evaluation>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecorderStatus {
+    Failure,
+    Pending,
+    Success,
+}
+
+impl Into<String> for RecorderStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecorderStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RecorderStatus::Failure => "Failure",
+            RecorderStatus::Pending => "Pending",
+            RecorderStatus::Success => "Success",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecorderStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failure" => Ok(RecorderStatus::Failure),
+            "Pending" => Ok(RecorderStatus::Pending),
+            "Success" => Ok(RecorderStatus::Success),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Specifies the types of AWS resource for which AWS Config records configuration changes.</p> <p>In the recording group, you specify whether all supported types or specific types of resources are recorded.</p> <p>By default, AWS Config records configuration changes for all supported types of regional resources that AWS Config discovers in the region in which it is running. Regional resources are tied to a region and can be used only in that region. Examples of regional resources are EC2 instances and EBS volumes.</p> <p>You can also have AWS Config record configuration changes for supported types of global resources (for example, IAM resources). Global resources are not tied to an individual region and can be used in all regions.</p> <important> <p>The configuration details for any global resource are the same in all regions. If you customize AWS Config in multiple regions to record global resources, it will create multiple configuration items each time a global resource changes: one configuration item for each region. These configuration items will contain identical data. To prevent duplicate configuration items, you should consider customizing AWS Config in only one region to record global resources, unless you want the configuration items to be available in multiple regions.</p> </important> <p>If you don't want AWS Config to record all resources, you can specify which types of resources it will record with the <code>resourceTypes</code> parameter.</p> <p>For a list of supported resource types, see <a href=\"http://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources\">Supported resource types</a>.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/config/latest/developerguide/select-resources.html\">Selecting Which Resources AWS Config Records</a>.</p>"]
@@ -1048,6 +1442,152 @@ pub struct ResourceIdentifier {
     #[serde(rename="resourceType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    AwsAcmCertificate,
+    AwsCloudTrailTrail,
+    AwsCloudWatchAlarm,
+    AwsEc2CustomerGateway,
+    AwsEc2Eip,
+    AwsEc2Host,
+    AwsEc2Instance,
+    AwsEc2InternetGateway,
+    AwsEc2NetworkAcl,
+    AwsEc2NetworkInterface,
+    AwsEc2RouteTable,
+    AwsEc2SecurityGroup,
+    AwsEc2Subnet,
+    AwsEc2Vpc,
+    AwsEc2Vpnconnection,
+    AwsEc2Vpngateway,
+    AwsEc2Volume,
+    AwsElasticLoadBalancingV2LoadBalancer,
+    AwsIamGroup,
+    AwsIamPolicy,
+    AwsIamRole,
+    AwsIamUser,
+    AwsRdsDbinstance,
+    AwsRdsDbsecurityGroup,
+    AwsRdsDbsnapshot,
+    AwsRdsDbsubnetGroup,
+    AwsRdsEventSubscription,
+    AwsRedshiftCluster,
+    AwsRedshiftClusterParameterGroup,
+    AwsRedshiftClusterSecurityGroup,
+    AwsRedshiftClusterSnapshot,
+    AwsRedshiftClusterSubnetGroup,
+    AwsRedshiftEventSubscription,
+    AwsS3Bucket,
+    AwsSsmManagedInstanceInventory,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::AwsAcmCertificate => "AWS::ACM::Certificate",
+            ResourceType::AwsCloudTrailTrail => "AWS::CloudTrail::Trail",
+            ResourceType::AwsCloudWatchAlarm => "AWS::CloudWatch::Alarm",
+            ResourceType::AwsEc2CustomerGateway => "AWS::EC2::CustomerGateway",
+            ResourceType::AwsEc2Eip => "AWS::EC2::EIP",
+            ResourceType::AwsEc2Host => "AWS::EC2::Host",
+            ResourceType::AwsEc2Instance => "AWS::EC2::Instance",
+            ResourceType::AwsEc2InternetGateway => "AWS::EC2::InternetGateway",
+            ResourceType::AwsEc2NetworkAcl => "AWS::EC2::NetworkAcl",
+            ResourceType::AwsEc2NetworkInterface => "AWS::EC2::NetworkInterface",
+            ResourceType::AwsEc2RouteTable => "AWS::EC2::RouteTable",
+            ResourceType::AwsEc2SecurityGroup => "AWS::EC2::SecurityGroup",
+            ResourceType::AwsEc2Subnet => "AWS::EC2::Subnet",
+            ResourceType::AwsEc2Vpc => "AWS::EC2::VPC",
+            ResourceType::AwsEc2Vpnconnection => "AWS::EC2::VPNConnection",
+            ResourceType::AwsEc2Vpngateway => "AWS::EC2::VPNGateway",
+            ResourceType::AwsEc2Volume => "AWS::EC2::Volume",
+            ResourceType::AwsElasticLoadBalancingV2LoadBalancer => {
+                "AWS::ElasticLoadBalancingV2::LoadBalancer"
+            }
+            ResourceType::AwsIamGroup => "AWS::IAM::Group",
+            ResourceType::AwsIamPolicy => "AWS::IAM::Policy",
+            ResourceType::AwsIamRole => "AWS::IAM::Role",
+            ResourceType::AwsIamUser => "AWS::IAM::User",
+            ResourceType::AwsRdsDbinstance => "AWS::RDS::DBInstance",
+            ResourceType::AwsRdsDbsecurityGroup => "AWS::RDS::DBSecurityGroup",
+            ResourceType::AwsRdsDbsnapshot => "AWS::RDS::DBSnapshot",
+            ResourceType::AwsRdsDbsubnetGroup => "AWS::RDS::DBSubnetGroup",
+            ResourceType::AwsRdsEventSubscription => "AWS::RDS::EventSubscription",
+            ResourceType::AwsRedshiftCluster => "AWS::Redshift::Cluster",
+            ResourceType::AwsRedshiftClusterParameterGroup => {
+                "AWS::Redshift::ClusterParameterGroup"
+            }
+            ResourceType::AwsRedshiftClusterSecurityGroup => "AWS::Redshift::ClusterSecurityGroup",
+            ResourceType::AwsRedshiftClusterSnapshot => "AWS::Redshift::ClusterSnapshot",
+            ResourceType::AwsRedshiftClusterSubnetGroup => "AWS::Redshift::ClusterSubnetGroup",
+            ResourceType::AwsRedshiftEventSubscription => "AWS::Redshift::EventSubscription",
+            ResourceType::AwsS3Bucket => "AWS::S3::Bucket",
+            ResourceType::AwsSsmManagedInstanceInventory => "AWS::SSM::ManagedInstanceInventory",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS::ACM::Certificate" => Ok(ResourceType::AwsAcmCertificate),
+            "AWS::CloudTrail::Trail" => Ok(ResourceType::AwsCloudTrailTrail),
+            "AWS::CloudWatch::Alarm" => Ok(ResourceType::AwsCloudWatchAlarm),
+            "AWS::EC2::CustomerGateway" => Ok(ResourceType::AwsEc2CustomerGateway),
+            "AWS::EC2::EIP" => Ok(ResourceType::AwsEc2Eip),
+            "AWS::EC2::Host" => Ok(ResourceType::AwsEc2Host),
+            "AWS::EC2::Instance" => Ok(ResourceType::AwsEc2Instance),
+            "AWS::EC2::InternetGateway" => Ok(ResourceType::AwsEc2InternetGateway),
+            "AWS::EC2::NetworkAcl" => Ok(ResourceType::AwsEc2NetworkAcl),
+            "AWS::EC2::NetworkInterface" => Ok(ResourceType::AwsEc2NetworkInterface),
+            "AWS::EC2::RouteTable" => Ok(ResourceType::AwsEc2RouteTable),
+            "AWS::EC2::SecurityGroup" => Ok(ResourceType::AwsEc2SecurityGroup),
+            "AWS::EC2::Subnet" => Ok(ResourceType::AwsEc2Subnet),
+            "AWS::EC2::VPC" => Ok(ResourceType::AwsEc2Vpc),
+            "AWS::EC2::VPNConnection" => Ok(ResourceType::AwsEc2Vpnconnection),
+            "AWS::EC2::VPNGateway" => Ok(ResourceType::AwsEc2Vpngateway),
+            "AWS::EC2::Volume" => Ok(ResourceType::AwsEc2Volume),
+            "AWS::ElasticLoadBalancingV2::LoadBalancer" => {
+                Ok(ResourceType::AwsElasticLoadBalancingV2LoadBalancer)
+            }
+            "AWS::IAM::Group" => Ok(ResourceType::AwsIamGroup),
+            "AWS::IAM::Policy" => Ok(ResourceType::AwsIamPolicy),
+            "AWS::IAM::Role" => Ok(ResourceType::AwsIamRole),
+            "AWS::IAM::User" => Ok(ResourceType::AwsIamUser),
+            "AWS::RDS::DBInstance" => Ok(ResourceType::AwsRdsDbinstance),
+            "AWS::RDS::DBSecurityGroup" => Ok(ResourceType::AwsRdsDbsecurityGroup),
+            "AWS::RDS::DBSnapshot" => Ok(ResourceType::AwsRdsDbsnapshot),
+            "AWS::RDS::DBSubnetGroup" => Ok(ResourceType::AwsRdsDbsubnetGroup),
+            "AWS::RDS::EventSubscription" => Ok(ResourceType::AwsRdsEventSubscription),
+            "AWS::Redshift::Cluster" => Ok(ResourceType::AwsRedshiftCluster),
+            "AWS::Redshift::ClusterParameterGroup" => {
+                Ok(ResourceType::AwsRedshiftClusterParameterGroup)
+            }
+            "AWS::Redshift::ClusterSecurityGroup" => {
+                Ok(ResourceType::AwsRedshiftClusterSecurityGroup)
+            }
+            "AWS::Redshift::ClusterSnapshot" => Ok(ResourceType::AwsRedshiftClusterSnapshot),
+            "AWS::Redshift::ClusterSubnetGroup" => Ok(ResourceType::AwsRedshiftClusterSubnetGroup),
+            "AWS::Redshift::EventSubscription" => Ok(ResourceType::AwsRedshiftEventSubscription),
+            "AWS::S3::Bucket" => Ok(ResourceType::AwsS3Bucket),
+            "AWS::SSM::ManagedInstanceInventory" => {
+                Ok(ResourceType::AwsSsmManagedInstanceInventory)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Defines which resources trigger an evaluation for an AWS Config rule. The scope can include one or more resource types, a combination of a tag key and value, or a combination of one resource type and one resource ID. Specify a scope to constrain which resources trigger an evaluation for a rule. Otherwise, evaluations for the rule are triggered when any resource in your recording group changes in configuration.</p>"]
@@ -3467,7 +4007,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteConfigRuleError::from_body(String::from_utf8_lossy(&response.body)
                                                          .as_ref()))
@@ -3493,7 +4033,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteConfigurationRecorderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -3515,7 +4055,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteDeliveryChannelError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))
@@ -3542,7 +4082,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteEvaluationResultsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteEvaluationResultsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3567,7 +4107,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeliverConfigSnapshotResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3596,7 +4136,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeComplianceByConfigRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeComplianceByConfigRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3622,7 +4162,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeComplianceByResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeComplianceByResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3649,7 +4189,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeConfigRuleEvaluationStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeConfigRuleEvaluationStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3673,7 +4213,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeConfigRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3703,7 +4243,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeConfigurationRecorderStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeConfigurationRecorderStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3729,7 +4269,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeConfigurationRecordersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeConfigurationRecordersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3755,7 +4295,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDeliveryChannelStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeDeliveryChannelStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3781,7 +4321,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDeliveryChannelsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeDeliveryChannelsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3807,7 +4347,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetComplianceDetailsByConfigRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetComplianceDetailsByConfigRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3833,7 +4373,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetComplianceDetailsByResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetComplianceDetailsByResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3857,7 +4397,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetComplianceSummaryByConfigRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetComplianceSummaryByConfigRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3884,7 +4424,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetComplianceSummaryByResourceTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetComplianceSummaryByResourceTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3910,7 +4450,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetResourceConfigHistoryResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetResourceConfigHistoryError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3936,7 +4476,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDiscoveredResourcesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListDiscoveredResourcesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3958,7 +4498,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutConfigRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -3983,7 +4523,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(PutConfigurationRecorderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4005,7 +4545,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutDeliveryChannelError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -4030,7 +4570,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutEvaluationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4059,7 +4599,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartConfigRulesEvaluationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StartConfigRulesEvaluationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4084,7 +4624,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(StartConfigurationRecorderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4107,7 +4647,7 @@ impl<P, D> ConfigService for ConfigServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(StopConfigurationRecorderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -11,21 +11,140 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+#[doc="Region of customer S3 bucket."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AWSRegion {
+    ApNortheast1,
+    ApSoutheast1,
+    ApSoutheast2,
+    EuCentral1,
+    EuWest1,
+    UsEast1,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for AWSRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AWSRegion {
+    fn into(self) -> &'static str {
+        match self {
+            AWSRegion::ApNortheast1 => "ap-northeast-1",
+            AWSRegion::ApSoutheast1 => "ap-southeast-1",
+            AWSRegion::ApSoutheast2 => "ap-southeast-2",
+            AWSRegion::EuCentral1 => "eu-central-1",
+            AWSRegion::EuWest1 => "eu-west-1",
+            AWSRegion::UsEast1 => "us-east-1",
+            AWSRegion::UsWest1 => "us-west-1",
+            AWSRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AWSRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(AWSRegion::ApNortheast1),
+            "ap-southeast-1" => Ok(AWSRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(AWSRegion::ApSoutheast2),
+            "eu-central-1" => Ok(AWSRegion::EuCentral1),
+            "eu-west-1" => Ok(AWSRegion::EuWest1),
+            "us-east-1" => Ok(AWSRegion::UsEast1),
+            "us-west-1" => Ok(AWSRegion::UsWest1),
+            "us-west-2" => Ok(AWSRegion::UsWest2),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Enable support for Redshift and/or QuickSight."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AdditionalArtifact {
+    Quicksight,
+    Redshift,
+}
+
+impl Into<String> for AdditionalArtifact {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AdditionalArtifact {
+    fn into(self) -> &'static str {
+        match self {
+            AdditionalArtifact::Quicksight => "QUICKSIGHT",
+            AdditionalArtifact::Redshift => "REDSHIFT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AdditionalArtifact {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "QUICKSIGHT" => Ok(AdditionalArtifact::Quicksight),
+            "REDSHIFT" => Ok(AdditionalArtifact::Redshift),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Preferred compression format for report."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CompressionFormat {
+    Gzip,
+    Zip,
+}
+
+impl Into<String> for CompressionFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CompressionFormat {
+    fn into(self) -> &'static str {
+        match self {
+            CompressionFormat::Gzip => "GZIP",
+            CompressionFormat::Zip => "ZIP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CompressionFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GZIP" => Ok(CompressionFormat::Gzip),
+            "ZIP" => Ok(CompressionFormat::Zip),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Request of DeleteReportDefinition"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeleteReportDefinitionRequest {
@@ -97,6 +216,105 @@ pub struct ReportDefinition {
     pub s3_region: String,
     #[serde(rename="TimeUnit")]
     pub time_unit: String,
+}
+
+#[doc="Preferred format for report."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportFormat {
+    TextORcsv,
+}
+
+impl Into<String> for ReportFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ReportFormat::TextORcsv => "textORcsv",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "textORcsv" => Ok(ReportFormat::TextORcsv),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Preference of including Resource IDs. You can include additional details about individual resource IDs in your report."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SchemaElement {
+    Resources,
+}
+
+impl Into<String> for SchemaElement {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SchemaElement {
+    fn into(self) -> &'static str {
+        match self {
+            SchemaElement::Resources => "RESOURCES",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SchemaElement {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RESOURCES" => Ok(SchemaElement::Resources),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="The frequency on which report data are measured and displayed."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TimeUnit {
+    Daily,
+    Hourly,
+}
+
+impl Into<String> for TimeUnit {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TimeUnit {
+    fn into(self) -> &'static str {
+        match self {
+            TimeUnit::Daily => "DAILY",
+            TimeUnit::Hourly => "HOURLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TimeUnit {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DAILY" => Ok(TimeUnit::Daily),
+            "HOURLY" => Ok(TimeUnit::Hourly),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by DeleteReportDefinition
@@ -405,7 +623,7 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteReportDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -434,7 +652,7 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeReportDefinitionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeReportDefinitionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -459,7 +677,7 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutReportDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -279,6 +275,50 @@ pub struct Operator {
     #[serde(rename="values")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub values: Option<Vec<String>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperatorType {
+    Between,
+    Eq,
+    Ge,
+    Le,
+    RefEq,
+}
+
+impl Into<String> for OperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            OperatorType::Between => "BETWEEN",
+            OperatorType::Eq => "EQ",
+            OperatorType::Ge => "GE",
+            OperatorType::Le => "LE",
+            OperatorType::RefEq => "REF_EQ",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BETWEEN" => Ok(OperatorType::Between),
+            "EQ" => Ok(OperatorType::Eq),
+            "GE" => Ok(OperatorType::Ge),
+            "LE" => Ok(OperatorType::Le),
+            "REF_EQ" => Ok(OperatorType::RefEq),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The attributes allowed or specified with a parameter object.</p>"]
@@ -614,6 +654,44 @@ pub struct TaskObject {
     #[serde(rename="taskId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub task_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaskStatus {
+    Failed,
+    False,
+    Finished,
+}
+
+impl Into<String> for TaskStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaskStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TaskStatus::Failed => "FAILED",
+            TaskStatus::False => "FALSE",
+            TaskStatus::Finished => "FINISHED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaskStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(TaskStatus::Failed),
+            "FALSE" => Ok(TaskStatus::False),
+            "FINISHED" => Ok(TaskStatus::Finished),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the parameters for ValidatePipelineDefinition.</p>"]
@@ -2547,7 +2625,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ActivatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2572,7 +2650,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -2598,7 +2676,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2625,7 +2703,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeactivatePipelineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2650,7 +2728,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeletePipelineError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -2675,7 +2753,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeObjectsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2702,7 +2780,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribePipelinesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2729,7 +2807,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<EvaluateExpressionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2757,7 +2835,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetPipelineDefinitionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2784,7 +2862,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPipelinesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2810,7 +2888,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PollForTaskOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(PollForTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2835,7 +2913,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutPipelineDefinitionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2862,7 +2940,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<QueryObjectsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2886,7 +2964,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTagsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RemoveTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2910,7 +2988,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ReportTaskProgressOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2938,7 +3016,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ReportTaskRunnerHeartbeatOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ReportTaskRunnerHeartbeatError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2960,7 +3038,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(SetStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -2982,7 +3060,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SetTaskStatusOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3009,7 +3087,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ValidatePipelineDefinitionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ValidatePipelineDefinitionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -82,6 +78,183 @@ pub struct Artifact {
     #[serde(rename="url")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactCategory {
+    File,
+    Log,
+    Screenshot,
+}
+
+impl Into<String> for ArtifactCategory {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactCategory {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactCategory::File => "FILE",
+            ArtifactCategory::Log => "LOG",
+            ArtifactCategory::Screenshot => "SCREENSHOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactCategory {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FILE" => Ok(ArtifactCategory::File),
+            "LOG" => Ok(ArtifactCategory::Log),
+            "SCREENSHOT" => Ok(ArtifactCategory::Screenshot),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactType {
+    AppiumJavaOutput,
+    AppiumJavaXmlOutput,
+    AppiumPythonOutput,
+    AppiumPythonXmlOutput,
+    AppiumServerOutput,
+    ApplicationCrashReport,
+    AutomationOutput,
+    CalabashJavaXmlOutput,
+    CalabashJsonOutput,
+    CalabashPrettyOutput,
+    CalabashStandardOutput,
+    DeviceLog,
+    ExerciserMonkeyOutput,
+    ExplorerEventLog,
+    ExplorerSummaryLog,
+    InstrumentationOutput,
+    MessageLog,
+    ResultLog,
+    Screenshot,
+    ServiceLog,
+    Unknown,
+    Video,
+    VideoLog,
+    WebkitLog,
+    XctestLog,
+}
+
+impl Into<String> for ArtifactType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactType {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactType::AppiumJavaOutput => "APPIUM_JAVA_OUTPUT",
+            ArtifactType::AppiumJavaXmlOutput => "APPIUM_JAVA_XML_OUTPUT",
+            ArtifactType::AppiumPythonOutput => "APPIUM_PYTHON_OUTPUT",
+            ArtifactType::AppiumPythonXmlOutput => "APPIUM_PYTHON_XML_OUTPUT",
+            ArtifactType::AppiumServerOutput => "APPIUM_SERVER_OUTPUT",
+            ArtifactType::ApplicationCrashReport => "APPLICATION_CRASH_REPORT",
+            ArtifactType::AutomationOutput => "AUTOMATION_OUTPUT",
+            ArtifactType::CalabashJavaXmlOutput => "CALABASH_JAVA_XML_OUTPUT",
+            ArtifactType::CalabashJsonOutput => "CALABASH_JSON_OUTPUT",
+            ArtifactType::CalabashPrettyOutput => "CALABASH_PRETTY_OUTPUT",
+            ArtifactType::CalabashStandardOutput => "CALABASH_STANDARD_OUTPUT",
+            ArtifactType::DeviceLog => "DEVICE_LOG",
+            ArtifactType::ExerciserMonkeyOutput => "EXERCISER_MONKEY_OUTPUT",
+            ArtifactType::ExplorerEventLog => "EXPLORER_EVENT_LOG",
+            ArtifactType::ExplorerSummaryLog => "EXPLORER_SUMMARY_LOG",
+            ArtifactType::InstrumentationOutput => "INSTRUMENTATION_OUTPUT",
+            ArtifactType::MessageLog => "MESSAGE_LOG",
+            ArtifactType::ResultLog => "RESULT_LOG",
+            ArtifactType::Screenshot => "SCREENSHOT",
+            ArtifactType::ServiceLog => "SERVICE_LOG",
+            ArtifactType::Unknown => "UNKNOWN",
+            ArtifactType::Video => "VIDEO",
+            ArtifactType::VideoLog => "VIDEO_LOG",
+            ArtifactType::WebkitLog => "WEBKIT_LOG",
+            ArtifactType::XctestLog => "XCTEST_LOG",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPIUM_JAVA_OUTPUT" => Ok(ArtifactType::AppiumJavaOutput),
+            "APPIUM_JAVA_XML_OUTPUT" => Ok(ArtifactType::AppiumJavaXmlOutput),
+            "APPIUM_PYTHON_OUTPUT" => Ok(ArtifactType::AppiumPythonOutput),
+            "APPIUM_PYTHON_XML_OUTPUT" => Ok(ArtifactType::AppiumPythonXmlOutput),
+            "APPIUM_SERVER_OUTPUT" => Ok(ArtifactType::AppiumServerOutput),
+            "APPLICATION_CRASH_REPORT" => Ok(ArtifactType::ApplicationCrashReport),
+            "AUTOMATION_OUTPUT" => Ok(ArtifactType::AutomationOutput),
+            "CALABASH_JAVA_XML_OUTPUT" => Ok(ArtifactType::CalabashJavaXmlOutput),
+            "CALABASH_JSON_OUTPUT" => Ok(ArtifactType::CalabashJsonOutput),
+            "CALABASH_PRETTY_OUTPUT" => Ok(ArtifactType::CalabashPrettyOutput),
+            "CALABASH_STANDARD_OUTPUT" => Ok(ArtifactType::CalabashStandardOutput),
+            "DEVICE_LOG" => Ok(ArtifactType::DeviceLog),
+            "EXERCISER_MONKEY_OUTPUT" => Ok(ArtifactType::ExerciserMonkeyOutput),
+            "EXPLORER_EVENT_LOG" => Ok(ArtifactType::ExplorerEventLog),
+            "EXPLORER_SUMMARY_LOG" => Ok(ArtifactType::ExplorerSummaryLog),
+            "INSTRUMENTATION_OUTPUT" => Ok(ArtifactType::InstrumentationOutput),
+            "MESSAGE_LOG" => Ok(ArtifactType::MessageLog),
+            "RESULT_LOG" => Ok(ArtifactType::ResultLog),
+            "SCREENSHOT" => Ok(ArtifactType::Screenshot),
+            "SERVICE_LOG" => Ok(ArtifactType::ServiceLog),
+            "UNKNOWN" => Ok(ArtifactType::Unknown),
+            "VIDEO" => Ok(ArtifactType::Video),
+            "VIDEO_LOG" => Ok(ArtifactType::VideoLog),
+            "WEBKIT_LOG" => Ok(ArtifactType::WebkitLog),
+            "XCTEST_LOG" => Ok(ArtifactType::XctestLog),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BillingMethod {
+    Metered,
+    Unmetered,
+}
+
+impl Into<String> for BillingMethod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BillingMethod {
+    fn into(self) -> &'static str {
+        match self {
+            BillingMethod::Metered => "METERED",
+            BillingMethod::Unmetered => "UNMETERED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BillingMethod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "METERED" => Ok(BillingMethod::Metered),
+            "UNMETERED" => Ok(BillingMethod::Unmetered),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the amount of CPU that an app is using on a physical device.</p> <p>Note that this does not represent system-wide CPU usage.</p>"]
@@ -304,6 +477,38 @@ pub struct CreateUploadResult {
     pub upload: Option<Upload>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CurrencyCode {
+    Usd,
+}
+
+impl Into<String> for CurrencyCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CurrencyCode {
+    fn into(self) -> &'static str {
+        match self {
+            CurrencyCode::Usd => "USD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CurrencyCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "USD" => Ok(CurrencyCode::Usd),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a request to the delete device pool operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeleteDevicePoolRequest {
@@ -447,6 +652,88 @@ pub struct Device {
     pub resolution: Option<Resolution>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeviceAttribute {
+    AppiumVersion,
+    Arn,
+    FormFactor,
+    Manufacturer,
+    Platform,
+    RemoteAccessEnabled,
+}
+
+impl Into<String> for DeviceAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeviceAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            DeviceAttribute::AppiumVersion => "APPIUM_VERSION",
+            DeviceAttribute::Arn => "ARN",
+            DeviceAttribute::FormFactor => "FORM_FACTOR",
+            DeviceAttribute::Manufacturer => "MANUFACTURER",
+            DeviceAttribute::Platform => "PLATFORM",
+            DeviceAttribute::RemoteAccessEnabled => "REMOTE_ACCESS_ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeviceAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPIUM_VERSION" => Ok(DeviceAttribute::AppiumVersion),
+            "ARN" => Ok(DeviceAttribute::Arn),
+            "FORM_FACTOR" => Ok(DeviceAttribute::FormFactor),
+            "MANUFACTURER" => Ok(DeviceAttribute::Manufacturer),
+            "PLATFORM" => Ok(DeviceAttribute::Platform),
+            "REMOTE_ACCESS_ENABLED" => Ok(DeviceAttribute::RemoteAccessEnabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeviceFormFactor {
+    Phone,
+    Tablet,
+}
+
+impl Into<String> for DeviceFormFactor {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeviceFormFactor {
+    fn into(self) -> &'static str {
+        match self {
+            DeviceFormFactor::Phone => "PHONE",
+            DeviceFormFactor::Tablet => "TABLET",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeviceFormFactor {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PHONE" => Ok(DeviceFormFactor::Phone),
+            "TABLET" => Ok(DeviceFormFactor::Tablet),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the total (metered or unmetered) minutes used by the resource to run tests. Contains the sum of minutes consumed by all children.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DeviceMinutes {
@@ -462,6 +749,41 @@ pub struct DeviceMinutes {
     #[serde(rename="unmetered")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub unmetered: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DevicePlatform {
+    Android,
+    Ios,
+}
+
+impl Into<String> for DevicePlatform {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DevicePlatform {
+    fn into(self) -> &'static str {
+        match self {
+            DevicePlatform::Android => "ANDROID",
+            DevicePlatform::Ios => "IOS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DevicePlatform {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ANDROID" => Ok(DevicePlatform::Android),
+            "IOS" => Ok(DevicePlatform::Ios),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a collection of device types.</p>"]
@@ -506,6 +828,41 @@ pub struct DevicePoolCompatibilityResult {
     pub incompatibility_messages: Option<Vec<IncompatibilityMessage>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DevicePoolType {
+    Curated,
+    Private,
+}
+
+impl Into<String> for DevicePoolType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DevicePoolType {
+    fn into(self) -> &'static str {
+        match self {
+            DevicePoolType::Curated => "CURATED",
+            DevicePoolType::Private => "PRIVATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DevicePoolType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CURATED" => Ok(DevicePoolType::Curated),
+            "PRIVATE" => Ok(DevicePoolType::Private),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents configuration information about a test run, such as the execution timeout (in minutes).</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ExecutionConfiguration {
@@ -521,6 +878,112 @@ pub struct ExecutionConfiguration {
     #[serde(rename="jobTimeoutMinutes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub job_timeout_minutes: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionResult {
+    Errored,
+    Failed,
+    Passed,
+    Pending,
+    Skipped,
+    Stopped,
+    Warned,
+}
+
+impl Into<String> for ExecutionResult {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionResult {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionResult::Errored => "ERRORED",
+            ExecutionResult::Failed => "FAILED",
+            ExecutionResult::Passed => "PASSED",
+            ExecutionResult::Pending => "PENDING",
+            ExecutionResult::Skipped => "SKIPPED",
+            ExecutionResult::Stopped => "STOPPED",
+            ExecutionResult::Warned => "WARNED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionResult {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ERRORED" => Ok(ExecutionResult::Errored),
+            "FAILED" => Ok(ExecutionResult::Failed),
+            "PASSED" => Ok(ExecutionResult::Passed),
+            "PENDING" => Ok(ExecutionResult::Pending),
+            "SKIPPED" => Ok(ExecutionResult::Skipped),
+            "STOPPED" => Ok(ExecutionResult::Stopped),
+            "WARNED" => Ok(ExecutionResult::Warned),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionStatus {
+    Completed,
+    Pending,
+    PendingConcurrency,
+    PendingDevice,
+    Preparing,
+    Processing,
+    Running,
+    Scheduling,
+    Stopping,
+}
+
+impl Into<String> for ExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionStatus::Completed => "COMPLETED",
+            ExecutionStatus::Pending => "PENDING",
+            ExecutionStatus::PendingConcurrency => "PENDING_CONCURRENCY",
+            ExecutionStatus::PendingDevice => "PENDING_DEVICE",
+            ExecutionStatus::Preparing => "PREPARING",
+            ExecutionStatus::Processing => "PROCESSING",
+            ExecutionStatus::Running => "RUNNING",
+            ExecutionStatus::Scheduling => "SCHEDULING",
+            ExecutionStatus::Stopping => "STOPPING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETED" => Ok(ExecutionStatus::Completed),
+            "PENDING" => Ok(ExecutionStatus::Pending),
+            "PENDING_CONCURRENCY" => Ok(ExecutionStatus::PendingConcurrency),
+            "PENDING_DEVICE" => Ok(ExecutionStatus::PendingDevice),
+            "PREPARING" => Ok(ExecutionStatus::Preparing),
+            "PROCESSING" => Ok(ExecutionStatus::Processing),
+            "RUNNING" => Ok(ExecutionStatus::Running),
+            "SCHEDULING" => Ok(ExecutionStatus::Scheduling),
+            "STOPPING" => Ok(ExecutionStatus::Stopping),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request sent to retrieve the account settings.</p>"]
@@ -1326,6 +1789,41 @@ pub struct NetworkProfile {
     pub uplink_loss_percent: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkProfileType {
+    Curated,
+    Private,
+}
+
+impl Into<String> for NetworkProfileType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkProfileType {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkProfileType::Curated => "CURATED",
+            NetworkProfileType::Private => "PRIVATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkProfileType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CURATED" => Ok(NetworkProfileType::Curated),
+            "PRIVATE" => Ok(NetworkProfileType::Private),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the metadata of a device offering.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Offering {
@@ -1408,6 +1906,76 @@ pub struct OfferingTransaction {
     #[serde(rename="transactionId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub transaction_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OfferingTransactionType {
+    Purchase,
+    Renew,
+    System,
+}
+
+impl Into<String> for OfferingTransactionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OfferingTransactionType {
+    fn into(self) -> &'static str {
+        match self {
+            OfferingTransactionType::Purchase => "PURCHASE",
+            OfferingTransactionType::Renew => "RENEW",
+            OfferingTransactionType::System => "SYSTEM",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OfferingTransactionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PURCHASE" => Ok(OfferingTransactionType::Purchase),
+            "RENEW" => Ok(OfferingTransactionType::Renew),
+            "SYSTEM" => Ok(OfferingTransactionType::System),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OfferingType {
+    Recurring,
+}
+
+impl Into<String> for OfferingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OfferingType {
+    fn into(self) -> &'static str {
+        match self {
+            OfferingType::Recurring => "RECURRING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OfferingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RECURRING" => Ok(OfferingType::Recurring),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a specific warning or failure.</p>"]
@@ -1537,6 +2105,38 @@ pub struct RecurringCharge {
     pub frequency: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecurringChargeFrequency {
+    Monthly,
+}
+
+impl Into<String> for RecurringChargeFrequency {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecurringChargeFrequency {
+    fn into(self) -> &'static str {
+        match self {
+            RecurringChargeFrequency::Monthly => "MONTHLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecurringChargeFrequency {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MONTHLY" => Ok(RecurringChargeFrequency::Monthly),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about the remote access session.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoteAccessSession {
@@ -1642,6 +2242,53 @@ pub struct Rule {
     pub value: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RuleOperator {
+    Contains,
+    Equals,
+    GreaterThan,
+    In,
+    LessThan,
+    NotIn,
+}
+
+impl Into<String> for RuleOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RuleOperator {
+    fn into(self) -> &'static str {
+        match self {
+            RuleOperator::Contains => "CONTAINS",
+            RuleOperator::Equals => "EQUALS",
+            RuleOperator::GreaterThan => "GREATER_THAN",
+            RuleOperator::In => "IN",
+            RuleOperator::LessThan => "LESS_THAN",
+            RuleOperator::NotIn => "NOT_IN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RuleOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTAINS" => Ok(RuleOperator::Contains),
+            "EQUALS" => Ok(RuleOperator::Equals),
+            "GREATER_THAN" => Ok(RuleOperator::GreaterThan),
+            "IN" => Ok(RuleOperator::In),
+            "LESS_THAN" => Ok(RuleOperator::LessThan),
+            "NOT_IN" => Ok(RuleOperator::NotIn),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents an app on a set of devices with a specific test and configuration.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Run {
@@ -1726,6 +2373,86 @@ pub struct Sample {
     #[serde(rename="url")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SampleType {
+    Cpu,
+    Memory,
+    NativeAvgDrawtime,
+    NativeFps,
+    NativeFrames,
+    NativeMaxDrawtime,
+    NativeMinDrawtime,
+    OpenglAvgDrawtime,
+    OpenglFps,
+    OpenglFrames,
+    OpenglMaxDrawtime,
+    OpenglMinDrawtime,
+    Rx,
+    RxRate,
+    Threads,
+    Tx,
+    TxRate,
+}
+
+impl Into<String> for SampleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SampleType {
+    fn into(self) -> &'static str {
+        match self {
+            SampleType::Cpu => "CPU",
+            SampleType::Memory => "MEMORY",
+            SampleType::NativeAvgDrawtime => "NATIVE_AVG_DRAWTIME",
+            SampleType::NativeFps => "NATIVE_FPS",
+            SampleType::NativeFrames => "NATIVE_FRAMES",
+            SampleType::NativeMaxDrawtime => "NATIVE_MAX_DRAWTIME",
+            SampleType::NativeMinDrawtime => "NATIVE_MIN_DRAWTIME",
+            SampleType::OpenglAvgDrawtime => "OPENGL_AVG_DRAWTIME",
+            SampleType::OpenglFps => "OPENGL_FPS",
+            SampleType::OpenglFrames => "OPENGL_FRAMES",
+            SampleType::OpenglMaxDrawtime => "OPENGL_MAX_DRAWTIME",
+            SampleType::OpenglMinDrawtime => "OPENGL_MIN_DRAWTIME",
+            SampleType::Rx => "RX",
+            SampleType::RxRate => "RX_RATE",
+            SampleType::Threads => "THREADS",
+            SampleType::Tx => "TX",
+            SampleType::TxRate => "TX_RATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SampleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CPU" => Ok(SampleType::Cpu),
+            "MEMORY" => Ok(SampleType::Memory),
+            "NATIVE_AVG_DRAWTIME" => Ok(SampleType::NativeAvgDrawtime),
+            "NATIVE_FPS" => Ok(SampleType::NativeFps),
+            "NATIVE_FRAMES" => Ok(SampleType::NativeFrames),
+            "NATIVE_MAX_DRAWTIME" => Ok(SampleType::NativeMaxDrawtime),
+            "NATIVE_MIN_DRAWTIME" => Ok(SampleType::NativeMinDrawtime),
+            "OPENGL_AVG_DRAWTIME" => Ok(SampleType::OpenglAvgDrawtime),
+            "OPENGL_FPS" => Ok(SampleType::OpenglFps),
+            "OPENGL_FRAMES" => Ok(SampleType::OpenglFrames),
+            "OPENGL_MAX_DRAWTIME" => Ok(SampleType::OpenglMaxDrawtime),
+            "OPENGL_MIN_DRAWTIME" => Ok(SampleType::OpenglMinDrawtime),
+            "RX" => Ok(SampleType::Rx),
+            "RX_RATE" => Ok(SampleType::RxRate),
+            "THREADS" => Ok(SampleType::Threads),
+            "TX" => Ok(SampleType::Tx),
+            "TX_RATE" => Ok(SampleType::TxRate),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the settings for a run. Includes things like location, radio states, auxiliary apps, and network profiles.</p>"]
@@ -1952,6 +2679,77 @@ pub struct Test {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TestType {
+    AppiumJavaJunit,
+    AppiumJavaTestng,
+    AppiumPython,
+    AppiumWebJavaJunit,
+    AppiumWebJavaTestng,
+    AppiumWebPython,
+    BuiltinExplorer,
+    BuiltinFuzz,
+    Calabash,
+    Instrumentation,
+    Uiautomation,
+    Uiautomator,
+    Xctest,
+    XctestUi,
+}
+
+impl Into<String> for TestType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TestType {
+    fn into(self) -> &'static str {
+        match self {
+            TestType::AppiumJavaJunit => "APPIUM_JAVA_JUNIT",
+            TestType::AppiumJavaTestng => "APPIUM_JAVA_TESTNG",
+            TestType::AppiumPython => "APPIUM_PYTHON",
+            TestType::AppiumWebJavaJunit => "APPIUM_WEB_JAVA_JUNIT",
+            TestType::AppiumWebJavaTestng => "APPIUM_WEB_JAVA_TESTNG",
+            TestType::AppiumWebPython => "APPIUM_WEB_PYTHON",
+            TestType::BuiltinExplorer => "BUILTIN_EXPLORER",
+            TestType::BuiltinFuzz => "BUILTIN_FUZZ",
+            TestType::Calabash => "CALABASH",
+            TestType::Instrumentation => "INSTRUMENTATION",
+            TestType::Uiautomation => "UIAUTOMATION",
+            TestType::Uiautomator => "UIAUTOMATOR",
+            TestType::Xctest => "XCTEST",
+            TestType::XctestUi => "XCTEST_UI",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TestType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPIUM_JAVA_JUNIT" => Ok(TestType::AppiumJavaJunit),
+            "APPIUM_JAVA_TESTNG" => Ok(TestType::AppiumJavaTestng),
+            "APPIUM_PYTHON" => Ok(TestType::AppiumPython),
+            "APPIUM_WEB_JAVA_JUNIT" => Ok(TestType::AppiumWebJavaJunit),
+            "APPIUM_WEB_JAVA_TESTNG" => Ok(TestType::AppiumWebJavaTestng),
+            "APPIUM_WEB_PYTHON" => Ok(TestType::AppiumWebPython),
+            "BUILTIN_EXPLORER" => Ok(TestType::BuiltinExplorer),
+            "BUILTIN_FUZZ" => Ok(TestType::BuiltinFuzz),
+            "CALABASH" => Ok(TestType::Calabash),
+            "INSTRUMENTATION" => Ok(TestType::Instrumentation),
+            "UIAUTOMATION" => Ok(TestType::Uiautomation),
+            "UIAUTOMATOR" => Ok(TestType::Uiautomator),
+            "XCTEST" => Ok(TestType::Xctest),
+            "XCTEST_UI" => Ok(TestType::XctestUi),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about free trial device minutes for an AWS account.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct TrialMinutes {
@@ -2130,6 +2928,124 @@ pub struct Upload {
     #[serde(rename="url")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UploadStatus {
+    Failed,
+    Initialized,
+    Processing,
+    Succeeded,
+}
+
+impl Into<String> for UploadStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UploadStatus {
+    fn into(self) -> &'static str {
+        match self {
+            UploadStatus::Failed => "FAILED",
+            UploadStatus::Initialized => "INITIALIZED",
+            UploadStatus::Processing => "PROCESSING",
+            UploadStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UploadStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(UploadStatus::Failed),
+            "INITIALIZED" => Ok(UploadStatus::Initialized),
+            "PROCESSING" => Ok(UploadStatus::Processing),
+            "SUCCEEDED" => Ok(UploadStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UploadType {
+    AndroidApp,
+    AppiumJavaJunitTestPackage,
+    AppiumJavaTestngTestPackage,
+    AppiumPythonTestPackage,
+    AppiumWebJavaJunitTestPackage,
+    AppiumWebJavaTestngTestPackage,
+    AppiumWebPythonTestPackage,
+    CalabashTestPackage,
+    ExternalData,
+    InstrumentationTestPackage,
+    IosApp,
+    UiautomationTestPackage,
+    UiautomatorTestPackage,
+    WebApp,
+    XctestTestPackage,
+    XctestUiTestPackage,
+}
+
+impl Into<String> for UploadType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UploadType {
+    fn into(self) -> &'static str {
+        match self {
+            UploadType::AndroidApp => "ANDROID_APP",
+            UploadType::AppiumJavaJunitTestPackage => "APPIUM_JAVA_JUNIT_TEST_PACKAGE",
+            UploadType::AppiumJavaTestngTestPackage => "APPIUM_JAVA_TESTNG_TEST_PACKAGE",
+            UploadType::AppiumPythonTestPackage => "APPIUM_PYTHON_TEST_PACKAGE",
+            UploadType::AppiumWebJavaJunitTestPackage => "APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE",
+            UploadType::AppiumWebJavaTestngTestPackage => "APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE",
+            UploadType::AppiumWebPythonTestPackage => "APPIUM_WEB_PYTHON_TEST_PACKAGE",
+            UploadType::CalabashTestPackage => "CALABASH_TEST_PACKAGE",
+            UploadType::ExternalData => "EXTERNAL_DATA",
+            UploadType::InstrumentationTestPackage => "INSTRUMENTATION_TEST_PACKAGE",
+            UploadType::IosApp => "IOS_APP",
+            UploadType::UiautomationTestPackage => "UIAUTOMATION_TEST_PACKAGE",
+            UploadType::UiautomatorTestPackage => "UIAUTOMATOR_TEST_PACKAGE",
+            UploadType::WebApp => "WEB_APP",
+            UploadType::XctestTestPackage => "XCTEST_TEST_PACKAGE",
+            UploadType::XctestUiTestPackage => "XCTEST_UI_TEST_PACKAGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UploadType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ANDROID_APP" => Ok(UploadType::AndroidApp),
+            "APPIUM_JAVA_JUNIT_TEST_PACKAGE" => Ok(UploadType::AppiumJavaJunitTestPackage),
+            "APPIUM_JAVA_TESTNG_TEST_PACKAGE" => Ok(UploadType::AppiumJavaTestngTestPackage),
+            "APPIUM_PYTHON_TEST_PACKAGE" => Ok(UploadType::AppiumPythonTestPackage),
+            "APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE" => Ok(UploadType::AppiumWebJavaJunitTestPackage),
+            "APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE" => Ok(UploadType::AppiumWebJavaTestngTestPackage),
+            "APPIUM_WEB_PYTHON_TEST_PACKAGE" => Ok(UploadType::AppiumWebPythonTestPackage),
+            "CALABASH_TEST_PACKAGE" => Ok(UploadType::CalabashTestPackage),
+            "EXTERNAL_DATA" => Ok(UploadType::ExternalData),
+            "INSTRUMENTATION_TEST_PACKAGE" => Ok(UploadType::InstrumentationTestPackage),
+            "IOS_APP" => Ok(UploadType::IosApp),
+            "UIAUTOMATION_TEST_PACKAGE" => Ok(UploadType::UiautomationTestPackage),
+            "UIAUTOMATOR_TEST_PACKAGE" => Ok(UploadType::UiautomatorTestPackage),
+            "WEB_APP" => Ok(UploadType::WebApp),
+            "XCTEST_TEST_PACKAGE" => Ok(UploadType::XctestTestPackage),
+            "XCTEST_UI_TEST_PACKAGE" => Ok(UploadType::XctestUiTestPackage),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by CreateDevicePool
@@ -6925,7 +7841,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDevicePoolResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6952,7 +7868,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateNetworkProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6979,7 +7895,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateProjectResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7007,7 +7923,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7031,7 +7947,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateUploadResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7057,7 +7973,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteDevicePoolResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7084,7 +8000,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteNetworkProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7111,7 +8027,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteProjectResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7139,7 +8055,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7161,7 +8077,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<DeleteRunResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -7187,7 +8103,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteUploadResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7210,7 +8126,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetAccountSettingsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7235,7 +8151,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetDeviceResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -7261,7 +8177,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDevicePoolResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7289,7 +8205,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDevicePoolCompatibilityResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetDevicePoolCompatibilityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7311,7 +8227,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetJobResult>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())
@@ -7337,7 +8253,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetNetworkProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7364,7 +8280,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetOfferingStatusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7389,7 +8305,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetProjectResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetProjectError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7414,7 +8330,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7439,7 +8355,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetRunResult>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())
@@ -7463,7 +8379,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetSuiteResult>(String::from_utf8_lossy(&response.body)
                                                               .as_ref())
                            .unwrap())
@@ -7487,7 +8403,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetTestResult>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -7511,7 +8427,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetUploadResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -7539,7 +8455,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<InstallToRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(InstallToRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7563,7 +8479,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListArtifactsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7589,7 +8505,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDevicePoolsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7616,7 +8532,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDevicesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListDevicesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7638,7 +8554,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ListJobsResult>(String::from_utf8_lossy(&response.body)
                                                               .as_ref())
                            .unwrap())
@@ -7664,7 +8580,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListNetworkProfilesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7692,7 +8608,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListOfferingPromotionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7721,7 +8637,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListOfferingTransactionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListOfferingTransactionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7745,7 +8661,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListOfferingsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7771,7 +8687,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListProjectsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7799,7 +8715,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRemoteAccessSessionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListRemoteAccessSessionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7821,7 +8737,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ListRunsResult>(String::from_utf8_lossy(&response.body)
                                                               .as_ref())
                            .unwrap())
@@ -7847,7 +8763,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListSamplesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListSamplesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7869,7 +8785,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListSuitesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListSuitesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7891,7 +8807,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ListTestsResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -7917,7 +8833,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListUniqueProblemsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7944,7 +8860,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListUploadsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListUploadsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7968,7 +8884,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PurchaseOfferingResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7995,7 +8911,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RenewOfferingResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8021,7 +8937,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ScheduleRunResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ScheduleRunError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8047,7 +8963,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopRemoteAccessSessionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StopRemoteAccessSessionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8069,7 +8985,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<StopRunResult>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -8095,7 +9011,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDevicePoolResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8122,7 +9038,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateNetworkProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8149,7 +9065,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateProjectResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -11,21 +11,52 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+#[doc="<p>Indicates the address family for the BGP peer.</p> <ul> <li> <p> <b>ipv4</b>: IPv4 address family</p> </li> <li> <p> <b>ipv6</b>: IPv6 address family</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AddressFamily {
+    Ipv4,
+    Ipv6,
+}
+
+impl Into<String> for AddressFamily {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AddressFamily {
+    fn into(self) -> &'static str {
+        match self {
+            AddressFamily::Ipv4 => "ipv4",
+            AddressFamily::Ipv6 => "ipv6",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AddressFamily {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ipv4" => Ok(AddressFamily::Ipv4),
+            "ipv6" => Ok(AddressFamily::Ipv6),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Container for the parameters to the AllocateConnectionOnInterconnect operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AllocateConnectionOnInterconnectRequest {
@@ -153,6 +184,85 @@ pub struct BGPPeer {
     pub customer_address: Option<String>,
 }
 
+#[doc="<p>The state of the BGP peer.</p> <ul> <li> <p> <b>Verifying</b>: The BGP peering addresses or ASN require validation before the BGP peer can be created. This state only applies to BGP peers on a public virtual interface. </p> </li> <li> <p> <b>Pending</b>: The BGP peer has been created, and is in this state until it is ready to be established.</p> </li> <li> <p> <b>Available</b>: The BGP peer can be established.</p> </li> <li> <p> <b>Deleting</b>: The BGP peer is in the process of being deleted.</p> </li> <li> <p> <b>Deleted</b>: The BGP peer has been deleted and cannot be established.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BGPPeerState {
+    Available,
+    Deleted,
+    Deleting,
+    Pending,
+    Verifying,
+}
+
+impl Into<String> for BGPPeerState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BGPPeerState {
+    fn into(self) -> &'static str {
+        match self {
+            BGPPeerState::Available => "available",
+            BGPPeerState::Deleted => "deleted",
+            BGPPeerState::Deleting => "deleting",
+            BGPPeerState::Pending => "pending",
+            BGPPeerState::Verifying => "verifying",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BGPPeerState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(BGPPeerState::Available),
+            "deleted" => Ok(BGPPeerState::Deleted),
+            "deleting" => Ok(BGPPeerState::Deleting),
+            "pending" => Ok(BGPPeerState::Pending),
+            "verifying" => Ok(BGPPeerState::Verifying),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>The Up/Down state of the BGP peer.</p> <ul> <li> <p> <b>Up</b>: The BGP peer is established.</p> </li> <li> <p> <b>Down</b>: The BGP peer is down.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BGPStatus {
+    Down,
+    Up,
+}
+
+impl Into<String> for BGPStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BGPStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BGPStatus::Down => "down",
+            BGPStatus::Up => "up",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BGPStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "down" => Ok(BGPStatus::Down),
+            "up" => Ok(BGPStatus::Up),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Container for the parameters to the ConfirmConnection operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ConfirmConnectionRequest {
@@ -245,6 +355,59 @@ pub struct Connection {
     #[serde(rename="vlan")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vlan: Option<i64>,
+}
+
+#[doc="<p>State of the connection.</p> <ul> <li> <p> <b>Ordering</b>: The initial state of a hosted connection provisioned on an interconnect. The connection stays in the ordering state until the owner of the hosted connection confirms or declines the connection order.</p> </li> <li> <p> <b>Requested</b>: The initial state of a standard connection. The connection stays in the requested state until the Letter of Authorization (LOA) is sent to the customer.</p> </li> <li> <p> <b>Pending</b>: The connection has been approved, and is being initialized.</p> </li> <li> <p> <b>Available</b>: The network link is up, and the connection is ready for use.</p> </li> <li> <p> <b>Down</b>: The network link is down.</p> </li> <li> <p> <b>Deleting</b>: The connection is in the process of being deleted.</p> </li> <li> <p> <b>Deleted</b>: The connection has been deleted.</p> </li> <li> <p> <b>Rejected</b>: A hosted connection in the 'Ordering' state will enter the 'Rejected' state if it is deleted by the end customer.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectionState {
+    Available,
+    Deleted,
+    Deleting,
+    Down,
+    Ordering,
+    Pending,
+    Rejected,
+    Requested,
+}
+
+impl Into<String> for ConnectionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectionState {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectionState::Available => "available",
+            ConnectionState::Deleted => "deleted",
+            ConnectionState::Deleting => "deleting",
+            ConnectionState::Down => "down",
+            ConnectionState::Ordering => "ordering",
+            ConnectionState::Pending => "pending",
+            ConnectionState::Rejected => "rejected",
+            ConnectionState::Requested => "requested",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(ConnectionState::Available),
+            "deleted" => Ok(ConnectionState::Deleted),
+            "deleting" => Ok(ConnectionState::Deleting),
+            "down" => Ok(ConnectionState::Down),
+            "ordering" => Ok(ConnectionState::Ordering),
+            "pending" => Ok(ConnectionState::Pending),
+            "rejected" => Ok(ConnectionState::Rejected),
+            "requested" => Ok(ConnectionState::Requested),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A structure containing a list of connections.</p>"]
@@ -591,6 +754,53 @@ pub struct Interconnect {
     pub region: Option<String>,
 }
 
+#[doc="<p>State of the interconnect.</p> <ul> <li> <p> <b>Requested</b>: The initial state of an interconnect. The interconnect stays in the requested state until the Letter of Authorization (LOA) is sent to the customer.</p> </li> <li> <p> <b>Pending</b>: The interconnect has been approved, and is being initialized.</p> </li> <li> <p> <b>Available</b>: The network link is up, and the interconnect is ready for use.</p> </li> <li> <p> <b>Down</b>: The network link is down.</p> </li> <li> <p> <b>Deleting</b>: The interconnect is in the process of being deleted.</p> </li> <li> <p> <b>Deleted</b>: The interconnect has been deleted.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InterconnectState {
+    Available,
+    Deleted,
+    Deleting,
+    Down,
+    Pending,
+    Requested,
+}
+
+impl Into<String> for InterconnectState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InterconnectState {
+    fn into(self) -> &'static str {
+        match self {
+            InterconnectState::Available => "available",
+            InterconnectState::Deleted => "deleted",
+            InterconnectState::Deleting => "deleting",
+            InterconnectState::Down => "down",
+            InterconnectState::Pending => "pending",
+            InterconnectState::Requested => "requested",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InterconnectState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(InterconnectState::Available),
+            "deleted" => Ok(InterconnectState::Deleted),
+            "deleting" => Ok(InterconnectState::Deleting),
+            "down" => Ok(InterconnectState::Down),
+            "pending" => Ok(InterconnectState::Pending),
+            "requested" => Ok(InterconnectState::Requested),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A structure containing a list of interconnects.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Interconnects {
@@ -649,6 +859,53 @@ pub struct Lag {
     pub region: Option<String>,
 }
 
+#[doc="<p>The state of the LAG.</p> <ul> <li> <p> <b>Requested</b>: The initial state of a LAG. The LAG stays in the requested state until the Letter of Authorization (LOA) is available.</p> </li> <li> <p> <b>Pending</b>: The LAG has been approved, and is being initialized.</p> </li> <li> <p> <b>Available</b>: The network link is established, and the LAG is ready for use.</p> </li> <li> <p> <b>Down</b>: The network link is down.</p> </li> <li> <p> <b>Deleting</b>: The LAG is in the process of being deleted.</p> </li> <li> <p> <b>Deleted</b>: The LAG has been deleted.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LagState {
+    Available,
+    Deleted,
+    Deleting,
+    Down,
+    Pending,
+    Requested,
+}
+
+impl Into<String> for LagState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LagState {
+    fn into(self) -> &'static str {
+        match self {
+            LagState::Available => "available",
+            LagState::Deleted => "deleted",
+            LagState::Deleting => "deleting",
+            LagState::Down => "down",
+            LagState::Pending => "pending",
+            LagState::Requested => "requested",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LagState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(LagState::Available),
+            "deleted" => Ok(LagState::Deleted),
+            "deleting" => Ok(LagState::Deleting),
+            "down" => Ok(LagState::Down),
+            "pending" => Ok(LagState::Pending),
+            "requested" => Ok(LagState::Requested),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A structure containing a list of LAGs.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Lags {
@@ -671,6 +928,38 @@ pub struct Loa {
     #[serde(rename="loaContentType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub loa_content_type: Option<String>,
+}
+
+#[doc="<p>A standard media type indicating the content type of the LOA-CFA document. Currently, the only supported value is \"application/pdf\".</p> <p>Default: application/pdf</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoaContentType {
+    ApplicationPdf,
+}
+
+impl Into<String> for LoaContentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoaContentType {
+    fn into(self) -> &'static str {
+        match self {
+            LoaContentType::ApplicationPdf => "application/pdf",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoaContentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "application/pdf" => Ok(LoaContentType::ApplicationPdf),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An AWS Direct Connect location where connections and interconnects can be requested.</p>"]
@@ -971,6 +1260,59 @@ pub struct VirtualInterface {
     #[serde(rename="vlan")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vlan: Option<i64>,
+}
+
+#[doc="<p>State of the virtual interface.</p> <ul> <li> <p> <b>Confirming</b>: The creation of the virtual interface is pending confirmation from the virtual interface owner. If the owner of the virtual interface is different from the owner of the connection on which it is provisioned, then the virtual interface will remain in this state until it is confirmed by the virtual interface owner.</p> </li> <li> <p> <b>Verifying</b>: This state only applies to public virtual interfaces. Each public virtual interface needs validation before the virtual interface can be created.</p> </li> <li> <p> <b>Pending</b>: A virtual interface is in this state from the time that it is created until the virtual interface is ready to forward traffic.</p> </li> <li> <p> <b>Available</b>: A virtual interface that is able to forward traffic.</p> </li> <li> <p> <b>Down</b>: A virtual interface that is BGP down.</p> </li> <li> <p> <b>Deleting</b>: A virtual interface is in this state immediately after calling <a>DeleteVirtualInterface</a> until it can no longer forward traffic.</p> </li> <li> <p> <b>Deleted</b>: A virtual interface that cannot forward traffic.</p> </li> <li> <p> <b>Rejected</b>: The virtual interface owner has declined creation of the virtual interface. If a virtual interface in the 'Confirming' state is deleted by the virtual interface owner, the virtual interface will enter the 'Rejected' state.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VirtualInterfaceState {
+    Available,
+    Confirming,
+    Deleted,
+    Deleting,
+    Down,
+    Pending,
+    Rejected,
+    Verifying,
+}
+
+impl Into<String> for VirtualInterfaceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VirtualInterfaceState {
+    fn into(self) -> &'static str {
+        match self {
+            VirtualInterfaceState::Available => "available",
+            VirtualInterfaceState::Confirming => "confirming",
+            VirtualInterfaceState::Deleted => "deleted",
+            VirtualInterfaceState::Deleting => "deleting",
+            VirtualInterfaceState::Down => "down",
+            VirtualInterfaceState::Pending => "pending",
+            VirtualInterfaceState::Rejected => "rejected",
+            VirtualInterfaceState::Verifying => "verifying",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VirtualInterfaceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(VirtualInterfaceState::Available),
+            "confirming" => Ok(VirtualInterfaceState::Confirming),
+            "deleted" => Ok(VirtualInterfaceState::Deleted),
+            "deleting" => Ok(VirtualInterfaceState::Deleting),
+            "down" => Ok(VirtualInterfaceState::Down),
+            "pending" => Ok(VirtualInterfaceState::Pending),
+            "rejected" => Ok(VirtualInterfaceState::Rejected),
+            "verifying" => Ok(VirtualInterfaceState::Verifying),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A structure containing a list of virtual interfaces.</p>"]
@@ -4193,7 +4535,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
                                                           .as_ref())
                            .unwrap())
@@ -4219,7 +4561,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
                                                           .as_ref())
                            .unwrap())
@@ -4247,7 +4589,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AllocatePrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4273,7 +4615,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AllocatePublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4297,7 +4639,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
                                                           .as_ref())
                            .unwrap())
@@ -4323,7 +4665,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
                                                           .as_ref())
                            .unwrap())
@@ -4349,7 +4691,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AssociateVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4373,7 +4715,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ConfirmConnectionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4402,7 +4744,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ConfirmPrivateVirtualInterfaceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ConfirmPrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4428,7 +4770,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ConfirmPublicVirtualInterfaceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ConfirmPublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4452,7 +4794,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateBGPPeerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4478,7 +4820,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
                                                           .as_ref())
                            .unwrap())
@@ -4507,7 +4849,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Interconnect>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())
@@ -4534,7 +4876,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&response.body).as_ref())
                        .unwrap())
             }
@@ -4561,7 +4903,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreatePrivateVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4587,7 +4929,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreatePublicVirtualInterfaceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4611,7 +4953,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteBGPPeerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4637,7 +4979,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
                                                           .as_ref())
                            .unwrap())
@@ -4666,7 +5008,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteInterconnectResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4691,7 +5033,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&response.body).as_ref())
                        .unwrap())
             }
@@ -4717,7 +5059,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteVirtualInterfaceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4745,7 +5087,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeConnectionLoaResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4772,7 +5114,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&response.body)
                                                            .as_ref())
                            .unwrap())
@@ -4803,7 +5145,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&response.body)
                                                            .as_ref())
                            .unwrap())
@@ -4829,7 +5171,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&response.body)
                                                            .as_ref())
                            .unwrap())
@@ -4856,7 +5198,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeInterconnectLoaResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeInterconnectLoaError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4880,7 +5222,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Interconnects>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -4907,7 +5249,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Lags>(String::from_utf8_lossy(&response.body).as_ref())
                        .unwrap())
             }
@@ -4932,7 +5274,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Loa>(String::from_utf8_lossy(&response.body).as_ref())
                        .unwrap())
             }
@@ -4954,7 +5296,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Locations>(String::from_utf8_lossy(&response.body)
                                                          .as_ref())
                            .unwrap())
@@ -4983,7 +5325,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTagsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5006,7 +5348,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<VirtualGateways>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -5032,7 +5374,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<VirtualInterfaces>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeVirtualInterfacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5058,7 +5400,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&response.body)
                                                           .as_ref())
                            .unwrap())
@@ -5084,7 +5426,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<TagResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5108,7 +5450,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UntagResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5132,7 +5474,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&response.body).as_ref())
                        .unwrap())
             }

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -57,6 +53,79 @@ pub struct AddTagsToResourceMessage {
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AddTagsToResourceResponse;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthMechanismValue {
+    Default,
+    MongodbCr,
+    ScramSha1,
+}
+
+impl Into<String> for AuthMechanismValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthMechanismValue {
+    fn into(self) -> &'static str {
+        match self {
+            AuthMechanismValue::Default => "default",
+            AuthMechanismValue::MongodbCr => "mongodb_cr",
+            AuthMechanismValue::ScramSha1 => "scram_sha_1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthMechanismValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(AuthMechanismValue::Default),
+            "mongodb_cr" => Ok(AuthMechanismValue::MongodbCr),
+            "scram_sha_1" => Ok(AuthMechanismValue::ScramSha1),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthTypeValue {
+    No,
+    Password,
+}
+
+impl Into<String> for AuthTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            AuthTypeValue::No => "no",
+            AuthTypeValue::Password => "password",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "no" => Ok(AuthTypeValue::No),
+            "password" => Ok(AuthTypeValue::Password),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -114,6 +183,41 @@ pub struct Certificate {
     #[serde(rename="ValidToDate")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub valid_to_date: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CompressionTypeValue {
+    Gzip,
+    None,
+}
+
+impl Into<String> for CompressionTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CompressionTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            CompressionTypeValue::Gzip => "gzip",
+            CompressionTypeValue::None => "none",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CompressionTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gzip" => Ok(CompressionTypeValue::Gzip),
+            "none" => Ok(CompressionTypeValue::None),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -926,6 +1030,47 @@ pub struct DescribeTableStatisticsResponse {
     pub table_statistics: Option<Vec<TableStatistics>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DmsSslModeValue {
+    None,
+    Require,
+    VerifyCa,
+    VerifyFull,
+}
+
+impl Into<String> for DmsSslModeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DmsSslModeValue {
+    fn into(self) -> &'static str {
+        match self {
+            DmsSslModeValue::None => "none",
+            DmsSslModeValue::Require => "require",
+            DmsSslModeValue::VerifyCa => "verify-ca",
+            DmsSslModeValue::VerifyFull => "verify-full",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DmsSslModeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(DmsSslModeValue::None),
+            "require" => Ok(DmsSslModeValue::Require),
+            "verify-ca" => Ok(DmsSslModeValue::VerifyCa),
+            "verify-full" => Ok(DmsSslModeValue::VerifyFull),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DynamoDbSettings {
@@ -1143,6 +1288,44 @@ pub struct ListTagsForResourceResponse {
     #[serde(rename="TagList")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tag_list: Option<Vec<Tag>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MigrationTypeValue {
+    Cdc,
+    FullLoad,
+    FullLoadAndCdc,
+}
+
+impl Into<String> for MigrationTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MigrationTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            MigrationTypeValue::Cdc => "cdc",
+            MigrationTypeValue::FullLoad => "full-load",
+            MigrationTypeValue::FullLoadAndCdc => "full-load-and-cdc",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MigrationTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cdc" => Ok(MigrationTypeValue::Cdc),
+            "full-load" => Ok(MigrationTypeValue::FullLoad),
+            "full-load-and-cdc" => Ok(MigrationTypeValue::FullLoadAndCdc),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -1418,6 +1601,41 @@ pub struct MongoDbSettings {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NestingLevelValue {
+    None,
+    One,
+}
+
+impl Into<String> for NestingLevelValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NestingLevelValue {
+    fn into(self) -> &'static str {
+        match self {
+            NestingLevelValue::None => "none",
+            NestingLevelValue::One => "one",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NestingLevelValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(NestingLevelValue::None),
+            "one" => Ok(NestingLevelValue::One),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct OrderableReplicationInstance {
@@ -1496,6 +1714,44 @@ pub struct RefreshSchemasStatus {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RefreshSchemasStatusTypeValue {
+    Failed,
+    Refreshing,
+    Successful,
+}
+
+impl Into<String> for RefreshSchemasStatusTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RefreshSchemasStatusTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            RefreshSchemasStatusTypeValue::Failed => "failed",
+            RefreshSchemasStatusTypeValue::Refreshing => "refreshing",
+            RefreshSchemasStatusTypeValue::Successful => "successful",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RefreshSchemasStatusTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "failed" => Ok(RefreshSchemasStatusTypeValue::Failed),
+            "refreshing" => Ok(RefreshSchemasStatusTypeValue::Refreshing),
+            "successful" => Ok(RefreshSchemasStatusTypeValue::Successful),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ReloadTablesMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the replication instance. </p>"]
@@ -1528,6 +1784,41 @@ pub struct RemoveTagsFromResourceMessage {
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoveTagsFromResourceResponse;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationEndpointTypeValue {
+    Source,
+    Target,
+}
+
+impl Into<String> for ReplicationEndpointTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationEndpointTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationEndpointTypeValue::Source => "source",
+            ReplicationEndpointTypeValue::Target => "target",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationEndpointTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "source" => Ok(ReplicationEndpointTypeValue::Source),
+            "target" => Ok(ReplicationEndpointTypeValue::Target),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -1779,6 +2070,38 @@ pub struct S3Settings {
     pub service_access_role_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    ReplicationInstance,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::ReplicationInstance => "replication-instance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "replication-instance" => Ok(SourceType::ReplicationInstance),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartReplicationTaskMessage {
@@ -1801,6 +2124,44 @@ pub struct StartReplicationTaskResponse {
     #[serde(rename="ReplicationTask")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub replication_task: Option<ReplicationTask>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StartReplicationTaskTypeValue {
+    ReloadTarget,
+    ResumeProcessing,
+    StartReplication,
+}
+
+impl Into<String> for StartReplicationTaskTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StartReplicationTaskTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            StartReplicationTaskTypeValue::ReloadTarget => "reload-target",
+            StartReplicationTaskTypeValue::ResumeProcessing => "resume-processing",
+            StartReplicationTaskTypeValue::StartReplication => "start-replication",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StartReplicationTaskTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "reload-target" => Ok(StartReplicationTaskTypeValue::ReloadTarget),
+            "resume-processing" => Ok(StartReplicationTaskTypeValue::ResumeProcessing),
+            "start-replication" => Ok(StartReplicationTaskTypeValue::StartReplication),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -5527,7 +5888,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddTagsToResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5554,7 +5915,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateEndpointResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5582,7 +5943,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateEventSubscriptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5608,7 +5969,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateReplicationInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateReplicationInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5634,7 +5995,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateReplicationSubnetGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5659,7 +6020,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5686,7 +6047,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5713,7 +6074,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteEndpointResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5741,7 +6102,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteEventSubscriptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5767,7 +6128,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteReplicationInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteReplicationInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5793,7 +6154,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteReplicationSubnetGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5818,7 +6179,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5845,7 +6206,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAccountAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5869,7 +6230,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCertificatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5896,7 +6257,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeConnectionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5924,7 +6285,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEndpointTypesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5951,7 +6312,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEndpointsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5979,7 +6340,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventCategoriesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeEventCategoriesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6005,7 +6366,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventSubscriptionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeEventSubscriptionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6029,7 +6390,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6055,7 +6416,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeOrderableReplicationInstancesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeOrderableReplicationInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6081,7 +6442,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeRefreshSchemasStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeRefreshSchemasStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6107,7 +6468,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeReplicationInstancesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeReplicationInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6133,7 +6494,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeReplicationSubnetGroupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeReplicationSubnetGroupsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6159,7 +6520,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeReplicationTasksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeReplicationTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6183,7 +6544,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeSchemasResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6211,7 +6572,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTableStatisticsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeTableStatisticsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6235,7 +6596,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ImportCertificateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6262,7 +6623,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6289,7 +6650,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyEndpointResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6317,7 +6678,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyEventSubscriptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ModifyEventSubscriptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6343,7 +6704,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyReplicationInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ModifyReplicationInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6369,7 +6730,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyReplicationSubnetGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ModifyReplicationSubnetGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6394,7 +6755,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6421,7 +6782,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RefreshSchemasResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6448,7 +6809,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ReloadTablesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6475,7 +6836,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTagsFromResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6503,7 +6864,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6530,7 +6891,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopReplicationTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6557,7 +6918,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<TestConnectionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -733,6 +729,141 @@ pub struct DirectoryLimits {
     pub connected_directories_limit_reached: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DirectorySize {
+    Large,
+    Small,
+}
+
+impl Into<String> for DirectorySize {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DirectorySize {
+    fn into(self) -> &'static str {
+        match self {
+            DirectorySize::Large => "Large",
+            DirectorySize::Small => "Small",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DirectorySize {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Large" => Ok(DirectorySize::Large),
+            "Small" => Ok(DirectorySize::Small),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DirectoryStage {
+    Active,
+    Created,
+    Creating,
+    Deleted,
+    Deleting,
+    Failed,
+    Impaired,
+    Inoperable,
+    Requested,
+    RestoreFailed,
+    Restoring,
+}
+
+impl Into<String> for DirectoryStage {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DirectoryStage {
+    fn into(self) -> &'static str {
+        match self {
+            DirectoryStage::Active => "Active",
+            DirectoryStage::Created => "Created",
+            DirectoryStage::Creating => "Creating",
+            DirectoryStage::Deleted => "Deleted",
+            DirectoryStage::Deleting => "Deleting",
+            DirectoryStage::Failed => "Failed",
+            DirectoryStage::Impaired => "Impaired",
+            DirectoryStage::Inoperable => "Inoperable",
+            DirectoryStage::Requested => "Requested",
+            DirectoryStage::RestoreFailed => "RestoreFailed",
+            DirectoryStage::Restoring => "Restoring",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DirectoryStage {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(DirectoryStage::Active),
+            "Created" => Ok(DirectoryStage::Created),
+            "Creating" => Ok(DirectoryStage::Creating),
+            "Deleted" => Ok(DirectoryStage::Deleted),
+            "Deleting" => Ok(DirectoryStage::Deleting),
+            "Failed" => Ok(DirectoryStage::Failed),
+            "Impaired" => Ok(DirectoryStage::Impaired),
+            "Inoperable" => Ok(DirectoryStage::Inoperable),
+            "Requested" => Ok(DirectoryStage::Requested),
+            "RestoreFailed" => Ok(DirectoryStage::RestoreFailed),
+            "Restoring" => Ok(DirectoryStage::Restoring),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DirectoryType {
+    Adconnector,
+    MicrosoftAD,
+    SimpleAD,
+}
+
+impl Into<String> for DirectoryType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DirectoryType {
+    fn into(self) -> &'static str {
+        match self {
+            DirectoryType::Adconnector => "ADConnector",
+            DirectoryType::MicrosoftAD => "MicrosoftAD",
+            DirectoryType::SimpleAD => "SimpleAD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DirectoryType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADConnector" => Ok(DirectoryType::Adconnector),
+            "MicrosoftAD" => Ok(DirectoryType::MicrosoftAD),
+            "SimpleAD" => Ok(DirectoryType::SimpleAD),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains VPC information for the <a>CreateDirectory</a> or <a>CreateMicrosoftAD</a> operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DirectoryVpcSettings {
@@ -929,6 +1060,53 @@ pub struct IpRouteInfo {
     pub ip_route_status_reason: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IpRouteStatusMsg {
+    AddFailed,
+    Added,
+    Adding,
+    RemoveFailed,
+    Removed,
+    Removing,
+}
+
+impl Into<String> for IpRouteStatusMsg {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IpRouteStatusMsg {
+    fn into(self) -> &'static str {
+        match self {
+            IpRouteStatusMsg::AddFailed => "AddFailed",
+            IpRouteStatusMsg::Added => "Added",
+            IpRouteStatusMsg::Adding => "Adding",
+            IpRouteStatusMsg::RemoveFailed => "RemoveFailed",
+            IpRouteStatusMsg::Removed => "Removed",
+            IpRouteStatusMsg::Removing => "Removing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IpRouteStatusMsg {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AddFailed" => Ok(IpRouteStatusMsg::AddFailed),
+            "Added" => Ok(IpRouteStatusMsg::Added),
+            "Adding" => Ok(IpRouteStatusMsg::Adding),
+            "RemoveFailed" => Ok(IpRouteStatusMsg::RemoveFailed),
+            "Removed" => Ok(IpRouteStatusMsg::Removed),
+            "Removing" => Ok(IpRouteStatusMsg::Removing),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListIpRoutesRequest {
     #[doc="<p>Identifier (ID) of the directory for which you want to retrieve the IP addresses.</p>"]
@@ -1010,6 +1188,47 @@ pub struct ListTagsForResourceResult {
     pub tags: Option<Vec<Tag>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RadiusAuthenticationProtocol {
+    Chap,
+    MsChapv1,
+    MsChapv2,
+    Pap,
+}
+
+impl Into<String> for RadiusAuthenticationProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RadiusAuthenticationProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            RadiusAuthenticationProtocol::Chap => "CHAP",
+            RadiusAuthenticationProtocol::MsChapv1 => "MS-CHAPv1",
+            RadiusAuthenticationProtocol::MsChapv2 => "MS-CHAPv2",
+            RadiusAuthenticationProtocol::Pap => "PAP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RadiusAuthenticationProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHAP" => Ok(RadiusAuthenticationProtocol::Chap),
+            "MS-CHAPv1" => Ok(RadiusAuthenticationProtocol::MsChapv1),
+            "MS-CHAPv2" => Ok(RadiusAuthenticationProtocol::MsChapv2),
+            "PAP" => Ok(RadiusAuthenticationProtocol::Pap),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about a Remote Authentication Dial In User Service (RADIUS) server.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RadiusSettings {
@@ -1045,6 +1264,44 @@ pub struct RadiusSettings {
     #[serde(rename="UseSameUsername")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub use_same_username: Option<bool>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RadiusStatus {
+    Completed,
+    Creating,
+    Failed,
+}
+
+impl Into<String> for RadiusStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RadiusStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RadiusStatus::Completed => "Completed",
+            RadiusStatus::Creating => "Creating",
+            RadiusStatus::Failed => "Failed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RadiusStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Completed" => Ok(RadiusStatus::Completed),
+            "Creating" => Ok(RadiusStatus::Creating),
+            "Failed" => Ok(RadiusStatus::Failed),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Registers a new event topic.</p>"]
@@ -1087,6 +1344,38 @@ pub struct RemoveTagsFromResourceRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoveTagsFromResourceResult;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationScope {
+    Domain,
+}
+
+impl Into<String> for ReplicationScope {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationScope {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationScope::Domain => "Domain",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationScope {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Domain" => Ok(ReplicationScope::Domain),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p>An object representing the inputs for the <a>RestoreFromSnapshot</a> operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1131,6 +1420,62 @@ pub struct SchemaExtensionInfo {
     #[serde(rename="StartDateTime")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub start_date_time: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SchemaExtensionStatus {
+    CancelInProgress,
+    Cancelled,
+    Completed,
+    CreatingSnapshot,
+    Failed,
+    Initializing,
+    Replicating,
+    RollbackInProgress,
+    UpdatingSchema,
+}
+
+impl Into<String> for SchemaExtensionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SchemaExtensionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            SchemaExtensionStatus::CancelInProgress => "CancelInProgress",
+            SchemaExtensionStatus::Cancelled => "Cancelled",
+            SchemaExtensionStatus::Completed => "Completed",
+            SchemaExtensionStatus::CreatingSnapshot => "CreatingSnapshot",
+            SchemaExtensionStatus::Failed => "Failed",
+            SchemaExtensionStatus::Initializing => "Initializing",
+            SchemaExtensionStatus::Replicating => "Replicating",
+            SchemaExtensionStatus::RollbackInProgress => "RollbackInProgress",
+            SchemaExtensionStatus::UpdatingSchema => "UpdatingSchema",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SchemaExtensionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CancelInProgress" => Ok(SchemaExtensionStatus::CancelInProgress),
+            "Cancelled" => Ok(SchemaExtensionStatus::Cancelled),
+            "Completed" => Ok(SchemaExtensionStatus::Completed),
+            "CreatingSnapshot" => Ok(SchemaExtensionStatus::CreatingSnapshot),
+            "Failed" => Ok(SchemaExtensionStatus::Failed),
+            "Initializing" => Ok(SchemaExtensionStatus::Initializing),
+            "Replicating" => Ok(SchemaExtensionStatus::Replicating),
+            "RollbackInProgress" => Ok(SchemaExtensionStatus::RollbackInProgress),
+            "UpdatingSchema" => Ok(SchemaExtensionStatus::UpdatingSchema),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a directory snapshot.</p>"]
@@ -1179,6 +1524,79 @@ pub struct SnapshotLimits {
     pub manual_snapshots_limit_reached: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnapshotStatus {
+    Completed,
+    Creating,
+    Failed,
+}
+
+impl Into<String> for SnapshotStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnapshotStatus {
+    fn into(self) -> &'static str {
+        match self {
+            SnapshotStatus::Completed => "Completed",
+            SnapshotStatus::Creating => "Creating",
+            SnapshotStatus::Failed => "Failed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnapshotStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Completed" => Ok(SnapshotStatus::Completed),
+            "Creating" => Ok(SnapshotStatus::Creating),
+            "Failed" => Ok(SnapshotStatus::Failed),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnapshotType {
+    Auto,
+    Manual,
+}
+
+impl Into<String> for SnapshotType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnapshotType {
+    fn into(self) -> &'static str {
+        match self {
+            SnapshotType::Auto => "Auto",
+            SnapshotType::Manual => "Manual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnapshotType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Auto" => Ok(SnapshotType::Auto),
+            "Manual" => Ok(SnapshotType::Manual),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartSchemaExtensionRequest {
     #[doc="<p>If true, creates a snapshot of the directory before applying the schema extension.</p>"]
@@ -1212,6 +1630,47 @@ pub struct Tag {
     #[doc="<p>The optional value of the tag. The string value can be Unicode characters. The string can contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>"]
     #[serde(rename="Value")]
     pub value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TopicStatus {
+    Deleted,
+    Failed,
+    Registered,
+    TopicNotFound,
+}
+
+impl Into<String> for TopicStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TopicStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TopicStatus::Deleted => "Deleted",
+            TopicStatus::Failed => "Failed",
+            TopicStatus::Registered => "Registered",
+            TopicStatus::TopicNotFound => "Topic not found",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TopicStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Deleted" => Ok(TopicStatus::Deleted),
+            "Failed" => Ok(TopicStatus::Failed),
+            "Registered" => Ok(TopicStatus::Registered),
+            "Topic not found" => Ok(TopicStatus::TopicNotFound),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a trust relationship between an Microsoft AD in the AWS cloud and an external domain.</p>"]
@@ -1257,6 +1716,129 @@ pub struct Trust {
     #[serde(rename="TrustType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub trust_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TrustDirection {
+    OneWayIncoming,
+    OneWayOutgoing,
+    TwoWay,
+}
+
+impl Into<String> for TrustDirection {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TrustDirection {
+    fn into(self) -> &'static str {
+        match self {
+            TrustDirection::OneWayIncoming => "One-Way: Incoming",
+            TrustDirection::OneWayOutgoing => "One-Way: Outgoing",
+            TrustDirection::TwoWay => "Two-Way",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TrustDirection {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "One-Way: Incoming" => Ok(TrustDirection::OneWayIncoming),
+            "One-Way: Outgoing" => Ok(TrustDirection::OneWayOutgoing),
+            "Two-Way" => Ok(TrustDirection::TwoWay),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TrustState {
+    Created,
+    Creating,
+    Deleted,
+    Deleting,
+    Failed,
+    Verified,
+    VerifyFailed,
+    Verifying,
+}
+
+impl Into<String> for TrustState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TrustState {
+    fn into(self) -> &'static str {
+        match self {
+            TrustState::Created => "Created",
+            TrustState::Creating => "Creating",
+            TrustState::Deleted => "Deleted",
+            TrustState::Deleting => "Deleting",
+            TrustState::Failed => "Failed",
+            TrustState::Verified => "Verified",
+            TrustState::VerifyFailed => "VerifyFailed",
+            TrustState::Verifying => "Verifying",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TrustState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(TrustState::Created),
+            "Creating" => Ok(TrustState::Creating),
+            "Deleted" => Ok(TrustState::Deleted),
+            "Deleting" => Ok(TrustState::Deleting),
+            "Failed" => Ok(TrustState::Failed),
+            "Verified" => Ok(TrustState::Verified),
+            "VerifyFailed" => Ok(TrustState::VerifyFailed),
+            "Verifying" => Ok(TrustState::Verifying),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TrustType {
+    Forest,
+}
+
+impl Into<String> for TrustType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TrustType {
+    fn into(self) -> &'static str {
+        match self {
+            TrustType::Forest => "Forest",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TrustType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Forest" => Ok(TrustType::Forest),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Updates a conditional forwarder.</p>"]
@@ -5191,7 +5773,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddIpRoutesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AddIpRoutesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5216,7 +5798,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddTagsToResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5245,7 +5827,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CancelSchemaExtensionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5272,7 +5854,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ConnectDirectoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5299,7 +5881,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAliasResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5323,7 +5905,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateComputerResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5352,7 +5934,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateConditionalForwarderResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateConditionalForwarderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5376,7 +5958,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDirectoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5404,7 +5986,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateMicrosoftADResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5431,7 +6013,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5458,7 +6040,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateTrustResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateTrustError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5484,7 +6066,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteConditionalForwarderResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteConditionalForwarderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5508,7 +6090,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteDirectoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5535,7 +6117,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5562,7 +6144,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteTrustResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteTrustError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5587,7 +6169,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeregisterEventTopicResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5616,7 +6198,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeConditionalForwardersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeConditionalForwardersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5641,7 +6223,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDirectoriesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5669,7 +6251,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventTopicsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5697,7 +6279,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeSnapshotsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5724,7 +6306,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTrustsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5751,7 +6333,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisableRadiusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5775,7 +6357,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisableSsoResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DisableSsoError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5799,7 +6381,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<EnableRadiusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5823,7 +6405,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<EnableSsoResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -5847,7 +6429,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDirectoryLimitsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5875,7 +6457,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetSnapshotLimitsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5902,7 +6484,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListIpRoutesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5929,7 +6511,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListSchemaExtensionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5957,7 +6539,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5985,7 +6567,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterEventTopicResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6012,7 +6594,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveIpRoutesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6041,7 +6623,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTagsFromResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6069,7 +6651,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RestoreFromSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6097,7 +6679,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartSchemaExtensionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6126,7 +6708,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateConditionalForwarderResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateConditionalForwarderError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6150,7 +6732,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateRadiusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6176,7 +6758,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<VerifyTrustResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(VerifyTrustError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -11,21 +11,55 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AttributeAction {
+    Add,
+    Delete,
+    Put,
+}
+
+impl Into<String> for AttributeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AttributeAction {
+    fn into(self) -> &'static str {
+        match self {
+            AttributeAction::Add => "ADD",
+            AttributeAction::Delete => "DELETE",
+            AttributeAction::Put => "PUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AttributeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADD" => Ok(AttributeAction::Add),
+            "DELETE" => Ok(AttributeAction::Delete),
+            "PUT" => Ok(AttributeAction::Put),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents an attribute for describing the key schema for the table and indexes.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttributeDefinition {
@@ -172,6 +206,74 @@ pub struct Capacity {
     pub capacity_units: Option<f64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    BeginsWith,
+    Between,
+    Contains,
+    Eq,
+    Ge,
+    Gt,
+    In,
+    Le,
+    Lt,
+    Ne,
+    NotContains,
+    NotNull,
+    Null,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::BeginsWith => "BEGINS_WITH",
+            ComparisonOperator::Between => "BETWEEN",
+            ComparisonOperator::Contains => "CONTAINS",
+            ComparisonOperator::Eq => "EQ",
+            ComparisonOperator::Ge => "GE",
+            ComparisonOperator::Gt => "GT",
+            ComparisonOperator::In => "IN",
+            ComparisonOperator::Le => "LE",
+            ComparisonOperator::Lt => "LT",
+            ComparisonOperator::Ne => "NE",
+            ComparisonOperator::NotContains => "NOT_CONTAINS",
+            ComparisonOperator::NotNull => "NOT_NULL",
+            ComparisonOperator::Null => "NULL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BEGINS_WITH" => Ok(ComparisonOperator::BeginsWith),
+            "BETWEEN" => Ok(ComparisonOperator::Between),
+            "CONTAINS" => Ok(ComparisonOperator::Contains),
+            "EQ" => Ok(ComparisonOperator::Eq),
+            "GE" => Ok(ComparisonOperator::Ge),
+            "GT" => Ok(ComparisonOperator::Gt),
+            "IN" => Ok(ComparisonOperator::In),
+            "LE" => Ok(ComparisonOperator::Le),
+            "LT" => Ok(ComparisonOperator::Lt),
+            "NE" => Ok(ComparisonOperator::Ne),
+            "NOT_CONTAINS" => Ok(ComparisonOperator::NotContains),
+            "NOT_NULL" => Ok(ComparisonOperator::NotNull),
+            "NULL" => Ok(ComparisonOperator::Null),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the selection criteria for a <code>Query</code> or <code>Scan</code> operation:</p> <ul> <li> <p>For a <code>Query</code> operation, <code>Condition</code> is used for specifying the <code>KeyConditions</code> to use when querying a table or an index. For <code>KeyConditions</code>, only the following comparison operators are supported:</p> <p> <code>EQ | LE | LT | GE | GT | BEGINS_WITH | BETWEEN</code> </p> <p> <code>Condition</code> is also used in a <code>QueryFilter</code>, which evaluates the query results and returns only the desired values.</p> </li> <li> <p>For a <code>Scan</code> operation, <code>Condition</code> is used in a <code>ScanFilter</code>, which evaluates the scan results and returns only the desired values.</p> </li> </ul>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct Condition {
@@ -182,6 +284,41 @@ pub struct Condition {
     #[doc="<p>A comparator for evaluating attributes. For example, equals, greater than, less than, etc.</p> <p>The following comparison operators are available:</p> <p> <code>EQ | NE | LE | LT | GE | GT | NOT_NULL | NULL | CONTAINS | NOT_CONTAINS | BEGINS_WITH | IN | BETWEEN</code> </p> <p>The following are descriptions of each comparison operator.</p> <ul> <li> <p> <code>EQ</code> : Equal. <code>EQ</code> is supported for all data types, including lists and maps.</p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> element of type String, Number, Binary, String Set, Number Set, or Binary Set. If an item contains an <code>AttributeValue</code> element of a different type than the one provided in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p> <p/> </li> <li> <p> <code>NE</code> : Not equal. <code>NE</code> is supported for all data types, including lists and maps.</p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> of type String, Number, Binary, String Set, Number Set, or Binary Set. If an item contains an <code>AttributeValue</code> of a different type than the one provided in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p> <p/> </li> <li> <p> <code>LE</code> : Less than or equal. </p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> element of type String, Number, or Binary (not a set type). If an item contains an <code>AttributeValue</code> element of a different type than the one provided in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p> <p/> </li> <li> <p> <code>LT</code> : Less than. </p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> of type String, Number, or Binary (not a set type). If an item contains an <code>AttributeValue</code> element of a different type than the one provided in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p> <p/> </li> <li> <p> <code>GE</code> : Greater than or equal. </p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> element of type String, Number, or Binary (not a set type). If an item contains an <code>AttributeValue</code> element of a different type than the one provided in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p> <p/> </li> <li> <p> <code>GT</code> : Greater than. </p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> element of type String, Number, or Binary (not a set type). If an item contains an <code>AttributeValue</code> element of a different type than the one provided in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p> <p/> </li> <li> <p> <code>NOT_NULL</code> : The attribute exists. <code>NOT_NULL</code> is supported for all data types, including lists and maps.</p> <note> <p>This operator tests for the existence of an attribute, not its data type. If the data type of attribute \"<code>a</code>\" is null, and you evaluate it using <code>NOT_NULL</code>, the result is a Boolean <code>true</code>. This result is because the attribute \"<code>a</code>\" exists; its data type is not relevant to the <code>NOT_NULL</code> comparison operator.</p> </note> </li> <li> <p> <code>NULL</code> : The attribute does not exist. <code>NULL</code> is supported for all data types, including lists and maps.</p> <note> <p>This operator tests for the nonexistence of an attribute, not its data type. If the data type of attribute \"<code>a</code>\" is null, and you evaluate it using <code>NULL</code>, the result is a Boolean <code>false</code>. This is because the attribute \"<code>a</code>\" exists; its data type is not relevant to the <code>NULL</code> comparison operator.</p> </note> </li> <li> <p> <code>CONTAINS</code> : Checks for a subsequence, or value in a set.</p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> element of type String, Number, or Binary (not a set type). If the target attribute of the comparison is of type String, then the operator checks for a substring match. If the target attribute of the comparison is of type Binary, then the operator looks for a subsequence of the target that matches the input. If the target attribute of the comparison is a set (\"<code>SS</code>\", \"<code>NS</code>\", or \"<code>BS</code>\"), then the operator evaluates to true if it finds an exact match with any member of the set.</p> <p>CONTAINS is supported for lists: When evaluating \"<code>a CONTAINS b</code>\", \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot be a set, a map, or a list.</p> </li> <li> <p> <code>NOT_CONTAINS</code> : Checks for absence of a subsequence, or absence of a value in a set.</p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> element of type String, Number, or Binary (not a set type). If the target attribute of the comparison is a String, then the operator checks for the absence of a substring match. If the target attribute of the comparison is Binary, then the operator checks for the absence of a subsequence of the target that matches the input. If the target attribute of the comparison is a set (\"<code>SS</code>\", \"<code>NS</code>\", or \"<code>BS</code>\"), then the operator evaluates to true if it <i>does not</i> find an exact match with any member of the set.</p> <p>NOT_CONTAINS is supported for lists: When evaluating \"<code>a NOT CONTAINS b</code>\", \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot be a set, a map, or a list.</p> </li> <li> <p> <code>BEGINS_WITH</code> : Checks for a prefix. </p> <p> <code>AttributeValueList</code> can contain only one <code>AttributeValue</code> of type String or Binary (not a Number or a set type). The target attribute of the comparison must be of type String or Binary (not a Number or a set type).</p> <p/> </li> <li> <p> <code>IN</code> : Checks for matching elements in a list.</p> <p> <code>AttributeValueList</code> can contain one or more <code>AttributeValue</code> elements of type String, Number, or Binary. These attributes are compared against an existing attribute of an item. If any elements of the input are equal to the item attribute, the expression evaluates to true.</p> </li> <li> <p> <code>BETWEEN</code> : Greater than or equal to the first value, and less than or equal to the second value. </p> <p> <code>AttributeValueList</code> must contain two <code>AttributeValue</code> elements of the same type, either String, Number, or Binary (not a set type). A target attribute matches if the target value is greater than, or equal to, the first element and less than, or equal to, the second element. If an item contains an <code>AttributeValue</code> element of a different type than the one provided in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code> does not compare to <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code> </p> </li> </ul> <p>For usage examples of <code>AttributeValueList</code> and <code>ComparisonOperator</code>, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html\">Legacy Conditional Parameters</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="ComparisonOperator")]
     pub comparison_operator: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConditionalOperator {
+    And,
+    Or,
+}
+
+impl Into<String> for ConditionalOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConditionalOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ConditionalOperator::And => "AND",
+            ConditionalOperator::Or => "OR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConditionalOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AND" => Ok(ConditionalOperator::And),
+            "OR" => Ok(ConditionalOperator::Or),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The capacity units consumed by an operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the request asked for it. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
@@ -553,6 +690,47 @@ pub struct GlobalSecondaryIndexUpdate {
     pub update: Option<UpdateGlobalSecondaryIndexAction>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IndexStatus {
+    Active,
+    Creating,
+    Deleting,
+    Updating,
+}
+
+impl Into<String> for IndexStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IndexStatus {
+    fn into(self) -> &'static str {
+        match self {
+            IndexStatus::Active => "ACTIVE",
+            IndexStatus::Creating => "CREATING",
+            IndexStatus::Deleting => "DELETING",
+            IndexStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IndexStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(IndexStatus::Active),
+            "CREATING" => Ok(IndexStatus::Creating),
+            "DELETING" => Ok(IndexStatus::Deleting),
+            "UPDATING" => Ok(IndexStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about item collections, if any, that were affected by the operation. <code>ItemCollectionMetrics</code> is only returned if the request asked for it. If the table does not have any local secondary indexes, this information is not returned in the response.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ItemCollectionMetrics {
@@ -575,6 +753,41 @@ pub struct KeySchemaElement {
     #[doc="<p>The role that this key attribute will assume:</p> <ul> <li> <p> <code>HASH</code> - partition key</p> </li> <li> <p> <code>RANGE</code> - sort key</p> </li> </ul> <note> <p>The partition key of an item is also known as its <i>hash attribute</i>. The term \"hash attribute\" derives from DynamoDB' usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values.</p> <p>The sort key of an item is also known as its <i>range attribute</i>. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.</p> </note>"]
     #[serde(rename="KeyType")]
     pub key_type: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyType {
+    Hash,
+    Range,
+}
+
+impl Into<String> for KeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyType {
+    fn into(self) -> &'static str {
+        match self {
+            KeyType::Hash => "HASH",
+            KeyType::Range => "RANGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HASH" => Ok(KeyType::Hash),
+            "RANGE" => Ok(KeyType::Range),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a set of primary keys and, for each key, the attributes to retrieve from the table.</p> <p>For each primary key, you must provide <i>all</i> of the key attributes. For example, with a simple primary key, you only need to provide the partition key. For a composite primary key, you must provide <i>both</i> the partition key and the sort key.</p>"]
@@ -704,6 +917,44 @@ pub struct Projection {
     #[serde(rename="ProjectionType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub projection_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProjectionType {
+    All,
+    Include,
+    KeysOnly,
+}
+
+impl Into<String> for ProjectionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProjectionType {
+    fn into(self) -> &'static str {
+        match self {
+            ProjectionType::All => "ALL",
+            ProjectionType::Include => "INCLUDE",
+            ProjectionType::KeysOnly => "KEYS_ONLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProjectionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(ProjectionType::All),
+            "INCLUDE" => Ok(ProjectionType::Include),
+            "KEYS_ONLY" => Ok(ProjectionType::KeysOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the provisioned throughput settings for a specified table or index. The settings can be modified using the <code>UpdateTable</code> operation.</p> <p>For current minimum and maximum provisioned throughput values, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Limits</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
@@ -907,6 +1158,161 @@ pub struct QueryOutput {
     pub scanned_count: Option<i64>,
 }
 
+#[doc="<p>Determines the level of detail about provisioned throughput consumption that is returned in the response:</p> <ul> <li> <p> <code>INDEXES</code> - The response includes the aggregate <code>ConsumedCapacity</code> for the operation, together with <code>ConsumedCapacity</code> for each table and secondary index that was accessed.</p> <p>Note that some operations, such as <code>GetItem</code> and <code>BatchGetItem</code>, do not access any indexes at all. In these cases, specifying <code>INDEXES</code> will only return <code>ConsumedCapacity</code> information for table(s).</p> </li> <li> <p> <code>TOTAL</code> - The response includes only the aggregate <code>ConsumedCapacity</code> for the operation.</p> </li> <li> <p> <code>NONE</code> - No <code>ConsumedCapacity</code> details are included in the response.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReturnConsumedCapacity {
+    Indexes,
+    None,
+    Total,
+}
+
+impl Into<String> for ReturnConsumedCapacity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReturnConsumedCapacity {
+    fn into(self) -> &'static str {
+        match self {
+            ReturnConsumedCapacity::Indexes => "INDEXES",
+            ReturnConsumedCapacity::None => "NONE",
+            ReturnConsumedCapacity::Total => "TOTAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReturnConsumedCapacity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INDEXES" => Ok(ReturnConsumedCapacity::Indexes),
+            "NONE" => Ok(ReturnConsumedCapacity::None),
+            "TOTAL" => Ok(ReturnConsumedCapacity::Total),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReturnItemCollectionMetrics {
+    None,
+    Size,
+}
+
+impl Into<String> for ReturnItemCollectionMetrics {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReturnItemCollectionMetrics {
+    fn into(self) -> &'static str {
+        match self {
+            ReturnItemCollectionMetrics::None => "NONE",
+            ReturnItemCollectionMetrics::Size => "SIZE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReturnItemCollectionMetrics {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NONE" => Ok(ReturnItemCollectionMetrics::None),
+            "SIZE" => Ok(ReturnItemCollectionMetrics::Size),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReturnValue {
+    AllNew,
+    AllOld,
+    None,
+    UpdatedNew,
+    UpdatedOld,
+}
+
+impl Into<String> for ReturnValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReturnValue {
+    fn into(self) -> &'static str {
+        match self {
+            ReturnValue::AllNew => "ALL_NEW",
+            ReturnValue::AllOld => "ALL_OLD",
+            ReturnValue::None => "NONE",
+            ReturnValue::UpdatedNew => "UPDATED_NEW",
+            ReturnValue::UpdatedOld => "UPDATED_OLD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReturnValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL_NEW" => Ok(ReturnValue::AllNew),
+            "ALL_OLD" => Ok(ReturnValue::AllOld),
+            "NONE" => Ok(ReturnValue::None),
+            "UPDATED_NEW" => Ok(ReturnValue::UpdatedNew),
+            "UPDATED_OLD" => Ok(ReturnValue::UpdatedOld),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalarAttributeType {
+    B,
+    N,
+    S,
+}
+
+impl Into<String> for ScalarAttributeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalarAttributeType {
+    fn into(self) -> &'static str {
+        match self {
+            ScalarAttributeType::B => "B",
+            ScalarAttributeType::N => "N",
+            ScalarAttributeType::S => "S",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalarAttributeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "B" => Ok(ScalarAttributeType::B),
+            "N" => Ok(ScalarAttributeType::N),
+            "S" => Ok(ScalarAttributeType::S),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of a <code>Scan</code> operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ScanInput {
@@ -1000,6 +1406,47 @@ pub struct ScanOutput {
     pub scanned_count: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Select {
+    AllAttributes,
+    AllProjectedAttributes,
+    Count,
+    SpecificAttributes,
+}
+
+impl Into<String> for Select {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Select {
+    fn into(self) -> &'static str {
+        match self {
+            Select::AllAttributes => "ALL_ATTRIBUTES",
+            Select::AllProjectedAttributes => "ALL_PROJECTED_ATTRIBUTES",
+            Select::Count => "COUNT",
+            Select::SpecificAttributes => "SPECIFIC_ATTRIBUTES",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Select {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL_ATTRIBUTES" => Ok(Select::AllAttributes),
+            "ALL_PROJECTED_ATTRIBUTES" => Ok(Select::AllProjectedAttributes),
+            "COUNT" => Ok(Select::Count),
+            "SPECIFIC_ATTRIBUTES" => Ok(Select::SpecificAttributes),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the DynamoDB Streams configuration for a table in DynamoDB.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StreamSpecification {
@@ -1011,6 +1458,47 @@ pub struct StreamSpecification {
     #[serde(rename="StreamViewType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stream_view_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StreamViewType {
+    KeysOnly,
+    NewAndOldImages,
+    NewImage,
+    OldImage,
+}
+
+impl Into<String> for StreamViewType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StreamViewType {
+    fn into(self) -> &'static str {
+        match self {
+            StreamViewType::KeysOnly => "KEYS_ONLY",
+            StreamViewType::NewAndOldImages => "NEW_AND_OLD_IMAGES",
+            StreamViewType::NewImage => "NEW_IMAGE",
+            StreamViewType::OldImage => "OLD_IMAGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StreamViewType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEYS_ONLY" => Ok(StreamViewType::KeysOnly),
+            "NEW_AND_OLD_IMAGES" => Ok(StreamViewType::NewAndOldImages),
+            "NEW_IMAGE" => Ok(StreamViewType::NewImage),
+            "OLD_IMAGE" => Ok(StreamViewType::OldImage),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the properties of a table.</p>"]
@@ -1074,6 +1562,47 @@ pub struct TableDescription {
     pub table_status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TableStatus {
+    Active,
+    Creating,
+    Deleting,
+    Updating,
+}
+
+impl Into<String> for TableStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TableStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TableStatus::Active => "ACTIVE",
+            TableStatus::Creating => "CREATING",
+            TableStatus::Deleting => "DELETING",
+            TableStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TableStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(TableStatus::Active),
+            "CREATING" => Ok(TableStatus::Creating),
+            "DELETING" => Ok(TableStatus::Deleting),
+            "UPDATING" => Ok(TableStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes a tag. A tag is a key-value pair. You can add up to 50 tags to a single DynamoDB table. </p> <p> AWS-assigned tag names and values are automatically assigned the aws: prefix, which the user cannot assign. AWS-assigned tag names do not count towards the tag limit of 50. User-assigned tag names have the prefix user: in the Cost Allocation Report. You cannot backdate the application of a tag. </p> <p>For an overview on tagging DynamoDB resources, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
@@ -1117,6 +1646,47 @@ pub struct TimeToLiveSpecification {
     #[doc="<p>Indicates whether Time To Live is to be enabled (true) or disabled (false) on the table.</p>"]
     #[serde(rename="Enabled")]
     pub enabled: bool,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TimeToLiveStatus {
+    Disabled,
+    Disabling,
+    Enabled,
+    Enabling,
+}
+
+impl Into<String> for TimeToLiveStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TimeToLiveStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TimeToLiveStatus::Disabled => "DISABLED",
+            TimeToLiveStatus::Disabling => "DISABLING",
+            TimeToLiveStatus::Enabled => "ENABLED",
+            TimeToLiveStatus::Enabling => "ENABLING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TimeToLiveStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(TimeToLiveStatus::Disabled),
+            "DISABLING" => Ok(TimeToLiveStatus::Disabling),
+            "ENABLED" => Ok(TimeToLiveStatus::Enabled),
+            "ENABLING" => Ok(TimeToLiveStatus::Enabling),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -3055,7 +3625,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetItemOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3081,7 +3651,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchWriteItemOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3108,7 +3678,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateTableOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateTableError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3130,7 +3700,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteItemOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteItemError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3154,7 +3724,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteTableOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteTableError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3175,7 +3745,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeLimitsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3202,7 +3772,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTableOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3228,7 +3798,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTimeToLiveOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3253,7 +3823,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetItemOutput>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -3277,7 +3847,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTablesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListTablesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3301,7 +3871,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsOfResourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3326,7 +3896,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<PutItemOutput>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -3350,7 +3920,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<QueryOutput>(String::from_utf8_lossy(&response.body)
                                                            .as_ref())
                            .unwrap())
@@ -3374,7 +3944,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ScanOutput>(String::from_utf8_lossy(&response.body)
                                                           .as_ref())
                            .unwrap())
@@ -3398,7 +3968,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -3418,7 +3988,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -3440,7 +4010,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateItemOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateItemError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3464,7 +4034,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateTableOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateTableError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3488,7 +4058,7 @@ impl<P, D> DynamoDb for DynamoDbClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateTimeToLiveOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -176,6 +172,41 @@ pub struct KeySchemaElement {
     pub key_type: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyType {
+    Hash,
+    Range,
+}
+
+impl Into<String> for KeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyType {
+    fn into(self) -> &'static str {
+        match self {
+            KeyType::Hash => "HASH",
+            KeyType::Range => "RANGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HASH" => Ok(KeyType::Hash),
+            "RANGE" => Ok(KeyType::Range),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of a <code>ListStreams</code> operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListStreamsInput {
@@ -204,6 +235,44 @@ pub struct ListStreamsOutput {
     #[serde(rename="Streams")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub streams: Option<Vec<Stream>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationType {
+    Insert,
+    Modify,
+    Remove,
+}
+
+impl Into<String> for OperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationType {
+    fn into(self) -> &'static str {
+        match self {
+            OperationType::Insert => "INSERT",
+            OperationType::Modify => "MODIFY",
+            OperationType::Remove => "REMOVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSERT" => Ok(OperationType::Insert),
+            "MODIFY" => Ok(OperationType::Modify),
+            "REMOVE" => Ok(OperationType::Remove),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A description of a unique event within a stream.</p>"]
@@ -267,6 +336,47 @@ pub struct Shard {
     #[serde(rename="ShardId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub shard_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShardIteratorType {
+    AfterSequenceNumber,
+    AtSequenceNumber,
+    Latest,
+    TrimHorizon,
+}
+
+impl Into<String> for ShardIteratorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShardIteratorType {
+    fn into(self) -> &'static str {
+        match self {
+            ShardIteratorType::AfterSequenceNumber => "AFTER_SEQUENCE_NUMBER",
+            ShardIteratorType::AtSequenceNumber => "AT_SEQUENCE_NUMBER",
+            ShardIteratorType::Latest => "LATEST",
+            ShardIteratorType::TrimHorizon => "TRIM_HORIZON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShardIteratorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AFTER_SEQUENCE_NUMBER" => Ok(ShardIteratorType::AfterSequenceNumber),
+            "AT_SEQUENCE_NUMBER" => Ok(ShardIteratorType::AtSequenceNumber),
+            "LATEST" => Ok(ShardIteratorType::Latest),
+            "TRIM_HORIZON" => Ok(ShardIteratorType::TrimHorizon),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents all of the data describing a particular stream.</p>"]
@@ -358,6 +468,88 @@ pub struct StreamRecord {
     #[serde(rename="StreamViewType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stream_view_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StreamStatus {
+    Disabled,
+    Disabling,
+    Enabled,
+    Enabling,
+}
+
+impl Into<String> for StreamStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StreamStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StreamStatus::Disabled => "DISABLED",
+            StreamStatus::Disabling => "DISABLING",
+            StreamStatus::Enabled => "ENABLED",
+            StreamStatus::Enabling => "ENABLING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StreamStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(StreamStatus::Disabled),
+            "DISABLING" => Ok(StreamStatus::Disabling),
+            "ENABLED" => Ok(StreamStatus::Enabled),
+            "ENABLING" => Ok(StreamStatus::Enabling),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StreamViewType {
+    KeysOnly,
+    NewAndOldImages,
+    NewImage,
+    OldImage,
+}
+
+impl Into<String> for StreamViewType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StreamViewType {
+    fn into(self) -> &'static str {
+        match self {
+            StreamViewType::KeysOnly => "KEYS_ONLY",
+            StreamViewType::NewAndOldImages => "NEW_AND_OLD_IMAGES",
+            StreamViewType::NewImage => "NEW_IMAGE",
+            StreamViewType::OldImage => "OLD_IMAGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StreamViewType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEYS_ONLY" => Ok(StreamViewType::KeysOnly),
+            "NEW_AND_OLD_IMAGES" => Ok(StreamViewType::NewAndOldImages),
+            "NEW_IMAGE" => Ok(StreamViewType::NewImage),
+            "OLD_IMAGE" => Ok(StreamViewType::OldImage),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by DescribeStream
@@ -768,7 +960,7 @@ impl<P, D> DynamoDbStreams for DynamoDbStreamsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -793,7 +985,7 @@ impl<P, D> DynamoDbStreams for DynamoDbStreamsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRecordsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetRecordsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -817,7 +1009,7 @@ impl<P, D> DynamoDbStreams for DynamoDbStreamsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetShardIteratorOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -844,7 +1036,7 @@ impl<P, D> DynamoDbStreams for DynamoDbStreamsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListStreamsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListStreamsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -304,6 +299,41 @@ impl AccountAttributeListDeserializer {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccountAttributeName {
+    DefaultVpc,
+    SupportedPlatforms,
+}
+
+impl Into<String> for AccountAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccountAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            AccountAttributeName::DefaultVpc => "default-vpc",
+            AccountAttributeName::SupportedPlatforms => "supported-platforms",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccountAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default-vpc" => Ok(AccountAttributeName::DefaultVpc),
+            "supported-platforms" => Ok(AccountAttributeName::SupportedPlatforms),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `AccountAttributeNameStringList` contents to a `SignedRequest`.
 struct AccountAttributeNameStringListSerializer;
 impl AccountAttributeNameStringListSerializer {
@@ -517,6 +547,47 @@ impl ActiveInstanceSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActivityStatus {
+    Error,
+    Fulfilled,
+    PendingFulfillment,
+    PendingTermination,
+}
+
+impl Into<String> for ActivityStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActivityStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ActivityStatus::Error => "error",
+            ActivityStatus::Fulfilled => "fulfilled",
+            ActivityStatus::PendingFulfillment => "pending_fulfillment",
+            ActivityStatus::PendingTermination => "pending_termination",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActivityStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "error" => Ok(ActivityStatus::Error),
+            "fulfilled" => Ok(ActivityStatus::Fulfilled),
+            "pending_fulfillment" => Ok(ActivityStatus::PendingFulfillment),
+            "pending_termination" => Ok(ActivityStatus::PendingTermination),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ActivityStatusDeserializer;
 impl ActivityStatusDeserializer {
     #[allow(unused_variables)]
@@ -666,6 +737,41 @@ impl AddressListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Affinity {
+    Default,
+    Host,
+}
+
+impl Into<String> for Affinity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Affinity {
+    fn into(self) -> &'static str {
+        match self {
+            Affinity::Default => "default",
+            Affinity::Host => "host",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Affinity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(Affinity::Default),
+            "host" => Ok(Affinity::Host),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the parameters for AllocateAddress.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct AllocateAddressRequest {
@@ -858,6 +964,50 @@ impl AllocationIdListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AllocationState {
+    Available,
+    PermanentFailure,
+    Released,
+    ReleasedPermanentFailure,
+    UnderAssessment,
+}
+
+impl Into<String> for AllocationState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AllocationState {
+    fn into(self) -> &'static str {
+        match self {
+            AllocationState::Available => "available",
+            AllocationState::PermanentFailure => "permanent-failure",
+            AllocationState::Released => "released",
+            AllocationState::ReleasedPermanentFailure => "released-permanent-failure",
+            AllocationState::UnderAssessment => "under-assessment",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AllocationState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(AllocationState::Available),
+            "permanent-failure" => Ok(AllocationState::PermanentFailure),
+            "released" => Ok(AllocationState::Released),
+            "released-permanent-failure" => Ok(AllocationState::ReleasedPermanentFailure),
+            "under-assessment" => Ok(AllocationState::UnderAssessment),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AllocationStateDeserializer;
 impl AllocationStateDeserializer {
     #[allow(unused_variables)]
@@ -872,6 +1022,41 @@ impl AllocationStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AllocationStrategy {
+    Diversified,
+    LowestPrice,
+}
+
+impl Into<String> for AllocationStrategy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AllocationStrategy {
+    fn into(self) -> &'static str {
+        match self {
+            AllocationStrategy::Diversified => "diversified",
+            AllocationStrategy::LowestPrice => "lowestPrice",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AllocationStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "diversified" => Ok(AllocationStrategy::Diversified),
+            "lowestPrice" => Ok(AllocationStrategy::LowestPrice),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AllocationStrategyDeserializer;
 impl AllocationStrategyDeserializer {
     #[allow(unused_variables)]
@@ -886,6 +1071,41 @@ impl AllocationStrategyDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArchitectureValues {
+    I386,
+    X8664,
+}
+
+impl Into<String> for ArchitectureValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArchitectureValues {
+    fn into(self) -> &'static str {
+        match self {
+            ArchitectureValues::I386 => "i386",
+            ArchitectureValues::X8664 => "x86_64",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArchitectureValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "i386" => Ok(ArchitectureValues::I386),
+            "x86_64" => Ok(ArchitectureValues::X8664),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ArchitectureValuesDeserializer;
 impl ArchitectureValuesDeserializer {
     #[allow(unused_variables)]
@@ -1809,6 +2029,47 @@ impl AttachVpnGatewayResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AttachmentStatus {
+    Attached,
+    Attaching,
+    Detached,
+    Detaching,
+}
+
+impl Into<String> for AttachmentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AttachmentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AttachmentStatus::Attached => "attached",
+            AttachmentStatus::Attaching => "attaching",
+            AttachmentStatus::Detached => "detached",
+            AttachmentStatus::Detaching => "detaching",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AttachmentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "attached" => Ok(AttachmentStatus::Attached),
+            "attaching" => Ok(AttachmentStatus::Attaching),
+            "detached" => Ok(AttachmentStatus::Detached),
+            "detaching" => Ok(AttachmentStatus::Detaching),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AttachmentStatusDeserializer;
 impl AttachmentStatusDeserializer {
     #[allow(unused_variables)]
@@ -2095,6 +2356,41 @@ impl AuthorizeSecurityGroupIngressRequestSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoPlacement {
+    Off,
+    On,
+}
+
+impl Into<String> for AutoPlacement {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoPlacement {
+    fn into(self) -> &'static str {
+        match self {
+            AutoPlacement::Off => "off",
+            AutoPlacement::On => "on",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoPlacement {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "off" => Ok(AutoPlacement::Off),
+            "on" => Ok(AutoPlacement::On),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AutoPlacementDeserializer;
 impl AutoPlacementDeserializer {
     #[allow(unused_variables)]
@@ -2308,6 +2604,47 @@ impl AvailabilityZoneMessageListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AvailabilityZoneState {
+    Available,
+    Impaired,
+    Information,
+    Unavailable,
+}
+
+impl Into<String> for AvailabilityZoneState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AvailabilityZoneState {
+    fn into(self) -> &'static str {
+        match self {
+            AvailabilityZoneState::Available => "available",
+            AvailabilityZoneState::Impaired => "impaired",
+            AvailabilityZoneState::Information => "information",
+            AvailabilityZoneState::Unavailable => "unavailable",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AvailabilityZoneState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(AvailabilityZoneState::Available),
+            "impaired" => Ok(AvailabilityZoneState::Impaired),
+            "information" => Ok(AvailabilityZoneState::Information),
+            "unavailable" => Ok(AvailabilityZoneState::Unavailable),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AvailabilityZoneStateDeserializer;
 impl AvailabilityZoneStateDeserializer {
     #[allow(unused_variables)]
@@ -2418,6 +2755,56 @@ impl AvailableInstanceCapacityListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BatchState {
+    Active,
+    Cancelled,
+    CancelledRunning,
+    CancelledTerminating,
+    Failed,
+    Modifying,
+    Submitted,
+}
+
+impl Into<String> for BatchState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BatchState {
+    fn into(self) -> &'static str {
+        match self {
+            BatchState::Active => "active",
+            BatchState::Cancelled => "cancelled",
+            BatchState::CancelledRunning => "cancelled_running",
+            BatchState::CancelledTerminating => "cancelled_terminating",
+            BatchState::Failed => "failed",
+            BatchState::Modifying => "modifying",
+            BatchState::Submitted => "submitted",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BatchState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(BatchState::Active),
+            "cancelled" => Ok(BatchState::Cancelled),
+            "cancelled_running" => Ok(BatchState::CancelledRunning),
+            "cancelled_terminating" => Ok(BatchState::CancelledTerminating),
+            "failed" => Ok(BatchState::Failed),
+            "modifying" => Ok(BatchState::Modifying),
+            "submitted" => Ok(BatchState::Submitted),
+            _ => Err(()),
+        }
+    }
+}
+
 struct BatchStateDeserializer;
 impl BatchStateDeserializer {
     #[allow(unused_variables)]
@@ -2648,7 +3035,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2934,6 +3321,56 @@ impl BundleTaskListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BundleTaskState {
+    Bundling,
+    Cancelling,
+    Complete,
+    Failed,
+    Pending,
+    Storing,
+    WaitingForShutdown,
+}
+
+impl Into<String> for BundleTaskState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BundleTaskState {
+    fn into(self) -> &'static str {
+        match self {
+            BundleTaskState::Bundling => "bundling",
+            BundleTaskState::Cancelling => "cancelling",
+            BundleTaskState::Complete => "complete",
+            BundleTaskState::Failed => "failed",
+            BundleTaskState::Pending => "pending",
+            BundleTaskState::Storing => "storing",
+            BundleTaskState::WaitingForShutdown => "waiting-for-shutdown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BundleTaskState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bundling" => Ok(BundleTaskState::Bundling),
+            "cancelling" => Ok(BundleTaskState::Cancelling),
+            "complete" => Ok(BundleTaskState::Complete),
+            "failed" => Ok(BundleTaskState::Failed),
+            "pending" => Ok(BundleTaskState::Pending),
+            "storing" => Ok(BundleTaskState::Storing),
+            "waiting-for-shutdown" => Ok(BundleTaskState::WaitingForShutdown),
+            _ => Err(()),
+        }
+    }
+}
+
 struct BundleTaskStateDeserializer;
 impl BundleTaskStateDeserializer {
     #[allow(unused_variables)]
@@ -2948,6 +3385,51 @@ impl BundleTaskStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelBatchErrorCode {
+    FleetRequestIdDoesNotExist,
+    FleetRequestIdMalformed,
+    FleetRequestNotInCancellableState,
+    UnexpectedError,
+}
+
+impl Into<String> for CancelBatchErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelBatchErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            CancelBatchErrorCode::FleetRequestIdDoesNotExist => "fleetRequestIdDoesNotExist",
+            CancelBatchErrorCode::FleetRequestIdMalformed => "fleetRequestIdMalformed",
+            CancelBatchErrorCode::FleetRequestNotInCancellableState => {
+                "fleetRequestNotInCancellableState"
+            }
+            CancelBatchErrorCode::UnexpectedError => "unexpectedError",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelBatchErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fleetRequestIdDoesNotExist" => Ok(CancelBatchErrorCode::FleetRequestIdDoesNotExist),
+            "fleetRequestIdMalformed" => Ok(CancelBatchErrorCode::FleetRequestIdMalformed),
+            "fleetRequestNotInCancellableState" => {
+                Ok(CancelBatchErrorCode::FleetRequestNotInCancellableState)
+            }
+            "unexpectedError" => Ok(CancelBatchErrorCode::UnexpectedError),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CancelBatchErrorCodeDeserializer;
 impl CancelBatchErrorCodeDeserializer {
     #[allow(unused_variables)]
@@ -3607,6 +4089,50 @@ impl CancelSpotFleetRequestsSuccessSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelSpotInstanceRequestState {
+    Active,
+    Cancelled,
+    Closed,
+    Completed,
+    Open,
+}
+
+impl Into<String> for CancelSpotInstanceRequestState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelSpotInstanceRequestState {
+    fn into(self) -> &'static str {
+        match self {
+            CancelSpotInstanceRequestState::Active => "active",
+            CancelSpotInstanceRequestState::Cancelled => "cancelled",
+            CancelSpotInstanceRequestState::Closed => "closed",
+            CancelSpotInstanceRequestState::Completed => "completed",
+            CancelSpotInstanceRequestState::Open => "open",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelSpotInstanceRequestState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(CancelSpotInstanceRequestState::Active),
+            "cancelled" => Ok(CancelSpotInstanceRequestState::Cancelled),
+            "closed" => Ok(CancelSpotInstanceRequestState::Closed),
+            "completed" => Ok(CancelSpotInstanceRequestState::Completed),
+            "open" => Ok(CancelSpotInstanceRequestState::Open),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CancelSpotInstanceRequestStateDeserializer;
 impl CancelSpotInstanceRequestStateDeserializer {
     #[allow(unused_variables)]
@@ -4130,6 +4656,38 @@ impl ConfirmProductInstanceResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContainerFormat {
+    Ova,
+}
+
+impl Into<String> for ContainerFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContainerFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ContainerFormat::Ova => "ova",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContainerFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ova" => Ok(ContainerFormat::Ova),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ContainerFormatDeserializer;
 impl ContainerFormatDeserializer {
     #[allow(unused_variables)]
@@ -4242,6 +4800,47 @@ impl ConversionTaskDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConversionTaskState {
+    Active,
+    Cancelled,
+    Cancelling,
+    Completed,
+}
+
+impl Into<String> for ConversionTaskState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConversionTaskState {
+    fn into(self) -> &'static str {
+        match self {
+            ConversionTaskState::Active => "active",
+            ConversionTaskState::Cancelled => "cancelled",
+            ConversionTaskState::Cancelling => "cancelling",
+            ConversionTaskState::Completed => "completed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConversionTaskState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ConversionTaskState::Active),
+            "cancelled" => Ok(ConversionTaskState::Cancelled),
+            "cancelling" => Ok(ConversionTaskState::Cancelling),
+            "completed" => Ok(ConversionTaskState::Completed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ConversionTaskStateDeserializer;
 impl ConversionTaskStateDeserializer {
     #[allow(unused_variables)]
@@ -6912,6 +7511,38 @@ impl CreateVpnGatewayResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CurrencyCodeValues {
+    Usd,
+}
+
+impl Into<String> for CurrencyCodeValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CurrencyCodeValues {
+    fn into(self) -> &'static str {
+        match self {
+            CurrencyCodeValues::Usd => "USD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CurrencyCodeValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "USD" => Ok(CurrencyCodeValues::Usd),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CurrencyCodeValuesDeserializer;
 impl CurrencyCodeValuesDeserializer {
     #[allow(unused_variables)]
@@ -7057,6 +7688,41 @@ impl CustomerGatewayListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DatafeedSubscriptionState {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for DatafeedSubscriptionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DatafeedSubscriptionState {
+    fn into(self) -> &'static str {
+        match self {
+            DatafeedSubscriptionState::Active => "Active",
+            DatafeedSubscriptionState::Inactive => "Inactive",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DatafeedSubscriptionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(DatafeedSubscriptionState::Active),
+            "Inactive" => Ok(DatafeedSubscriptionState::Inactive),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DatafeedSubscriptionStateDeserializer;
 impl DatafeedSubscriptionStateDeserializer {
     #[allow(unused_variables)]
@@ -14809,6 +15475,41 @@ impl DetachVpnGatewayRequestSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeviceType {
+    Ebs,
+    InstanceStore,
+}
+
+impl Into<String> for DeviceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeviceType {
+    fn into(self) -> &'static str {
+        match self {
+            DeviceType::Ebs => "ebs",
+            DeviceType::InstanceStore => "instance-store",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeviceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ebs" => Ok(DeviceType::Ebs),
+            "instance-store" => Ok(DeviceType::InstanceStore),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DeviceTypeDeserializer;
 impl DeviceTypeDeserializer {
     #[allow(unused_variables)]
@@ -15665,6 +16366,44 @@ impl DiskImageDetailSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DiskImageFormat {
+    Raw,
+    Vhd,
+    Vmdk,
+}
+
+impl Into<String> for DiskImageFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DiskImageFormat {
+    fn into(self) -> &'static str {
+        match self {
+            DiskImageFormat::Raw => "RAW",
+            DiskImageFormat::Vhd => "VHD",
+            DiskImageFormat::Vmdk => "VMDK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DiskImageFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RAW" => Ok(DiskImageFormat::Raw),
+            "VHD" => Ok(DiskImageFormat::Vhd),
+            "VMDK" => Ok(DiskImageFormat::Vmdk),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DiskImageFormatDeserializer;
 impl DiskImageFormatDeserializer {
     #[allow(unused_variables)]
@@ -15744,6 +16483,41 @@ impl DiskImageVolumeDescriptionDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainType {
+    Standard,
+    Vpc,
+}
+
+impl Into<String> for DomainType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainType {
+    fn into(self) -> &'static str {
+        match self {
+            DomainType::Standard => "standard",
+            DomainType::Vpc => "vpc",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "standard" => Ok(DomainType::Standard),
+            "vpc" => Ok(DomainType::Vpc),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DomainTypeDeserializer;
 impl DomainTypeDeserializer {
     #[allow(unused_variables)]
@@ -15765,7 +16539,7 @@ impl DoubleDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -16310,6 +17084,50 @@ impl EnableVpcClassicLinkResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventCode {
+    InstanceReboot,
+    InstanceRetirement,
+    InstanceStop,
+    SystemMaintenance,
+    SystemReboot,
+}
+
+impl Into<String> for EventCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventCode {
+    fn into(self) -> &'static str {
+        match self {
+            EventCode::InstanceReboot => "instance-reboot",
+            EventCode::InstanceRetirement => "instance-retirement",
+            EventCode::InstanceStop => "instance-stop",
+            EventCode::SystemMaintenance => "system-maintenance",
+            EventCode::SystemReboot => "system-reboot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "instance-reboot" => Ok(EventCode::InstanceReboot),
+            "instance-retirement" => Ok(EventCode::InstanceRetirement),
+            "instance-stop" => Ok(EventCode::InstanceStop),
+            "system-maintenance" => Ok(EventCode::SystemMaintenance),
+            "system-reboot" => Ok(EventCode::SystemReboot),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventCodeDeserializer;
 impl EventCodeDeserializer {
     #[allow(unused_variables)]
@@ -16386,6 +17204,44 @@ impl EventInformationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    Error,
+    FleetRequestChange,
+    InstanceChange,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::Error => "error",
+            EventType::FleetRequestChange => "fleetRequestChange",
+            EventType::InstanceChange => "instanceChange",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "error" => Ok(EventType::Error),
+            "fleetRequestChange" => Ok(EventType::FleetRequestChange),
+            "instanceChange" => Ok(EventType::InstanceChange),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventTypeDeserializer;
 impl EventTypeDeserializer {
     #[allow(unused_variables)]
@@ -16400,6 +17256,41 @@ impl EventTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExcessCapacityTerminationPolicy {
+    Default,
+    NoTermination,
+}
+
+impl Into<String> for ExcessCapacityTerminationPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExcessCapacityTerminationPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ExcessCapacityTerminationPolicy::Default => "default",
+            ExcessCapacityTerminationPolicy::NoTermination => "noTermination",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExcessCapacityTerminationPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(ExcessCapacityTerminationPolicy::Default),
+            "noTermination" => Ok(ExcessCapacityTerminationPolicy::NoTermination),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ExcessCapacityTerminationPolicyDeserializer;
 impl ExcessCapacityTerminationPolicyDeserializer {
     #[allow(unused_variables)]
@@ -16422,6 +17313,44 @@ impl ExecutableByStringListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExportEnvironment {
+    Citrix,
+    Microsoft,
+    Vmware,
+}
+
+impl Into<String> for ExportEnvironment {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExportEnvironment {
+    fn into(self) -> &'static str {
+        match self {
+            ExportEnvironment::Citrix => "citrix",
+            ExportEnvironment::Microsoft => "microsoft",
+            ExportEnvironment::Vmware => "vmware",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExportEnvironment {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "citrix" => Ok(ExportEnvironment::Citrix),
+            "microsoft" => Ok(ExportEnvironment::Microsoft),
+            "vmware" => Ok(ExportEnvironment::Vmware),
+            _ => Err(()),
         }
     }
 }
@@ -16574,6 +17503,47 @@ impl ExportTaskListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExportTaskState {
+    Active,
+    Cancelled,
+    Cancelling,
+    Completed,
+}
+
+impl Into<String> for ExportTaskState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExportTaskState {
+    fn into(self) -> &'static str {
+        match self {
+            ExportTaskState::Active => "active",
+            ExportTaskState::Cancelled => "cancelled",
+            ExportTaskState::Cancelling => "cancelling",
+            ExportTaskState::Completed => "completed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExportTaskState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ExportTaskState::Active),
+            "cancelled" => Ok(ExportTaskState::Cancelled),
+            "cancelling" => Ok(ExportTaskState::Cancelling),
+            "completed" => Ok(ExportTaskState::Completed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ExportTaskStateDeserializer;
 impl ExportTaskStateDeserializer {
     #[allow(unused_variables)]
@@ -16739,6 +17709,41 @@ impl FilterListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetType {
+    Maintain,
+    Request,
+}
+
+impl Into<String> for FleetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetType {
+    fn into(self) -> &'static str {
+        match self {
+            FleetType::Maintain => "maintain",
+            FleetType::Request => "request",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "maintain" => Ok(FleetType::Maintain),
+            "request" => Ok(FleetType::Request),
+            _ => Err(()),
+        }
+    }
+}
+
 struct FleetTypeDeserializer;
 impl FleetTypeDeserializer {
     #[allow(unused_variables)]
@@ -16760,7 +17765,7 @@ impl FloatDeserializer {
                                        stack: &mut T)
                                        -> Result<f32, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f32::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f32>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -16910,6 +17915,44 @@ impl FlowLogSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FlowLogsResourceType {
+    NetworkInterface,
+    Subnet,
+    Vpc,
+}
+
+impl Into<String> for FlowLogsResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FlowLogsResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            FlowLogsResourceType::NetworkInterface => "NetworkInterface",
+            FlowLogsResourceType::Subnet => "Subnet",
+            FlowLogsResourceType::Vpc => "VPC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FlowLogsResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NetworkInterface" => Ok(FlowLogsResourceType::NetworkInterface),
+            "Subnet" => Ok(FlowLogsResourceType::Subnet),
+            "VPC" => Ok(FlowLogsResourceType::Vpc),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an Amazon FPGA image (AFI).</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct FpgaImage {
@@ -17139,6 +18182,47 @@ impl FpgaImageStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FpgaImageStateCode {
+    Available,
+    Failed,
+    Pending,
+    Unavailable,
+}
+
+impl Into<String> for FpgaImageStateCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FpgaImageStateCode {
+    fn into(self) -> &'static str {
+        match self {
+            FpgaImageStateCode::Available => "available",
+            FpgaImageStateCode::Failed => "failed",
+            FpgaImageStateCode::Pending => "pending",
+            FpgaImageStateCode::Unavailable => "unavailable",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FpgaImageStateCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(FpgaImageStateCode::Available),
+            "failed" => Ok(FpgaImageStateCode::Failed),
+            "pending" => Ok(FpgaImageStateCode::Pending),
+            "unavailable" => Ok(FpgaImageStateCode::Unavailable),
+            _ => Err(()),
+        }
+    }
+}
+
 struct FpgaImageStateCodeDeserializer;
 impl FpgaImageStateCodeDeserializer {
     #[allow(unused_variables)]
@@ -17153,6 +18237,38 @@ impl FpgaImageStateCodeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GatewayType {
+    Ipsec1,
+}
+
+impl Into<String> for GatewayType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GatewayType {
+    fn into(self) -> &'static str {
+        match self {
+            GatewayType::Ipsec1 => "ipsec.1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GatewayType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ipsec.1" => Ok(GatewayType::Ipsec1),
+            _ => Err(()),
+        }
+    }
+}
+
 struct GatewayTypeDeserializer;
 impl GatewayTypeDeserializer {
     #[allow(unused_variables)]
@@ -18547,6 +19663,76 @@ impl HostReservationSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HostTenancy {
+    Dedicated,
+    Host,
+}
+
+impl Into<String> for HostTenancy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HostTenancy {
+    fn into(self) -> &'static str {
+        match self {
+            HostTenancy::Dedicated => "dedicated",
+            HostTenancy::Host => "host",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HostTenancy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dedicated" => Ok(HostTenancy::Dedicated),
+            "host" => Ok(HostTenancy::Host),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HypervisorType {
+    Ovm,
+    Xen,
+}
+
+impl Into<String> for HypervisorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HypervisorType {
+    fn into(self) -> &'static str {
+        match self {
+            HypervisorType::Ovm => "ovm",
+            HypervisorType::Xen => "xen",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HypervisorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ovm" => Ok(HypervisorType::Ovm),
+            "xen" => Ok(HypervisorType::Xen),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HypervisorTypeDeserializer;
 impl HypervisorTypeDeserializer {
     #[allow(unused_variables)]
@@ -18729,6 +19915,47 @@ impl IamInstanceProfileAssociationSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IamInstanceProfileAssociationState {
+    Associated,
+    Associating,
+    Disassociated,
+    Disassociating,
+}
+
+impl Into<String> for IamInstanceProfileAssociationState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IamInstanceProfileAssociationState {
+    fn into(self) -> &'static str {
+        match self {
+            IamInstanceProfileAssociationState::Associated => "associated",
+            IamInstanceProfileAssociationState::Associating => "associating",
+            IamInstanceProfileAssociationState::Disassociated => "disassociated",
+            IamInstanceProfileAssociationState::Disassociating => "disassociating",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IamInstanceProfileAssociationState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "associated" => Ok(IamInstanceProfileAssociationState::Associated),
+            "associating" => Ok(IamInstanceProfileAssociationState::Associating),
+            "disassociated" => Ok(IamInstanceProfileAssociationState::Disassociated),
+            "disassociating" => Ok(IamInstanceProfileAssociationState::Disassociating),
+            _ => Err(()),
+        }
+    }
+}
+
 struct IamInstanceProfileAssociationStateDeserializer;
 impl IamInstanceProfileAssociationStateDeserializer {
     #[allow(unused_variables)]
@@ -19288,6 +20515,56 @@ impl ImageAttributeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageAttributeName {
+    BlockDeviceMapping,
+    Description,
+    Kernel,
+    LaunchPermission,
+    ProductCodes,
+    Ramdisk,
+    SriovNetSupport,
+}
+
+impl Into<String> for ImageAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            ImageAttributeName::BlockDeviceMapping => "blockDeviceMapping",
+            ImageAttributeName::Description => "description",
+            ImageAttributeName::Kernel => "kernel",
+            ImageAttributeName::LaunchPermission => "launchPermission",
+            ImageAttributeName::ProductCodes => "productCodes",
+            ImageAttributeName::Ramdisk => "ramdisk",
+            ImageAttributeName::SriovNetSupport => "sriovNetSupport",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "blockDeviceMapping" => Ok(ImageAttributeName::BlockDeviceMapping),
+            "description" => Ok(ImageAttributeName::Description),
+            "kernel" => Ok(ImageAttributeName::Kernel),
+            "launchPermission" => Ok(ImageAttributeName::LaunchPermission),
+            "productCodes" => Ok(ImageAttributeName::ProductCodes),
+            "ramdisk" => Ok(ImageAttributeName::Ramdisk),
+            "sriovNetSupport" => Ok(ImageAttributeName::SriovNetSupport),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the disk container object for an import image task.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct ImageDiskContainer {
@@ -19404,6 +20681,56 @@ impl ImageListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageState {
+    Available,
+    Deregistered,
+    Error,
+    Failed,
+    Invalid,
+    Pending,
+    Transient,
+}
+
+impl Into<String> for ImageState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageState {
+    fn into(self) -> &'static str {
+        match self {
+            ImageState::Available => "available",
+            ImageState::Deregistered => "deregistered",
+            ImageState::Error => "error",
+            ImageState::Failed => "failed",
+            ImageState::Invalid => "invalid",
+            ImageState::Pending => "pending",
+            ImageState::Transient => "transient",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(ImageState::Available),
+            "deregistered" => Ok(ImageState::Deregistered),
+            "error" => Ok(ImageState::Error),
+            "failed" => Ok(ImageState::Failed),
+            "invalid" => Ok(ImageState::Invalid),
+            "pending" => Ok(ImageState::Pending),
+            "transient" => Ok(ImageState::Transient),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ImageStateDeserializer;
 impl ImageStateDeserializer {
     #[allow(unused_variables)]
@@ -19418,6 +20745,44 @@ impl ImageStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageTypeValues {
+    Kernel,
+    Machine,
+    Ramdisk,
+}
+
+impl Into<String> for ImageTypeValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageTypeValues {
+    fn into(self) -> &'static str {
+        match self {
+            ImageTypeValues::Kernel => "kernel",
+            ImageTypeValues::Machine => "machine",
+            ImageTypeValues::Ramdisk => "ramdisk",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageTypeValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "kernel" => Ok(ImageTypeValues::Kernel),
+            "machine" => Ok(ImageTypeValues::Machine),
+            "ramdisk" => Ok(ImageTypeValues::Ramdisk),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ImageTypeValuesDeserializer;
 impl ImageTypeValuesDeserializer {
     #[allow(unused_variables)]
@@ -21056,6 +22421,81 @@ impl InstanceAttributeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceAttributeName {
+    BlockDeviceMapping,
+    DisableApiTermination,
+    EbsOptimized,
+    EnaSupport,
+    GroupSet,
+    InstanceInitiatedShutdownBehavior,
+    InstanceType,
+    Kernel,
+    ProductCodes,
+    Ramdisk,
+    RootDeviceName,
+    SourceDestCheck,
+    SriovNetSupport,
+    UserData,
+}
+
+impl Into<String> for InstanceAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceAttributeName::BlockDeviceMapping => "blockDeviceMapping",
+            InstanceAttributeName::DisableApiTermination => "disableApiTermination",
+            InstanceAttributeName::EbsOptimized => "ebsOptimized",
+            InstanceAttributeName::EnaSupport => "enaSupport",
+            InstanceAttributeName::GroupSet => "groupSet",
+            InstanceAttributeName::InstanceInitiatedShutdownBehavior => {
+                "instanceInitiatedShutdownBehavior"
+            }
+            InstanceAttributeName::InstanceType => "instanceType",
+            InstanceAttributeName::Kernel => "kernel",
+            InstanceAttributeName::ProductCodes => "productCodes",
+            InstanceAttributeName::Ramdisk => "ramdisk",
+            InstanceAttributeName::RootDeviceName => "rootDeviceName",
+            InstanceAttributeName::SourceDestCheck => "sourceDestCheck",
+            InstanceAttributeName::SriovNetSupport => "sriovNetSupport",
+            InstanceAttributeName::UserData => "userData",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "blockDeviceMapping" => Ok(InstanceAttributeName::BlockDeviceMapping),
+            "disableApiTermination" => Ok(InstanceAttributeName::DisableApiTermination),
+            "ebsOptimized" => Ok(InstanceAttributeName::EbsOptimized),
+            "enaSupport" => Ok(InstanceAttributeName::EnaSupport),
+            "groupSet" => Ok(InstanceAttributeName::GroupSet),
+            "instanceInitiatedShutdownBehavior" => {
+                Ok(InstanceAttributeName::InstanceInitiatedShutdownBehavior)
+            }
+            "instanceType" => Ok(InstanceAttributeName::InstanceType),
+            "kernel" => Ok(InstanceAttributeName::Kernel),
+            "productCodes" => Ok(InstanceAttributeName::ProductCodes),
+            "ramdisk" => Ok(InstanceAttributeName::Ramdisk),
+            "rootDeviceName" => Ok(InstanceAttributeName::RootDeviceName),
+            "sourceDestCheck" => Ok(InstanceAttributeName::SourceDestCheck),
+            "sriovNetSupport" => Ok(InstanceAttributeName::SriovNetSupport),
+            "userData" => Ok(InstanceAttributeName::UserData),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes a block device mapping.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct InstanceBlockDeviceMapping {
@@ -21428,6 +22868,41 @@ impl InstanceExportDetailsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceHealthStatus {
+    Healthy,
+    Unhealthy,
+}
+
+impl Into<String> for InstanceHealthStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceHealthStatus {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceHealthStatus::Healthy => "healthy",
+            InstanceHealthStatus::Unhealthy => "unhealthy",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceHealthStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "healthy" => Ok(InstanceHealthStatus::Healthy),
+            "unhealthy" => Ok(InstanceHealthStatus::Unhealthy),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InstanceHealthStatusDeserializer;
 impl InstanceHealthStatusDeserializer {
     #[allow(unused_variables)]
@@ -21610,6 +23085,41 @@ impl InstanceIpv6AddressListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             InstanceIpv6AddressSerializer::serialize(params, &key, obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceLifecycleType {
+    Scheduled,
+    Spot,
+}
+
+impl Into<String> for InstanceLifecycleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceLifecycleType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceLifecycleType::Scheduled => "scheduled",
+            InstanceLifecycleType::Spot => "spot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceLifecycleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "scheduled" => Ok(InstanceLifecycleType::Scheduled),
+            "spot" => Ok(InstanceLifecycleType::Spot),
+            _ => Err(()),
         }
     }
 }
@@ -22595,6 +24105,53 @@ impl InstanceStateChangeListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceStateName {
+    Pending,
+    Running,
+    ShuttingDown,
+    Stopped,
+    Stopping,
+    Terminated,
+}
+
+impl Into<String> for InstanceStateName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceStateName {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceStateName::Pending => "pending",
+            InstanceStateName::Running => "running",
+            InstanceStateName::ShuttingDown => "shutting-down",
+            InstanceStateName::Stopped => "stopped",
+            InstanceStateName::Stopping => "stopping",
+            InstanceStateName::Terminated => "terminated",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceStateName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(InstanceStateName::Pending),
+            "running" => Ok(InstanceStateName::Running),
+            "shutting-down" => Ok(InstanceStateName::ShuttingDown),
+            "stopped" => Ok(InstanceStateName::Stopped),
+            "stopping" => Ok(InstanceStateName::Stopping),
+            "terminated" => Ok(InstanceStateName::Terminated),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InstanceStateNameDeserializer;
 impl InstanceStateNameDeserializer {
     #[allow(unused_variables)]
@@ -23000,6 +24557,266 @@ impl InstanceStatusSummaryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceType {
+    C1Medium,
+    C1Xlarge,
+    C32Xlarge,
+    C34Xlarge,
+    C38Xlarge,
+    C3Large,
+    C3Xlarge,
+    C42Xlarge,
+    C44Xlarge,
+    C48Xlarge,
+    C4Large,
+    C4Xlarge,
+    Cc14Xlarge,
+    Cc28Xlarge,
+    Cg14Xlarge,
+    Cr18Xlarge,
+    D22Xlarge,
+    D24Xlarge,
+    D28Xlarge,
+    D2Xlarge,
+    F116Xlarge,
+    F12Xlarge,
+    G22Xlarge,
+    G28Xlarge,
+    Hi14Xlarge,
+    Hs18Xlarge,
+    I22Xlarge,
+    I24Xlarge,
+    I28Xlarge,
+    I2Xlarge,
+    I316Xlarge,
+    I32Xlarge,
+    I34Xlarge,
+    I38Xlarge,
+    I3Large,
+    I3Xlarge,
+    M1Large,
+    M1Medium,
+    M1Small,
+    M1Xlarge,
+    M22Xlarge,
+    M24Xlarge,
+    M2Xlarge,
+    M32Xlarge,
+    M3Large,
+    M3Medium,
+    M3Xlarge,
+    M410Xlarge,
+    M416Xlarge,
+    M42Xlarge,
+    M44Xlarge,
+    M4Large,
+    M4Xlarge,
+    P216Xlarge,
+    P28Xlarge,
+    P2Xlarge,
+    R32Xlarge,
+    R34Xlarge,
+    R38Xlarge,
+    R3Large,
+    R3Xlarge,
+    R416Xlarge,
+    R42Xlarge,
+    R44Xlarge,
+    R48Xlarge,
+    R4Large,
+    R4Xlarge,
+    T1Micro,
+    T22Xlarge,
+    T2Large,
+    T2Medium,
+    T2Micro,
+    T2Nano,
+    T2Small,
+    T2Xlarge,
+    X116Xlarge,
+    X132Xlarge,
+}
+
+impl Into<String> for InstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceType::C1Medium => "c1.medium",
+            InstanceType::C1Xlarge => "c1.xlarge",
+            InstanceType::C32Xlarge => "c3.2xlarge",
+            InstanceType::C34Xlarge => "c3.4xlarge",
+            InstanceType::C38Xlarge => "c3.8xlarge",
+            InstanceType::C3Large => "c3.large",
+            InstanceType::C3Xlarge => "c3.xlarge",
+            InstanceType::C42Xlarge => "c4.2xlarge",
+            InstanceType::C44Xlarge => "c4.4xlarge",
+            InstanceType::C48Xlarge => "c4.8xlarge",
+            InstanceType::C4Large => "c4.large",
+            InstanceType::C4Xlarge => "c4.xlarge",
+            InstanceType::Cc14Xlarge => "cc1.4xlarge",
+            InstanceType::Cc28Xlarge => "cc2.8xlarge",
+            InstanceType::Cg14Xlarge => "cg1.4xlarge",
+            InstanceType::Cr18Xlarge => "cr1.8xlarge",
+            InstanceType::D22Xlarge => "d2.2xlarge",
+            InstanceType::D24Xlarge => "d2.4xlarge",
+            InstanceType::D28Xlarge => "d2.8xlarge",
+            InstanceType::D2Xlarge => "d2.xlarge",
+            InstanceType::F116Xlarge => "f1.16xlarge",
+            InstanceType::F12Xlarge => "f1.2xlarge",
+            InstanceType::G22Xlarge => "g2.2xlarge",
+            InstanceType::G28Xlarge => "g2.8xlarge",
+            InstanceType::Hi14Xlarge => "hi1.4xlarge",
+            InstanceType::Hs18Xlarge => "hs1.8xlarge",
+            InstanceType::I22Xlarge => "i2.2xlarge",
+            InstanceType::I24Xlarge => "i2.4xlarge",
+            InstanceType::I28Xlarge => "i2.8xlarge",
+            InstanceType::I2Xlarge => "i2.xlarge",
+            InstanceType::I316Xlarge => "i3.16xlarge",
+            InstanceType::I32Xlarge => "i3.2xlarge",
+            InstanceType::I34Xlarge => "i3.4xlarge",
+            InstanceType::I38Xlarge => "i3.8xlarge",
+            InstanceType::I3Large => "i3.large",
+            InstanceType::I3Xlarge => "i3.xlarge",
+            InstanceType::M1Large => "m1.large",
+            InstanceType::M1Medium => "m1.medium",
+            InstanceType::M1Small => "m1.small",
+            InstanceType::M1Xlarge => "m1.xlarge",
+            InstanceType::M22Xlarge => "m2.2xlarge",
+            InstanceType::M24Xlarge => "m2.4xlarge",
+            InstanceType::M2Xlarge => "m2.xlarge",
+            InstanceType::M32Xlarge => "m3.2xlarge",
+            InstanceType::M3Large => "m3.large",
+            InstanceType::M3Medium => "m3.medium",
+            InstanceType::M3Xlarge => "m3.xlarge",
+            InstanceType::M410Xlarge => "m4.10xlarge",
+            InstanceType::M416Xlarge => "m4.16xlarge",
+            InstanceType::M42Xlarge => "m4.2xlarge",
+            InstanceType::M44Xlarge => "m4.4xlarge",
+            InstanceType::M4Large => "m4.large",
+            InstanceType::M4Xlarge => "m4.xlarge",
+            InstanceType::P216Xlarge => "p2.16xlarge",
+            InstanceType::P28Xlarge => "p2.8xlarge",
+            InstanceType::P2Xlarge => "p2.xlarge",
+            InstanceType::R32Xlarge => "r3.2xlarge",
+            InstanceType::R34Xlarge => "r3.4xlarge",
+            InstanceType::R38Xlarge => "r3.8xlarge",
+            InstanceType::R3Large => "r3.large",
+            InstanceType::R3Xlarge => "r3.xlarge",
+            InstanceType::R416Xlarge => "r4.16xlarge",
+            InstanceType::R42Xlarge => "r4.2xlarge",
+            InstanceType::R44Xlarge => "r4.4xlarge",
+            InstanceType::R48Xlarge => "r4.8xlarge",
+            InstanceType::R4Large => "r4.large",
+            InstanceType::R4Xlarge => "r4.xlarge",
+            InstanceType::T1Micro => "t1.micro",
+            InstanceType::T22Xlarge => "t2.2xlarge",
+            InstanceType::T2Large => "t2.large",
+            InstanceType::T2Medium => "t2.medium",
+            InstanceType::T2Micro => "t2.micro",
+            InstanceType::T2Nano => "t2.nano",
+            InstanceType::T2Small => "t2.small",
+            InstanceType::T2Xlarge => "t2.xlarge",
+            InstanceType::X116Xlarge => "x1.16xlarge",
+            InstanceType::X132Xlarge => "x1.32xlarge",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "c1.medium" => Ok(InstanceType::C1Medium),
+            "c1.xlarge" => Ok(InstanceType::C1Xlarge),
+            "c3.2xlarge" => Ok(InstanceType::C32Xlarge),
+            "c3.4xlarge" => Ok(InstanceType::C34Xlarge),
+            "c3.8xlarge" => Ok(InstanceType::C38Xlarge),
+            "c3.large" => Ok(InstanceType::C3Large),
+            "c3.xlarge" => Ok(InstanceType::C3Xlarge),
+            "c4.2xlarge" => Ok(InstanceType::C42Xlarge),
+            "c4.4xlarge" => Ok(InstanceType::C44Xlarge),
+            "c4.8xlarge" => Ok(InstanceType::C48Xlarge),
+            "c4.large" => Ok(InstanceType::C4Large),
+            "c4.xlarge" => Ok(InstanceType::C4Xlarge),
+            "cc1.4xlarge" => Ok(InstanceType::Cc14Xlarge),
+            "cc2.8xlarge" => Ok(InstanceType::Cc28Xlarge),
+            "cg1.4xlarge" => Ok(InstanceType::Cg14Xlarge),
+            "cr1.8xlarge" => Ok(InstanceType::Cr18Xlarge),
+            "d2.2xlarge" => Ok(InstanceType::D22Xlarge),
+            "d2.4xlarge" => Ok(InstanceType::D24Xlarge),
+            "d2.8xlarge" => Ok(InstanceType::D28Xlarge),
+            "d2.xlarge" => Ok(InstanceType::D2Xlarge),
+            "f1.16xlarge" => Ok(InstanceType::F116Xlarge),
+            "f1.2xlarge" => Ok(InstanceType::F12Xlarge),
+            "g2.2xlarge" => Ok(InstanceType::G22Xlarge),
+            "g2.8xlarge" => Ok(InstanceType::G28Xlarge),
+            "hi1.4xlarge" => Ok(InstanceType::Hi14Xlarge),
+            "hs1.8xlarge" => Ok(InstanceType::Hs18Xlarge),
+            "i2.2xlarge" => Ok(InstanceType::I22Xlarge),
+            "i2.4xlarge" => Ok(InstanceType::I24Xlarge),
+            "i2.8xlarge" => Ok(InstanceType::I28Xlarge),
+            "i2.xlarge" => Ok(InstanceType::I2Xlarge),
+            "i3.16xlarge" => Ok(InstanceType::I316Xlarge),
+            "i3.2xlarge" => Ok(InstanceType::I32Xlarge),
+            "i3.4xlarge" => Ok(InstanceType::I34Xlarge),
+            "i3.8xlarge" => Ok(InstanceType::I38Xlarge),
+            "i3.large" => Ok(InstanceType::I3Large),
+            "i3.xlarge" => Ok(InstanceType::I3Xlarge),
+            "m1.large" => Ok(InstanceType::M1Large),
+            "m1.medium" => Ok(InstanceType::M1Medium),
+            "m1.small" => Ok(InstanceType::M1Small),
+            "m1.xlarge" => Ok(InstanceType::M1Xlarge),
+            "m2.2xlarge" => Ok(InstanceType::M22Xlarge),
+            "m2.4xlarge" => Ok(InstanceType::M24Xlarge),
+            "m2.xlarge" => Ok(InstanceType::M2Xlarge),
+            "m3.2xlarge" => Ok(InstanceType::M32Xlarge),
+            "m3.large" => Ok(InstanceType::M3Large),
+            "m3.medium" => Ok(InstanceType::M3Medium),
+            "m3.xlarge" => Ok(InstanceType::M3Xlarge),
+            "m4.10xlarge" => Ok(InstanceType::M410Xlarge),
+            "m4.16xlarge" => Ok(InstanceType::M416Xlarge),
+            "m4.2xlarge" => Ok(InstanceType::M42Xlarge),
+            "m4.4xlarge" => Ok(InstanceType::M44Xlarge),
+            "m4.large" => Ok(InstanceType::M4Large),
+            "m4.xlarge" => Ok(InstanceType::M4Xlarge),
+            "p2.16xlarge" => Ok(InstanceType::P216Xlarge),
+            "p2.8xlarge" => Ok(InstanceType::P28Xlarge),
+            "p2.xlarge" => Ok(InstanceType::P2Xlarge),
+            "r3.2xlarge" => Ok(InstanceType::R32Xlarge),
+            "r3.4xlarge" => Ok(InstanceType::R34Xlarge),
+            "r3.8xlarge" => Ok(InstanceType::R38Xlarge),
+            "r3.large" => Ok(InstanceType::R3Large),
+            "r3.xlarge" => Ok(InstanceType::R3Xlarge),
+            "r4.16xlarge" => Ok(InstanceType::R416Xlarge),
+            "r4.2xlarge" => Ok(InstanceType::R42Xlarge),
+            "r4.4xlarge" => Ok(InstanceType::R44Xlarge),
+            "r4.8xlarge" => Ok(InstanceType::R48Xlarge),
+            "r4.large" => Ok(InstanceType::R4Large),
+            "r4.xlarge" => Ok(InstanceType::R4Xlarge),
+            "t1.micro" => Ok(InstanceType::T1Micro),
+            "t2.2xlarge" => Ok(InstanceType::T22Xlarge),
+            "t2.large" => Ok(InstanceType::T2Large),
+            "t2.medium" => Ok(InstanceType::T2Medium),
+            "t2.micro" => Ok(InstanceType::T2Micro),
+            "t2.nano" => Ok(InstanceType::T2Nano),
+            "t2.small" => Ok(InstanceType::T2Small),
+            "t2.xlarge" => Ok(InstanceType::T2Xlarge),
+            "x1.16xlarge" => Ok(InstanceType::X116Xlarge),
+            "x1.32xlarge" => Ok(InstanceType::X132Xlarge),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InstanceTypeDeserializer;
 impl InstanceTypeDeserializer {
     #[allow(unused_variables)]
@@ -23033,7 +24850,7 @@ impl IntegerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -24367,6 +26184,47 @@ impl LaunchSpecsListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ListingState {
+    Available,
+    Cancelled,
+    Pending,
+    Sold,
+}
+
+impl Into<String> for ListingState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ListingState {
+    fn into(self) -> &'static str {
+        match self {
+            ListingState::Available => "available",
+            ListingState::Cancelled => "cancelled",
+            ListingState::Pending => "pending",
+            ListingState::Sold => "sold",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ListingState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(ListingState::Available),
+            "cancelled" => Ok(ListingState::Cancelled),
+            "pending" => Ok(ListingState::Pending),
+            "sold" => Ok(ListingState::Sold),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ListingStateDeserializer;
 impl ListingStateDeserializer {
     #[allow(unused_variables)]
@@ -24381,6 +26239,47 @@ impl ListingStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ListingStatus {
+    Active,
+    Cancelled,
+    Closed,
+    Pending,
+}
+
+impl Into<String> for ListingStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ListingStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ListingStatus::Active => "active",
+            ListingStatus::Cancelled => "cancelled",
+            ListingStatus::Closed => "closed",
+            ListingStatus::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ListingStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ListingStatus::Active),
+            "cancelled" => Ok(ListingStatus::Cancelled),
+            "closed" => Ok(ListingStatus::Closed),
+            "pending" => Ok(ListingStatus::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ListingStatusDeserializer;
 impl ListingStatusDeserializer {
     #[allow(unused_variables)]
@@ -24402,7 +26301,7 @@ impl LongDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -25664,6 +27563,47 @@ impl MonitoringDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MonitoringState {
+    Disabled,
+    Disabling,
+    Enabled,
+    Pending,
+}
+
+impl Into<String> for MonitoringState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MonitoringState {
+    fn into(self) -> &'static str {
+        match self {
+            MonitoringState::Disabled => "disabled",
+            MonitoringState::Disabling => "disabling",
+            MonitoringState::Enabled => "enabled",
+            MonitoringState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MonitoringState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(MonitoringState::Disabled),
+            "disabling" => Ok(MonitoringState::Disabling),
+            "enabled" => Ok(MonitoringState::Enabled),
+            "pending" => Ok(MonitoringState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MonitoringStateDeserializer;
 impl MonitoringStateDeserializer {
     #[allow(unused_variables)]
@@ -25760,6 +27700,41 @@ impl MoveAddressToVpcResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MoveStatus {
+    MovingToVpc,
+    RestoringToClassic,
+}
+
+impl Into<String> for MoveStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MoveStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MoveStatus::MovingToVpc => "movingToVpc",
+            MoveStatus::RestoringToClassic => "restoringToClassic",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MoveStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "movingToVpc" => Ok(MoveStatus::MovingToVpc),
+            "restoringToClassic" => Ok(MoveStatus::RestoringToClassic),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MoveStatusDeserializer;
 impl MoveStatusDeserializer {
     #[allow(unused_variables)]
@@ -26127,6 +28102,50 @@ impl NatGatewayListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NatGatewayState {
+    Available,
+    Deleted,
+    Deleting,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for NatGatewayState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NatGatewayState {
+    fn into(self) -> &'static str {
+        match self {
+            NatGatewayState::Available => "available",
+            NatGatewayState::Deleted => "deleted",
+            NatGatewayState::Deleting => "deleting",
+            NatGatewayState::Failed => "failed",
+            NatGatewayState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NatGatewayState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(NatGatewayState::Available),
+            "deleted" => Ok(NatGatewayState::Deleted),
+            "deleting" => Ok(NatGatewayState::Deleting),
+            "failed" => Ok(NatGatewayState::Failed),
+            "pending" => Ok(NatGatewayState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct NatGatewayStateDeserializer;
 impl NatGatewayStateDeserializer {
     #[allow(unused_variables)]
@@ -26859,6 +28878,47 @@ impl NetworkInterfaceAttachmentChangesSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkInterfaceAttribute {
+    Attachment,
+    Description,
+    GroupSet,
+    SourceDestCheck,
+}
+
+impl Into<String> for NetworkInterfaceAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkInterfaceAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkInterfaceAttribute::Attachment => "attachment",
+            NetworkInterfaceAttribute::Description => "description",
+            NetworkInterfaceAttribute::GroupSet => "groupSet",
+            NetworkInterfaceAttribute::SourceDestCheck => "sourceDestCheck",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkInterfaceAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "attachment" => Ok(NetworkInterfaceAttribute::Attachment),
+            "description" => Ok(NetworkInterfaceAttribute::Description),
+            "groupSet" => Ok(NetworkInterfaceAttribute::GroupSet),
+            "sourceDestCheck" => Ok(NetworkInterfaceAttribute::SourceDestCheck),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `NetworkInterfaceIdList` contents to a `SignedRequest`.
 struct NetworkInterfaceIdListSerializer;
 impl NetworkInterfaceIdListSerializer {
@@ -27114,6 +29174,47 @@ impl NetworkInterfacePrivateIpAddressListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkInterfaceStatus {
+    Attaching,
+    Available,
+    Detaching,
+    InUse,
+}
+
+impl Into<String> for NetworkInterfaceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkInterfaceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkInterfaceStatus::Attaching => "attaching",
+            NetworkInterfaceStatus::Available => "available",
+            NetworkInterfaceStatus::Detaching => "detaching",
+            NetworkInterfaceStatus::InUse => "in-use",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkInterfaceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "attaching" => Ok(NetworkInterfaceStatus::Attaching),
+            "available" => Ok(NetworkInterfaceStatus::Available),
+            "detaching" => Ok(NetworkInterfaceStatus::Detaching),
+            "in-use" => Ok(NetworkInterfaceStatus::InUse),
+            _ => Err(()),
+        }
+    }
+}
+
 struct NetworkInterfaceStatusDeserializer;
 impl NetworkInterfaceStatusDeserializer {
     #[allow(unused_variables)]
@@ -27128,6 +29229,41 @@ impl NetworkInterfaceStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkInterfaceType {
+    Interface,
+    NatGateway,
+}
+
+impl Into<String> for NetworkInterfaceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkInterfaceType {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkInterfaceType::Interface => "interface",
+            NetworkInterfaceType::NatGateway => "natGateway",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkInterfaceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "interface" => Ok(NetworkInterfaceType::Interface),
+            "natGateway" => Ok(NetworkInterfaceType::NatGateway),
+            _ => Err(()),
+        }
+    }
+}
+
 struct NetworkInterfaceTypeDeserializer;
 impl NetworkInterfaceTypeDeserializer {
     #[allow(unused_variables)]
@@ -27249,6 +29385,41 @@ impl OccurrenceDaySetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OfferingClassType {
+    Convertible,
+    Standard,
+}
+
+impl Into<String> for OfferingClassType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OfferingClassType {
+    fn into(self) -> &'static str {
+        match self {
+            OfferingClassType::Convertible => "convertible",
+            OfferingClassType::Standard => "standard",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OfferingClassType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "convertible" => Ok(OfferingClassType::Convertible),
+            "standard" => Ok(OfferingClassType::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
 struct OfferingClassTypeDeserializer;
 impl OfferingClassTypeDeserializer {
     #[allow(unused_variables)]
@@ -27263,6 +29434,53 @@ impl OfferingClassTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OfferingTypeValues {
+    AllUpfront,
+    HeavyUtilization,
+    LightUtilization,
+    MediumUtilization,
+    NoUpfront,
+    PartialUpfront,
+}
+
+impl Into<String> for OfferingTypeValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OfferingTypeValues {
+    fn into(self) -> &'static str {
+        match self {
+            OfferingTypeValues::AllUpfront => "All Upfront",
+            OfferingTypeValues::HeavyUtilization => "Heavy Utilization",
+            OfferingTypeValues::LightUtilization => "Light Utilization",
+            OfferingTypeValues::MediumUtilization => "Medium Utilization",
+            OfferingTypeValues::NoUpfront => "No Upfront",
+            OfferingTypeValues::PartialUpfront => "Partial Upfront",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OfferingTypeValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All Upfront" => Ok(OfferingTypeValues::AllUpfront),
+            "Heavy Utilization" => Ok(OfferingTypeValues::HeavyUtilization),
+            "Light Utilization" => Ok(OfferingTypeValues::LightUtilization),
+            "Medium Utilization" => Ok(OfferingTypeValues::MediumUtilization),
+            "No Upfront" => Ok(OfferingTypeValues::NoUpfront),
+            "Partial Upfront" => Ok(OfferingTypeValues::PartialUpfront),
+            _ => Err(()),
+        }
+    }
+}
+
 struct OfferingTypeValuesDeserializer;
 impl OfferingTypeValuesDeserializer {
     #[allow(unused_variables)]
@@ -27278,6 +29496,41 @@ impl OfferingTypeValuesDeserializer {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationType {
+    Add,
+    Remove,
+}
+
+impl Into<String> for OperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationType {
+    fn into(self) -> &'static str {
+        match self {
+            OperationType::Add => "add",
+            OperationType::Remove => "remove",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "add" => Ok(OperationType::Add),
+            "remove" => Ok(OperationType::Remove),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `OwnerStringList` contents to a `SignedRequest`.
 struct OwnerStringListSerializer;
 impl OwnerStringListSerializer {
@@ -27285,6 +29538,44 @@ impl OwnerStringListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PaymentOption {
+    AllUpfront,
+    NoUpfront,
+    PartialUpfront,
+}
+
+impl Into<String> for PaymentOption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PaymentOption {
+    fn into(self) -> &'static str {
+        match self {
+            PaymentOption::AllUpfront => "AllUpfront",
+            PaymentOption::NoUpfront => "NoUpfront",
+            PaymentOption::PartialUpfront => "PartialUpfront",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PaymentOption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AllUpfront" => Ok(PaymentOption::AllUpfront),
+            "NoUpfront" => Ok(PaymentOption::NoUpfront),
+            "PartialUpfront" => Ok(PaymentOption::PartialUpfront),
+            _ => Err(()),
         }
     }
 }
@@ -27469,6 +29760,38 @@ impl PeeringConnectionOptionsRequestSerializer {
                        &field_value.to_string());
         }
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PermissionGroup {
+    All,
+}
+
+impl Into<String> for PermissionGroup {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PermissionGroup {
+    fn into(self) -> &'static str {
+        match self {
+            PermissionGroup::All => "all",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PermissionGroup {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(PermissionGroup::All),
+            _ => Err(()),
+        }
     }
 }
 
@@ -27702,6 +30025,47 @@ impl PlacementGroupListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlacementGroupState {
+    Available,
+    Deleted,
+    Deleting,
+    Pending,
+}
+
+impl Into<String> for PlacementGroupState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlacementGroupState {
+    fn into(self) -> &'static str {
+        match self {
+            PlacementGroupState::Available => "available",
+            PlacementGroupState::Deleted => "deleted",
+            PlacementGroupState::Deleting => "deleting",
+            PlacementGroupState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlacementGroupState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(PlacementGroupState::Available),
+            "deleted" => Ok(PlacementGroupState::Deleted),
+            "deleting" => Ok(PlacementGroupState::Deleting),
+            "pending" => Ok(PlacementGroupState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PlacementGroupStateDeserializer;
 impl PlacementGroupStateDeserializer {
     #[allow(unused_variables)]
@@ -27728,6 +30092,38 @@ impl PlacementGroupStringListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlacementStrategy {
+    Cluster,
+}
+
+impl Into<String> for PlacementStrategy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlacementStrategy {
+    fn into(self) -> &'static str {
+        match self {
+            PlacementStrategy::Cluster => "cluster",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlacementStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cluster" => Ok(PlacementStrategy::Cluster),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PlacementStrategyDeserializer;
 impl PlacementStrategyDeserializer {
     #[allow(unused_variables)]
@@ -27742,6 +30138,38 @@ impl PlacementStrategyDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformValues {
+    Windows,
+}
+
+impl Into<String> for PlatformValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformValues {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformValues::Windows => "Windows",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Windows" => Ok(PlatformValues::Windows),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PlatformValuesDeserializer;
 impl PlatformValuesDeserializer {
     #[allow(unused_variables)]
@@ -28604,6 +31032,41 @@ impl ProductCodeStringListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductCodeValues {
+    Devpay,
+    Marketplace,
+}
+
+impl Into<String> for ProductCodeValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductCodeValues {
+    fn into(self) -> &'static str {
+        match self {
+            ProductCodeValues::Devpay => "devpay",
+            ProductCodeValues::Marketplace => "marketplace",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductCodeValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "devpay" => Ok(ProductCodeValues::Devpay),
+            "marketplace" => Ok(ProductCodeValues::Marketplace),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ProductCodeValuesDeserializer;
 impl ProductCodeValuesDeserializer {
     #[allow(unused_variables)]
@@ -29312,6 +31775,47 @@ impl PurchasedScheduledInstanceSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RIProductDescription {
+    LinuxUNIX,
+    LinuxUNIXAmazonVPC,
+    Windows,
+    WindowsAmazonVPC,
+}
+
+impl Into<String> for RIProductDescription {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RIProductDescription {
+    fn into(self) -> &'static str {
+        match self {
+            RIProductDescription::LinuxUNIX => "Linux/UNIX",
+            RIProductDescription::LinuxUNIXAmazonVPC => "Linux/UNIX (Amazon VPC)",
+            RIProductDescription::Windows => "Windows",
+            RIProductDescription::WindowsAmazonVPC => "Windows (Amazon VPC)",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RIProductDescription {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Linux/UNIX" => Ok(RIProductDescription::LinuxUNIX),
+            "Linux/UNIX (Amazon VPC)" => Ok(RIProductDescription::LinuxUNIXAmazonVPC),
+            "Windows" => Ok(RIProductDescription::Windows),
+            "Windows (Amazon VPC)" => Ok(RIProductDescription::WindowsAmazonVPC),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RIProductDescriptionDeserializer;
 impl RIProductDescriptionDeserializer {
     #[allow(unused_variables)]
@@ -29421,6 +31925,38 @@ impl RecurringChargeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecurringChargeFrequency {
+    Hourly,
+}
+
+impl Into<String> for RecurringChargeFrequency {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecurringChargeFrequency {
+    fn into(self) -> &'static str {
+        match self {
+            RecurringChargeFrequency::Hourly => "Hourly",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecurringChargeFrequency {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Hourly" => Ok(RecurringChargeFrequency::Hourly),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RecurringChargeFrequencyDeserializer;
 impl RecurringChargeFrequencyDeserializer {
     #[allow(unused_variables)]
@@ -30297,6 +32833,62 @@ impl ReplaceRouteTableAssociationResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportInstanceReasonCodes {
+    InstanceStuckInState,
+    NotAcceptingCredentials,
+    Other,
+    PasswordNotAvailable,
+    PerformanceEbsVolume,
+    PerformanceInstanceStore,
+    PerformanceNetwork,
+    PerformanceOther,
+    Unresponsive,
+}
+
+impl Into<String> for ReportInstanceReasonCodes {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportInstanceReasonCodes {
+    fn into(self) -> &'static str {
+        match self {
+            ReportInstanceReasonCodes::InstanceStuckInState => "instance-stuck-in-state",
+            ReportInstanceReasonCodes::NotAcceptingCredentials => "not-accepting-credentials",
+            ReportInstanceReasonCodes::Other => "other",
+            ReportInstanceReasonCodes::PasswordNotAvailable => "password-not-available",
+            ReportInstanceReasonCodes::PerformanceEbsVolume => "performance-ebs-volume",
+            ReportInstanceReasonCodes::PerformanceInstanceStore => "performance-instance-store",
+            ReportInstanceReasonCodes::PerformanceNetwork => "performance-network",
+            ReportInstanceReasonCodes::PerformanceOther => "performance-other",
+            ReportInstanceReasonCodes::Unresponsive => "unresponsive",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportInstanceReasonCodes {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "instance-stuck-in-state" => Ok(ReportInstanceReasonCodes::InstanceStuckInState),
+            "not-accepting-credentials" => Ok(ReportInstanceReasonCodes::NotAcceptingCredentials),
+            "other" => Ok(ReportInstanceReasonCodes::Other),
+            "password-not-available" => Ok(ReportInstanceReasonCodes::PasswordNotAvailable),
+            "performance-ebs-volume" => Ok(ReportInstanceReasonCodes::PerformanceEbsVolume),
+            "performance-instance-store" => Ok(ReportInstanceReasonCodes::PerformanceInstanceStore),
+            "performance-network" => Ok(ReportInstanceReasonCodes::PerformanceNetwork),
+            "performance-other" => Ok(ReportInstanceReasonCodes::PerformanceOther),
+            "unresponsive" => Ok(ReportInstanceReasonCodes::Unresponsive),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the parameters for ReportInstanceStatus.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct ReportInstanceStatusRequest {
@@ -30346,6 +32938,41 @@ impl ReportInstanceStatusRequestSerializer {
         }
         params.put(&format!("{}{}", prefix, "Status"), &obj.status);
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportStatusType {
+    Impaired,
+    Ok,
+}
+
+impl Into<String> for ReportStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            ReportStatusType::Impaired => "impaired",
+            ReportStatusType::Ok => "ok",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "impaired" => Ok(ReportStatusType::Impaired),
+            "ok" => Ok(ReportStatusType::Ok),
+            _ => Err(()),
+        }
     }
 }
 
@@ -30820,6 +33447,47 @@ impl ReservationListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReservationState {
+    Active,
+    PaymentFailed,
+    PaymentPending,
+    Retired,
+}
+
+impl Into<String> for ReservationState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReservationState {
+    fn into(self) -> &'static str {
+        match self {
+            ReservationState::Active => "active",
+            ReservationState::PaymentFailed => "payment-failed",
+            ReservationState::PaymentPending => "payment-pending",
+            ReservationState::Retired => "retired",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReservationState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ReservationState::Active),
+            "payment-failed" => Ok(ReservationState::PaymentFailed),
+            "payment-pending" => Ok(ReservationState::PaymentPending),
+            "retired" => Ok(ReservationState::Retired),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReservationStateDeserializer;
 impl ReservationStateDeserializer {
     #[allow(unused_variables)]
@@ -31038,6 +33706,47 @@ impl ReservedInstanceReservationValueSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReservedInstanceState {
+    Active,
+    PaymentFailed,
+    PaymentPending,
+    Retired,
+}
+
+impl Into<String> for ReservedInstanceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReservedInstanceState {
+    fn into(self) -> &'static str {
+        match self {
+            ReservedInstanceState::Active => "active",
+            ReservedInstanceState::PaymentFailed => "payment-failed",
+            ReservedInstanceState::PaymentPending => "payment-pending",
+            ReservedInstanceState::Retired => "retired",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReservedInstanceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ReservedInstanceState::Active),
+            "payment-failed" => Ok(ReservedInstanceState::PaymentFailed),
+            "payment-pending" => Ok(ReservedInstanceState::PaymentPending),
+            "retired" => Ok(ReservedInstanceState::Retired),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReservedInstanceStateDeserializer;
 impl ReservedInstanceStateDeserializer {
     #[allow(unused_variables)]
@@ -32069,6 +34778,38 @@ impl ReservedIntancesIdsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResetImageAttributeName {
+    LaunchPermission,
+}
+
+impl Into<String> for ResetImageAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResetImageAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            ResetImageAttributeName::LaunchPermission => "launchPermission",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResetImageAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "launchPermission" => Ok(ResetImageAttributeName::LaunchPermission),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the parameters for ResetImageAttribute.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct ResetImageAttributeRequest {
@@ -32200,6 +34941,86 @@ impl ResourceIdListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    CustomerGateway,
+    DhcpOptions,
+    Image,
+    Instance,
+    InternetGateway,
+    NetworkAcl,
+    NetworkInterface,
+    ReservedInstances,
+    RouteTable,
+    SecurityGroup,
+    Snapshot,
+    SpotInstancesRequest,
+    Subnet,
+    Volume,
+    Vpc,
+    VpnConnection,
+    VpnGateway,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::CustomerGateway => "customer-gateway",
+            ResourceType::DhcpOptions => "dhcp-options",
+            ResourceType::Image => "image",
+            ResourceType::Instance => "instance",
+            ResourceType::InternetGateway => "internet-gateway",
+            ResourceType::NetworkAcl => "network-acl",
+            ResourceType::NetworkInterface => "network-interface",
+            ResourceType::ReservedInstances => "reserved-instances",
+            ResourceType::RouteTable => "route-table",
+            ResourceType::SecurityGroup => "security-group",
+            ResourceType::Snapshot => "snapshot",
+            ResourceType::SpotInstancesRequest => "spot-instances-request",
+            ResourceType::Subnet => "subnet",
+            ResourceType::Volume => "volume",
+            ResourceType::Vpc => "vpc",
+            ResourceType::VpnConnection => "vpn-connection",
+            ResourceType::VpnGateway => "vpn-gateway",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "customer-gateway" => Ok(ResourceType::CustomerGateway),
+            "dhcp-options" => Ok(ResourceType::DhcpOptions),
+            "image" => Ok(ResourceType::Image),
+            "instance" => Ok(ResourceType::Instance),
+            "internet-gateway" => Ok(ResourceType::InternetGateway),
+            "network-acl" => Ok(ResourceType::NetworkAcl),
+            "network-interface" => Ok(ResourceType::NetworkInterface),
+            "reserved-instances" => Ok(ResourceType::ReservedInstances),
+            "route-table" => Ok(ResourceType::RouteTable),
+            "security-group" => Ok(ResourceType::SecurityGroup),
+            "snapshot" => Ok(ResourceType::Snapshot),
+            "spot-instances-request" => Ok(ResourceType::SpotInstancesRequest),
+            "subnet" => Ok(ResourceType::Subnet),
+            "volume" => Ok(ResourceType::Volume),
+            "vpc" => Ok(ResourceType::Vpc),
+            "vpn-connection" => Ok(ResourceType::VpnConnection),
+            "vpn-gateway" => Ok(ResourceType::VpnGateway),
+            _ => Err(()),
         }
     }
 }
@@ -32698,6 +35519,44 @@ impl RouteListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RouteOrigin {
+    CreateRoute,
+    CreateRouteTable,
+    EnableVgwRoutePropagation,
+}
+
+impl Into<String> for RouteOrigin {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RouteOrigin {
+    fn into(self) -> &'static str {
+        match self {
+            RouteOrigin::CreateRoute => "CreateRoute",
+            RouteOrigin::CreateRouteTable => "CreateRouteTable",
+            RouteOrigin::EnableVgwRoutePropagation => "EnableVgwRoutePropagation",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RouteOrigin {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreateRoute" => Ok(RouteOrigin::CreateRoute),
+            "CreateRouteTable" => Ok(RouteOrigin::CreateRouteTable),
+            "EnableVgwRoutePropagation" => Ok(RouteOrigin::EnableVgwRoutePropagation),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RouteOriginDeserializer;
 impl RouteOriginDeserializer {
     #[allow(unused_variables)]
@@ -32712,6 +35571,41 @@ impl RouteOriginDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RouteState {
+    Active,
+    Blackhole,
+}
+
+impl Into<String> for RouteState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RouteState {
+    fn into(self) -> &'static str {
+        match self {
+            RouteState::Active => "active",
+            RouteState::Blackhole => "blackhole",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RouteState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(RouteState::Active),
+            "blackhole" => Ok(RouteState::Blackhole),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RouteStateDeserializer;
 impl RouteStateDeserializer {
     #[allow(unused_variables)]
@@ -32955,6 +35849,41 @@ impl RouteTableListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RuleAction {
+    Allow,
+    Deny,
+}
+
+impl Into<String> for RuleAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RuleAction {
+    fn into(self) -> &'static str {
+        match self {
+            RuleAction::Allow => "allow",
+            RuleAction::Deny => "deny",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RuleAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow" => Ok(RuleAction::Allow),
+            "deny" => Ok(RuleAction::Deny),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RuleActionDeserializer;
 impl RuleActionDeserializer {
     #[allow(unused_variables)]
@@ -34386,6 +37315,41 @@ impl ScheduledInstancesSecurityGroupIdSetSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Scope {
+    AvailabilityZone,
+    Region,
+}
+
+impl Into<String> for Scope {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Scope {
+    fn into(self) -> &'static str {
+        match self {
+            Scope::AvailabilityZone => "Availability Zone",
+            Scope::Region => "Region",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Scope {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Availability Zone" => Ok(Scope::AvailabilityZone),
+            "Region" => Ok(Scope::Region),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ScopeDeserializer;
 impl ScopeDeserializer {
     #[allow(unused_variables)]
@@ -34702,6 +37666,41 @@ impl SecurityGroupStringListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShutdownBehavior {
+    Stop,
+    Terminate,
+}
+
+impl Into<String> for ShutdownBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShutdownBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            ShutdownBehavior::Stop => "stop",
+            ShutdownBehavior::Terminate => "terminate",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShutdownBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "stop" => Ok(ShutdownBehavior::Stop),
+            "terminate" => Ok(ShutdownBehavior::Terminate),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the time period for a Scheduled Instance to start its first schedule. The time period must span less than one day.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct SlotDateTimeRangeRequest {
@@ -34884,6 +37883,41 @@ impl SnapshotDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnapshotAttributeName {
+    CreateVolumePermission,
+    ProductCodes,
+}
+
+impl Into<String> for SnapshotAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnapshotAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            SnapshotAttributeName::CreateVolumePermission => "createVolumePermission",
+            SnapshotAttributeName::ProductCodes => "productCodes",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnapshotAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "createVolumePermission" => Ok(SnapshotAttributeName::CreateVolumePermission),
+            "productCodes" => Ok(SnapshotAttributeName::ProductCodes),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the snapshot created from the imported disk.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct SnapshotDetail {
@@ -35122,6 +38156,44 @@ impl SnapshotListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnapshotState {
+    Completed,
+    Error,
+    Pending,
+}
+
+impl Into<String> for SnapshotState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnapshotState {
+    fn into(self) -> &'static str {
+        match self {
+            SnapshotState::Completed => "completed",
+            SnapshotState::Error => "error",
+            SnapshotState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnapshotState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "completed" => Ok(SnapshotState::Completed),
+            "error" => Ok(SnapshotState::Error),
+            "pending" => Ok(SnapshotState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SnapshotStateDeserializer;
 impl SnapshotStateDeserializer {
     #[allow(unused_variables)]
@@ -36119,6 +39191,50 @@ impl SpotInstanceRequestListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SpotInstanceState {
+    Active,
+    Cancelled,
+    Closed,
+    Failed,
+    Open,
+}
+
+impl Into<String> for SpotInstanceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SpotInstanceState {
+    fn into(self) -> &'static str {
+        match self {
+            SpotInstanceState::Active => "active",
+            SpotInstanceState::Cancelled => "cancelled",
+            SpotInstanceState::Closed => "closed",
+            SpotInstanceState::Failed => "failed",
+            SpotInstanceState::Open => "open",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SpotInstanceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(SpotInstanceState::Active),
+            "cancelled" => Ok(SpotInstanceState::Cancelled),
+            "closed" => Ok(SpotInstanceState::Closed),
+            "failed" => Ok(SpotInstanceState::Failed),
+            "open" => Ok(SpotInstanceState::Open),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SpotInstanceStateDeserializer;
 impl SpotInstanceStateDeserializer {
     #[allow(unused_variables)]
@@ -36247,6 +39363,41 @@ impl SpotInstanceStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SpotInstanceType {
+    OneTime,
+    Persistent,
+}
+
+impl Into<String> for SpotInstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SpotInstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            SpotInstanceType::OneTime => "one-time",
+            SpotInstanceType::Persistent => "persistent",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SpotInstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "one-time" => Ok(SpotInstanceType::OneTime),
+            "persistent" => Ok(SpotInstanceType::Persistent),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SpotInstanceTypeDeserializer;
 impl SpotInstanceTypeDeserializer {
     #[allow(unused_variables)]
@@ -36790,6 +39941,47 @@ impl StartInstancesResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum State {
+    Available,
+    Deleted,
+    Deleting,
+    Pending,
+}
+
+impl Into<String> for State {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for State {
+    fn into(self) -> &'static str {
+        match self {
+            State::Available => "Available",
+            State::Deleted => "Deleted",
+            State::Deleting => "Deleting",
+            State::Pending => "Pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for State {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Available" => Ok(State::Available),
+            "Deleted" => Ok(State::Deleted),
+            "Deleting" => Ok(State::Deleting),
+            "Pending" => Ok(State::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StateDeserializer;
 impl StateDeserializer {
     #[allow(unused_variables)]
@@ -36858,6 +40050,44 @@ impl StateReasonDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Status {
+    InClassic,
+    InVpc,
+    MoveInProgress,
+}
+
+impl Into<String> for Status {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Status {
+    fn into(self) -> &'static str {
+        match self {
+            Status::InClassic => "InClassic",
+            Status::InVpc => "InVpc",
+            Status::MoveInProgress => "MoveInProgress",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Status {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InClassic" => Ok(Status::InClassic),
+            "InVpc" => Ok(Status::InVpc),
+            "MoveInProgress" => Ok(Status::MoveInProgress),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatusDeserializer;
 impl StatusDeserializer {
     #[allow(unused_variables)]
@@ -36872,6 +40102,38 @@ impl StatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusName {
+    Reachability,
+}
+
+impl Into<String> for StatusName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusName {
+    fn into(self) -> &'static str {
+        match self {
+            StatusName::Reachability => "reachability",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "reachability" => Ok(StatusName::Reachability),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatusNameDeserializer;
 impl StatusNameDeserializer {
     #[allow(unused_variables)]
@@ -36886,6 +40148,47 @@ impl StatusNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusType {
+    Failed,
+    Initializing,
+    InsufficientData,
+    Passed,
+}
+
+impl Into<String> for StatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusType {
+    fn into(self) -> &'static str {
+        match self {
+            StatusType::Failed => "failed",
+            StatusType::Initializing => "initializing",
+            StatusType::InsufficientData => "insufficient-data",
+            StatusType::Passed => "passed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "failed" => Ok(StatusType::Failed),
+            "initializing" => Ok(StatusType::Initializing),
+            "insufficient-data" => Ok(StatusType::InsufficientData),
+            "passed" => Ok(StatusType::Passed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatusTypeDeserializer;
 impl StatusTypeDeserializer {
     #[allow(unused_variables)]
@@ -37258,6 +40561,53 @@ impl SubnetCidrBlockStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubnetCidrBlockStateCode {
+    Associated,
+    Associating,
+    Disassociated,
+    Disassociating,
+    Failed,
+    Failing,
+}
+
+impl Into<String> for SubnetCidrBlockStateCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubnetCidrBlockStateCode {
+    fn into(self) -> &'static str {
+        match self {
+            SubnetCidrBlockStateCode::Associated => "associated",
+            SubnetCidrBlockStateCode::Associating => "associating",
+            SubnetCidrBlockStateCode::Disassociated => "disassociated",
+            SubnetCidrBlockStateCode::Disassociating => "disassociating",
+            SubnetCidrBlockStateCode::Failed => "failed",
+            SubnetCidrBlockStateCode::Failing => "failing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubnetCidrBlockStateCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "associated" => Ok(SubnetCidrBlockStateCode::Associated),
+            "associating" => Ok(SubnetCidrBlockStateCode::Associating),
+            "disassociated" => Ok(SubnetCidrBlockStateCode::Disassociated),
+            "disassociating" => Ok(SubnetCidrBlockStateCode::Disassociating),
+            "failed" => Ok(SubnetCidrBlockStateCode::Failed),
+            "failing" => Ok(SubnetCidrBlockStateCode::Failing),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SubnetCidrBlockStateCodeDeserializer;
 impl SubnetCidrBlockStateCodeDeserializer {
     #[allow(unused_variables)]
@@ -37429,6 +40779,41 @@ impl SubnetListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubnetState {
+    Available,
+    Pending,
+}
+
+impl Into<String> for SubnetState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubnetState {
+    fn into(self) -> &'static str {
+        match self {
+            SubnetState::Available => "available",
+            SubnetState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubnetState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(SubnetState::Available),
+            "pending" => Ok(SubnetState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SubnetStateDeserializer;
 impl SubnetStateDeserializer {
     #[allow(unused_variables)]
@@ -37443,6 +40828,50 @@ impl SubnetStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SummaryStatus {
+    Impaired,
+    Initializing,
+    InsufficientData,
+    NotApplicable,
+    Ok,
+}
+
+impl Into<String> for SummaryStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SummaryStatus {
+    fn into(self) -> &'static str {
+        match self {
+            SummaryStatus::Impaired => "impaired",
+            SummaryStatus::Initializing => "initializing",
+            SummaryStatus::InsufficientData => "insufficient-data",
+            SummaryStatus::NotApplicable => "not-applicable",
+            SummaryStatus::Ok => "ok",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SummaryStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "impaired" => Ok(SummaryStatus::Impaired),
+            "initializing" => Ok(SummaryStatus::Initializing),
+            "insufficient-data" => Ok(SummaryStatus::InsufficientData),
+            "not-applicable" => Ok(SummaryStatus::NotApplicable),
+            "ok" => Ok(SummaryStatus::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SummaryStatusDeserializer;
 impl SummaryStatusDeserializer {
     #[allow(unused_variables)]
@@ -37926,6 +41355,41 @@ impl TargetReservationValueSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TelemetryStatus {
+    Down,
+    Up,
+}
+
+impl Into<String> for TelemetryStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TelemetryStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TelemetryStatus::Down => "DOWN",
+            TelemetryStatus::Up => "UP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TelemetryStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DOWN" => Ok(TelemetryStatus::Down),
+            "UP" => Ok(TelemetryStatus::Up),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TelemetryStatusDeserializer;
 impl TelemetryStatusDeserializer {
     #[allow(unused_variables)]
@@ -37940,6 +41404,44 @@ impl TelemetryStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Tenancy {
+    Dedicated,
+    Default,
+    Host,
+}
+
+impl Into<String> for Tenancy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Tenancy {
+    fn into(self) -> &'static str {
+        match self {
+            Tenancy::Dedicated => "dedicated",
+            Tenancy::Default => "default",
+            Tenancy::Host => "host",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Tenancy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dedicated" => Ok(Tenancy::Dedicated),
+            "default" => Ok(Tenancy::Default),
+            "host" => Ok(Tenancy::Host),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TenancyDeserializer;
 impl TenancyDeserializer {
     #[allow(unused_variables)]
@@ -38033,6 +41535,44 @@ impl TerminateInstancesResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TrafficType {
+    Accept,
+    All,
+    Reject,
+}
+
+impl Into<String> for TrafficType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TrafficType {
+    fn into(self) -> &'static str {
+        match self {
+            TrafficType::Accept => "ACCEPT",
+            TrafficType::All => "ALL",
+            TrafficType::Reject => "REJECT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TrafficType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCEPT" => Ok(TrafficType::Accept),
+            "ALL" => Ok(TrafficType::All),
+            "REJECT" => Ok(TrafficType::Reject),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TrafficTypeDeserializer;
 impl TrafficTypeDeserializer {
     #[allow(unused_variables)]
@@ -38939,6 +42479,41 @@ impl VgwTelemetryListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VirtualizationType {
+    Hvm,
+    Paravirtual,
+}
+
+impl Into<String> for VirtualizationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VirtualizationType {
+    fn into(self) -> &'static str {
+        match self {
+            VirtualizationType::Hvm => "hvm",
+            VirtualizationType::Paravirtual => "paravirtual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VirtualizationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hvm" => Ok(VirtualizationType::Hvm),
+            "paravirtual" => Ok(VirtualizationType::Paravirtual),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VirtualizationTypeDeserializer;
 impl VirtualizationTypeDeserializer {
     #[allow(unused_variables)]
@@ -39191,6 +42766,47 @@ impl VolumeAttachmentListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeAttachmentState {
+    Attached,
+    Attaching,
+    Detached,
+    Detaching,
+}
+
+impl Into<String> for VolumeAttachmentState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeAttachmentState {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeAttachmentState::Attached => "attached",
+            VolumeAttachmentState::Attaching => "attaching",
+            VolumeAttachmentState::Detached => "detached",
+            VolumeAttachmentState::Detaching => "detaching",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeAttachmentState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "attached" => Ok(VolumeAttachmentState::Attached),
+            "attaching" => Ok(VolumeAttachmentState::Attaching),
+            "detached" => Ok(VolumeAttachmentState::Detached),
+            "detaching" => Ok(VolumeAttachmentState::Detaching),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeAttachmentStateDeserializer;
 impl VolumeAttachmentStateDeserializer {
     #[allow(unused_variables)]
@@ -39205,6 +42821,41 @@ impl VolumeAttachmentStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeAttributeName {
+    AutoEnableIO,
+    ProductCodes,
+}
+
+impl Into<String> for VolumeAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeAttributeName::AutoEnableIO => "autoEnableIO",
+            VolumeAttributeName::ProductCodes => "productCodes",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "autoEnableIO" => Ok(VolumeAttributeName::AutoEnableIO),
+            "productCodes" => Ok(VolumeAttributeName::ProductCodes),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an EBS volume.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct VolumeDetail {
@@ -39439,6 +43090,47 @@ impl VolumeModificationListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeModificationState {
+    Completed,
+    Failed,
+    Modifying,
+    Optimizing,
+}
+
+impl Into<String> for VolumeModificationState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeModificationState {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeModificationState::Completed => "completed",
+            VolumeModificationState::Failed => "failed",
+            VolumeModificationState::Modifying => "modifying",
+            VolumeModificationState::Optimizing => "optimizing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeModificationState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "completed" => Ok(VolumeModificationState::Completed),
+            "failed" => Ok(VolumeModificationState::Failed),
+            "modifying" => Ok(VolumeModificationState::Modifying),
+            "optimizing" => Ok(VolumeModificationState::Optimizing),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeModificationStateDeserializer;
 impl VolumeModificationStateDeserializer {
     #[allow(unused_variables)]
@@ -39453,6 +43145,53 @@ impl VolumeModificationStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeState {
+    Available,
+    Creating,
+    Deleted,
+    Deleting,
+    Error,
+    InUse,
+}
+
+impl Into<String> for VolumeState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeState {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeState::Available => "available",
+            VolumeState::Creating => "creating",
+            VolumeState::Deleted => "deleted",
+            VolumeState::Deleting => "deleting",
+            VolumeState::Error => "error",
+            VolumeState::InUse => "in-use",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(VolumeState::Available),
+            "creating" => Ok(VolumeState::Creating),
+            "deleted" => Ok(VolumeState::Deleted),
+            "deleting" => Ok(VolumeState::Deleting),
+            "error" => Ok(VolumeState::Error),
+            "in-use" => Ok(VolumeState::InUse),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeStateDeserializer;
 impl VolumeStateDeserializer {
     #[allow(unused_variables)]
@@ -39841,6 +43580,44 @@ impl VolumeStatusInfoDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeStatusInfoStatus {
+    Impaired,
+    InsufficientData,
+    Ok,
+}
+
+impl Into<String> for VolumeStatusInfoStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeStatusInfoStatus {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeStatusInfoStatus::Impaired => "impaired",
+            VolumeStatusInfoStatus::InsufficientData => "insufficient-data",
+            VolumeStatusInfoStatus::Ok => "ok",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeStatusInfoStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "impaired" => Ok(VolumeStatusInfoStatus::Impaired),
+            "insufficient-data" => Ok(VolumeStatusInfoStatus::InsufficientData),
+            "ok" => Ok(VolumeStatusInfoStatus::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeStatusInfoStatusDeserializer;
 impl VolumeStatusInfoStatusDeserializer {
     #[allow(unused_variables)]
@@ -39973,6 +43750,41 @@ impl VolumeStatusListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeStatusName {
+    IoEnabled,
+    IoPerformance,
+}
+
+impl Into<String> for VolumeStatusName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeStatusName {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeStatusName::IoEnabled => "io-enabled",
+            VolumeStatusName::IoPerformance => "io-performance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeStatusName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "io-enabled" => Ok(VolumeStatusName::IoEnabled),
+            "io-performance" => Ok(VolumeStatusName::IoPerformance),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeStatusNameDeserializer;
 impl VolumeStatusNameDeserializer {
     #[allow(unused_variables)]
@@ -39987,6 +43799,50 @@ impl VolumeStatusNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeType {
+    Gp2,
+    Io1,
+    Sc1,
+    St1,
+    Standard,
+}
+
+impl Into<String> for VolumeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeType {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeType::Gp2 => "gp2",
+            VolumeType::Io1 => "io1",
+            VolumeType::Sc1 => "sc1",
+            VolumeType::St1 => "st1",
+            VolumeType::Standard => "standard",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gp2" => Ok(VolumeType::Gp2),
+            "io1" => Ok(VolumeType::Io1),
+            "sc1" => Ok(VolumeType::Sc1),
+            "st1" => Ok(VolumeType::St1),
+            "standard" => Ok(VolumeType::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeTypeDeserializer;
 impl VolumeTypeDeserializer {
     #[allow(unused_variables)]
@@ -40189,6 +44045,41 @@ impl VpcAttachmentListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpcAttributeName {
+    EnableDnsHostnames,
+    EnableDnsSupport,
+}
+
+impl Into<String> for VpcAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpcAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            VpcAttributeName::EnableDnsHostnames => "enableDnsHostnames",
+            VpcAttributeName::EnableDnsSupport => "enableDnsSupport",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpcAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "enableDnsHostnames" => Ok(VpcAttributeName::EnableDnsHostnames),
+            "enableDnsSupport" => Ok(VpcAttributeName::EnableDnsSupport),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the state of a CIDR block.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct VpcCidrBlockState {
@@ -40245,6 +44136,53 @@ impl VpcCidrBlockStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpcCidrBlockStateCode {
+    Associated,
+    Associating,
+    Disassociated,
+    Disassociating,
+    Failed,
+    Failing,
+}
+
+impl Into<String> for VpcCidrBlockStateCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpcCidrBlockStateCode {
+    fn into(self) -> &'static str {
+        match self {
+            VpcCidrBlockStateCode::Associated => "associated",
+            VpcCidrBlockStateCode::Associating => "associating",
+            VpcCidrBlockStateCode::Disassociated => "disassociated",
+            VpcCidrBlockStateCode::Disassociating => "disassociating",
+            VpcCidrBlockStateCode::Failed => "failed",
+            VpcCidrBlockStateCode::Failing => "failing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpcCidrBlockStateCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "associated" => Ok(VpcCidrBlockStateCode::Associated),
+            "associating" => Ok(VpcCidrBlockStateCode::Associating),
+            "disassociated" => Ok(VpcCidrBlockStateCode::Disassociated),
+            "disassociating" => Ok(VpcCidrBlockStateCode::Disassociating),
+            "failed" => Ok(VpcCidrBlockStateCode::Failed),
+            "failing" => Ok(VpcCidrBlockStateCode::Failing),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpcCidrBlockStateCodeDeserializer;
 impl VpcCidrBlockStateCodeDeserializer {
     #[allow(unused_variables)]
@@ -40900,6 +44838,62 @@ impl VpcPeeringConnectionStateReasonDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpcPeeringConnectionStateReasonCode {
+    Active,
+    Deleted,
+    Deleting,
+    Expired,
+    Failed,
+    InitiatingRequest,
+    PendingAcceptance,
+    Provisioning,
+    Rejected,
+}
+
+impl Into<String> for VpcPeeringConnectionStateReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpcPeeringConnectionStateReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            VpcPeeringConnectionStateReasonCode::Active => "active",
+            VpcPeeringConnectionStateReasonCode::Deleted => "deleted",
+            VpcPeeringConnectionStateReasonCode::Deleting => "deleting",
+            VpcPeeringConnectionStateReasonCode::Expired => "expired",
+            VpcPeeringConnectionStateReasonCode::Failed => "failed",
+            VpcPeeringConnectionStateReasonCode::InitiatingRequest => "initiating-request",
+            VpcPeeringConnectionStateReasonCode::PendingAcceptance => "pending-acceptance",
+            VpcPeeringConnectionStateReasonCode::Provisioning => "provisioning",
+            VpcPeeringConnectionStateReasonCode::Rejected => "rejected",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpcPeeringConnectionStateReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(VpcPeeringConnectionStateReasonCode::Active),
+            "deleted" => Ok(VpcPeeringConnectionStateReasonCode::Deleted),
+            "deleting" => Ok(VpcPeeringConnectionStateReasonCode::Deleting),
+            "expired" => Ok(VpcPeeringConnectionStateReasonCode::Expired),
+            "failed" => Ok(VpcPeeringConnectionStateReasonCode::Failed),
+            "initiating-request" => Ok(VpcPeeringConnectionStateReasonCode::InitiatingRequest),
+            "pending-acceptance" => Ok(VpcPeeringConnectionStateReasonCode::PendingAcceptance),
+            "provisioning" => Ok(VpcPeeringConnectionStateReasonCode::Provisioning),
+            "rejected" => Ok(VpcPeeringConnectionStateReasonCode::Rejected),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpcPeeringConnectionStateReasonCodeDeserializer;
 impl VpcPeeringConnectionStateReasonCodeDeserializer {
     #[allow(unused_variables)]
@@ -40987,6 +44981,41 @@ impl VpcPeeringConnectionVpcInfoDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpcState {
+    Available,
+    Pending,
+}
+
+impl Into<String> for VpcState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpcState {
+    fn into(self) -> &'static str {
+        match self {
+            VpcState::Available => "available",
+            VpcState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpcState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(VpcState::Available),
+            "pending" => Ok(VpcState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpcStateDeserializer;
 impl VpcStateDeserializer {
     #[allow(unused_variables)]
@@ -41372,6 +45401,47 @@ impl VpnGatewayListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpnState {
+    Available,
+    Deleted,
+    Deleting,
+    Pending,
+}
+
+impl Into<String> for VpnState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpnState {
+    fn into(self) -> &'static str {
+        match self {
+            VpnState::Available => "available",
+            VpnState::Deleted => "deleted",
+            VpnState::Deleting => "deleting",
+            VpnState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpnState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(VpnState::Available),
+            "deleted" => Ok(VpnState::Deleted),
+            "deleting" => Ok(VpnState::Deleting),
+            "pending" => Ok(VpnState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpnStateDeserializer;
 impl VpnStateDeserializer {
     #[allow(unused_variables)]
@@ -41490,6 +45560,38 @@ impl VpnStaticRouteListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpnStaticRouteSource {
+    Static,
+}
+
+impl Into<String> for VpnStaticRouteSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpnStaticRouteSource {
+    fn into(self) -> &'static str {
+        match self {
+            VpnStaticRouteSource::Static => "Static",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpnStaticRouteSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Static" => Ok(VpnStaticRouteSource::Static),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpnStaticRouteSourceDeserializer;
 impl VpnStaticRouteSourceDeserializer {
     #[allow(unused_variables)]
@@ -57487,7 +61589,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57527,7 +61629,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57566,7 +61668,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57607,7 +61709,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57647,7 +61749,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57689,7 +61791,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -57715,7 +61817,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57757,7 +61859,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -57785,7 +61887,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57824,7 +61926,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57867,7 +61969,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57907,7 +62009,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57947,7 +62049,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -57989,7 +62091,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -58017,7 +62119,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58057,7 +62159,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58097,7 +62199,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58139,7 +62241,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -58165,7 +62267,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -58191,7 +62293,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58232,7 +62334,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58274,7 +62376,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -58301,7 +62403,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -58328,7 +62430,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58371,7 +62473,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58411,7 +62513,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58451,7 +62553,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58491,7 +62593,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58529,7 +62631,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58567,7 +62669,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58608,7 +62710,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58648,7 +62750,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58691,7 +62793,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58730,7 +62832,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58771,7 +62873,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58812,7 +62914,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58851,7 +62953,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58891,7 +62993,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58929,7 +63031,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -58968,7 +63070,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59010,7 +63112,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59052,7 +63154,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59080,7 +63182,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59120,7 +63222,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59148,7 +63250,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59187,7 +63289,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59225,7 +63327,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59267,7 +63369,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59309,7 +63411,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59350,7 +63452,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59389,7 +63491,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59427,7 +63529,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59449,7 +63551,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59486,7 +63588,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59524,7 +63626,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59567,7 +63669,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59606,7 +63708,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59648,7 +63750,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59674,7 +63776,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59716,7 +63818,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59743,7 +63845,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59771,7 +63873,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59810,7 +63912,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59851,7 +63953,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59876,7 +63978,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59902,7 +64004,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -59944,7 +64046,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59971,7 +64073,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -59998,7 +64100,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60025,7 +64127,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60050,7 +64152,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60074,7 +64176,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60101,7 +64203,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60126,7 +64228,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60153,7 +64255,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60177,7 +64279,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60201,7 +64303,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60223,7 +64325,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60247,7 +64349,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60271,7 +64373,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60314,7 +64416,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60353,7 +64455,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60380,7 +64482,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60406,7 +64508,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60431,7 +64533,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -60459,7 +64561,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60498,7 +64600,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60541,7 +64643,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60580,7 +64682,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60623,7 +64725,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60663,7 +64765,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60703,7 +64805,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60742,7 +64844,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60786,7 +64888,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60825,7 +64927,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60867,7 +64969,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60909,7 +65011,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60952,7 +65054,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -60992,7 +65094,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61031,7 +65133,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61069,7 +65171,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61108,7 +65210,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61151,7 +65253,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61190,7 +65292,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61231,7 +65333,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61273,7 +65375,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61313,7 +65415,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61352,7 +65454,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61393,7 +65495,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61433,7 +65535,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61476,7 +65578,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61515,7 +65617,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61558,7 +65660,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61597,7 +65699,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61639,7 +65741,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61682,7 +65784,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61722,7 +65824,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61762,7 +65864,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61801,7 +65903,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61843,7 +65945,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61885,7 +65987,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61925,7 +66027,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -61962,7 +66064,7 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62003,7 +66105,7 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62042,7 +66144,7 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62082,7 +66184,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62122,7 +66224,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62162,7 +66264,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62202,7 +66304,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62243,7 +66345,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62282,7 +66384,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62325,7 +66427,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62365,7 +66467,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62405,7 +66507,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62445,7 +66547,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62485,7 +66587,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62525,7 +66627,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62565,7 +66667,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62604,7 +66706,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62645,7 +66747,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62686,7 +66788,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62725,7 +66827,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62767,7 +66869,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62809,7 +66911,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62848,7 +66950,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62891,7 +66993,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62932,7 +67034,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -62972,7 +67074,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63011,7 +67113,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63054,7 +67156,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63093,7 +67195,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63134,7 +67236,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63174,7 +67276,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63216,7 +67318,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63258,7 +67360,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63285,7 +67387,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63312,7 +67414,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63352,7 +67454,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63379,7 +67481,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63406,7 +67508,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63447,7 +67549,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63486,7 +67588,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63514,7 +67616,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63553,7 +67655,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63581,7 +67683,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63621,7 +67723,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63660,7 +67762,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63684,7 +67786,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63711,7 +67813,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63754,7 +67856,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63793,7 +67895,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63835,7 +67937,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63878,7 +67980,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63917,7 +68019,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63959,7 +68061,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -63998,7 +68100,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64036,7 +68138,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64077,7 +68179,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64117,7 +68219,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64158,7 +68260,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64198,7 +68300,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64234,7 +68336,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64261,7 +68363,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64288,7 +68390,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64315,7 +68417,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64342,7 +68444,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64381,7 +68483,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64408,7 +68510,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64447,7 +68549,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64474,7 +68576,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64514,7 +68616,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64541,7 +68643,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64581,7 +68683,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64608,7 +68710,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64635,7 +68737,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64678,7 +68780,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64717,7 +68819,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64759,7 +68861,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64802,7 +68904,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64842,7 +68944,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64882,7 +68984,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64919,7 +69021,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64946,7 +69048,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -64987,7 +69089,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65024,7 +69126,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65051,7 +69153,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65093,7 +69195,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65133,7 +69235,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65172,7 +69274,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65197,7 +69299,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65224,7 +69326,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65263,7 +69365,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65290,7 +69392,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65332,7 +69434,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65374,7 +69476,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65401,7 +69503,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65428,7 +69530,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65454,7 +69556,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65482,7 +69584,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65521,7 +69623,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65547,7 +69649,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65571,7 +69673,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65612,7 +69714,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65652,7 +69754,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65693,7 +69795,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65733,7 +69835,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65776,7 +69878,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -65816,7 +69918,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -65842,7 +69944,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -444,6 +440,50 @@ pub struct ImageFailure {
     pub image_id: Option<ImageIdentifier>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageFailureCode {
+    ImageNotFound,
+    ImageTagDoesNotMatchDigest,
+    InvalidImageDigest,
+    InvalidImageTag,
+    MissingDigestAndTag,
+}
+
+impl Into<String> for ImageFailureCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageFailureCode {
+    fn into(self) -> &'static str {
+        match self {
+            ImageFailureCode::ImageNotFound => "ImageNotFound",
+            ImageFailureCode::ImageTagDoesNotMatchDigest => "ImageTagDoesNotMatchDigest",
+            ImageFailureCode::InvalidImageDigest => "InvalidImageDigest",
+            ImageFailureCode::InvalidImageTag => "InvalidImageTag",
+            ImageFailureCode::MissingDigestAndTag => "MissingDigestAndTag",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageFailureCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ImageNotFound" => Ok(ImageFailureCode::ImageNotFound),
+            "ImageTagDoesNotMatchDigest" => Ok(ImageFailureCode::ImageTagDoesNotMatchDigest),
+            "InvalidImageDigest" => Ok(ImageFailureCode::InvalidImageDigest),
+            "InvalidImageTag" => Ok(ImageFailureCode::InvalidImageTag),
+            "MissingDigestAndTag" => Ok(ImageFailureCode::MissingDigestAndTag),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object with identifying information for an Amazon ECR image.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImageIdentifier {
@@ -501,6 +541,41 @@ pub struct Layer {
     pub media_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LayerAvailability {
+    Available,
+    Unavailable,
+}
+
+impl Into<String> for LayerAvailability {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LayerAvailability {
+    fn into(self) -> &'static str {
+        match self {
+            LayerAvailability::Available => "AVAILABLE",
+            LayerAvailability::Unavailable => "UNAVAILABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LayerAvailability {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(LayerAvailability::Available),
+            "UNAVAILABLE" => Ok(LayerAvailability::Unavailable),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object representing an Amazon ECR image layer failure.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct LayerFailure {
@@ -516,6 +591,41 @@ pub struct LayerFailure {
     #[serde(rename="layerDigest")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub layer_digest: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LayerFailureCode {
+    InvalidLayerDigest,
+    MissingLayerDigest,
+}
+
+impl Into<String> for LayerFailureCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LayerFailureCode {
+    fn into(self) -> &'static str {
+        match self {
+            LayerFailureCode::InvalidLayerDigest => "InvalidLayerDigest",
+            LayerFailureCode::MissingLayerDigest => "MissingLayerDigest",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LayerFailureCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InvalidLayerDigest" => Ok(LayerFailureCode::InvalidLayerDigest),
+            "MissingLayerDigest" => Ok(LayerFailureCode::MissingLayerDigest),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An object representing a filter on a <a>ListImages</a> operation.</p>"]
@@ -645,6 +755,41 @@ pub struct SetRepositoryPolicyResponse {
     #[serde(rename="repositoryName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub repository_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TagStatus {
+    Tagged,
+    Untagged,
+}
+
+impl Into<String> for TagStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TagStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TagStatus::Tagged => "TAGGED",
+            TagStatus::Untagged => "UNTAGGED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TagStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TAGGED" => Ok(TagStatus::Tagged),
+            "UNTAGGED" => Ok(TagStatus::Untagged),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2399,7 +2544,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchCheckLayerAvailabilityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(BatchCheckLayerAvailabilityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2424,7 +2569,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchDeleteImageResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2452,7 +2597,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchGetImageResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2479,7 +2624,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CompleteLayerUploadResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2507,7 +2652,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateRepositoryResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2535,7 +2680,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRepositoryResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2564,7 +2709,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRepositoryPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2592,7 +2737,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeImagesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2620,7 +2765,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeRepositoriesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2649,7 +2794,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetAuthorizationTokenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2678,7 +2823,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDownloadUrlForLayerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2706,7 +2851,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRepositoryPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2734,7 +2879,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<InitiateLayerUploadResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2762,7 +2907,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListImagesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListImagesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2785,7 +2930,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutImageResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(PutImageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2810,7 +2955,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SetRepositoryPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2838,7 +2983,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UploadLayerPartResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -11,21 +11,64 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AgentUpdateStatus {
+    Failed,
+    Pending,
+    Staged,
+    Staging,
+    Updated,
+    Updating,
+}
+
+impl Into<String> for AgentUpdateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AgentUpdateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AgentUpdateStatus::Failed => "FAILED",
+            AgentUpdateStatus::Pending => "PENDING",
+            AgentUpdateStatus::Staged => "STAGED",
+            AgentUpdateStatus::Staging => "STAGING",
+            AgentUpdateStatus::Updated => "UPDATED",
+            AgentUpdateStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AgentUpdateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(AgentUpdateStatus::Failed),
+            "PENDING" => Ok(AgentUpdateStatus::Pending),
+            "STAGED" => Ok(AgentUpdateStatus::Staged),
+            "STAGING" => Ok(AgentUpdateStatus::Staging),
+            "UPDATED" => Ok(AgentUpdateStatus::Updated),
+            "UPDATING" => Ok(AgentUpdateStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An attribute is a name-value pair associated with an Amazon ECS object. Attributes enable you to extend the Amazon ECS data model by adding custom metadata to your resources. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes\">Attributes</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Attribute {
@@ -276,6 +319,41 @@ pub struct ContainerInstance {
     #[serde(rename="versionInfo")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub version_info: Option<VersionInfo>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContainerInstanceStatus {
+    Active,
+    Draining,
+}
+
+impl Into<String> for ContainerInstanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContainerInstanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ContainerInstanceStatus::Active => "ACTIVE",
+            ContainerInstanceStatus::Draining => "DRAINING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContainerInstanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ContainerInstanceStatus::Active),
+            "DRAINING" => Ok(ContainerInstanceStatus::Draining),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The overrides that should be sent to a container.</p>"]
@@ -615,6 +693,44 @@ pub struct DescribeTasksResponse {
     #[serde(rename="tasks")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tasks: Option<Vec<Task>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DesiredStatus {
+    Pending,
+    Running,
+    Stopped,
+}
+
+impl Into<String> for DesiredStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DesiredStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DesiredStatus::Pending => "PENDING",
+            DesiredStatus::Running => "RUNNING",
+            DesiredStatus::Stopped => "STOPPED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DesiredStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PENDING" => Ok(DesiredStatus::Pending),
+            "RUNNING" => Ok(DesiredStatus::Running),
+            "STOPPED" => Ok(DesiredStatus::Stopped),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -963,6 +1079,56 @@ pub struct LogConfiguration {
     pub options: Option<::std::collections::HashMap<String, String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LogDriver {
+    Awslogs,
+    Fluentd,
+    Gelf,
+    Journald,
+    JsonFile,
+    Splunk,
+    Syslog,
+}
+
+impl Into<String> for LogDriver {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LogDriver {
+    fn into(self) -> &'static str {
+        match self {
+            LogDriver::Awslogs => "awslogs",
+            LogDriver::Fluentd => "fluentd",
+            LogDriver::Gelf => "gelf",
+            LogDriver::Journald => "journald",
+            LogDriver::JsonFile => "json-file",
+            LogDriver::Splunk => "splunk",
+            LogDriver::Syslog => "syslog",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LogDriver {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "awslogs" => Ok(LogDriver::Awslogs),
+            "fluentd" => Ok(LogDriver::Fluentd),
+            "gelf" => Ok(LogDriver::Gelf),
+            "journald" => Ok(LogDriver::Journald),
+            "json-file" => Ok(LogDriver::JsonFile),
+            "splunk" => Ok(LogDriver::Splunk),
+            "syslog" => Ok(LogDriver::Syslog),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Details on a volume mount point that is used in a container definition.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MountPoint {
@@ -1001,6 +1167,44 @@ pub struct NetworkBinding {
     pub protocol: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkMode {
+    Bridge,
+    Host,
+    None,
+}
+
+impl Into<String> for NetworkMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkMode {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkMode::Bridge => "bridge",
+            NetworkMode::Host => "host",
+            NetworkMode::None => "none",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bridge" => Ok(NetworkMode::Bridge),
+            "host" => Ok(NetworkMode::Host),
+            "none" => Ok(NetworkMode::None),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object representing a constraint on task placement. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html\">Task Placement Constraints</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlacementConstraint {
@@ -1014,6 +1218,41 @@ pub struct PlacementConstraint {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlacementConstraintType {
+    DistinctInstance,
+    MemberOf,
+}
+
+impl Into<String> for PlacementConstraintType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlacementConstraintType {
+    fn into(self) -> &'static str {
+        match self {
+            PlacementConstraintType::DistinctInstance => "distinctInstance",
+            PlacementConstraintType::MemberOf => "memberOf",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlacementConstraintType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "distinctInstance" => Ok(PlacementConstraintType::DistinctInstance),
+            "memberOf" => Ok(PlacementConstraintType::MemberOf),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The task placement strategy for a task or service. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html\">Task Placement Strategies</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlacementStrategy {
@@ -1025,6 +1264,44 @@ pub struct PlacementStrategy {
     #[serde(rename="type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlacementStrategyType {
+    Binpack,
+    Random,
+    Spread,
+}
+
+impl Into<String> for PlacementStrategyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlacementStrategyType {
+    fn into(self) -> &'static str {
+        match self {
+            PlacementStrategyType::Binpack => "binpack",
+            PlacementStrategyType::Random => "random",
+            PlacementStrategyType::Spread => "spread",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlacementStrategyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "binpack" => Ok(PlacementStrategyType::Binpack),
+            "random" => Ok(PlacementStrategyType::Random),
+            "spread" => Ok(PlacementStrategyType::Spread),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Port mappings allow containers to access ports on the host container instance to send or receive traffic. Port mappings are specified as part of the container definition. After a task reaches the <code>RUNNING</code> status, manual and automatic host and container port assignments are visible in the <code>networkBindings</code> section of <a>DescribeTasks</a> API responses.</p>"]
@@ -1299,6 +1576,41 @@ pub struct ServiceEvent {
     pub message: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrder {
+    Asc,
+    Desc,
+}
+
+impl Into<String> for SortOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrder {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrder::Asc => "ASC",
+            SortOrder::Desc => "DESC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASC" => Ok(SortOrder::Asc),
+            "DESC" => Ok(SortOrder::Desc),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartTaskRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster on which to start your task. If you do not specify a cluster, the default cluster is assumed.</p>"]
@@ -1428,6 +1740,38 @@ pub struct SubmitTaskStateChangeResponse {
     pub acknowledgment: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TargetType {
+    ContainerInstance,
+}
+
+impl Into<String> for TargetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TargetType {
+    fn into(self) -> &'static str {
+        match self {
+            TargetType::ContainerInstance => "container-instance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TargetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "container-instance" => Ok(TargetType::ContainerInstance),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Details on a task in a cluster.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Task {
@@ -1538,6 +1882,44 @@ pub struct TaskDefinition {
     pub volumes: Option<Vec<Volume>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaskDefinitionFamilyStatus {
+    Active,
+    All,
+    Inactive,
+}
+
+impl Into<String> for TaskDefinitionFamilyStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaskDefinitionFamilyStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TaskDefinitionFamilyStatus::Active => "ACTIVE",
+            TaskDefinitionFamilyStatus::All => "ALL",
+            TaskDefinitionFamilyStatus::Inactive => "INACTIVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaskDefinitionFamilyStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(TaskDefinitionFamilyStatus::Active),
+            "ALL" => Ok(TaskDefinitionFamilyStatus::All),
+            "INACTIVE" => Ok(TaskDefinitionFamilyStatus::Inactive),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object representing a constraint on task placement in the task definition. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html\">Task Placement Constraints</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TaskDefinitionPlacementConstraint {
@@ -1549,6 +1931,73 @@ pub struct TaskDefinitionPlacementConstraint {
     #[serde(rename="type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaskDefinitionPlacementConstraintType {
+    MemberOf,
+}
+
+impl Into<String> for TaskDefinitionPlacementConstraintType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaskDefinitionPlacementConstraintType {
+    fn into(self) -> &'static str {
+        match self {
+            TaskDefinitionPlacementConstraintType::MemberOf => "memberOf",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaskDefinitionPlacementConstraintType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "memberOf" => Ok(TaskDefinitionPlacementConstraintType::MemberOf),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaskDefinitionStatus {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for TaskDefinitionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaskDefinitionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TaskDefinitionStatus::Active => "ACTIVE",
+            TaskDefinitionStatus::Inactive => "INACTIVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaskDefinitionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(TaskDefinitionStatus::Active),
+            "INACTIVE" => Ok(TaskDefinitionStatus::Inactive),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The overrides associated with a task.</p>"]
@@ -1564,6 +2013,41 @@ pub struct TaskOverride {
     pub task_role_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TransportProtocol {
+    Tcp,
+    Udp,
+}
+
+impl Into<String> for TransportProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TransportProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            TransportProtocol::Tcp => "tcp",
+            TransportProtocol::Udp => "udp",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TransportProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tcp" => Ok(TransportProtocol::Tcp),
+            "udp" => Ok(TransportProtocol::Udp),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The <code>ulimit</code> settings to pass to the container.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Ulimit {
@@ -1576,6 +2060,80 @@ pub struct Ulimit {
     #[doc="<p>The soft limit for the ulimit type.</p>"]
     #[serde(rename="softLimit")]
     pub soft_limit: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UlimitName {
+    Core,
+    Cpu,
+    Data,
+    Fsize,
+    Locks,
+    Memlock,
+    Msgqueue,
+    Nice,
+    Nofile,
+    Nproc,
+    Rss,
+    Rtprio,
+    Rttime,
+    Sigpending,
+    Stack,
+}
+
+impl Into<String> for UlimitName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UlimitName {
+    fn into(self) -> &'static str {
+        match self {
+            UlimitName::Core => "core",
+            UlimitName::Cpu => "cpu",
+            UlimitName::Data => "data",
+            UlimitName::Fsize => "fsize",
+            UlimitName::Locks => "locks",
+            UlimitName::Memlock => "memlock",
+            UlimitName::Msgqueue => "msgqueue",
+            UlimitName::Nice => "nice",
+            UlimitName::Nofile => "nofile",
+            UlimitName::Nproc => "nproc",
+            UlimitName::Rss => "rss",
+            UlimitName::Rtprio => "rtprio",
+            UlimitName::Rttime => "rttime",
+            UlimitName::Sigpending => "sigpending",
+            UlimitName::Stack => "stack",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UlimitName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "core" => Ok(UlimitName::Core),
+            "cpu" => Ok(UlimitName::Cpu),
+            "data" => Ok(UlimitName::Data),
+            "fsize" => Ok(UlimitName::Fsize),
+            "locks" => Ok(UlimitName::Locks),
+            "memlock" => Ok(UlimitName::Memlock),
+            "msgqueue" => Ok(UlimitName::Msgqueue),
+            "nice" => Ok(UlimitName::Nice),
+            "nofile" => Ok(UlimitName::Nofile),
+            "nproc" => Ok(UlimitName::Nproc),
+            "rss" => Ok(UlimitName::Rss),
+            "rtprio" => Ok(UlimitName::Rtprio),
+            "rttime" => Ok(UlimitName::Rttime),
+            "sigpending" => Ok(UlimitName::Sigpending),
+            "stack" => Ok(UlimitName::Stack),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -4673,7 +5231,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateClusterResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4700,7 +5258,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateServiceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4727,7 +5285,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4755,7 +5313,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteClusterResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4782,7 +5340,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteServiceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4810,7 +5368,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeregisterContainerInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeregisterContainerInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4836,7 +5394,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeregisterTaskDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeregisterTaskDefinitionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4861,7 +5419,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeClustersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4890,7 +5448,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeContainerInstancesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeContainerInstancesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4915,7 +5473,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeServicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4944,7 +5502,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTaskDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4972,7 +5530,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTasksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5000,7 +5558,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DiscoverPollEndpointResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5028,7 +5586,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5056,7 +5614,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListClustersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5084,7 +5642,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListContainerInstancesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5112,7 +5670,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListServicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5140,7 +5698,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTaskDefinitionFamiliesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListTaskDefinitionFamiliesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5165,7 +5723,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTaskDefinitionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5191,7 +5749,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTasksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5216,7 +5774,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5244,7 +5802,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterContainerInstanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RegisterContainerInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5270,7 +5828,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterTaskDefinitionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5295,7 +5853,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<RunTaskResponse>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -5320,7 +5878,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StartTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5343,7 +5901,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StopTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5369,7 +5927,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SubmitContainerStateChangeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(SubmitContainerStateChangeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5395,7 +5953,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SubmitTaskStateChangeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5424,7 +5982,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateContainerAgentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5453,7 +6011,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateContainerInstancesStateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateContainerInstancesStateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5478,7 +6036,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateServiceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -37,6 +32,41 @@ enum DeserializerNext {
     Skip,
     Element(String),
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AZMode {
+    CrossAz,
+    SingleAz,
+}
+
+impl Into<String> for AZMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AZMode {
+    fn into(self) -> &'static str {
+        match self {
+            AZMode::CrossAz => "cross-az",
+            AZMode::SingleAz => "single-az",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AZMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cross-az" => Ok(AZMode::CrossAz),
+            "single-az" => Ok(AZMode::SingleAz),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of an AddTagsToResource operation.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct AddTagsToResourceMessage {
@@ -195,6 +225,47 @@ impl AuthorizeCacheSecurityGroupIngressResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutomaticFailoverStatus {
+    Disabled,
+    Disabling,
+    Enabled,
+    Enabling,
+}
+
+impl Into<String> for AutomaticFailoverStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutomaticFailoverStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AutomaticFailoverStatus::Disabled => "disabled",
+            AutomaticFailoverStatus::Disabling => "disabling",
+            AutomaticFailoverStatus::Enabled => "enabled",
+            AutomaticFailoverStatus::Enabling => "enabling",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutomaticFailoverStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(AutomaticFailoverStatus::Disabled),
+            "disabling" => Ok(AutomaticFailoverStatus::Disabling),
+            "enabled" => Ok(AutomaticFailoverStatus::Enabled),
+            "enabling" => Ok(AutomaticFailoverStatus::Enabling),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AutomaticFailoverStatusDeserializer;
 impl AutomaticFailoverStatusDeserializer {
     #[allow(unused_variables)]
@@ -317,7 +388,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -331,7 +402,7 @@ impl BooleanOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1990,6 +2061,41 @@ impl CacheSubnetGroupsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeType {
+    Immediate,
+    RequiresReboot,
+}
+
+impl Into<String> for ChangeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeType {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeType::Immediate => "immediate",
+            ChangeType::RequiresReboot => "requires-reboot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "immediate" => Ok(ChangeType::Immediate),
+            "requires-reboot" => Ok(ChangeType::RequiresReboot),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeTypeDeserializer;
 impl ChangeTypeDeserializer {
     #[allow(unused_variables)]
@@ -3815,7 +3921,7 @@ impl DoubleDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4220,7 +4326,7 @@ impl IntegerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4234,7 +4340,7 @@ impl IntegerOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5515,6 +5621,41 @@ impl ParametersListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PendingAutomaticFailoverStatus {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for PendingAutomaticFailoverStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PendingAutomaticFailoverStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PendingAutomaticFailoverStatus::Disabled => "disabled",
+            PendingAutomaticFailoverStatus::Enabled => "enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PendingAutomaticFailoverStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(PendingAutomaticFailoverStatus::Disabled),
+            "enabled" => Ok(PendingAutomaticFailoverStatus::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PendingAutomaticFailoverStatusDeserializer;
 impl PendingAutomaticFailoverStatusDeserializer {
     #[allow(unused_variables)]
@@ -7071,6 +7212,50 @@ impl SnapshotListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    CacheCluster,
+    CacheParameterGroup,
+    CacheSecurityGroup,
+    CacheSubnetGroup,
+    ReplicationGroup,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::CacheCluster => "cache-cluster",
+            SourceType::CacheParameterGroup => "cache-parameter-group",
+            SourceType::CacheSecurityGroup => "cache-security-group",
+            SourceType::CacheSubnetGroup => "cache-subnet-group",
+            SourceType::ReplicationGroup => "replication-group",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cache-cluster" => Ok(SourceType::CacheCluster),
+            "cache-parameter-group" => Ok(SourceType::CacheParameterGroup),
+            "cache-security-group" => Ok(SourceType::CacheSecurityGroup),
+            "cache-subnet-group" => Ok(SourceType::CacheSubnetGroup),
+            "replication-group" => Ok(SourceType::ReplicationGroup),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -11056,7 +11241,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11102,7 +11287,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11144,7 +11329,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11187,7 +11372,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11232,7 +11417,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11277,7 +11462,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11322,7 +11507,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11368,7 +11553,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11413,7 +11598,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11457,7 +11642,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11501,7 +11686,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11527,7 +11712,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11553,7 +11738,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11581,7 +11766,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11626,7 +11811,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11670,7 +11855,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11715,7 +11900,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11759,7 +11944,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11803,7 +11988,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11847,7 +12032,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11891,7 +12076,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11935,7 +12120,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11977,7 +12162,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12022,7 +12207,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12066,7 +12251,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12110,7 +12295,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12152,7 +12337,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12198,7 +12383,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12240,7 +12425,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12284,7 +12469,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12329,7 +12514,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12374,7 +12559,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12420,7 +12605,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12467,7 +12652,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12509,7 +12694,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12553,7 +12738,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12598,7 +12783,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12643,7 +12828,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12685,7 +12870,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -87,13 +82,51 @@ impl AbortableOperationInProgressDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionHistoryStatus {
+    Completed,
+    Failed,
+    Unknown,
+}
+
+impl Into<String> for ActionHistoryStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionHistoryStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ActionHistoryStatus::Completed => "Completed",
+            ActionHistoryStatus::Failed => "Failed",
+            ActionHistoryStatus::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionHistoryStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Completed" => Ok(ActionHistoryStatus::Completed),
+            "Failed" => Ok(ActionHistoryStatus::Failed),
+            "Unknown" => Ok(ActionHistoryStatus::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ActionHistoryStatusDeserializer;
 impl ActionHistoryStatusDeserializer {
     #[allow(unused_variables)]
@@ -108,6 +141,47 @@ impl ActionHistoryStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionStatus {
+    Pending,
+    Running,
+    Scheduled,
+    Unknown,
+}
+
+impl Into<String> for ActionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ActionStatus::Pending => "Pending",
+            ActionStatus::Running => "Running",
+            ActionStatus::Scheduled => "Scheduled",
+            ActionStatus::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(ActionStatus::Pending),
+            "Running" => Ok(ActionStatus::Running),
+            "Scheduled" => Ok(ActionStatus::Scheduled),
+            "Unknown" => Ok(ActionStatus::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ActionStatusDeserializer;
 impl ActionStatusDeserializer {
     #[allow(unused_variables)]
@@ -122,6 +196,44 @@ impl ActionStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionType {
+    InstanceRefresh,
+    PlatformUpdate,
+    Unknown,
+}
+
+impl Into<String> for ActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionType {
+    fn into(self) -> &'static str {
+        match self {
+            ActionType::InstanceRefresh => "InstanceRefresh",
+            ActionType::PlatformUpdate => "PlatformUpdate",
+            ActionType::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InstanceRefresh" => Ok(ActionType::InstanceRefresh),
+            "PlatformUpdate" => Ok(ActionType::PlatformUpdate),
+            "Unknown" => Ok(ActionType::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ActionTypeDeserializer;
 impl ActionTypeDeserializer {
     #[allow(unused_variables)]
@@ -925,6 +1037,50 @@ impl ApplicationVersionLifecycleConfigSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApplicationVersionStatus {
+    Building,
+    Failed,
+    Processed,
+    Processing,
+    Unprocessed,
+}
+
+impl Into<String> for ApplicationVersionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApplicationVersionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ApplicationVersionStatus::Building => "Building",
+            ApplicationVersionStatus::Failed => "Failed",
+            ApplicationVersionStatus::Processed => "Processed",
+            ApplicationVersionStatus::Processing => "Processing",
+            ApplicationVersionStatus::Unprocessed => "Unprocessed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApplicationVersionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Building" => Ok(ApplicationVersionStatus::Building),
+            "Failed" => Ok(ApplicationVersionStatus::Failed),
+            "Processed" => Ok(ApplicationVersionStatus::Processed),
+            "Processing" => Ok(ApplicationVersionStatus::Processing),
+            "Unprocessed" => Ok(ApplicationVersionStatus::Unprocessed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ApplicationVersionStatusDeserializer;
 impl ApplicationVersionStatusDeserializer {
     #[allow(unused_variables)]
@@ -1221,7 +1377,7 @@ impl BoxedBooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1235,7 +1391,7 @@ impl BoxedIntDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1561,7 +1717,7 @@ impl CnameAvailabilityDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1601,6 +1757,82 @@ impl ComposeEnvironmentsMessageSerializer {
                                                field_value);
         }
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComputeType {
+    BuildGeneral1Large,
+    BuildGeneral1Medium,
+    BuildGeneral1Small,
+}
+
+impl Into<String> for ComputeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComputeType {
+    fn into(self) -> &'static str {
+        match self {
+            ComputeType::BuildGeneral1Large => "BUILD_GENERAL1_LARGE",
+            ComputeType::BuildGeneral1Medium => "BUILD_GENERAL1_MEDIUM",
+            ComputeType::BuildGeneral1Small => "BUILD_GENERAL1_SMALL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComputeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BUILD_GENERAL1_LARGE" => Ok(ComputeType::BuildGeneral1Large),
+            "BUILD_GENERAL1_MEDIUM" => Ok(ComputeType::BuildGeneral1Medium),
+            "BUILD_GENERAL1_SMALL" => Ok(ComputeType::BuildGeneral1Small),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigurationDeploymentStatus {
+    Deployed,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for ConfigurationDeploymentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigurationDeploymentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigurationDeploymentStatus::Deployed => "deployed",
+            ConfigurationDeploymentStatus::Failed => "failed",
+            ConfigurationDeploymentStatus::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigurationDeploymentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "deployed" => Ok(ConfigurationDeploymentStatus::Deployed),
+            "failed" => Ok(ConfigurationDeploymentStatus::Failed),
+            "pending" => Ok(ConfigurationDeploymentStatus::Pending),
+            _ => Err(()),
+        }
     }
 }
 
@@ -2027,6 +2259,41 @@ impl ConfigurationOptionValueDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigurationOptionValueType {
+    List,
+    Scalar,
+}
+
+impl Into<String> for ConfigurationOptionValueType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigurationOptionValueType {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigurationOptionValueType::List => "List",
+            ConfigurationOptionValueType::Scalar => "Scalar",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigurationOptionValueType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "List" => Ok(ConfigurationOptionValueType::List),
+            "Scalar" => Ok(ConfigurationOptionValueType::Scalar),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ConfigurationOptionValueTypeDeserializer;
 impl ConfigurationOptionValueTypeDeserializer {
     #[allow(unused_variables)]
@@ -4322,6 +4589,47 @@ impl EnvironmentDescriptionsMessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentHealth {
+    Green,
+    Grey,
+    Red,
+    Yellow,
+}
+
+impl Into<String> for EnvironmentHealth {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentHealth {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentHealth::Green => "Green",
+            EnvironmentHealth::Grey => "Grey",
+            EnvironmentHealth::Red => "Red",
+            EnvironmentHealth::Yellow => "Yellow",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentHealth {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Green" => Ok(EnvironmentHealth::Green),
+            "Grey" => Ok(EnvironmentHealth::Grey),
+            "Red" => Ok(EnvironmentHealth::Red),
+            "Yellow" => Ok(EnvironmentHealth::Yellow),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EnvironmentHealthDeserializer;
 impl EnvironmentHealthDeserializer {
     #[allow(unused_variables)]
@@ -4337,6 +4645,59 @@ impl EnvironmentHealthDeserializer {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentHealthAttribute {
+    All,
+    ApplicationMetrics,
+    Causes,
+    Color,
+    HealthStatus,
+    InstancesHealth,
+    RefreshedAt,
+    Status,
+}
+
+impl Into<String> for EnvironmentHealthAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentHealthAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentHealthAttribute::All => "All",
+            EnvironmentHealthAttribute::ApplicationMetrics => "ApplicationMetrics",
+            EnvironmentHealthAttribute::Causes => "Causes",
+            EnvironmentHealthAttribute::Color => "Color",
+            EnvironmentHealthAttribute::HealthStatus => "HealthStatus",
+            EnvironmentHealthAttribute::InstancesHealth => "InstancesHealth",
+            EnvironmentHealthAttribute::RefreshedAt => "RefreshedAt",
+            EnvironmentHealthAttribute::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentHealthAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(EnvironmentHealthAttribute::All),
+            "ApplicationMetrics" => Ok(EnvironmentHealthAttribute::ApplicationMetrics),
+            "Causes" => Ok(EnvironmentHealthAttribute::Causes),
+            "Color" => Ok(EnvironmentHealthAttribute::Color),
+            "HealthStatus" => Ok(EnvironmentHealthAttribute::HealthStatus),
+            "InstancesHealth" => Ok(EnvironmentHealthAttribute::InstancesHealth),
+            "RefreshedAt" => Ok(EnvironmentHealthAttribute::RefreshedAt),
+            "Status" => Ok(EnvironmentHealthAttribute::Status),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `EnvironmentHealthAttributes` contents to a `SignedRequest`.
 struct EnvironmentHealthAttributesSerializer;
 impl EnvironmentHealthAttributesSerializer {
@@ -4344,6 +4705,59 @@ impl EnvironmentHealthAttributesSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentHealthStatus {
+    Degraded,
+    Info,
+    NoData,
+    Ok,
+    Pending,
+    Severe,
+    Unknown,
+    Warning,
+}
+
+impl Into<String> for EnvironmentHealthStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentHealthStatus {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentHealthStatus::Degraded => "Degraded",
+            EnvironmentHealthStatus::Info => "Info",
+            EnvironmentHealthStatus::NoData => "NoData",
+            EnvironmentHealthStatus::Ok => "Ok",
+            EnvironmentHealthStatus::Pending => "Pending",
+            EnvironmentHealthStatus::Severe => "Severe",
+            EnvironmentHealthStatus::Unknown => "Unknown",
+            EnvironmentHealthStatus::Warning => "Warning",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentHealthStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Degraded" => Ok(EnvironmentHealthStatus::Degraded),
+            "Info" => Ok(EnvironmentHealthStatus::Info),
+            "NoData" => Ok(EnvironmentHealthStatus::NoData),
+            "Ok" => Ok(EnvironmentHealthStatus::Ok),
+            "Pending" => Ok(EnvironmentHealthStatus::Pending),
+            "Severe" => Ok(EnvironmentHealthStatus::Severe),
+            "Unknown" => Ok(EnvironmentHealthStatus::Unknown),
+            "Warning" => Ok(EnvironmentHealthStatus::Warning),
+            _ => Err(()),
         }
     }
 }
@@ -4501,6 +4915,41 @@ impl EnvironmentInfoDescriptionListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentInfoType {
+    Bundle,
+    Tail,
+}
+
+impl Into<String> for EnvironmentInfoType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentInfoType {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentInfoType::Bundle => "bundle",
+            EnvironmentInfoType::Tail => "tail",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentInfoType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bundle" => Ok(EnvironmentInfoType::Bundle),
+            "tail" => Ok(EnvironmentInfoType::Tail),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EnvironmentInfoTypeDeserializer;
 impl EnvironmentInfoTypeDeserializer {
     #[allow(unused_variables)]
@@ -4828,6 +5277,50 @@ impl EnvironmentResourcesDescriptionDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentStatus {
+    Launching,
+    Ready,
+    Terminated,
+    Terminating,
+    Updating,
+}
+
+impl Into<String> for EnvironmentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentStatus::Launching => "Launching",
+            EnvironmentStatus::Ready => "Ready",
+            EnvironmentStatus::Terminated => "Terminated",
+            EnvironmentStatus::Terminating => "Terminating",
+            EnvironmentStatus::Updating => "Updating",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Launching" => Ok(EnvironmentStatus::Launching),
+            "Ready" => Ok(EnvironmentStatus::Ready),
+            "Terminated" => Ok(EnvironmentStatus::Terminated),
+            "Terminating" => Ok(EnvironmentStatus::Terminating),
+            "Updating" => Ok(EnvironmentStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EnvironmentStatusDeserializer;
 impl EnvironmentStatusDeserializer {
     #[allow(unused_variables)]
@@ -5150,6 +5643,53 @@ impl EventMessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventSeverity {
+    Debug,
+    Error,
+    Fatal,
+    Info,
+    Trace,
+    Warn,
+}
+
+impl Into<String> for EventSeverity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventSeverity {
+    fn into(self) -> &'static str {
+        match self {
+            EventSeverity::Debug => "DEBUG",
+            EventSeverity::Error => "ERROR",
+            EventSeverity::Fatal => "FATAL",
+            EventSeverity::Info => "INFO",
+            EventSeverity::Trace => "TRACE",
+            EventSeverity::Warn => "WARN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventSeverity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEBUG" => Ok(EventSeverity::Debug),
+            "ERROR" => Ok(EventSeverity::Error),
+            "FATAL" => Ok(EventSeverity::Fatal),
+            "INFO" => Ok(EventSeverity::Info),
+            "TRACE" => Ok(EventSeverity::Trace),
+            "WARN" => Ok(EventSeverity::Warn),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventSeverityDeserializer;
 impl EventSeverityDeserializer {
     #[allow(unused_variables)]
@@ -5164,6 +5704,56 @@ impl EventSeverityDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailureType {
+    CancellationFailed,
+    InternalFailure,
+    InvalidEnvironmentState,
+    PermissionsError,
+    RollbackFailed,
+    RollbackSuccessful,
+    UpdateCancelled,
+}
+
+impl Into<String> for FailureType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailureType {
+    fn into(self) -> &'static str {
+        match self {
+            FailureType::CancellationFailed => "CancellationFailed",
+            FailureType::InternalFailure => "InternalFailure",
+            FailureType::InvalidEnvironmentState => "InvalidEnvironmentState",
+            FailureType::PermissionsError => "PermissionsError",
+            FailureType::RollbackFailed => "RollbackFailed",
+            FailureType::RollbackSuccessful => "RollbackSuccessful",
+            FailureType::UpdateCancelled => "UpdateCancelled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailureType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CancellationFailed" => Ok(FailureType::CancellationFailed),
+            "InternalFailure" => Ok(FailureType::InternalFailure),
+            "InvalidEnvironmentState" => Ok(FailureType::InvalidEnvironmentState),
+            "PermissionsError" => Ok(FailureType::PermissionsError),
+            "RollbackFailed" => Ok(FailureType::RollbackFailed),
+            "RollbackSuccessful" => Ok(FailureType::RollbackSuccessful),
+            "UpdateCancelled" => Ok(FailureType::UpdateCancelled),
+            _ => Err(()),
+        }
+    }
+}
+
 struct FailureTypeDeserializer;
 impl FailureTypeDeserializer {
     #[allow(unused_variables)]
@@ -5449,6 +6039,68 @@ impl InstanceListDeserializer {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstancesHealthAttribute {
+    All,
+    ApplicationMetrics,
+    AvailabilityZone,
+    Causes,
+    Color,
+    Deployment,
+    HealthStatus,
+    InstanceType,
+    LaunchedAt,
+    RefreshedAt,
+    System,
+}
+
+impl Into<String> for InstancesHealthAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstancesHealthAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            InstancesHealthAttribute::All => "All",
+            InstancesHealthAttribute::ApplicationMetrics => "ApplicationMetrics",
+            InstancesHealthAttribute::AvailabilityZone => "AvailabilityZone",
+            InstancesHealthAttribute::Causes => "Causes",
+            InstancesHealthAttribute::Color => "Color",
+            InstancesHealthAttribute::Deployment => "Deployment",
+            InstancesHealthAttribute::HealthStatus => "HealthStatus",
+            InstancesHealthAttribute::InstanceType => "InstanceType",
+            InstancesHealthAttribute::LaunchedAt => "LaunchedAt",
+            InstancesHealthAttribute::RefreshedAt => "RefreshedAt",
+            InstancesHealthAttribute::System => "System",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstancesHealthAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(InstancesHealthAttribute::All),
+            "ApplicationMetrics" => Ok(InstancesHealthAttribute::ApplicationMetrics),
+            "AvailabilityZone" => Ok(InstancesHealthAttribute::AvailabilityZone),
+            "Causes" => Ok(InstancesHealthAttribute::Causes),
+            "Color" => Ok(InstancesHealthAttribute::Color),
+            "Deployment" => Ok(InstancesHealthAttribute::Deployment),
+            "HealthStatus" => Ok(InstancesHealthAttribute::HealthStatus),
+            "InstanceType" => Ok(InstancesHealthAttribute::InstanceType),
+            "LaunchedAt" => Ok(InstancesHealthAttribute::LaunchedAt),
+            "RefreshedAt" => Ok(InstancesHealthAttribute::RefreshedAt),
+            "System" => Ok(InstancesHealthAttribute::System),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `InstancesHealthAttributes` contents to a `SignedRequest`.
 struct InstancesHealthAttributesSerializer;
 impl InstancesHealthAttributesSerializer {
@@ -5467,7 +6119,7 @@ impl IntegerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5917,7 +6569,7 @@ impl LoadAverageValueDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6595,7 +7247,7 @@ impl NullableDoubleDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6609,7 +7261,7 @@ impl NullableIntegerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6623,7 +7275,7 @@ impl NullableLongDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6679,7 +7331,7 @@ impl OptionRestrictionMaxLengthDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6693,7 +7345,7 @@ impl OptionRestrictionMaxValueDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6707,7 +7359,7 @@ impl OptionRestrictionMinValueDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7288,6 +7940,50 @@ impl PlatformProgrammingLanguagesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformStatus {
+    Creating,
+    Deleted,
+    Deleting,
+    Failed,
+    Ready,
+}
+
+impl Into<String> for PlatformStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformStatus::Creating => "Creating",
+            PlatformStatus::Deleted => "Deleted",
+            PlatformStatus::Deleting => "Deleting",
+            PlatformStatus::Failed => "Failed",
+            PlatformStatus::Ready => "Ready",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Creating" => Ok(PlatformStatus::Creating),
+            "Deleted" => Ok(PlatformStatus::Deleted),
+            "Deleting" => Ok(PlatformStatus::Deleting),
+            "Failed" => Ok(PlatformStatus::Failed),
+            "Ready" => Ok(PlatformStatus::Ready),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PlatformStatusDeserializer;
 impl PlatformStatusDeserializer {
     #[allow(unused_variables)]
@@ -7628,7 +8324,7 @@ impl RequestCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -8276,6 +8972,41 @@ impl SourceLocationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceRepository {
+    CodeCommit,
+    S3,
+}
+
+impl Into<String> for SourceRepository {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceRepository {
+    fn into(self) -> &'static str {
+        match self {
+            SourceRepository::CodeCommit => "CodeCommit",
+            SourceRepository::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceRepository {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CodeCommit" => Ok(SourceRepository::CodeCommit),
+            "S3" => Ok(SourceRepository::S3),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceRepositoryDeserializer;
 impl SourceRepositoryDeserializer {
     #[allow(unused_variables)]
@@ -8290,6 +9021,41 @@ impl SourceRepositoryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    Git,
+    Zip,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::Git => "Git",
+            SourceType::Zip => "Zip",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Git" => Ok(SourceType::Git),
+            "Zip" => Ok(SourceType::Zip),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -9044,7 +9810,7 @@ impl UserDefinedOptionDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -9217,6 +9983,41 @@ impl ValidationMessagesListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ValidationSeverity {
+    Error,
+    Warning,
+}
+
+impl Into<String> for ValidationSeverity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ValidationSeverity {
+    fn into(self) -> &'static str {
+        match self {
+            ValidationSeverity::Error => "error",
+            ValidationSeverity::Warning => "warning",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ValidationSeverity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "error" => Ok(ValidationSeverity::Error),
+            "warning" => Ok(ValidationSeverity::Warning),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ValidationSeverityDeserializer;
 impl ValidationSeverityDeserializer {
     #[allow(unused_variables)]
@@ -12469,7 +13270,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12497,7 +13298,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12540,7 +13341,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12583,7 +13384,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12628,7 +13429,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12674,7 +13475,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12717,7 +13518,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12761,7 +13562,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12806,7 +13607,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12850,7 +13651,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12893,7 +13694,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12920,7 +13721,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12946,7 +13747,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12972,7 +13773,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12999,7 +13800,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13044,7 +13845,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13087,7 +13888,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13133,7 +13934,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13178,7 +13979,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13221,7 +14022,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13265,7 +14066,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13308,7 +14109,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13351,7 +14152,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13394,7 +14195,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13439,7 +14240,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13484,7 +14285,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13529,7 +14330,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13573,7 +14374,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13615,7 +14416,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13659,7 +14460,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13686,7 +14487,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13713,7 +14514,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13741,7 +14542,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13783,7 +14584,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13810,7 +14611,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13854,7 +14655,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13897,7 +14698,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13940,7 +14741,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -13983,7 +14784,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -14027,7 +14828,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -14072,7 +14873,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -3115,7 +3111,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body = response.body;
 
@@ -3155,7 +3151,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -3197,7 +3193,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -3242,7 +3238,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -3286,7 +3282,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body = response.body;
 
@@ -3331,7 +3327,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body = response.body;
 
@@ -3382,7 +3378,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3433,7 +3429,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3484,7 +3480,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3534,7 +3530,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3573,7 +3569,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3614,7 +3610,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3657,7 +3653,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3697,7 +3693,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3738,7 +3734,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3784,7 +3780,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -3828,7 +3824,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -140,7 +135,7 @@ impl AccessLogEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -154,7 +149,7 @@ impl AccessLogIntervalDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -196,7 +191,7 @@ impl AccessPointPortDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1121,7 +1116,7 @@ impl ConnectionDrainingEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1135,7 +1130,7 @@ impl ConnectionDrainingTimeoutDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1214,7 +1209,7 @@ impl CookieExpirationPeriodDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1637,7 +1632,7 @@ impl CrossZoneLoadBalancingEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2644,7 +2639,7 @@ impl HealthCheckIntervalDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2672,7 +2667,7 @@ impl HealthCheckTimeoutDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2686,7 +2681,7 @@ impl HealthyThresholdDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2700,7 +2695,7 @@ impl IdleTimeoutDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2795,7 +2790,7 @@ impl InstancePortDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5424,7 +5419,7 @@ impl UnhealthyThresholdDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7855,7 +7850,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7897,7 +7892,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7940,7 +7935,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -7982,7 +7977,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8027,7 +8022,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8070,7 +8065,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8112,7 +8107,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8157,7 +8152,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8202,7 +8197,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8246,7 +8241,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8291,7 +8286,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8336,7 +8331,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8381,7 +8376,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8425,7 +8420,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8470,7 +8465,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8515,7 +8510,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8558,7 +8553,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8601,7 +8596,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8644,7 +8639,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8688,7 +8683,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8732,7 +8727,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8775,7 +8770,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8820,7 +8815,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8864,7 +8859,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8907,7 +8902,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8948,7 +8943,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8987,7 +8982,7 @@ fn set_load_balancer_listener_ssl_certificate(&self, input: &SetLoadBalancerList
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9027,7 +9022,7 @@ fn set_load_balancer_policies_for_backend_server(&self, input: &SetLoadBalancerP
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9070,7 +9065,7 @@ fn set_load_balancer_policies_for_backend_server(&self, input: &SetLoadBalancerP
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -107,6 +102,38 @@ impl ActionSerializer {
                    &obj.target_group_arn);
         params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionTypeEnum {
+    Forward,
+}
+
+impl Into<String> for ActionTypeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionTypeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            ActionTypeEnum::Forward => "forward",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionTypeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "forward" => Ok(ActionTypeEnum::Forward),
+            _ => Err(()),
+        }
     }
 }
 
@@ -543,7 +570,7 @@ impl CipherPriorityDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2110,7 +2137,7 @@ impl HealthCheckIntervalSecondsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2138,7 +2165,7 @@ impl HealthCheckThresholdCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2152,7 +2179,7 @@ impl HealthCheckTimeoutSecondsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2173,6 +2200,41 @@ impl HttpCodeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IpAddressType {
+    Dualstack,
+    Ipv4,
+}
+
+impl Into<String> for IpAddressType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IpAddressType {
+    fn into(self) -> &'static str {
+        match self {
+            IpAddressType::Dualstack => "dualstack",
+            IpAddressType::Ipv4 => "ipv4",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IpAddressType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dualstack" => Ok(IpAddressType::Dualstack),
+            "ipv4" => Ok(IpAddressType::Ipv4),
+            _ => Err(()),
+        }
+    }
+}
+
 struct IpAddressTypeDeserializer;
 impl IpAddressTypeDeserializer {
     #[allow(unused_variables)]
@@ -2194,7 +2256,7 @@ impl IsDefaultDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2876,6 +2938,41 @@ impl LoadBalancerNamesSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoadBalancerSchemeEnum {
+    Internal,
+    InternetFacing,
+}
+
+impl Into<String> for LoadBalancerSchemeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoadBalancerSchemeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            LoadBalancerSchemeEnum::Internal => "internal",
+            LoadBalancerSchemeEnum::InternetFacing => "internet-facing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoadBalancerSchemeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "internal" => Ok(LoadBalancerSchemeEnum::Internal),
+            "internet-facing" => Ok(LoadBalancerSchemeEnum::InternetFacing),
+            _ => Err(()),
+        }
+    }
+}
+
 struct LoadBalancerSchemeEnumDeserializer;
 impl LoadBalancerSchemeEnumDeserializer {
     #[allow(unused_variables)]
@@ -2946,6 +3043,44 @@ impl LoadBalancerStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoadBalancerStateEnum {
+    Active,
+    Failed,
+    Provisioning,
+}
+
+impl Into<String> for LoadBalancerStateEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoadBalancerStateEnum {
+    fn into(self) -> &'static str {
+        match self {
+            LoadBalancerStateEnum::Active => "active",
+            LoadBalancerStateEnum::Failed => "failed",
+            LoadBalancerStateEnum::Provisioning => "provisioning",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoadBalancerStateEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(LoadBalancerStateEnum::Active),
+            "failed" => Ok(LoadBalancerStateEnum::Failed),
+            "provisioning" => Ok(LoadBalancerStateEnum::Provisioning),
+            _ => Err(()),
+        }
+    }
+}
+
 struct LoadBalancerStateEnumDeserializer;
 impl LoadBalancerStateEnumDeserializer {
     #[allow(unused_variables)]
@@ -2960,6 +3095,38 @@ impl LoadBalancerStateEnumDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoadBalancerTypeEnum {
+    Application,
+}
+
+impl Into<String> for LoadBalancerTypeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoadBalancerTypeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            LoadBalancerTypeEnum::Application => "application",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoadBalancerTypeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "application" => Ok(LoadBalancerTypeEnum::Application),
+            _ => Err(()),
+        }
+    }
+}
+
 struct LoadBalancerTypeEnumDeserializer;
 impl LoadBalancerTypeEnumDeserializer {
     #[allow(unused_variables)]
@@ -3590,13 +3757,48 @@ impl PortDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProtocolEnum {
+    Http,
+    Https,
+}
+
+impl Into<String> for ProtocolEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProtocolEnum {
+    fn into(self) -> &'static str {
+        match self {
+            ProtocolEnum::Http => "HTTP",
+            ProtocolEnum::Https => "HTTPS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProtocolEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HTTP" => Ok(ProtocolEnum::Http),
+            "HTTPS" => Ok(ProtocolEnum::Https),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ProtocolEnumDeserializer;
 impl ProtocolEnumDeserializer {
     #[allow(unused_variables)]
@@ -5546,6 +5748,69 @@ impl TargetHealthDescriptionsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TargetHealthReasonEnum {
+    ElbInitialHealthChecking,
+    ElbInternalError,
+    ElbRegistrationInProgress,
+    TargetDeregistrationInProgress,
+    TargetFailedHealthChecks,
+    TargetInvalidState,
+    TargetNotInUse,
+    TargetNotRegistered,
+    TargetResponseCodeMismatch,
+    TargetTimeout,
+}
+
+impl Into<String> for TargetHealthReasonEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TargetHealthReasonEnum {
+    fn into(self) -> &'static str {
+        match self {
+            TargetHealthReasonEnum::ElbInitialHealthChecking => "Elb.InitialHealthChecking",
+            TargetHealthReasonEnum::ElbInternalError => "Elb.InternalError",
+            TargetHealthReasonEnum::ElbRegistrationInProgress => "Elb.RegistrationInProgress",
+            TargetHealthReasonEnum::TargetDeregistrationInProgress => {
+                "Target.DeregistrationInProgress"
+            }
+            TargetHealthReasonEnum::TargetFailedHealthChecks => "Target.FailedHealthChecks",
+            TargetHealthReasonEnum::TargetInvalidState => "Target.InvalidState",
+            TargetHealthReasonEnum::TargetNotInUse => "Target.NotInUse",
+            TargetHealthReasonEnum::TargetNotRegistered => "Target.NotRegistered",
+            TargetHealthReasonEnum::TargetResponseCodeMismatch => "Target.ResponseCodeMismatch",
+            TargetHealthReasonEnum::TargetTimeout => "Target.Timeout",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TargetHealthReasonEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Elb.InitialHealthChecking" => Ok(TargetHealthReasonEnum::ElbInitialHealthChecking),
+            "Elb.InternalError" => Ok(TargetHealthReasonEnum::ElbInternalError),
+            "Elb.RegistrationInProgress" => Ok(TargetHealthReasonEnum::ElbRegistrationInProgress),
+            "Target.DeregistrationInProgress" => {
+                Ok(TargetHealthReasonEnum::TargetDeregistrationInProgress)
+            }
+            "Target.FailedHealthChecks" => Ok(TargetHealthReasonEnum::TargetFailedHealthChecks),
+            "Target.InvalidState" => Ok(TargetHealthReasonEnum::TargetInvalidState),
+            "Target.NotInUse" => Ok(TargetHealthReasonEnum::TargetNotInUse),
+            "Target.NotRegistered" => Ok(TargetHealthReasonEnum::TargetNotRegistered),
+            "Target.ResponseCodeMismatch" => Ok(TargetHealthReasonEnum::TargetResponseCodeMismatch),
+            "Target.Timeout" => Ok(TargetHealthReasonEnum::TargetTimeout),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TargetHealthReasonEnumDeserializer;
 impl TargetHealthReasonEnumDeserializer {
     #[allow(unused_variables)]
@@ -5560,6 +5825,50 @@ impl TargetHealthReasonEnumDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TargetHealthStateEnum {
+    Draining,
+    Healthy,
+    Initial,
+    Unhealthy,
+    Unused,
+}
+
+impl Into<String> for TargetHealthStateEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TargetHealthStateEnum {
+    fn into(self) -> &'static str {
+        match self {
+            TargetHealthStateEnum::Draining => "draining",
+            TargetHealthStateEnum::Healthy => "healthy",
+            TargetHealthStateEnum::Initial => "initial",
+            TargetHealthStateEnum::Unhealthy => "unhealthy",
+            TargetHealthStateEnum::Unused => "unused",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TargetHealthStateEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "draining" => Ok(TargetHealthStateEnum::Draining),
+            "healthy" => Ok(TargetHealthStateEnum::Healthy),
+            "initial" => Ok(TargetHealthStateEnum::Initial),
+            "unhealthy" => Ok(TargetHealthStateEnum::Unhealthy),
+            "unused" => Ok(TargetHealthStateEnum::Unused),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TargetHealthStateEnumDeserializer;
 impl TargetHealthStateEnumDeserializer {
     #[allow(unused_variables)]
@@ -8327,7 +8636,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8368,7 +8677,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8412,7 +8721,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8454,7 +8763,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8495,7 +8804,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8539,7 +8848,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8583,7 +8892,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8625,7 +8934,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8666,7 +8975,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8710,7 +9019,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8755,7 +9064,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8799,7 +9108,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8844,7 +9153,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8887,7 +9196,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8931,7 +9240,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -8974,7 +9283,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9018,7 +9327,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9062,7 +9371,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9104,7 +9413,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9148,7 +9457,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9192,7 +9501,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9237,7 +9546,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9277,7 +9586,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9318,7 +9627,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9363,7 +9672,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9405,7 +9714,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9447,7 +9756,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9488,7 +9797,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9532,7 +9841,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9576,7 +9885,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -9618,7 +9927,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -11,21 +11,58 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionOnFailure {
+    CancelAndWait,
+    Continue,
+    TerminateCluster,
+    TerminateJobFlow,
+}
+
+impl Into<String> for ActionOnFailure {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionOnFailure {
+    fn into(self) -> &'static str {
+        match self {
+            ActionOnFailure::CancelAndWait => "CANCEL_AND_WAIT",
+            ActionOnFailure::Continue => "CONTINUE",
+            ActionOnFailure::TerminateCluster => "TERMINATE_CLUSTER",
+            ActionOnFailure::TerminateJobFlow => "TERMINATE_JOB_FLOW",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionOnFailure {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCEL_AND_WAIT" => Ok(ActionOnFailure::CancelAndWait),
+            "CONTINUE" => Ok(ActionOnFailure::Continue),
+            "TERMINATE_CLUSTER" => Ok(ActionOnFailure::TerminateCluster),
+            "TERMINATE_JOB_FLOW" => Ok(ActionOnFailure::TerminateJobFlow),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AddInstanceFleetInput {
     #[doc="<p>The unique identifier of the cluster.</p>"]
@@ -107,6 +144,44 @@ pub struct AddTagsInput {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AddTagsOutput;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AdjustmentType {
+    ChangeInCapacity,
+    ExactCapacity,
+    PercentChangeInCapacity,
+}
+
+impl Into<String> for AdjustmentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AdjustmentType {
+    fn into(self) -> &'static str {
+        match self {
+            AdjustmentType::ChangeInCapacity => "CHANGE_IN_CAPACITY",
+            AdjustmentType::ExactCapacity => "EXACT_CAPACITY",
+            AdjustmentType::PercentChangeInCapacity => "PERCENT_CHANGE_IN_CAPACITY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AdjustmentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHANGE_IN_CAPACITY" => Ok(AdjustmentType::ChangeInCapacity),
+            "EXACT_CAPACITY" => Ok(AdjustmentType::ExactCapacity),
+            "PERCENT_CHANGE_IN_CAPACITY" => Ok(AdjustmentType::PercentChangeInCapacity),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An application is any Amazon or third-party software that you can add to the cluster. This structure contains a list of strings that indicates the software to use with the cluster and accepts a user argument list. Amazon EMR accepts and forwards the argument list to the corresponding installation script as bootstrap action argument. For more information, see <a href=\"http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-mapr.html\">Using the MapR Distribution for Hadoop</a>. Currently supported values are:</p> <ul> <li> <p>\"mapr-m3\" - launch the cluster using MapR M3 Edition.</p> </li> <li> <p>\"mapr-m5\" - launch the cluster using MapR M5 Edition.</p> </li> <li> <p>\"mapr\" with the user arguments specifying \"--edition,m3\" or \"--edition,m5\" - launch the cluster using MapR M3 or M5 Edition, respectively.</p> </li> </ul> <note> <p>In Amazon EMR releases 4.0 and greater, the only accepted parameter is the application name. To pass arguments to applications, you supply a configuration for each application.</p> </note>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Application {
@@ -156,6 +231,53 @@ pub struct AutoScalingPolicyDescription {
     pub status: Option<AutoScalingPolicyStatus>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoScalingPolicyState {
+    Attached,
+    Attaching,
+    Detached,
+    Detaching,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for AutoScalingPolicyState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoScalingPolicyState {
+    fn into(self) -> &'static str {
+        match self {
+            AutoScalingPolicyState::Attached => "ATTACHED",
+            AutoScalingPolicyState::Attaching => "ATTACHING",
+            AutoScalingPolicyState::Detached => "DETACHED",
+            AutoScalingPolicyState::Detaching => "DETACHING",
+            AutoScalingPolicyState::Failed => "FAILED",
+            AutoScalingPolicyState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoScalingPolicyState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ATTACHED" => Ok(AutoScalingPolicyState::Attached),
+            "ATTACHING" => Ok(AutoScalingPolicyState::Attaching),
+            "DETACHED" => Ok(AutoScalingPolicyState::Detached),
+            "DETACHING" => Ok(AutoScalingPolicyState::Detaching),
+            "FAILED" => Ok(AutoScalingPolicyState::Failed),
+            "PENDING" => Ok(AutoScalingPolicyState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The reason for an <a>AutoScalingPolicyStatus</a> change.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AutoScalingPolicyStateChangeReason {
@@ -167,6 +289,44 @@ pub struct AutoScalingPolicyStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoScalingPolicyStateChangeReasonCode {
+    CleanupFailure,
+    ProvisionFailure,
+    UserRequest,
+}
+
+impl Into<String> for AutoScalingPolicyStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoScalingPolicyStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            AutoScalingPolicyStateChangeReasonCode::CleanupFailure => "CLEANUP_FAILURE",
+            AutoScalingPolicyStateChangeReasonCode::ProvisionFailure => "PROVISION_FAILURE",
+            AutoScalingPolicyStateChangeReasonCode::UserRequest => "USER_REQUEST",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoScalingPolicyStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLEANUP_FAILURE" => Ok(AutoScalingPolicyStateChangeReasonCode::CleanupFailure),
+            "PROVISION_FAILURE" => Ok(AutoScalingPolicyStateChangeReasonCode::ProvisionFailure),
+            "USER_REQUEST" => Ok(AutoScalingPolicyStateChangeReasonCode::UserRequest),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The status of an automatic scaling policy. </p>"]
@@ -239,6 +399,41 @@ pub struct CancelStepsOutput {
     #[serde(rename="CancelStepsInfoList")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub cancel_steps_info_list: Option<Vec<CancelStepsInfo>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelStepsRequestStatus {
+    Failed,
+    Submitted,
+}
+
+impl Into<String> for CancelStepsRequestStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelStepsRequestStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CancelStepsRequestStatus::Failed => "FAILED",
+            CancelStepsRequestStatus::Submitted => "SUBMITTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelStepsRequestStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(CancelStepsRequestStatus::Failed),
+            "SUBMITTED" => Ok(CancelStepsRequestStatus::Submitted),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The definition of a CloudWatch metric alarm, which determines when an automatic scaling activity is triggered. When the defined alarm conditions are satisfied, scaling activity begins.</p>"]
@@ -367,6 +562,56 @@ pub struct Cluster {
     pub visible_to_all_users: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClusterState {
+    Bootstrapping,
+    Running,
+    Starting,
+    Terminated,
+    TerminatedWithErrors,
+    Terminating,
+    Waiting,
+}
+
+impl Into<String> for ClusterState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClusterState {
+    fn into(self) -> &'static str {
+        match self {
+            ClusterState::Bootstrapping => "BOOTSTRAPPING",
+            ClusterState::Running => "RUNNING",
+            ClusterState::Starting => "STARTING",
+            ClusterState::Terminated => "TERMINATED",
+            ClusterState::TerminatedWithErrors => "TERMINATED_WITH_ERRORS",
+            ClusterState::Terminating => "TERMINATING",
+            ClusterState::Waiting => "WAITING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClusterState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BOOTSTRAPPING" => Ok(ClusterState::Bootstrapping),
+            "RUNNING" => Ok(ClusterState::Running),
+            "STARTING" => Ok(ClusterState::Starting),
+            "TERMINATED" => Ok(ClusterState::Terminated),
+            "TERMINATED_WITH_ERRORS" => Ok(ClusterState::TerminatedWithErrors),
+            "TERMINATING" => Ok(ClusterState::Terminating),
+            "WAITING" => Ok(ClusterState::Waiting),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The reason that the cluster changed to its current state.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ClusterStateChangeReason {
@@ -378,6 +623,56 @@ pub struct ClusterStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClusterStateChangeReasonCode {
+    AllStepsCompleted,
+    BootstrapFailure,
+    InstanceFailure,
+    InternalError,
+    StepFailure,
+    UserRequest,
+    ValidationError,
+}
+
+impl Into<String> for ClusterStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClusterStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            ClusterStateChangeReasonCode::AllStepsCompleted => "ALL_STEPS_COMPLETED",
+            ClusterStateChangeReasonCode::BootstrapFailure => "BOOTSTRAP_FAILURE",
+            ClusterStateChangeReasonCode::InstanceFailure => "INSTANCE_FAILURE",
+            ClusterStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+            ClusterStateChangeReasonCode::StepFailure => "STEP_FAILURE",
+            ClusterStateChangeReasonCode::UserRequest => "USER_REQUEST",
+            ClusterStateChangeReasonCode::ValidationError => "VALIDATION_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClusterStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL_STEPS_COMPLETED" => Ok(ClusterStateChangeReasonCode::AllStepsCompleted),
+            "BOOTSTRAP_FAILURE" => Ok(ClusterStateChangeReasonCode::BootstrapFailure),
+            "INSTANCE_FAILURE" => Ok(ClusterStateChangeReasonCode::InstanceFailure),
+            "INTERNAL_ERROR" => Ok(ClusterStateChangeReasonCode::InternalError),
+            "STEP_FAILURE" => Ok(ClusterStateChangeReasonCode::StepFailure),
+            "USER_REQUEST" => Ok(ClusterStateChangeReasonCode::UserRequest),
+            "VALIDATION_ERROR" => Ok(ClusterStateChangeReasonCode::ValidationError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The detailed status of the cluster.</p>"]
@@ -450,6 +745,47 @@ pub struct Command {
     #[serde(rename="ScriptPath")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub script_path: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::GreaterThan => "GREATER_THAN",
+            ComparisonOperator::GreaterThanOrEqual => "GREATER_THAN_OR_EQUAL",
+            ComparisonOperator::LessThan => "LESS_THAN",
+            ComparisonOperator::LessThanOrEqual => "LESS_THAN_OR_EQUAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GREATER_THAN" => Ok(ComparisonOperator::GreaterThan),
+            "GREATER_THAN_OR_EQUAL" => Ok(ComparisonOperator::GreaterThanOrEqual),
+            "LESS_THAN" => Ok(ComparisonOperator::LessThan),
+            "LESS_THAN_OR_EQUAL" => Ok(ComparisonOperator::LessThanOrEqual),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<note> <p>Amazon EMR releases 4.x or later.</p> </note> <p>An optional configuration specification to be used when provisioning cluster instances, which can include configurations for applications and software bundled with Amazon EMR. A configuration consists of a classification, properties, and optional nested configurations. A classification refers to an application-specific configuration file. Properties are the settings you want to change in that file. For more information, see <a href=\"http://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html\">Configuring Applications</a>.</p>"]
@@ -800,6 +1136,41 @@ pub struct Instance {
     pub status: Option<InstanceStatus>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceCollectionType {
+    InstanceFleet,
+    InstanceGroup,
+}
+
+impl Into<String> for InstanceCollectionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceCollectionType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceCollectionType::InstanceFleet => "INSTANCE_FLEET",
+            InstanceCollectionType::InstanceGroup => "INSTANCE_GROUP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceCollectionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSTANCE_FLEET" => Ok(InstanceCollectionType::InstanceFleet),
+            "INSTANCE_GROUP" => Ok(InstanceCollectionType::InstanceGroup),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an instance fleet, which is a group of EC2 instances that host a particular node type (master, core, or task) in an Amazon EMR cluster. Instance fleets can consist of a mix of instance types and On-Demand and Spot instances, which are provisioned to meet a defined target capacity. </p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceFleet {
@@ -897,6 +1268,56 @@ pub struct InstanceFleetProvisioningSpecifications {
     pub spot_specification: SpotProvisioningSpecification,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceFleetState {
+    Bootstrapping,
+    Provisioning,
+    Resizing,
+    Running,
+    Suspended,
+    Terminated,
+    Terminating,
+}
+
+impl Into<String> for InstanceFleetState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceFleetState {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceFleetState::Bootstrapping => "BOOTSTRAPPING",
+            InstanceFleetState::Provisioning => "PROVISIONING",
+            InstanceFleetState::Resizing => "RESIZING",
+            InstanceFleetState::Running => "RUNNING",
+            InstanceFleetState::Suspended => "SUSPENDED",
+            InstanceFleetState::Terminated => "TERMINATED",
+            InstanceFleetState::Terminating => "TERMINATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceFleetState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BOOTSTRAPPING" => Ok(InstanceFleetState::Bootstrapping),
+            "PROVISIONING" => Ok(InstanceFleetState::Provisioning),
+            "RESIZING" => Ok(InstanceFleetState::Resizing),
+            "RUNNING" => Ok(InstanceFleetState::Running),
+            "SUSPENDED" => Ok(InstanceFleetState::Suspended),
+            "TERMINATED" => Ok(InstanceFleetState::Terminated),
+            "TERMINATING" => Ok(InstanceFleetState::Terminating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides status change reason details for the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceFleetStateChangeReason {
@@ -908,6 +1329,47 @@ pub struct InstanceFleetStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceFleetStateChangeReasonCode {
+    ClusterTerminated,
+    InstanceFailure,
+    InternalError,
+    ValidationError,
+}
+
+impl Into<String> for InstanceFleetStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceFleetStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceFleetStateChangeReasonCode::ClusterTerminated => "CLUSTER_TERMINATED",
+            InstanceFleetStateChangeReasonCode::InstanceFailure => "INSTANCE_FAILURE",
+            InstanceFleetStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+            InstanceFleetStateChangeReasonCode::ValidationError => "VALIDATION_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceFleetStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLUSTER_TERMINATED" => Ok(InstanceFleetStateChangeReasonCode::ClusterTerminated),
+            "INSTANCE_FAILURE" => Ok(InstanceFleetStateChangeReasonCode::InstanceFailure),
+            "INTERNAL_ERROR" => Ok(InstanceFleetStateChangeReasonCode::InternalError),
+            "VALIDATION_ERROR" => Ok(InstanceFleetStateChangeReasonCode::ValidationError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The status of the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
@@ -942,6 +1404,44 @@ pub struct InstanceFleetTimeline {
     #[serde(rename="ReadyDateTime")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub ready_date_time: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceFleetType {
+    Core,
+    Master,
+    Task,
+}
+
+impl Into<String> for InstanceFleetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceFleetType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceFleetType::Core => "CORE",
+            InstanceFleetType::Master => "MASTER",
+            InstanceFleetType::Task => "TASK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceFleetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CORE" => Ok(InstanceFleetType::Core),
+            "MASTER" => Ok(InstanceFleetType::Master),
+            "TASK" => Ok(InstanceFleetType::Task),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>This entity represents an instance group, which is a group of instances that have common purpose. For example, CORE instance group is used for HDFS.</p>"]
@@ -1117,6 +1617,65 @@ pub struct InstanceGroupModifyConfig {
     pub shrink_policy: Option<ShrinkPolicy>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceGroupState {
+    Arrested,
+    Bootstrapping,
+    Ended,
+    Provisioning,
+    Resizing,
+    Running,
+    ShuttingDown,
+    Suspended,
+    Terminated,
+    Terminating,
+}
+
+impl Into<String> for InstanceGroupState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceGroupState {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceGroupState::Arrested => "ARRESTED",
+            InstanceGroupState::Bootstrapping => "BOOTSTRAPPING",
+            InstanceGroupState::Ended => "ENDED",
+            InstanceGroupState::Provisioning => "PROVISIONING",
+            InstanceGroupState::Resizing => "RESIZING",
+            InstanceGroupState::Running => "RUNNING",
+            InstanceGroupState::ShuttingDown => "SHUTTING_DOWN",
+            InstanceGroupState::Suspended => "SUSPENDED",
+            InstanceGroupState::Terminated => "TERMINATED",
+            InstanceGroupState::Terminating => "TERMINATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceGroupState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ARRESTED" => Ok(InstanceGroupState::Arrested),
+            "BOOTSTRAPPING" => Ok(InstanceGroupState::Bootstrapping),
+            "ENDED" => Ok(InstanceGroupState::Ended),
+            "PROVISIONING" => Ok(InstanceGroupState::Provisioning),
+            "RESIZING" => Ok(InstanceGroupState::Resizing),
+            "RUNNING" => Ok(InstanceGroupState::Running),
+            "SHUTTING_DOWN" => Ok(InstanceGroupState::ShuttingDown),
+            "SUSPENDED" => Ok(InstanceGroupState::Suspended),
+            "TERMINATED" => Ok(InstanceGroupState::Terminated),
+            "TERMINATING" => Ok(InstanceGroupState::Terminating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The status change reason details for the instance group.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceGroupStateChangeReason {
@@ -1128,6 +1687,47 @@ pub struct InstanceGroupStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceGroupStateChangeReasonCode {
+    ClusterTerminated,
+    InstanceFailure,
+    InternalError,
+    ValidationError,
+}
+
+impl Into<String> for InstanceGroupStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceGroupStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceGroupStateChangeReasonCode::ClusterTerminated => "CLUSTER_TERMINATED",
+            InstanceGroupStateChangeReasonCode::InstanceFailure => "INSTANCE_FAILURE",
+            InstanceGroupStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+            InstanceGroupStateChangeReasonCode::ValidationError => "VALIDATION_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceGroupStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLUSTER_TERMINATED" => Ok(InstanceGroupStateChangeReasonCode::ClusterTerminated),
+            "INSTANCE_FAILURE" => Ok(InstanceGroupStateChangeReasonCode::InstanceFailure),
+            "INTERNAL_ERROR" => Ok(InstanceGroupStateChangeReasonCode::InternalError),
+            "VALIDATION_ERROR" => Ok(InstanceGroupStateChangeReasonCode::ValidationError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The details of the instance group status.</p>"]
@@ -1164,6 +1764,44 @@ pub struct InstanceGroupTimeline {
     pub ready_date_time: Option<f64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceGroupType {
+    Core,
+    Master,
+    Task,
+}
+
+impl Into<String> for InstanceGroupType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceGroupType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceGroupType::Core => "CORE",
+            InstanceGroupType::Master => "MASTER",
+            InstanceGroupType::Task => "TASK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceGroupType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CORE" => Ok(InstanceGroupType::Core),
+            "MASTER" => Ok(InstanceGroupType::Master),
+            "TASK" => Ok(InstanceGroupType::Task),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Custom policy for requesting termination protection or termination of specific instances when shrinking an instance group.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceResizePolicy {
@@ -1181,6 +1819,88 @@ pub struct InstanceResizePolicy {
     pub instances_to_terminate: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceRoleType {
+    Core,
+    Master,
+    Task,
+}
+
+impl Into<String> for InstanceRoleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceRoleType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceRoleType::Core => "CORE",
+            InstanceRoleType::Master => "MASTER",
+            InstanceRoleType::Task => "TASK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceRoleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CORE" => Ok(InstanceRoleType::Core),
+            "MASTER" => Ok(InstanceRoleType::Master),
+            "TASK" => Ok(InstanceRoleType::Task),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceState {
+    AwaitingFulfillment,
+    Bootstrapping,
+    Provisioning,
+    Running,
+    Terminated,
+}
+
+impl Into<String> for InstanceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceState {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceState::AwaitingFulfillment => "AWAITING_FULFILLMENT",
+            InstanceState::Bootstrapping => "BOOTSTRAPPING",
+            InstanceState::Provisioning => "PROVISIONING",
+            InstanceState::Running => "RUNNING",
+            InstanceState::Terminated => "TERMINATED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWAITING_FULFILLMENT" => Ok(InstanceState::AwaitingFulfillment),
+            "BOOTSTRAPPING" => Ok(InstanceState::Bootstrapping),
+            "PROVISIONING" => Ok(InstanceState::Provisioning),
+            "RUNNING" => Ok(InstanceState::Running),
+            "TERMINATED" => Ok(InstanceState::Terminated),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The details of the status change reason for the instance.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceStateChangeReason {
@@ -1192,6 +1912,50 @@ pub struct InstanceStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceStateChangeReasonCode {
+    BootstrapFailure,
+    ClusterTerminated,
+    InstanceFailure,
+    InternalError,
+    ValidationError,
+}
+
+impl Into<String> for InstanceStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceStateChangeReasonCode::BootstrapFailure => "BOOTSTRAP_FAILURE",
+            InstanceStateChangeReasonCode::ClusterTerminated => "CLUSTER_TERMINATED",
+            InstanceStateChangeReasonCode::InstanceFailure => "INSTANCE_FAILURE",
+            InstanceStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+            InstanceStateChangeReasonCode::ValidationError => "VALIDATION_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BOOTSTRAP_FAILURE" => Ok(InstanceStateChangeReasonCode::BootstrapFailure),
+            "CLUSTER_TERMINATED" => Ok(InstanceStateChangeReasonCode::ClusterTerminated),
+            "INSTANCE_FAILURE" => Ok(InstanceStateChangeReasonCode::InstanceFailure),
+            "INTERNAL_ERROR" => Ok(InstanceStateChangeReasonCode::InternalError),
+            "VALIDATION_ERROR" => Ok(InstanceStateChangeReasonCode::ValidationError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The instance status details.</p>"]
@@ -1344,6 +2108,59 @@ pub struct JobFlowDetail {
     #[serde(rename="VisibleToAllUsers")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub visible_to_all_users: Option<bool>,
+}
+
+#[doc="<p>The type of instance.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobFlowExecutionState {
+    Bootstrapping,
+    Completed,
+    Failed,
+    Running,
+    ShuttingDown,
+    Starting,
+    Terminated,
+    Waiting,
+}
+
+impl Into<String> for JobFlowExecutionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobFlowExecutionState {
+    fn into(self) -> &'static str {
+        match self {
+            JobFlowExecutionState::Bootstrapping => "BOOTSTRAPPING",
+            JobFlowExecutionState::Completed => "COMPLETED",
+            JobFlowExecutionState::Failed => "FAILED",
+            JobFlowExecutionState::Running => "RUNNING",
+            JobFlowExecutionState::ShuttingDown => "SHUTTING_DOWN",
+            JobFlowExecutionState::Starting => "STARTING",
+            JobFlowExecutionState::Terminated => "TERMINATED",
+            JobFlowExecutionState::Waiting => "WAITING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobFlowExecutionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BOOTSTRAPPING" => Ok(JobFlowExecutionState::Bootstrapping),
+            "COMPLETED" => Ok(JobFlowExecutionState::Completed),
+            "FAILED" => Ok(JobFlowExecutionState::Failed),
+            "RUNNING" => Ok(JobFlowExecutionState::Running),
+            "SHUTTING_DOWN" => Ok(JobFlowExecutionState::ShuttingDown),
+            "STARTING" => Ok(JobFlowExecutionState::Starting),
+            "TERMINATED" => Ok(JobFlowExecutionState::Terminated),
+            "WAITING" => Ok(JobFlowExecutionState::Waiting),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the status of the cluster (job flow).</p>"]
@@ -1718,6 +2535,41 @@ pub struct ListStepsOutput {
     pub steps: Option<Vec<StepSummary>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MarketType {
+    OnDemand,
+    Spot,
+}
+
+impl Into<String> for MarketType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MarketType {
+    fn into(self) -> &'static str {
+        match self {
+            MarketType::OnDemand => "ON_DEMAND",
+            MarketType::Spot => "SPOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MarketType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ON_DEMAND" => Ok(MarketType::OnDemand),
+            "SPOT" => Ok(MarketType::Spot),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A CloudWatch dimension, which is specified using a <code>Key</code> (known as a <code>Name</code> in CloudWatch), <code>Value</code> pair. By default, Amazon EMR uses one dimension whose <code>Key</code> is <code>JobFlowID</code> and <code>Value</code> is a variable representing the cluster ID, which is <code>${emr.clusterId}</code>. This enables the rule to bootstrap when the cluster ID becomes available.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricDimension {
@@ -1912,6 +2764,41 @@ pub struct RunJobFlowOutput {
     pub job_flow_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScaleDownBehavior {
+    TerminateAtInstanceHour,
+    TerminateAtTaskCompletion,
+}
+
+impl Into<String> for ScaleDownBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScaleDownBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            ScaleDownBehavior::TerminateAtInstanceHour => "TERMINATE_AT_INSTANCE_HOUR",
+            ScaleDownBehavior::TerminateAtTaskCompletion => "TERMINATE_AT_TASK_COMPLETION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScaleDownBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TERMINATE_AT_INSTANCE_HOUR" => Ok(ScaleDownBehavior::TerminateAtInstanceHour),
+            "TERMINATE_AT_TASK_COMPLETION" => Ok(ScaleDownBehavior::TerminateAtTaskCompletion),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The type of adjustment the automatic scaling activity makes when triggered, and the periodicity of the adjustment.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalingAction {
@@ -2052,6 +2939,85 @@ pub struct SpotProvisioningSpecification {
     pub timeout_duration_minutes: i64,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SpotProvisioningTimeoutAction {
+    SwitchToOnDemand,
+    TerminateCluster,
+}
+
+impl Into<String> for SpotProvisioningTimeoutAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SpotProvisioningTimeoutAction {
+    fn into(self) -> &'static str {
+        match self {
+            SpotProvisioningTimeoutAction::SwitchToOnDemand => "SWITCH_TO_ON_DEMAND",
+            SpotProvisioningTimeoutAction::TerminateCluster => "TERMINATE_CLUSTER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SpotProvisioningTimeoutAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SWITCH_TO_ON_DEMAND" => Ok(SpotProvisioningTimeoutAction::SwitchToOnDemand),
+            "TERMINATE_CLUSTER" => Ok(SpotProvisioningTimeoutAction::TerminateCluster),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Statistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for Statistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Statistic {
+    fn into(self) -> &'static str {
+        match self {
+            Statistic::Average => "AVERAGE",
+            Statistic::Maximum => "MAXIMUM",
+            Statistic::Minimum => "MINIMUM",
+            Statistic::SampleCount => "SAMPLE_COUNT",
+            Statistic::Sum => "SUM",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Statistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVERAGE" => Ok(Statistic::Average),
+            "MAXIMUM" => Ok(Statistic::Maximum),
+            "MINIMUM" => Ok(Statistic::Minimum),
+            "SAMPLE_COUNT" => Ok(Statistic::SampleCount),
+            "SUM" => Ok(Statistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>This represents a step in a cluster.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Step {
@@ -2103,6 +3069,56 @@ pub struct StepDetail {
     pub step_config: StepConfig,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StepExecutionState {
+    Cancelled,
+    Completed,
+    Continue,
+    Failed,
+    Interrupted,
+    Pending,
+    Running,
+}
+
+impl Into<String> for StepExecutionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StepExecutionState {
+    fn into(self) -> &'static str {
+        match self {
+            StepExecutionState::Cancelled => "CANCELLED",
+            StepExecutionState::Completed => "COMPLETED",
+            StepExecutionState::Continue => "CONTINUE",
+            StepExecutionState::Failed => "FAILED",
+            StepExecutionState::Interrupted => "INTERRUPTED",
+            StepExecutionState::Pending => "PENDING",
+            StepExecutionState::Running => "RUNNING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StepExecutionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(StepExecutionState::Cancelled),
+            "COMPLETED" => Ok(StepExecutionState::Completed),
+            "CONTINUE" => Ok(StepExecutionState::Continue),
+            "FAILED" => Ok(StepExecutionState::Failed),
+            "INTERRUPTED" => Ok(StepExecutionState::Interrupted),
+            "PENDING" => Ok(StepExecutionState::Pending),
+            "RUNNING" => Ok(StepExecutionState::Running),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The execution state of a step.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StepExecutionStatusDetail {
@@ -2126,6 +3142,56 @@ pub struct StepExecutionStatusDetail {
     pub state: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StepState {
+    Cancelled,
+    CancelPending,
+    Completed,
+    Failed,
+    Interrupted,
+    Pending,
+    Running,
+}
+
+impl Into<String> for StepState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StepState {
+    fn into(self) -> &'static str {
+        match self {
+            StepState::Cancelled => "CANCELLED",
+            StepState::CancelPending => "CANCEL_PENDING",
+            StepState::Completed => "COMPLETED",
+            StepState::Failed => "FAILED",
+            StepState::Interrupted => "INTERRUPTED",
+            StepState::Pending => "PENDING",
+            StepState::Running => "RUNNING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StepState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(StepState::Cancelled),
+            "CANCEL_PENDING" => Ok(StepState::CancelPending),
+            "COMPLETED" => Ok(StepState::Completed),
+            "FAILED" => Ok(StepState::Failed),
+            "INTERRUPTED" => Ok(StepState::Interrupted),
+            "PENDING" => Ok(StepState::Pending),
+            "RUNNING" => Ok(StepState::Running),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The details of the step state change reason.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StepStateChangeReason {
@@ -2137,6 +3203,38 @@ pub struct StepStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StepStateChangeReasonCode {
+    None,
+}
+
+impl Into<String> for StepStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StepStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            StepStateChangeReasonCode::None => "NONE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StepStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NONE" => Ok(StepStateChangeReasonCode::None),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The execution status details of the cluster step.</p>"]
@@ -2234,6 +3332,116 @@ pub struct TerminateJobFlowsInput {
     #[doc="<p>A list of job flows to be shutdown.</p>"]
     #[serde(rename="JobFlowIds")]
     pub job_flow_ids: Vec<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Unit {
+    Bits,
+    BitsPerSecond,
+    Bytes,
+    BytesPerSecond,
+    Count,
+    CountPerSecond,
+    GigaBits,
+    GigaBitsPerSecond,
+    GigaBytes,
+    GigaBytesPerSecond,
+    KiloBits,
+    KiloBitsPerSecond,
+    KiloBytes,
+    KiloBytesPerSecond,
+    MegaBits,
+    MegaBitsPerSecond,
+    MegaBytes,
+    MegaBytesPerSecond,
+    MicroSeconds,
+    MilliSeconds,
+    None,
+    Percent,
+    Seconds,
+    TeraBits,
+    TeraBitsPerSecond,
+    TeraBytes,
+    TeraBytesPerSecond,
+}
+
+impl Into<String> for Unit {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Unit {
+    fn into(self) -> &'static str {
+        match self {
+            Unit::Bits => "BITS",
+            Unit::BitsPerSecond => "BITS_PER_SECOND",
+            Unit::Bytes => "BYTES",
+            Unit::BytesPerSecond => "BYTES_PER_SECOND",
+            Unit::Count => "COUNT",
+            Unit::CountPerSecond => "COUNT_PER_SECOND",
+            Unit::GigaBits => "GIGA_BITS",
+            Unit::GigaBitsPerSecond => "GIGA_BITS_PER_SECOND",
+            Unit::GigaBytes => "GIGA_BYTES",
+            Unit::GigaBytesPerSecond => "GIGA_BYTES_PER_SECOND",
+            Unit::KiloBits => "KILO_BITS",
+            Unit::KiloBitsPerSecond => "KILO_BITS_PER_SECOND",
+            Unit::KiloBytes => "KILO_BYTES",
+            Unit::KiloBytesPerSecond => "KILO_BYTES_PER_SECOND",
+            Unit::MegaBits => "MEGA_BITS",
+            Unit::MegaBitsPerSecond => "MEGA_BITS_PER_SECOND",
+            Unit::MegaBytes => "MEGA_BYTES",
+            Unit::MegaBytesPerSecond => "MEGA_BYTES_PER_SECOND",
+            Unit::MicroSeconds => "MICRO_SECONDS",
+            Unit::MilliSeconds => "MILLI_SECONDS",
+            Unit::None => "NONE",
+            Unit::Percent => "PERCENT",
+            Unit::Seconds => "SECONDS",
+            Unit::TeraBits => "TERA_BITS",
+            Unit::TeraBitsPerSecond => "TERA_BITS_PER_SECOND",
+            Unit::TeraBytes => "TERA_BYTES",
+            Unit::TeraBytesPerSecond => "TERA_BYTES_PER_SECOND",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Unit {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BITS" => Ok(Unit::Bits),
+            "BITS_PER_SECOND" => Ok(Unit::BitsPerSecond),
+            "BYTES" => Ok(Unit::Bytes),
+            "BYTES_PER_SECOND" => Ok(Unit::BytesPerSecond),
+            "COUNT" => Ok(Unit::Count),
+            "COUNT_PER_SECOND" => Ok(Unit::CountPerSecond),
+            "GIGA_BITS" => Ok(Unit::GigaBits),
+            "GIGA_BITS_PER_SECOND" => Ok(Unit::GigaBitsPerSecond),
+            "GIGA_BYTES" => Ok(Unit::GigaBytes),
+            "GIGA_BYTES_PER_SECOND" => Ok(Unit::GigaBytesPerSecond),
+            "KILO_BITS" => Ok(Unit::KiloBits),
+            "KILO_BITS_PER_SECOND" => Ok(Unit::KiloBitsPerSecond),
+            "KILO_BYTES" => Ok(Unit::KiloBytes),
+            "KILO_BYTES_PER_SECOND" => Ok(Unit::KiloBytesPerSecond),
+            "MEGA_BITS" => Ok(Unit::MegaBits),
+            "MEGA_BITS_PER_SECOND" => Ok(Unit::MegaBitsPerSecond),
+            "MEGA_BYTES" => Ok(Unit::MegaBytes),
+            "MEGA_BYTES_PER_SECOND" => Ok(Unit::MegaBytesPerSecond),
+            "MICRO_SECONDS" => Ok(Unit::MicroSeconds),
+            "MILLI_SECONDS" => Ok(Unit::MilliSeconds),
+            "NONE" => Ok(Unit::None),
+            "PERCENT" => Ok(Unit::Percent),
+            "SECONDS" => Ok(Unit::Seconds),
+            "TERA_BITS" => Ok(Unit::TeraBits),
+            "TERA_BITS_PER_SECOND" => Ok(Unit::TeraBitsPerSecond),
+            "TERA_BYTES" => Ok(Unit::TeraBytes),
+            "TERA_BYTES_PER_SECOND" => Ok(Unit::TeraBytesPerSecond),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>EBS volume specifications such as volume type, IOPS, and size (GiB) that will be requested for the EBS volume attached to an EC2 instance in the cluster.</p>"]
@@ -4550,7 +5758,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddInstanceFleetOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4577,7 +5785,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddInstanceGroupsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4604,7 +5812,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddJobFlowStepsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4629,7 +5837,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -4655,7 +5863,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CancelStepsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CancelStepsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4681,7 +5889,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateSecurityConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateSecurityConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4707,7 +5915,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteSecurityConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteSecurityConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4731,7 +5939,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeClusterOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4758,7 +5966,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeJobFlowsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4787,7 +5995,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeSecurityConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeSecurityConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4811,7 +6019,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStepOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4837,7 +6045,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListBootstrapActionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4864,7 +6072,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListClustersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4890,7 +6098,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListInstanceFleetsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4917,7 +6125,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListInstanceGroupsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4944,7 +6152,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4972,7 +6180,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListSecurityConfigurationsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListSecurityConfigurationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4994,7 +6202,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ListStepsOutput>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -5020,7 +6228,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(ModifyInstanceFleetError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -5045,7 +6253,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(ModifyInstanceGroupsError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -5070,7 +6278,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutAutoScalingPolicyOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5098,7 +6306,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveAutoScalingPolicyOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RemoveAutoScalingPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5120,7 +6328,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTagsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RemoveTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5142,7 +6350,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RunJobFlowOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RunJobFlowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5166,7 +6374,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(SetTerminationProtectionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -5188,7 +6396,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(SetVisibleToAllUsersError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -5213,7 +6421,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(TerminateJobFlowsError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -405,6 +401,41 @@ pub struct Rule {
     #[serde(rename="State")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RuleState {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for RuleState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RuleState {
+    fn into(self) -> &'static str {
+        match self {
+            RuleState::Disabled => "DISABLED",
+            RuleState::Enabled => "ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RuleState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(RuleState::Disabled),
+            "ENABLED" => Ok(RuleState::Enabled),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>This parameter contains the criteria (either InstanceIds or a tag) used to specify which EC2 instances are to be sent the command. </p>"]
@@ -1546,7 +1577,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -1568,7 +1599,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1592,7 +1623,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DisableRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -1612,7 +1643,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(EnableRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -1635,7 +1666,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRuleNamesByTargetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1660,7 +1691,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListRulesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1684,7 +1715,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTargetsByRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1709,7 +1740,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(PutEventsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1731,7 +1762,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<PutRuleResponse>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -1757,7 +1788,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutTargetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(PutTargetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1781,7 +1812,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTargetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1807,7 +1838,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<TestEventPatternResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -54,6 +50,47 @@ pub struct CloudWatchLoggingOptions {
     #[serde(rename="LogStreamName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub log_stream_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CompressionFormat {
+    Gzip,
+    Snappy,
+    Uncompressed,
+    Zip,
+}
+
+impl Into<String> for CompressionFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CompressionFormat {
+    fn into(self) -> &'static str {
+        match self {
+            CompressionFormat::Gzip => "GZIP",
+            CompressionFormat::Snappy => "Snappy",
+            CompressionFormat::Uncompressed => "UNCOMPRESSED",
+            CompressionFormat::Zip => "ZIP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CompressionFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GZIP" => Ok(CompressionFormat::Gzip),
+            "Snappy" => Ok(CompressionFormat::Snappy),
+            "UNCOMPRESSED" => Ok(CompressionFormat::Uncompressed),
+            "ZIP" => Ok(CompressionFormat::Zip),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a <code>COPY</code> command for Amazon Redshift.</p>"]
@@ -138,6 +175,44 @@ pub struct DeliveryStreamDescription {
     #[doc="<p>Each time the destination is updated for a delivery stream, the version ID is changed, and the current version ID is required when updating the destination. This is so that the service knows it is applying the changes to the correct version of the delivery stream.</p>"]
     #[serde(rename="VersionId")]
     pub version_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeliveryStreamStatus {
+    Active,
+    Creating,
+    Deleting,
+}
+
+impl Into<String> for DeliveryStreamStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeliveryStreamStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DeliveryStreamStatus::Active => "ACTIVE",
+            DeliveryStreamStatus::Creating => "CREATING",
+            DeliveryStreamStatus::Deleting => "DELETING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeliveryStreamStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(DeliveryStreamStatus::Active),
+            "CREATING" => Ok(DeliveryStreamStatus::Creating),
+            "DELETING" => Ok(DeliveryStreamStatus::Deleting),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -337,6 +412,50 @@ pub struct ElasticsearchDestinationUpdate {
     pub type_name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ElasticsearchIndexRotationPeriod {
+    NoRotation,
+    OneDay,
+    OneHour,
+    OneMonth,
+    OneWeek,
+}
+
+impl Into<String> for ElasticsearchIndexRotationPeriod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ElasticsearchIndexRotationPeriod {
+    fn into(self) -> &'static str {
+        match self {
+            ElasticsearchIndexRotationPeriod::NoRotation => "NoRotation",
+            ElasticsearchIndexRotationPeriod::OneDay => "OneDay",
+            ElasticsearchIndexRotationPeriod::OneHour => "OneHour",
+            ElasticsearchIndexRotationPeriod::OneMonth => "OneMonth",
+            ElasticsearchIndexRotationPeriod::OneWeek => "OneWeek",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ElasticsearchIndexRotationPeriod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NoRotation" => Ok(ElasticsearchIndexRotationPeriod::NoRotation),
+            "OneDay" => Ok(ElasticsearchIndexRotationPeriod::OneDay),
+            "OneHour" => Ok(ElasticsearchIndexRotationPeriod::OneHour),
+            "OneMonth" => Ok(ElasticsearchIndexRotationPeriod::OneMonth),
+            "OneWeek" => Ok(ElasticsearchIndexRotationPeriod::OneWeek),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Configures retry behavior in the event that Firehose is unable to deliver documents to Amazon ES.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticsearchRetryOptions {
@@ -344,6 +463,41 @@ pub struct ElasticsearchRetryOptions {
     #[serde(rename="DurationInSeconds")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub duration_in_seconds: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ElasticsearchS3BackupMode {
+    AllDocuments,
+    FailedDocumentsOnly,
+}
+
+impl Into<String> for ElasticsearchS3BackupMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ElasticsearchS3BackupMode {
+    fn into(self) -> &'static str {
+        match self {
+            ElasticsearchS3BackupMode::AllDocuments => "AllDocuments",
+            ElasticsearchS3BackupMode::FailedDocumentsOnly => "FailedDocumentsOnly",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ElasticsearchS3BackupMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AllDocuments" => Ok(ElasticsearchS3BackupMode::AllDocuments),
+            "FailedDocumentsOnly" => Ok(ElasticsearchS3BackupMode::FailedDocumentsOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the encryption for a destination in Amazon S3.</p>"]
@@ -517,6 +671,38 @@ pub struct ListDeliveryStreamsOutput {
     pub has_more_delivery_streams: bool,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NoEncryptionConfig {
+    NoEncryption,
+}
+
+impl Into<String> for NoEncryptionConfig {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NoEncryptionConfig {
+    fn into(self) -> &'static str {
+        match self {
+            NoEncryptionConfig::NoEncryption => "NoEncryption",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NoEncryptionConfig {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NoEncryption" => Ok(NoEncryptionConfig::NoEncryption),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes a data processing configuration.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProcessingConfiguration {
@@ -551,6 +737,73 @@ pub struct ProcessorParameter {
     #[doc="<p>The parameter value.</p>"]
     #[serde(rename="ParameterValue")]
     pub parameter_value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProcessorParameterName {
+    LambdaArn,
+    NumberOfRetries,
+}
+
+impl Into<String> for ProcessorParameterName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProcessorParameterName {
+    fn into(self) -> &'static str {
+        match self {
+            ProcessorParameterName::LambdaArn => "LambdaArn",
+            ProcessorParameterName::NumberOfRetries => "NumberOfRetries",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProcessorParameterName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LambdaArn" => Ok(ProcessorParameterName::LambdaArn),
+            "NumberOfRetries" => Ok(ProcessorParameterName::NumberOfRetries),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProcessorType {
+    Lambda,
+}
+
+impl Into<String> for ProcessorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProcessorType {
+    fn into(self) -> &'static str {
+        match self {
+            ProcessorType::Lambda => "Lambda",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProcessorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Lambda" => Ok(ProcessorType::Lambda),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -759,6 +1012,76 @@ pub struct RedshiftRetryOptions {
     #[serde(rename="DurationInSeconds")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub duration_in_seconds: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RedshiftS3BackupMode {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for RedshiftS3BackupMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RedshiftS3BackupMode {
+    fn into(self) -> &'static str {
+        match self {
+            RedshiftS3BackupMode::Disabled => "Disabled",
+            RedshiftS3BackupMode::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RedshiftS3BackupMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(RedshiftS3BackupMode::Disabled),
+            "Enabled" => Ok(RedshiftS3BackupMode::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum S3BackupMode {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for S3BackupMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for S3BackupMode {
+    fn into(self) -> &'static str {
+        match self {
+            S3BackupMode::Disabled => "Disabled",
+            S3BackupMode::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for S3BackupMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(S3BackupMode::Disabled),
+            "Enabled" => Ok(S3BackupMode::Enabled),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the configuration of a destination in Amazon S3.</p>"]
@@ -1546,7 +1869,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDeliveryStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1573,7 +1896,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteDeliveryStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1601,7 +1924,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDeliveryStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1628,7 +1951,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDeliveryStreamsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1653,7 +1976,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<PutRecordOutput>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -1679,7 +2002,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutRecordBatchOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1706,7 +2029,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDestinationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -107,6 +103,89 @@ pub struct Build {
     #[serde(rename="Version")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BuildStatus {
+    Failed,
+    Initialized,
+    Ready,
+}
+
+impl Into<String> for BuildStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BuildStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BuildStatus::Failed => "FAILED",
+            BuildStatus::Initialized => "INITIALIZED",
+            BuildStatus::Ready => "READY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BuildStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(BuildStatus::Failed),
+            "INITIALIZED" => Ok(BuildStatus::Initialized),
+            "READY" => Ok(BuildStatus::Ready),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperatorType {
+    GreaterThanOrEqualToThreshold,
+    GreaterThanThreshold,
+    LessThanOrEqualToThreshold,
+    LessThanThreshold,
+}
+
+impl Into<String> for ComparisonOperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperatorType::GreaterThanOrEqualToThreshold => {
+                "GreaterThanOrEqualToThreshold"
+            }
+            ComparisonOperatorType::GreaterThanThreshold => "GreaterThanThreshold",
+            ComparisonOperatorType::LessThanOrEqualToThreshold => "LessThanOrEqualToThreshold",
+            ComparisonOperatorType::LessThanThreshold => "LessThanThreshold",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GreaterThanOrEqualToThreshold" => {
+                Ok(ComparisonOperatorType::GreaterThanOrEqualToThreshold)
+            }
+            "GreaterThanThreshold" => Ok(ComparisonOperatorType::GreaterThanThreshold),
+            "LessThanOrEqualToThreshold" => Ok(ComparisonOperatorType::LessThanOrEqualToThreshold),
+            "LessThanThreshold" => Ok(ComparisonOperatorType::LessThanThreshold),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -913,6 +992,119 @@ pub struct EC2InstanceLimit {
     pub instance_limit: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EC2InstanceType {
+    C32Xlarge,
+    C34Xlarge,
+    C38Xlarge,
+    C3Large,
+    C3Xlarge,
+    C42Xlarge,
+    C44Xlarge,
+    C48Xlarge,
+    C4Large,
+    C4Xlarge,
+    M32Xlarge,
+    M3Large,
+    M3Medium,
+    M3Xlarge,
+    M410Xlarge,
+    M42Xlarge,
+    M44Xlarge,
+    M4Large,
+    M4Xlarge,
+    R32Xlarge,
+    R34Xlarge,
+    R38Xlarge,
+    R3Large,
+    R3Xlarge,
+    T2Large,
+    T2Medium,
+    T2Micro,
+    T2Small,
+}
+
+impl Into<String> for EC2InstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EC2InstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            EC2InstanceType::C32Xlarge => "c3.2xlarge",
+            EC2InstanceType::C34Xlarge => "c3.4xlarge",
+            EC2InstanceType::C38Xlarge => "c3.8xlarge",
+            EC2InstanceType::C3Large => "c3.large",
+            EC2InstanceType::C3Xlarge => "c3.xlarge",
+            EC2InstanceType::C42Xlarge => "c4.2xlarge",
+            EC2InstanceType::C44Xlarge => "c4.4xlarge",
+            EC2InstanceType::C48Xlarge => "c4.8xlarge",
+            EC2InstanceType::C4Large => "c4.large",
+            EC2InstanceType::C4Xlarge => "c4.xlarge",
+            EC2InstanceType::M32Xlarge => "m3.2xlarge",
+            EC2InstanceType::M3Large => "m3.large",
+            EC2InstanceType::M3Medium => "m3.medium",
+            EC2InstanceType::M3Xlarge => "m3.xlarge",
+            EC2InstanceType::M410Xlarge => "m4.10xlarge",
+            EC2InstanceType::M42Xlarge => "m4.2xlarge",
+            EC2InstanceType::M44Xlarge => "m4.4xlarge",
+            EC2InstanceType::M4Large => "m4.large",
+            EC2InstanceType::M4Xlarge => "m4.xlarge",
+            EC2InstanceType::R32Xlarge => "r3.2xlarge",
+            EC2InstanceType::R34Xlarge => "r3.4xlarge",
+            EC2InstanceType::R38Xlarge => "r3.8xlarge",
+            EC2InstanceType::R3Large => "r3.large",
+            EC2InstanceType::R3Xlarge => "r3.xlarge",
+            EC2InstanceType::T2Large => "t2.large",
+            EC2InstanceType::T2Medium => "t2.medium",
+            EC2InstanceType::T2Micro => "t2.micro",
+            EC2InstanceType::T2Small => "t2.small",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EC2InstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "c3.2xlarge" => Ok(EC2InstanceType::C32Xlarge),
+            "c3.4xlarge" => Ok(EC2InstanceType::C34Xlarge),
+            "c3.8xlarge" => Ok(EC2InstanceType::C38Xlarge),
+            "c3.large" => Ok(EC2InstanceType::C3Large),
+            "c3.xlarge" => Ok(EC2InstanceType::C3Xlarge),
+            "c4.2xlarge" => Ok(EC2InstanceType::C42Xlarge),
+            "c4.4xlarge" => Ok(EC2InstanceType::C44Xlarge),
+            "c4.8xlarge" => Ok(EC2InstanceType::C48Xlarge),
+            "c4.large" => Ok(EC2InstanceType::C4Large),
+            "c4.xlarge" => Ok(EC2InstanceType::C4Xlarge),
+            "m3.2xlarge" => Ok(EC2InstanceType::M32Xlarge),
+            "m3.large" => Ok(EC2InstanceType::M3Large),
+            "m3.medium" => Ok(EC2InstanceType::M3Medium),
+            "m3.xlarge" => Ok(EC2InstanceType::M3Xlarge),
+            "m4.10xlarge" => Ok(EC2InstanceType::M410Xlarge),
+            "m4.2xlarge" => Ok(EC2InstanceType::M42Xlarge),
+            "m4.4xlarge" => Ok(EC2InstanceType::M44Xlarge),
+            "m4.large" => Ok(EC2InstanceType::M4Large),
+            "m4.xlarge" => Ok(EC2InstanceType::M4Xlarge),
+            "r3.2xlarge" => Ok(EC2InstanceType::R32Xlarge),
+            "r3.4xlarge" => Ok(EC2InstanceType::R34Xlarge),
+            "r3.8xlarge" => Ok(EC2InstanceType::R38Xlarge),
+            "r3.large" => Ok(EC2InstanceType::R3Large),
+            "r3.xlarge" => Ok(EC2InstanceType::R3Xlarge),
+            "t2.large" => Ok(EC2InstanceType::T2Large),
+            "t2.medium" => Ok(EC2InstanceType::T2Medium),
+            "t2.micro" => Ok(EC2InstanceType::T2Micro),
+            "t2.small" => Ok(EC2InstanceType::T2Small),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Log entry describing an event involving Amazon GameLift resources (such as a fleet). In addition to tracking activity, event codes and messages can provide additional information for troubleshooting and debugging problems.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Event {
@@ -936,6 +1128,135 @@ pub struct Event {
     #[serde(rename="ResourceId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub resource_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventCode {
+    FleetActivationFailed,
+    FleetActivationFailedNoInstances,
+    FleetBinaryDownloadFailed,
+    FleetCreated,
+    FleetDeleted,
+    FleetInitializationFailed,
+    FleetNewGameSessionProtectionPolicyUpdated,
+    FleetScalingEvent,
+    FleetStateActivating,
+    FleetStateActive,
+    FleetStateBuilding,
+    FleetStateDownloading,
+    FleetStateError,
+    FleetStateValidating,
+    FleetValidationExecutableRuntimeFailure,
+    FleetValidationLaunchPathNotFound,
+    FleetValidationTimedOut,
+    GameSessionActivationTimeout,
+    GenericEvent,
+    ServerProcessCrashed,
+    ServerProcessForceTerminated,
+    ServerProcessInvalidPath,
+    ServerProcessProcessExitTimeout,
+    ServerProcessProcessReadyTimeout,
+    ServerProcessSdkInitializationTimeout,
+    ServerProcessTerminatedUnhealthy,
+}
+
+impl Into<String> for EventCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventCode {
+    fn into(self) -> &'static str {
+        match self {
+            EventCode::FleetActivationFailed => "FLEET_ACTIVATION_FAILED",
+            EventCode::FleetActivationFailedNoInstances => "FLEET_ACTIVATION_FAILED_NO_INSTANCES",
+            EventCode::FleetBinaryDownloadFailed => "FLEET_BINARY_DOWNLOAD_FAILED",
+            EventCode::FleetCreated => "FLEET_CREATED",
+            EventCode::FleetDeleted => "FLEET_DELETED",
+            EventCode::FleetInitializationFailed => "FLEET_INITIALIZATION_FAILED",
+            EventCode::FleetNewGameSessionProtectionPolicyUpdated => {
+                "FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED"
+            }
+            EventCode::FleetScalingEvent => "FLEET_SCALING_EVENT",
+            EventCode::FleetStateActivating => "FLEET_STATE_ACTIVATING",
+            EventCode::FleetStateActive => "FLEET_STATE_ACTIVE",
+            EventCode::FleetStateBuilding => "FLEET_STATE_BUILDING",
+            EventCode::FleetStateDownloading => "FLEET_STATE_DOWNLOADING",
+            EventCode::FleetStateError => "FLEET_STATE_ERROR",
+            EventCode::FleetStateValidating => "FLEET_STATE_VALIDATING",
+            EventCode::FleetValidationExecutableRuntimeFailure => {
+                "FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE"
+            }
+            EventCode::FleetValidationLaunchPathNotFound => {
+                "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND"
+            }
+            EventCode::FleetValidationTimedOut => "FLEET_VALIDATION_TIMED_OUT",
+            EventCode::GameSessionActivationTimeout => "GAME_SESSION_ACTIVATION_TIMEOUT",
+            EventCode::GenericEvent => "GENERIC_EVENT",
+            EventCode::ServerProcessCrashed => "SERVER_PROCESS_CRASHED",
+            EventCode::ServerProcessForceTerminated => "SERVER_PROCESS_FORCE_TERMINATED",
+            EventCode::ServerProcessInvalidPath => "SERVER_PROCESS_INVALID_PATH",
+            EventCode::ServerProcessProcessExitTimeout => "SERVER_PROCESS_PROCESS_EXIT_TIMEOUT",
+            EventCode::ServerProcessProcessReadyTimeout => "SERVER_PROCESS_PROCESS_READY_TIMEOUT",
+            EventCode::ServerProcessSdkInitializationTimeout => {
+                "SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT"
+            }
+            EventCode::ServerProcessTerminatedUnhealthy => "SERVER_PROCESS_TERMINATED_UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FLEET_ACTIVATION_FAILED" => Ok(EventCode::FleetActivationFailed),
+            "FLEET_ACTIVATION_FAILED_NO_INSTANCES" => {
+                Ok(EventCode::FleetActivationFailedNoInstances)
+            }
+            "FLEET_BINARY_DOWNLOAD_FAILED" => Ok(EventCode::FleetBinaryDownloadFailed),
+            "FLEET_CREATED" => Ok(EventCode::FleetCreated),
+            "FLEET_DELETED" => Ok(EventCode::FleetDeleted),
+            "FLEET_INITIALIZATION_FAILED" => Ok(EventCode::FleetInitializationFailed),
+            "FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED" => {
+                Ok(EventCode::FleetNewGameSessionProtectionPolicyUpdated)
+            }
+            "FLEET_SCALING_EVENT" => Ok(EventCode::FleetScalingEvent),
+            "FLEET_STATE_ACTIVATING" => Ok(EventCode::FleetStateActivating),
+            "FLEET_STATE_ACTIVE" => Ok(EventCode::FleetStateActive),
+            "FLEET_STATE_BUILDING" => Ok(EventCode::FleetStateBuilding),
+            "FLEET_STATE_DOWNLOADING" => Ok(EventCode::FleetStateDownloading),
+            "FLEET_STATE_ERROR" => Ok(EventCode::FleetStateError),
+            "FLEET_STATE_VALIDATING" => Ok(EventCode::FleetStateValidating),
+            "FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE" => {
+                Ok(EventCode::FleetValidationExecutableRuntimeFailure)
+            }
+            "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND" => {
+                Ok(EventCode::FleetValidationLaunchPathNotFound)
+            }
+            "FLEET_VALIDATION_TIMED_OUT" => Ok(EventCode::FleetValidationTimedOut),
+            "GAME_SESSION_ACTIVATION_TIMEOUT" => Ok(EventCode::GameSessionActivationTimeout),
+            "GENERIC_EVENT" => Ok(EventCode::GenericEvent),
+            "SERVER_PROCESS_CRASHED" => Ok(EventCode::ServerProcessCrashed),
+            "SERVER_PROCESS_FORCE_TERMINATED" => Ok(EventCode::ServerProcessForceTerminated),
+            "SERVER_PROCESS_INVALID_PATH" => Ok(EventCode::ServerProcessInvalidPath),
+            "SERVER_PROCESS_PROCESS_EXIT_TIMEOUT" => Ok(EventCode::ServerProcessProcessExitTimeout),
+            "SERVER_PROCESS_PROCESS_READY_TIMEOUT" => {
+                Ok(EventCode::ServerProcessProcessReadyTimeout)
+            }
+            "SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT" => {
+                Ok(EventCode::ServerProcessSdkInitializationTimeout)
+            }
+            "SERVER_PROCESS_TERMINATED_UNHEALTHY" => {
+                Ok(EventCode::ServerProcessTerminatedUnhealthy)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>General properties describing a fleet.</p>"]
@@ -1018,6 +1339,62 @@ pub struct FleetCapacity {
     #[serde(rename="InstanceType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetStatus {
+    Activating,
+    Active,
+    Building,
+    Deleting,
+    Downloading,
+    Error,
+    New,
+    Terminated,
+    Validating,
+}
+
+impl Into<String> for FleetStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetStatus {
+    fn into(self) -> &'static str {
+        match self {
+            FleetStatus::Activating => "ACTIVATING",
+            FleetStatus::Active => "ACTIVE",
+            FleetStatus::Building => "BUILDING",
+            FleetStatus::Deleting => "DELETING",
+            FleetStatus::Downloading => "DOWNLOADING",
+            FleetStatus::Error => "ERROR",
+            FleetStatus::New => "NEW",
+            FleetStatus::Terminated => "TERMINATED",
+            FleetStatus::Validating => "VALIDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVATING" => Ok(FleetStatus::Activating),
+            "ACTIVE" => Ok(FleetStatus::Active),
+            "BUILDING" => Ok(FleetStatus::Building),
+            "DELETING" => Ok(FleetStatus::Deleting),
+            "DOWNLOADING" => Ok(FleetStatus::Downloading),
+            "ERROR" => Ok(FleetStatus::Error),
+            "NEW" => Ok(FleetStatus::New),
+            "TERMINATED" => Ok(FleetStatus::Terminated),
+            "VALIDATING" => Ok(FleetStatus::Validating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Current status of fleet utilization, including the number of game and player sessions being hosted.</p>"]
@@ -1191,6 +1568,47 @@ pub struct GameSessionPlacement {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GameSessionPlacementState {
+    Cancelled,
+    Fulfilled,
+    Pending,
+    TimedOut,
+}
+
+impl Into<String> for GameSessionPlacementState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GameSessionPlacementState {
+    fn into(self) -> &'static str {
+        match self {
+            GameSessionPlacementState::Cancelled => "CANCELLED",
+            GameSessionPlacementState::Fulfilled => "FULFILLED",
+            GameSessionPlacementState::Pending => "PENDING",
+            GameSessionPlacementState::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GameSessionPlacementState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(GameSessionPlacementState::Cancelled),
+            "FULFILLED" => Ok(GameSessionPlacementState::Fulfilled),
+            "PENDING" => Ok(GameSessionPlacementState::Pending),
+            "TIMED_OUT" => Ok(GameSessionPlacementState::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Configuration of a queue that is used to process game session placement requests. The queue configuration identifies several game features:</p> <ul> <li> <p>The destinations where a new game session can potentially be hosted. Amazon GameLift tries these destinations in an order based on either the queue's default order or player latency information, if provided in a placement request. With latency information, Amazon GameLift can place game sessions where the majority of players are reporting the lowest possible latency. </p> </li> <li> <p>The length of time that placement requests can wait in the queue before timing out. </p> </li> <li> <p>A set of optional latency policies that protect individual players from high latencies, preventing game sessions from being placed where any individual player is reporting latency higher than a policy's maximum.</p> </li> </ul> <p>Queue-related operations include the following:</p> <ul> <li> <p> <a>CreateGameSessionQueue</a> </p> </li> <li> <p> <a>DescribeGameSessionQueues</a> </p> </li> <li> <p> <a>UpdateGameSessionQueue</a> </p> </li> <li> <p> <a>DeleteGameSessionQueue</a> </p> </li> </ul>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct GameSessionQueue {
@@ -1223,6 +1641,50 @@ pub struct GameSessionQueueDestination {
     #[serde(rename="DestinationArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub destination_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GameSessionStatus {
+    Activating,
+    Active,
+    Error,
+    Terminated,
+    Terminating,
+}
+
+impl Into<String> for GameSessionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GameSessionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            GameSessionStatus::Activating => "ACTIVATING",
+            GameSessionStatus::Active => "ACTIVE",
+            GameSessionStatus::Error => "ERROR",
+            GameSessionStatus::Terminated => "TERMINATED",
+            GameSessionStatus::Terminating => "TERMINATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GameSessionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVATING" => Ok(GameSessionStatus::Activating),
+            "ACTIVE" => Ok(GameSessionStatus::Active),
+            "ERROR" => Ok(GameSessionStatus::Error),
+            "TERMINATED" => Ok(GameSessionStatus::Terminated),
+            "TERMINATING" => Ok(GameSessionStatus::Terminating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -1333,6 +1795,44 @@ pub struct InstanceCredentials {
     pub user_name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceStatus {
+    Active,
+    Pending,
+    Terminating,
+}
+
+impl Into<String> for InstanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceStatus::Active => "ACTIVE",
+            InstanceStatus::Pending => "PENDING",
+            InstanceStatus::Terminating => "TERMINATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(InstanceStatus::Active),
+            "PENDING" => Ok(InstanceStatus::Pending),
+            "TERMINATING" => Ok(InstanceStatus::Terminating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A range of IP addresses and port settings that allow inbound traffic to connect to server processes on Amazon GameLift. Each game session hosted on a fleet is assigned a unique combination of IP address and port number, which must fall into the fleet's allowed ranges. This combination is included in the <a>GameSession</a> object. </p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IpPermission {
@@ -1348,6 +1848,41 @@ pub struct IpPermission {
     #[doc="<p>Ending value for a range of allowed port numbers. Port numbers are end-inclusive. This value must be higher than <code>FromPort</code>.</p>"]
     #[serde(rename="ToPort")]
     pub to_port: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IpProtocol {
+    Tcp,
+    Udp,
+}
+
+impl Into<String> for IpProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IpProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            IpProtocol::Tcp => "TCP",
+            IpProtocol::Udp => "UDP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IpProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TCP" => Ok(IpProtocol::Tcp),
+            "UDP" => Ok(IpProtocol::Udp),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -1444,6 +1979,103 @@ pub struct ListFleetsOutput {
     pub next_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricName {
+    ActivatingGameSessions,
+    ActiveGameSessions,
+    ActiveInstances,
+    AvailableGameSessions,
+    AvailablePlayerSessions,
+    CurrentPlayerSessions,
+    IdleInstances,
+    PercentAvailableGameSessions,
+    PercentIdleInstances,
+    QueueDepth,
+    WaitTime,
+}
+
+impl Into<String> for MetricName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricName {
+    fn into(self) -> &'static str {
+        match self {
+            MetricName::ActivatingGameSessions => "ActivatingGameSessions",
+            MetricName::ActiveGameSessions => "ActiveGameSessions",
+            MetricName::ActiveInstances => "ActiveInstances",
+            MetricName::AvailableGameSessions => "AvailableGameSessions",
+            MetricName::AvailablePlayerSessions => "AvailablePlayerSessions",
+            MetricName::CurrentPlayerSessions => "CurrentPlayerSessions",
+            MetricName::IdleInstances => "IdleInstances",
+            MetricName::PercentAvailableGameSessions => "PercentAvailableGameSessions",
+            MetricName::PercentIdleInstances => "PercentIdleInstances",
+            MetricName::QueueDepth => "QueueDepth",
+            MetricName::WaitTime => "WaitTime",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivatingGameSessions" => Ok(MetricName::ActivatingGameSessions),
+            "ActiveGameSessions" => Ok(MetricName::ActiveGameSessions),
+            "ActiveInstances" => Ok(MetricName::ActiveInstances),
+            "AvailableGameSessions" => Ok(MetricName::AvailableGameSessions),
+            "AvailablePlayerSessions" => Ok(MetricName::AvailablePlayerSessions),
+            "CurrentPlayerSessions" => Ok(MetricName::CurrentPlayerSessions),
+            "IdleInstances" => Ok(MetricName::IdleInstances),
+            "PercentAvailableGameSessions" => Ok(MetricName::PercentAvailableGameSessions),
+            "PercentIdleInstances" => Ok(MetricName::PercentIdleInstances),
+            "QueueDepth" => Ok(MetricName::QueueDepth),
+            "WaitTime" => Ok(MetricName::WaitTime),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperatingSystem {
+    AmazonLinux,
+    Windows2012,
+}
+
+impl Into<String> for OperatingSystem {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperatingSystem {
+    fn into(self) -> &'static str {
+        match self {
+            OperatingSystem::AmazonLinux => "AMAZON_LINUX",
+            OperatingSystem::Windows2012 => "WINDOWS_2012",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperatingSystem {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AMAZON_LINUX" => Ok(OperatingSystem::AmazonLinux),
+            "WINDOWS_2012" => Ok(OperatingSystem::Windows2012),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a player session that was created as part of a <a>StartGameSessionPlacement</a> request. This object contains only the player ID and player session ID. To retrieve full details on a player session, call <a>DescribePlayerSessions</a> with the player session ID.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PlacedPlayerSession {
@@ -1530,6 +2162,117 @@ pub struct PlayerSession {
     #[serde(rename="TerminationTime")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub termination_time: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlayerSessionCreationPolicy {
+    AcceptAll,
+    DenyAll,
+}
+
+impl Into<String> for PlayerSessionCreationPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlayerSessionCreationPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            PlayerSessionCreationPolicy::AcceptAll => "ACCEPT_ALL",
+            PlayerSessionCreationPolicy::DenyAll => "DENY_ALL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlayerSessionCreationPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCEPT_ALL" => Ok(PlayerSessionCreationPolicy::AcceptAll),
+            "DENY_ALL" => Ok(PlayerSessionCreationPolicy::DenyAll),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlayerSessionStatus {
+    Active,
+    Completed,
+    Reserved,
+    Timedout,
+}
+
+impl Into<String> for PlayerSessionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlayerSessionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PlayerSessionStatus::Active => "ACTIVE",
+            PlayerSessionStatus::Completed => "COMPLETED",
+            PlayerSessionStatus::Reserved => "RESERVED",
+            PlayerSessionStatus::Timedout => "TIMEDOUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlayerSessionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(PlayerSessionStatus::Active),
+            "COMPLETED" => Ok(PlayerSessionStatus::Completed),
+            "RESERVED" => Ok(PlayerSessionStatus::Reserved),
+            "TIMEDOUT" => Ok(PlayerSessionStatus::Timedout),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProtectionPolicy {
+    FullProtection,
+    NoProtection,
+}
+
+impl Into<String> for ProtectionPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProtectionPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ProtectionPolicy::FullProtection => "FullProtection",
+            ProtectionPolicy::NoProtection => "NoProtection",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProtectionPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FullProtection" => Ok(ProtectionPolicy::FullProtection),
+            "NoProtection" => Ok(ProtectionPolicy::NoProtection),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -1638,6 +2381,41 @@ pub struct RoutingStrategy {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RoutingStrategyType {
+    Simple,
+    Terminal,
+}
+
+impl Into<String> for RoutingStrategyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RoutingStrategyType {
+    fn into(self) -> &'static str {
+        match self {
+            RoutingStrategyType::Simple => "SIMPLE",
+            RoutingStrategyType::Terminal => "TERMINAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RoutingStrategyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SIMPLE" => Ok(RoutingStrategyType::Simple),
+            "TERMINAL" => Ok(RoutingStrategyType::Terminal),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Collection of server process configurations that describe what processes should be run on each instance in a fleet. An instance can launch and maintain multiple server processes based on the runtime configuration; it regularly checks for an updated runtime configuration and starts new server processes to match the latest version.</p> <p>The key purpose of a runtime configuration with multiple server process configurations is to be able to run more than one kind of game server in a single fleet. You can include configurations for more than one server executable in order to run two or more different programs to run on the same instance. This option might be useful, for example, to run more than one version of your game server on the same fleet. Another option is to specify configurations for the same server executable but with different launch parameters.</p> <p>A Amazon GameLift instance is limited to 50 processes running simultaneously. To calculate the total number of processes specified in a runtime configuration, add the values of the <code>ConcurrentExecutions</code> parameter for each <code> <a>ServerProcess</a> </code> object in the runtime configuration.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RuntimeConfiguration {
@@ -1670,6 +2448,44 @@ pub struct S3Location {
     #[serde(rename="RoleArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingAdjustmentType {
+    ChangeInCapacity,
+    ExactCapacity,
+    PercentChangeInCapacity,
+}
+
+impl Into<String> for ScalingAdjustmentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingAdjustmentType {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingAdjustmentType::ChangeInCapacity => "ChangeInCapacity",
+            ScalingAdjustmentType::ExactCapacity => "ExactCapacity",
+            ScalingAdjustmentType::PercentChangeInCapacity => "PercentChangeInCapacity",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingAdjustmentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ChangeInCapacity" => Ok(ScalingAdjustmentType::ChangeInCapacity),
+            "ExactCapacity" => Ok(ScalingAdjustmentType::ExactCapacity),
+            "PercentChangeInCapacity" => Ok(ScalingAdjustmentType::PercentChangeInCapacity),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Rule that controls how a fleet is scaled. Scaling policies are uniquely identified by the combination of name and fleet ID.</p>"]
@@ -1711,6 +2527,56 @@ pub struct ScalingPolicy {
     #[serde(rename="Threshold")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub threshold: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingStatusType {
+    Active,
+    Deleted,
+    DeleteRequested,
+    Deleting,
+    Error,
+    UpdateRequested,
+    Updating,
+}
+
+impl Into<String> for ScalingStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingStatusType::Active => "ACTIVE",
+            ScalingStatusType::Deleted => "DELETED",
+            ScalingStatusType::DeleteRequested => "DELETE_REQUESTED",
+            ScalingStatusType::Deleting => "DELETING",
+            ScalingStatusType::Error => "ERROR",
+            ScalingStatusType::UpdateRequested => "UPDATE_REQUESTED",
+            ScalingStatusType::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ScalingStatusType::Active),
+            "DELETED" => Ok(ScalingStatusType::Deleted),
+            "DELETE_REQUESTED" => Ok(ScalingStatusType::DeleteRequested),
+            "DELETING" => Ok(ScalingStatusType::Deleting),
+            "ERROR" => Ok(ScalingStatusType::Error),
+            "UPDATE_REQUESTED" => Ok(ScalingStatusType::UpdateRequested),
+            "UPDATING" => Ok(ScalingStatusType::Updating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -6892,7 +7758,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAliasOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6916,7 +7782,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateBuildOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateBuildError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6940,7 +7806,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateFleetOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6964,7 +7830,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateGameSessionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6992,7 +7858,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateGameSessionQueueOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7019,7 +7885,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreatePlayerSessionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7046,7 +7912,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreatePlayerSessionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7071,7 +7937,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -7091,7 +7957,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteBuildError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -7111,7 +7977,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteFleetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -7134,7 +8000,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteGameSessionQueueOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7161,7 +8027,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteScalingPolicyError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -7186,7 +8052,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAliasOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7212,7 +8078,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeBuildOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7239,7 +8105,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEC2InstanceLimitsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeEC2InstanceLimitsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7264,7 +8130,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeFleetAttributesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeFleetAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7289,7 +8155,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeFleetCapacityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7316,7 +8182,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeFleetEventsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7344,7 +8210,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeFleetPortSettingsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeFleetPortSettingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7369,7 +8235,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeFleetUtilizationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeFleetUtilizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7394,7 +8260,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeGameSessionDetailsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeGameSessionDetailsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7419,7 +8285,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeGameSessionPlacementOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeGameSessionPlacementError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7444,7 +8310,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeGameSessionQueuesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeGameSessionQueuesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7468,7 +8334,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeGameSessionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7495,7 +8361,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeInstancesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7523,7 +8389,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribePlayerSessionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7551,7 +8417,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeRuntimeConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeRuntimeConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7576,7 +8442,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeScalingPoliciesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeScalingPoliciesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7601,7 +8467,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetGameSessionLogUrlOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7628,7 +8494,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstanceAccessOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7655,7 +8521,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAliasesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListAliasesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7677,7 +8543,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListBuildsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListBuildsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7699,7 +8565,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListFleetsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListFleetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7723,7 +8589,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutScalingPolicyOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7751,7 +8617,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RequestUploadCredentialsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RequestUploadCredentialsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7775,7 +8641,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ResolveAliasOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7801,7 +8667,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SearchGameSessionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7829,7 +8695,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartGameSessionPlacementOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StartGameSessionPlacementError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7854,7 +8720,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopGameSessionPlacementOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StopGameSessionPlacementError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7878,7 +8744,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateAliasOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7902,7 +8768,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateBuildOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateBuildError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7927,7 +8793,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateFleetAttributesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7954,7 +8820,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateFleetCapacityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7982,7 +8848,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateFleetPortSettingsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateFleetPortSettingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8006,7 +8872,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateGameSessionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8034,7 +8900,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateGameSessionQueueOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8062,7 +8928,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateRuntimeConfigurationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateRuntimeConfigurationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -50,6 +46,41 @@ pub struct AbortVaultLockInput {
     #[doc="<p>The name of the vault.</p>"]
     #[serde(rename="vaultName")]
     pub vault_name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionCode {
+    ArchiveRetrieval,
+    InventoryRetrieval,
+}
+
+impl Into<String> for ActionCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionCode {
+    fn into(self) -> &'static str {
+        match self {
+            ActionCode::ArchiveRetrieval => "ArchiveRetrieval",
+            ActionCode::InventoryRetrieval => "InventoryRetrieval",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ArchiveRetrieval" => Ok(ActionCode::ArchiveRetrieval),
+            "InventoryRetrieval" => Ok(ActionCode::InventoryRetrieval),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The input values for <code>AddTagsToVault</code>.</p>"]
@@ -924,6 +955,44 @@ pub struct SetVaultNotificationsInput {
     #[serde(rename="vaultNotificationConfig")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vault_notification_config: Option<VaultNotificationConfig>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusCode {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for StatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            StatusCode::Failed => "Failed",
+            StatusCode::InProgress => "InProgress",
+            StatusCode::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(StatusCode::Failed),
+            "InProgress" => Ok(StatusCode::InProgress),
+            "Succeeded" => Ok(StatusCode::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides options to add an archive to a vault.</p>"]
@@ -4298,7 +4367,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4332,7 +4401,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4366,7 +4435,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4403,7 +4472,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -4458,7 +4527,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4494,7 +4563,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -4539,7 +4608,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4572,7 +4641,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4605,7 +4674,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4638,7 +4707,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4672,7 +4741,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4715,7 +4784,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4760,7 +4829,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4807,7 +4876,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = GetJobOutputOutput::default();
                 result.body = Some(response.body);
@@ -4833,7 +4902,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
                     let value = content_type.to_owned();
                     result.content_type = Some(value)
                 };
-                result.status = Some(StatusCode::to_u16(&response.status) as i64);
+                result.status = Some(::hyper::status::StatusCode::to_u16(&response.status) as i64);
                 Ok(result)
             }
             _ => {
@@ -4865,7 +4934,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4911,7 +4980,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4957,7 +5026,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -5003,7 +5072,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body = response.body;
 
@@ -5054,7 +5123,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -5105,7 +5174,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -5165,7 +5234,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -5215,7 +5284,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -5267,7 +5336,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -5310,7 +5379,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -5354,7 +5423,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -5403,7 +5472,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -5446,7 +5515,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -5493,7 +5562,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5528,7 +5597,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5564,7 +5633,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5600,7 +5669,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5636,7 +5705,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -5693,7 +5762,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
 
                 let mut body = response.body;
 

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -278,6 +274,44 @@ pub struct EntityFilter {
     pub tags: Option<Vec<::std::collections::HashMap<String, String>>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EntityStatusCode {
+    Impaired,
+    Unimpaired,
+    Unknown,
+}
+
+impl Into<String> for EntityStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EntityStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            EntityStatusCode::Impaired => "IMPAIRED",
+            EntityStatusCode::Unimpaired => "UNIMPAIRED",
+            EntityStatusCode::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EntityStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IMPAIRED" => Ok(EntityStatusCode::Impaired),
+            "UNIMPAIRED" => Ok(EntityStatusCode::Unimpaired),
+            "UNKNOWN" => Ok(EntityStatusCode::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Summary information about an event, returned by the <a>DescribeEvents</a> operation. The <a>DescribeEventDetails</a> operation also returns this information, as well as the <a>EventDescription</a> and additional event metadata.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Event {
@@ -334,6 +368,38 @@ pub struct EventAggregate {
     #[serde(rename="count")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub count: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventAggregateField {
+    EventTypeCategory,
+}
+
+impl Into<String> for EventAggregateField {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventAggregateField {
+    fn into(self) -> &'static str {
+        match self {
+            EventAggregateField::EventTypeCategory => "eventTypeCategory",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventAggregateField {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "eventTypeCategory" => Ok(EventAggregateField::EventTypeCategory),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Detailed information about an event. A combination of an <a>Event</a> object, an <a>EventDescription</a> object, and additional metadata about the event. Returned by the <a>DescribeEventDetails</a> operation.</p>"]
@@ -425,6 +491,82 @@ pub struct EventFilter {
     #[serde(rename="tags")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<::std::collections::HashMap<String, String>>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventStatusCode {
+    Closed,
+    Open,
+    Upcoming,
+}
+
+impl Into<String> for EventStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            EventStatusCode::Closed => "closed",
+            EventStatusCode::Open => "open",
+            EventStatusCode::Upcoming => "upcoming",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "closed" => Ok(EventStatusCode::Closed),
+            "open" => Ok(EventStatusCode::Open),
+            "upcoming" => Ok(EventStatusCode::Upcoming),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventTypeCategory {
+    AccountNotification,
+    Issue,
+    ScheduledChange,
+}
+
+impl Into<String> for EventTypeCategory {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventTypeCategory {
+    fn into(self) -> &'static str {
+        match self {
+            EventTypeCategory::AccountNotification => "accountNotification",
+            EventTypeCategory::Issue => "issue",
+            EventTypeCategory::ScheduledChange => "scheduledChange",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventTypeCategory {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "accountNotification" => Ok(EventTypeCategory::AccountNotification),
+            "issue" => Ok(EventTypeCategory::Issue),
+            "scheduledChange" => Ok(EventTypeCategory::ScheduledChange),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The values to use to filter results from the <a>DescribeEventTypes</a> operation.</p>"]
@@ -990,7 +1132,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAffectedEntitiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeAffectedEntitiesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1016,7 +1158,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEntityAggregatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeEntityAggregatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1041,7 +1183,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventAggregatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeEventAggregatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1066,7 +1208,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventDetailsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1093,7 +1235,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventTypesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1120,7 +1262,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -480,6 +475,44 @@ impl ArnTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssignmentStatusType {
+    Any,
+    Assigned,
+    Unassigned,
+}
+
+impl Into<String> for AssignmentStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssignmentStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            AssignmentStatusType::Any => "Any",
+            AssignmentStatusType::Assigned => "Assigned",
+            AssignmentStatusType::Unassigned => "Unassigned",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssignmentStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Any" => Ok(AssignmentStatusType::Any),
+            "Assigned" => Ok(AssignmentStatusType::Assigned),
+            "Unassigned" => Ok(AssignmentStatusType::Unassigned),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone)]
 pub struct AttachGroupPolicyRequest {
     #[doc="<p>The name (friendly name, not ARN) of the group to attach the policy to.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
@@ -655,7 +688,7 @@ impl AttachmentCountTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -669,7 +702,7 @@ impl BooleanObjectTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -683,7 +716,7 @@ impl BooleanTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -886,7 +919,7 @@ impl ColumnNumberDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -999,6 +1032,71 @@ impl ContextKeyNamesResultListTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContextKeyTypeEnum {
+    Binary,
+    BinaryList,
+    Boolean,
+    BooleanList,
+    Date,
+    DateList,
+    Ip,
+    IpList,
+    Numeric,
+    NumericList,
+    String,
+    StringList,
+}
+
+impl Into<String> for ContextKeyTypeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContextKeyTypeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            ContextKeyTypeEnum::Binary => "binary",
+            ContextKeyTypeEnum::BinaryList => "binaryList",
+            ContextKeyTypeEnum::Boolean => "boolean",
+            ContextKeyTypeEnum::BooleanList => "booleanList",
+            ContextKeyTypeEnum::Date => "date",
+            ContextKeyTypeEnum::DateList => "dateList",
+            ContextKeyTypeEnum::Ip => "ip",
+            ContextKeyTypeEnum::IpList => "ipList",
+            ContextKeyTypeEnum::Numeric => "numeric",
+            ContextKeyTypeEnum::NumericList => "numericList",
+            ContextKeyTypeEnum::String => "string",
+            ContextKeyTypeEnum::StringList => "stringList",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContextKeyTypeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "binary" => Ok(ContextKeyTypeEnum::Binary),
+            "binaryList" => Ok(ContextKeyTypeEnum::BinaryList),
+            "boolean" => Ok(ContextKeyTypeEnum::Boolean),
+            "booleanList" => Ok(ContextKeyTypeEnum::BooleanList),
+            "date" => Ok(ContextKeyTypeEnum::Date),
+            "dateList" => Ok(ContextKeyTypeEnum::DateList),
+            "ip" => Ok(ContextKeyTypeEnum::Ip),
+            "ipList" => Ok(ContextKeyTypeEnum::IpList),
+            "numeric" => Ok(ContextKeyTypeEnum::Numeric),
+            "numericList" => Ok(ContextKeyTypeEnum::NumericList),
+            "string" => Ok(ContextKeyTypeEnum::String),
+            "stringList" => Ok(ContextKeyTypeEnum::StringList),
+            _ => Err(()),
+        }
+    }
+}
+
 
 /// Serialize `ContextKeyValueListType` contents to a `SignedRequest`.
 struct ContextKeyValueListTypeSerializer;
@@ -2623,6 +2721,41 @@ impl EnableMFADeviceRequestSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EncodingType {
+    Pem,
+    Ssh,
+}
+
+impl Into<String> for EncodingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EncodingType {
+    fn into(self) -> &'static str {
+        match self {
+            EncodingType::Pem => "PEM",
+            EncodingType::Ssh => "SSH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EncodingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PEM" => Ok(EncodingType::Pem),
+            "SSH" => Ok(EncodingType::Ssh),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `EntityListType` contents to a `SignedRequest`.
 struct EntityListTypeSerializer;
 impl EntityListTypeSerializer {
@@ -2630,6 +2763,50 @@ impl EntityListTypeSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EntityType {
+    AwsmanagedPolicy,
+    Group,
+    LocalManagedPolicy,
+    Role,
+    User,
+}
+
+impl Into<String> for EntityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EntityType {
+    fn into(self) -> &'static str {
+        match self {
+            EntityType::AwsmanagedPolicy => "AWSManagedPolicy",
+            EntityType::Group => "Group",
+            EntityType::LocalManagedPolicy => "LocalManagedPolicy",
+            EntityType::Role => "Role",
+            EntityType::User => "User",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EntityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWSManagedPolicy" => Ok(EntityType::AwsmanagedPolicy),
+            "Group" => Ok(EntityType::Group),
+            "LocalManagedPolicy" => Ok(EntityType::LocalManagedPolicy),
+            "Role" => Ok(EntityType::Role),
+            "User" => Ok(EntityType::User),
+            _ => Err(()),
         }
     }
 }
@@ -4889,7 +5066,7 @@ impl LineNumberDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7553,7 +7730,7 @@ impl MaxPasswordAgeTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7608,7 +7785,7 @@ impl MinimumPasswordLengthTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7884,7 +8061,7 @@ impl PasswordReusePreventionTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -8178,6 +8355,44 @@ impl PolicyDocumentVersionListTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyEvaluationDecisionType {
+    Allowed,
+    ExplicitDeny,
+    ImplicitDeny,
+}
+
+impl Into<String> for PolicyEvaluationDecisionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyEvaluationDecisionType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyEvaluationDecisionType::Allowed => "allowed",
+            PolicyEvaluationDecisionType::ExplicitDeny => "explicitDeny",
+            PolicyEvaluationDecisionType::ImplicitDeny => "implicitDeny",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyEvaluationDecisionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allowed" => Ok(PolicyEvaluationDecisionType::Allowed),
+            "explicitDeny" => Ok(PolicyEvaluationDecisionType::ExplicitDeny),
+            "implicitDeny" => Ok(PolicyEvaluationDecisionType::ImplicitDeny),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PolicyEvaluationDecisionTypeDeserializer;
 impl PolicyEvaluationDecisionTypeDeserializer {
     #[allow(unused_variables)]
@@ -8510,6 +8725,94 @@ impl PolicyRoleListTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyScopeType {
+    Aws,
+    All,
+    Local,
+}
+
+impl Into<String> for PolicyScopeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyScopeType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyScopeType::Aws => "AWS",
+            PolicyScopeType::All => "All",
+            PolicyScopeType::Local => "Local",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyScopeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(PolicyScopeType::Aws),
+            "All" => Ok(PolicyScopeType::All),
+            "Local" => Ok(PolicyScopeType::Local),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicySourceType {
+    AwsManaged,
+    Group,
+    None,
+    Resource,
+    Role,
+    User,
+    UserManaged,
+}
+
+impl Into<String> for PolicySourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicySourceType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicySourceType::AwsManaged => "aws-managed",
+            PolicySourceType::Group => "group",
+            PolicySourceType::None => "none",
+            PolicySourceType::Resource => "resource",
+            PolicySourceType::Role => "role",
+            PolicySourceType::User => "user",
+            PolicySourceType::UserManaged => "user-managed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicySourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "aws-managed" => Ok(PolicySourceType::AwsManaged),
+            "group" => Ok(PolicySourceType::Group),
+            "none" => Ok(PolicySourceType::None),
+            "resource" => Ok(PolicySourceType::Resource),
+            "role" => Ok(PolicySourceType::Role),
+            "user" => Ok(PolicySourceType::User),
+            "user-managed" => Ok(PolicySourceType::UserManaged),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PolicySourceTypeDeserializer;
 impl PolicySourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -8976,6 +9279,38 @@ impl ReportContentTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportFormatType {
+    TextCsv,
+}
+
+impl Into<String> for ReportFormatType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportFormatType {
+    fn into(self) -> &'static str {
+        match self {
+            ReportFormatType::TextCsv => "text/csv",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportFormatType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text/csv" => Ok(ReportFormatType::TextCsv),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReportFormatTypeDeserializer;
 impl ReportFormatTypeDeserializer {
     #[allow(unused_variables)]
@@ -9004,6 +9339,44 @@ impl ReportStateDescriptionTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportStateType {
+    Complete,
+    Inprogress,
+    Started,
+}
+
+impl Into<String> for ReportStateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportStateType {
+    fn into(self) -> &'static str {
+        match self {
+            ReportStateType::Complete => "COMPLETE",
+            ReportStateType::Inprogress => "INPROGRESS",
+            ReportStateType::Started => "STARTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportStateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETE" => Ok(ReportStateType::Complete),
+            "INPROGRESS" => Ok(ReportStateType::Inprogress),
+            "STARTED" => Ok(ReportStateType::Started),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReportStateTypeDeserializer;
 impl ReportStateTypeDeserializer {
     #[allow(unused_variables)]
@@ -10782,6 +11155,41 @@ impl StatementListTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusType {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for StatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusType {
+    fn into(self) -> &'static str {
+        match self {
+            StatusType::Active => "Active",
+            StatusType::Inactive => "Inactive",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(StatusType::Active),
+            "Inactive" => Ok(StatusType::Inactive),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatusTypeDeserializer;
 impl StatusTypeDeserializer {
     #[allow(unused_variables)]
@@ -10810,6 +11218,116 @@ impl StringTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SummaryKeyType {
+    AccessKeysPerUserQuota,
+    AccountAccessKeysPresent,
+    AccountMFAEnabled,
+    AccountSigningCertificatesPresent,
+    AttachedPoliciesPerGroupQuota,
+    AttachedPoliciesPerRoleQuota,
+    AttachedPoliciesPerUserQuota,
+    GroupPolicySizeQuota,
+    Groups,
+    GroupsPerUserQuota,
+    GroupsQuota,
+    Mfadevices,
+    MfadevicesInUse,
+    Policies,
+    PoliciesQuota,
+    PolicySizeQuota,
+    PolicyVersionsInUse,
+    PolicyVersionsInUseQuota,
+    ServerCertificates,
+    ServerCertificatesQuota,
+    SigningCertificatesPerUserQuota,
+    UserPolicySizeQuota,
+    Users,
+    UsersQuota,
+    VersionsPerPolicyQuota,
+}
+
+impl Into<String> for SummaryKeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SummaryKeyType {
+    fn into(self) -> &'static str {
+        match self {
+            SummaryKeyType::AccessKeysPerUserQuota => "AccessKeysPerUserQuota",
+            SummaryKeyType::AccountAccessKeysPresent => "AccountAccessKeysPresent",
+            SummaryKeyType::AccountMFAEnabled => "AccountMFAEnabled",
+            SummaryKeyType::AccountSigningCertificatesPresent => {
+                "AccountSigningCertificatesPresent"
+            }
+            SummaryKeyType::AttachedPoliciesPerGroupQuota => "AttachedPoliciesPerGroupQuota",
+            SummaryKeyType::AttachedPoliciesPerRoleQuota => "AttachedPoliciesPerRoleQuota",
+            SummaryKeyType::AttachedPoliciesPerUserQuota => "AttachedPoliciesPerUserQuota",
+            SummaryKeyType::GroupPolicySizeQuota => "GroupPolicySizeQuota",
+            SummaryKeyType::Groups => "Groups",
+            SummaryKeyType::GroupsPerUserQuota => "GroupsPerUserQuota",
+            SummaryKeyType::GroupsQuota => "GroupsQuota",
+            SummaryKeyType::Mfadevices => "MFADevices",
+            SummaryKeyType::MfadevicesInUse => "MFADevicesInUse",
+            SummaryKeyType::Policies => "Policies",
+            SummaryKeyType::PoliciesQuota => "PoliciesQuota",
+            SummaryKeyType::PolicySizeQuota => "PolicySizeQuota",
+            SummaryKeyType::PolicyVersionsInUse => "PolicyVersionsInUse",
+            SummaryKeyType::PolicyVersionsInUseQuota => "PolicyVersionsInUseQuota",
+            SummaryKeyType::ServerCertificates => "ServerCertificates",
+            SummaryKeyType::ServerCertificatesQuota => "ServerCertificatesQuota",
+            SummaryKeyType::SigningCertificatesPerUserQuota => "SigningCertificatesPerUserQuota",
+            SummaryKeyType::UserPolicySizeQuota => "UserPolicySizeQuota",
+            SummaryKeyType::Users => "Users",
+            SummaryKeyType::UsersQuota => "UsersQuota",
+            SummaryKeyType::VersionsPerPolicyQuota => "VersionsPerPolicyQuota",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SummaryKeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AccessKeysPerUserQuota" => Ok(SummaryKeyType::AccessKeysPerUserQuota),
+            "AccountAccessKeysPresent" => Ok(SummaryKeyType::AccountAccessKeysPresent),
+            "AccountMFAEnabled" => Ok(SummaryKeyType::AccountMFAEnabled),
+            "AccountSigningCertificatesPresent" => {
+                Ok(SummaryKeyType::AccountSigningCertificatesPresent)
+            }
+            "AttachedPoliciesPerGroupQuota" => Ok(SummaryKeyType::AttachedPoliciesPerGroupQuota),
+            "AttachedPoliciesPerRoleQuota" => Ok(SummaryKeyType::AttachedPoliciesPerRoleQuota),
+            "AttachedPoliciesPerUserQuota" => Ok(SummaryKeyType::AttachedPoliciesPerUserQuota),
+            "GroupPolicySizeQuota" => Ok(SummaryKeyType::GroupPolicySizeQuota),
+            "Groups" => Ok(SummaryKeyType::Groups),
+            "GroupsPerUserQuota" => Ok(SummaryKeyType::GroupsPerUserQuota),
+            "GroupsQuota" => Ok(SummaryKeyType::GroupsQuota),
+            "MFADevices" => Ok(SummaryKeyType::Mfadevices),
+            "MFADevicesInUse" => Ok(SummaryKeyType::MfadevicesInUse),
+            "Policies" => Ok(SummaryKeyType::Policies),
+            "PoliciesQuota" => Ok(SummaryKeyType::PoliciesQuota),
+            "PolicySizeQuota" => Ok(SummaryKeyType::PolicySizeQuota),
+            "PolicyVersionsInUse" => Ok(SummaryKeyType::PolicyVersionsInUse),
+            "PolicyVersionsInUseQuota" => Ok(SummaryKeyType::PolicyVersionsInUseQuota),
+            "ServerCertificates" => Ok(SummaryKeyType::ServerCertificates),
+            "ServerCertificatesQuota" => Ok(SummaryKeyType::ServerCertificatesQuota),
+            "SigningCertificatesPerUserQuota" => {
+                Ok(SummaryKeyType::SigningCertificatesPerUserQuota)
+            }
+            "UserPolicySizeQuota" => Ok(SummaryKeyType::UserPolicySizeQuota),
+            "Users" => Ok(SummaryKeyType::Users),
+            "UsersQuota" => Ok(SummaryKeyType::UsersQuota),
+            "VersionsPerPolicyQuota" => Ok(SummaryKeyType::VersionsPerPolicyQuota),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SummaryKeyTypeDeserializer;
 impl SummaryKeyTypeDeserializer {
     #[allow(unused_variables)]
@@ -10855,7 +11373,7 @@ impl SummaryValueTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -22297,7 +22815,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -22323,7 +22841,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -22347,7 +22865,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -22374,7 +22892,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -22401,7 +22919,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -22428,7 +22946,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -22453,7 +22971,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -22480,7 +22998,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22524,7 +23042,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -22551,7 +23069,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22593,7 +23111,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22638,7 +23156,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22683,7 +23201,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22725,7 +23243,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22768,7 +23286,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22812,7 +23330,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22853,7 +23371,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22898,7 +23416,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22943,7 +23461,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -22985,7 +23503,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -23027,7 +23545,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -23072,7 +23590,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23099,7 +23617,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23126,7 +23644,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23151,7 +23669,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23175,7 +23693,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23199,7 +23717,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23226,7 +23744,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23253,7 +23771,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23280,7 +23798,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23304,7 +23822,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23330,7 +23848,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23355,7 +23873,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23379,7 +23897,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23406,7 +23924,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23433,7 +23951,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23460,7 +23978,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23486,7 +24004,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23512,7 +24030,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23536,7 +24054,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23560,7 +24078,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23587,7 +24105,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23614,7 +24132,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23641,7 +24159,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23668,7 +24186,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23695,7 +24213,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23722,7 +24240,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -23767,7 +24285,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -23813,7 +24331,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -23855,7 +24373,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -23897,7 +24415,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -23942,7 +24460,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -23987,7 +24505,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24030,7 +24548,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24072,7 +24590,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24113,7 +24631,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24157,7 +24675,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24201,7 +24719,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24246,7 +24764,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24288,7 +24806,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24329,7 +24847,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24371,7 +24889,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24412,7 +24930,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24455,7 +24973,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24499,7 +25017,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24544,7 +25062,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24587,7 +25105,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24628,7 +25146,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24671,7 +25189,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24715,7 +25233,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24760,7 +25278,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24803,7 +25321,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24848,7 +25366,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24893,7 +25411,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24938,7 +25456,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -24982,7 +25500,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25023,7 +25541,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25068,7 +25586,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25114,7 +25632,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25156,7 +25674,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25201,7 +25719,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25243,7 +25761,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25286,7 +25804,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25330,7 +25848,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25372,7 +25890,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25413,7 +25931,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25457,7 +25975,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25502,7 +26020,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25548,7 +26066,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25591,7 +26109,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25635,7 +26153,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25677,7 +26195,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25719,7 +26237,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25762,7 +26280,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25787,7 +26305,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25811,7 +26329,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25840,7 +26358,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25866,7 +26384,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25892,7 +26410,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25920,7 +26438,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -25962,7 +26480,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25989,7 +26507,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26015,7 +26533,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -26060,7 +26578,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -26103,7 +26621,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26130,7 +26648,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26156,7 +26674,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26181,7 +26699,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26205,7 +26723,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26233,7 +26751,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26260,7 +26778,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -26305,7 +26823,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -26349,7 +26867,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26376,7 +26894,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26402,7 +26920,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26428,7 +26946,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26452,7 +26970,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26476,7 +26994,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -26521,7 +27039,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -26566,7 +27084,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -376,7 +371,7 @@ impl ErrorCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -678,7 +673,7 @@ impl IsCanceledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -692,7 +687,7 @@ impl IsTruncatedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -785,6 +780,41 @@ impl JobIdListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+#[doc="Specifies whether the job to initiate is an import or export job."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobType {
+    Export,
+    Import,
+}
+
+impl Into<String> for JobType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobType {
+    fn into(self) -> &'static str {
+        match self {
+            JobType::Export => "Export",
+            JobType::Import => "Import",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Export" => Ok(JobType::Export),
+            "Import" => Ok(JobType::Import),
+            _ => Err(()),
         }
     }
 }
@@ -1048,7 +1078,7 @@ impl SuccessDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1957,7 +1987,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -1997,7 +2027,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2041,7 +2071,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2084,7 +2114,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2124,7 +2154,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2164,7 +2194,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -11,21 +11,84 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccessDeniedErrorCode {
+    AccessDeniedToAssessmentRun,
+    AccessDeniedToAssessmentTarget,
+    AccessDeniedToAssessmentTemplate,
+    AccessDeniedToFinding,
+    AccessDeniedToIamRole,
+    AccessDeniedToResourceGroup,
+    AccessDeniedToRulesPackage,
+    AccessDeniedToSnsTopic,
+}
+
+impl Into<String> for AccessDeniedErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccessDeniedErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            AccessDeniedErrorCode::AccessDeniedToAssessmentRun => "ACCESS_DENIED_TO_ASSESSMENT_RUN",
+            AccessDeniedErrorCode::AccessDeniedToAssessmentTarget => {
+                "ACCESS_DENIED_TO_ASSESSMENT_TARGET"
+            }
+            AccessDeniedErrorCode::AccessDeniedToAssessmentTemplate => {
+                "ACCESS_DENIED_TO_ASSESSMENT_TEMPLATE"
+            }
+            AccessDeniedErrorCode::AccessDeniedToFinding => "ACCESS_DENIED_TO_FINDING",
+            AccessDeniedErrorCode::AccessDeniedToIamRole => "ACCESS_DENIED_TO_IAM_ROLE",
+            AccessDeniedErrorCode::AccessDeniedToResourceGroup => "ACCESS_DENIED_TO_RESOURCE_GROUP",
+            AccessDeniedErrorCode::AccessDeniedToRulesPackage => "ACCESS_DENIED_TO_RULES_PACKAGE",
+            AccessDeniedErrorCode::AccessDeniedToSnsTopic => "ACCESS_DENIED_TO_SNS_TOPIC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccessDeniedErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCESS_DENIED_TO_ASSESSMENT_RUN" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToAssessmentRun)
+            }
+            "ACCESS_DENIED_TO_ASSESSMENT_TARGET" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToAssessmentTarget)
+            }
+            "ACCESS_DENIED_TO_ASSESSMENT_TEMPLATE" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToAssessmentTemplate)
+            }
+            "ACCESS_DENIED_TO_FINDING" => Ok(AccessDeniedErrorCode::AccessDeniedToFinding),
+            "ACCESS_DENIED_TO_IAM_ROLE" => Ok(AccessDeniedErrorCode::AccessDeniedToIamRole),
+            "ACCESS_DENIED_TO_RESOURCE_GROUP" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToResourceGroup)
+            }
+            "ACCESS_DENIED_TO_RULES_PACKAGE" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToRulesPackage)
+            }
+            "ACCESS_DENIED_TO_SNS_TOPIC" => Ok(AccessDeniedErrorCode::AccessDeniedToSnsTopic),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AddAttributesToFindingsRequest {
     #[doc="<p>The array of attributes that you want to assign to specified findings.</p>"]
@@ -61,6 +124,88 @@ pub struct AgentFilter {
     #[doc="<p>The current health state of the agent. Values can be set to <b>HEALTHY</b> or <b>UNHEALTHY</b>.</p>"]
     #[serde(rename="agentHealths")]
     pub agent_healths: Vec<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AgentHealth {
+    Healthy,
+    Unhealthy,
+}
+
+impl Into<String> for AgentHealth {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AgentHealth {
+    fn into(self) -> &'static str {
+        match self {
+            AgentHealth::Healthy => "HEALTHY",
+            AgentHealth::Unhealthy => "UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AgentHealth {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HEALTHY" => Ok(AgentHealth::Healthy),
+            "UNHEALTHY" => Ok(AgentHealth::Unhealthy),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AgentHealthCode {
+    Idle,
+    Running,
+    Shutdown,
+    Throttled,
+    Unhealthy,
+    Unknown,
+}
+
+impl Into<String> for AgentHealthCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AgentHealthCode {
+    fn into(self) -> &'static str {
+        match self {
+            AgentHealthCode::Idle => "IDLE",
+            AgentHealthCode::Running => "RUNNING",
+            AgentHealthCode::Shutdown => "SHUTDOWN",
+            AgentHealthCode::Throttled => "THROTTLED",
+            AgentHealthCode::Unhealthy => "UNHEALTHY",
+            AgentHealthCode::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AgentHealthCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IDLE" => Ok(AgentHealthCode::Idle),
+            "RUNNING" => Ok(AgentHealthCode::Running),
+            "SHUTDOWN" => Ok(AgentHealthCode::Shutdown),
+            "THROTTLED" => Ok(AgentHealthCode::Throttled),
+            "UNHEALTHY" => Ok(AgentHealthCode::Unhealthy),
+            "UNKNOWN" => Ok(AgentHealthCode::Unknown),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Used as a response element in the <a>PreviewAgents</a> action.</p>"]
@@ -214,6 +359,116 @@ pub struct AssessmentRunNotification {
     pub sns_topic_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssessmentRunNotificationSnsStatusCode {
+    AccessDenied,
+    InternalError,
+    Success,
+    TopicDoesNotExist,
+}
+
+impl Into<String> for AssessmentRunNotificationSnsStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssessmentRunNotificationSnsStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            AssessmentRunNotificationSnsStatusCode::AccessDenied => "ACCESS_DENIED",
+            AssessmentRunNotificationSnsStatusCode::InternalError => "INTERNAL_ERROR",
+            AssessmentRunNotificationSnsStatusCode::Success => "SUCCESS",
+            AssessmentRunNotificationSnsStatusCode::TopicDoesNotExist => "TOPIC_DOES_NOT_EXIST",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssessmentRunNotificationSnsStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCESS_DENIED" => Ok(AssessmentRunNotificationSnsStatusCode::AccessDenied),
+            "INTERNAL_ERROR" => Ok(AssessmentRunNotificationSnsStatusCode::InternalError),
+            "SUCCESS" => Ok(AssessmentRunNotificationSnsStatusCode::Success),
+            "TOPIC_DOES_NOT_EXIST" => Ok(AssessmentRunNotificationSnsStatusCode::TopicDoesNotExist),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssessmentRunState {
+    CollectingData,
+    Completed,
+    CompletedWithErrors,
+    Created,
+    DataCollected,
+    Error,
+    EvaluatingRules,
+    Failed,
+    StartDataCollectionInProgress,
+    StartDataCollectionPending,
+    StartEvaluatingRulesPending,
+    StopDataCollectionPending,
+}
+
+impl Into<String> for AssessmentRunState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssessmentRunState {
+    fn into(self) -> &'static str {
+        match self {
+            AssessmentRunState::CollectingData => "COLLECTING_DATA",
+            AssessmentRunState::Completed => "COMPLETED",
+            AssessmentRunState::CompletedWithErrors => "COMPLETED_WITH_ERRORS",
+            AssessmentRunState::Created => "CREATED",
+            AssessmentRunState::DataCollected => "DATA_COLLECTED",
+            AssessmentRunState::Error => "ERROR",
+            AssessmentRunState::EvaluatingRules => "EVALUATING_RULES",
+            AssessmentRunState::Failed => "FAILED",
+            AssessmentRunState::StartDataCollectionInProgress => {
+                "START_DATA_COLLECTION_IN_PROGRESS"
+            }
+            AssessmentRunState::StartDataCollectionPending => "START_DATA_COLLECTION_PENDING",
+            AssessmentRunState::StartEvaluatingRulesPending => "START_EVALUATING_RULES_PENDING",
+            AssessmentRunState::StopDataCollectionPending => "STOP_DATA_COLLECTION_PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssessmentRunState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COLLECTING_DATA" => Ok(AssessmentRunState::CollectingData),
+            "COMPLETED" => Ok(AssessmentRunState::Completed),
+            "COMPLETED_WITH_ERRORS" => Ok(AssessmentRunState::CompletedWithErrors),
+            "CREATED" => Ok(AssessmentRunState::Created),
+            "DATA_COLLECTED" => Ok(AssessmentRunState::DataCollected),
+            "ERROR" => Ok(AssessmentRunState::Error),
+            "EVALUATING_RULES" => Ok(AssessmentRunState::EvaluatingRules),
+            "FAILED" => Ok(AssessmentRunState::Failed),
+            "START_DATA_COLLECTION_IN_PROGRESS" => {
+                Ok(AssessmentRunState::StartDataCollectionInProgress)
+            }
+            "START_DATA_COLLECTION_PENDING" => Ok(AssessmentRunState::StartDataCollectionPending),
+            "START_EVALUATING_RULES_PENDING" => Ok(AssessmentRunState::StartEvaluatingRulesPending),
+            "STOP_DATA_COLLECTION_PENDING" => Ok(AssessmentRunState::StopDataCollectionPending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Used as one of the elements of the <a>AssessmentRun</a> data type.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AssessmentRunStateChange {
@@ -323,6 +578,38 @@ pub struct AssetAttributes {
     #[doc="<p>The schema version of this data type.</p>"]
     #[serde(rename="schemaVersion")]
     pub schema_version: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssetType {
+    Ec2Instance,
+}
+
+impl Into<String> for AssetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssetType {
+    fn into(self) -> &'static str {
+        match self {
+            AssetType::Ec2Instance => "ec2-instance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ec2-instance" => Ok(AssetType::Ec2Instance),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>This data type is used as a request parameter in the <a>AddAttributesToFindings</a> and <a>CreateAssessmentTemplate</a> actions.</p>"]
@@ -573,6 +860,53 @@ pub struct FailedItemDetails {
     pub retryable: bool,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailedItemErrorCode {
+    AccessDenied,
+    DuplicateArn,
+    InternalError,
+    InvalidArn,
+    ItemDoesNotExist,
+    LimitExceeded,
+}
+
+impl Into<String> for FailedItemErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailedItemErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            FailedItemErrorCode::AccessDenied => "ACCESS_DENIED",
+            FailedItemErrorCode::DuplicateArn => "DUPLICATE_ARN",
+            FailedItemErrorCode::InternalError => "INTERNAL_ERROR",
+            FailedItemErrorCode::InvalidArn => "INVALID_ARN",
+            FailedItemErrorCode::ItemDoesNotExist => "ITEM_DOES_NOT_EXIST",
+            FailedItemErrorCode::LimitExceeded => "LIMIT_EXCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailedItemErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCESS_DENIED" => Ok(FailedItemErrorCode::AccessDenied),
+            "DUPLICATE_ARN" => Ok(FailedItemErrorCode::DuplicateArn),
+            "INTERNAL_ERROR" => Ok(FailedItemErrorCode::InternalError),
+            "INVALID_ARN" => Ok(FailedItemErrorCode::InvalidArn),
+            "ITEM_DOES_NOT_EXIST" => Ok(FailedItemErrorCode::ItemDoesNotExist),
+            "LIMIT_EXCEEDED" => Ok(FailedItemErrorCode::LimitExceeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about an Amazon Inspector finding. This data type is used as the response element in the <a>DescribeFindings</a> action.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Finding {
@@ -720,6 +1054,50 @@ pub struct GetTelemetryMetadataResponse {
     pub telemetry_metadata: Vec<TelemetryMetadata>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InspectorEvent {
+    AssessmentRunCompleted,
+    AssessmentRunStarted,
+    AssessmentRunStateChanged,
+    FindingReported,
+    Other,
+}
+
+impl Into<String> for InspectorEvent {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InspectorEvent {
+    fn into(self) -> &'static str {
+        match self {
+            InspectorEvent::AssessmentRunCompleted => "ASSESSMENT_RUN_COMPLETED",
+            InspectorEvent::AssessmentRunStarted => "ASSESSMENT_RUN_STARTED",
+            InspectorEvent::AssessmentRunStateChanged => "ASSESSMENT_RUN_STATE_CHANGED",
+            InspectorEvent::FindingReported => "FINDING_REPORTED",
+            InspectorEvent::Other => "OTHER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InspectorEvent {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSESSMENT_RUN_COMPLETED" => Ok(InspectorEvent::AssessmentRunCompleted),
+            "ASSESSMENT_RUN_STARTED" => Ok(InspectorEvent::AssessmentRunStarted),
+            "ASSESSMENT_RUN_STATE_CHANGED" => Ok(InspectorEvent::AssessmentRunStateChanged),
+            "FINDING_REPORTED" => Ok(InspectorEvent::FindingReported),
+            "OTHER" => Ok(InspectorEvent::Other),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>This data type is used in the <a>Finding</a> data type.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InspectorServiceAttributes {
@@ -734,6 +1112,396 @@ pub struct InspectorServiceAttributes {
     #[doc="<p>The schema version of this data type.</p>"]
     #[serde(rename="schemaVersion")]
     pub schema_version: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvalidCrossAccountRoleErrorCode {
+    RoleDoesNotExistOrInvalidTrustRelationship,
+    RoleDoesNotHaveCorrectPolicy,
+}
+
+impl Into<String> for InvalidCrossAccountRoleErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvalidCrossAccountRoleErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            InvalidCrossAccountRoleErrorCode::RoleDoesNotExistOrInvalidTrustRelationship => {
+                "ROLE_DOES_NOT_EXIST_OR_INVALID_TRUST_RELATIONSHIP"
+            }
+            InvalidCrossAccountRoleErrorCode::RoleDoesNotHaveCorrectPolicy => {
+                "ROLE_DOES_NOT_HAVE_CORRECT_POLICY"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvalidCrossAccountRoleErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ROLE_DOES_NOT_EXIST_OR_INVALID_TRUST_RELATIONSHIP" => {
+                Ok(InvalidCrossAccountRoleErrorCode::RoleDoesNotExistOrInvalidTrustRelationship)
+            }
+            "ROLE_DOES_NOT_HAVE_CORRECT_POLICY" => {
+                Ok(InvalidCrossAccountRoleErrorCode::RoleDoesNotHaveCorrectPolicy)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvalidInputErrorCode {
+    AssessmentTargetNameAlreadyTaken,
+    AssessmentTemplateNameAlreadyTaken,
+    InvalidAgentId,
+    InvalidAssessmentRunArn,
+    InvalidAssessmentRunCompletionTimeRange,
+    InvalidAssessmentRunDurationRange,
+    InvalidAssessmentRunStartTimeRange,
+    InvalidAssessmentRunState,
+    InvalidAssessmentRunStateChangeTimeRange,
+    InvalidAssessmentTargetArn,
+    InvalidAssessmentTargetName,
+    InvalidAssessmentTargetNamePattern,
+    InvalidAssessmentTemplateArn,
+    InvalidAssessmentTemplateDuration,
+    InvalidAssessmentTemplateDurationRange,
+    InvalidAssessmentTemplateName,
+    InvalidAssessmentTemplateNamePattern,
+    InvalidAttribute,
+    InvalidAutoScalingGroup,
+    InvalidEvent,
+    InvalidFindingArn,
+    InvalidIamRoleArn,
+    InvalidLocale,
+    InvalidMaxResults,
+    InvalidNumberOfAgentIds,
+    InvalidNumberOfAssessmentRunArns,
+    InvalidNumberOfAssessmentRunStates,
+    InvalidNumberOfAssessmentTargetArns,
+    InvalidNumberOfAssessmentTemplateArns,
+    InvalidNumberOfAttributes,
+    InvalidNumberOfAutoScalingGroups,
+    InvalidNumberOfFindingArns,
+    InvalidNumberOfResourceGroupArns,
+    InvalidNumberOfResourceGroupTags,
+    InvalidNumberOfRulesPackageArns,
+    InvalidNumberOfRuleNames,
+    InvalidNumberOfSeverities,
+    InvalidNumberOfTags,
+    InvalidNumberOfUserAttributes,
+    InvalidPaginationToken,
+    InvalidResourceArn,
+    InvalidResourceGroupArn,
+    InvalidResourceGroupTagKey,
+    InvalidResourceGroupTagValue,
+    InvalidRulesPackageArn,
+    InvalidRuleName,
+    InvalidSeverity,
+    InvalidSnsTopicArn,
+    InvalidTag,
+    InvalidTagKey,
+    InvalidTagValue,
+    InvalidUserAttribute,
+    InvalidUserAttributeKey,
+    InvalidUserAttributeValue,
+}
+
+impl Into<String> for InvalidInputErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvalidInputErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            InvalidInputErrorCode::AssessmentTargetNameAlreadyTaken => {
+                "ASSESSMENT_TARGET_NAME_ALREADY_TAKEN"
+            }
+            InvalidInputErrorCode::AssessmentTemplateNameAlreadyTaken => {
+                "ASSESSMENT_TEMPLATE_NAME_ALREADY_TAKEN"
+            }
+            InvalidInputErrorCode::InvalidAgentId => "INVALID_AGENT_ID",
+            InvalidInputErrorCode::InvalidAssessmentRunArn => "INVALID_ASSESSMENT_RUN_ARN",
+            InvalidInputErrorCode::InvalidAssessmentRunCompletionTimeRange => {
+                "INVALID_ASSESSMENT_RUN_COMPLETION_TIME_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentRunDurationRange => {
+                "INVALID_ASSESSMENT_RUN_DURATION_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentRunStartTimeRange => {
+                "INVALID_ASSESSMENT_RUN_START_TIME_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentRunState => "INVALID_ASSESSMENT_RUN_STATE",
+            InvalidInputErrorCode::InvalidAssessmentRunStateChangeTimeRange => {
+                "INVALID_ASSESSMENT_RUN_STATE_CHANGE_TIME_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTargetArn => "INVALID_ASSESSMENT_TARGET_ARN",
+            InvalidInputErrorCode::InvalidAssessmentTargetName => "INVALID_ASSESSMENT_TARGET_NAME",
+            InvalidInputErrorCode::InvalidAssessmentTargetNamePattern => {
+                "INVALID_ASSESSMENT_TARGET_NAME_PATTERN"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateArn => {
+                "INVALID_ASSESSMENT_TEMPLATE_ARN"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateDuration => {
+                "INVALID_ASSESSMENT_TEMPLATE_DURATION"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateDurationRange => {
+                "INVALID_ASSESSMENT_TEMPLATE_DURATION_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateName => {
+                "INVALID_ASSESSMENT_TEMPLATE_NAME"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateNamePattern => {
+                "INVALID_ASSESSMENT_TEMPLATE_NAME_PATTERN"
+            }
+            InvalidInputErrorCode::InvalidAttribute => "INVALID_ATTRIBUTE",
+            InvalidInputErrorCode::InvalidAutoScalingGroup => "INVALID_AUTO_SCALING_GROUP",
+            InvalidInputErrorCode::InvalidEvent => "INVALID_EVENT",
+            InvalidInputErrorCode::InvalidFindingArn => "INVALID_FINDING_ARN",
+            InvalidInputErrorCode::InvalidIamRoleArn => "INVALID_IAM_ROLE_ARN",
+            InvalidInputErrorCode::InvalidLocale => "INVALID_LOCALE",
+            InvalidInputErrorCode::InvalidMaxResults => "INVALID_MAX_RESULTS",
+            InvalidInputErrorCode::InvalidNumberOfAgentIds => "INVALID_NUMBER_OF_AGENT_IDS",
+            InvalidInputErrorCode::InvalidNumberOfAssessmentRunArns => {
+                "INVALID_NUMBER_OF_ASSESSMENT_RUN_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfAssessmentRunStates => {
+                "INVALID_NUMBER_OF_ASSESSMENT_RUN_STATES"
+            }
+            InvalidInputErrorCode::InvalidNumberOfAssessmentTargetArns => {
+                "INVALID_NUMBER_OF_ASSESSMENT_TARGET_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfAssessmentTemplateArns => {
+                "INVALID_NUMBER_OF_ASSESSMENT_TEMPLATE_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfAttributes => "INVALID_NUMBER_OF_ATTRIBUTES",
+            InvalidInputErrorCode::InvalidNumberOfAutoScalingGroups => {
+                "INVALID_NUMBER_OF_AUTO_SCALING_GROUPS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfFindingArns => "INVALID_NUMBER_OF_FINDING_ARNS",
+            InvalidInputErrorCode::InvalidNumberOfResourceGroupArns => {
+                "INVALID_NUMBER_OF_RESOURCE_GROUP_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfResourceGroupTags => {
+                "INVALID_NUMBER_OF_RESOURCE_GROUP_TAGS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfRulesPackageArns => {
+                "INVALID_NUMBER_OF_RULES_PACKAGE_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfRuleNames => "INVALID_NUMBER_OF_RULE_NAMES",
+            InvalidInputErrorCode::InvalidNumberOfSeverities => "INVALID_NUMBER_OF_SEVERITIES",
+            InvalidInputErrorCode::InvalidNumberOfTags => "INVALID_NUMBER_OF_TAGS",
+            InvalidInputErrorCode::InvalidNumberOfUserAttributes => {
+                "INVALID_NUMBER_OF_USER_ATTRIBUTES"
+            }
+            InvalidInputErrorCode::InvalidPaginationToken => "INVALID_PAGINATION_TOKEN",
+            InvalidInputErrorCode::InvalidResourceArn => "INVALID_RESOURCE_ARN",
+            InvalidInputErrorCode::InvalidResourceGroupArn => "INVALID_RESOURCE_GROUP_ARN",
+            InvalidInputErrorCode::InvalidResourceGroupTagKey => "INVALID_RESOURCE_GROUP_TAG_KEY",
+            InvalidInputErrorCode::InvalidResourceGroupTagValue => {
+                "INVALID_RESOURCE_GROUP_TAG_VALUE"
+            }
+            InvalidInputErrorCode::InvalidRulesPackageArn => "INVALID_RULES_PACKAGE_ARN",
+            InvalidInputErrorCode::InvalidRuleName => "INVALID_RULE_NAME",
+            InvalidInputErrorCode::InvalidSeverity => "INVALID_SEVERITY",
+            InvalidInputErrorCode::InvalidSnsTopicArn => "INVALID_SNS_TOPIC_ARN",
+            InvalidInputErrorCode::InvalidTag => "INVALID_TAG",
+            InvalidInputErrorCode::InvalidTagKey => "INVALID_TAG_KEY",
+            InvalidInputErrorCode::InvalidTagValue => "INVALID_TAG_VALUE",
+            InvalidInputErrorCode::InvalidUserAttribute => "INVALID_USER_ATTRIBUTE",
+            InvalidInputErrorCode::InvalidUserAttributeKey => "INVALID_USER_ATTRIBUTE_KEY",
+            InvalidInputErrorCode::InvalidUserAttributeValue => "INVALID_USER_ATTRIBUTE_VALUE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvalidInputErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSESSMENT_TARGET_NAME_ALREADY_TAKEN" => {
+                Ok(InvalidInputErrorCode::AssessmentTargetNameAlreadyTaken)
+            }
+            "ASSESSMENT_TEMPLATE_NAME_ALREADY_TAKEN" => {
+                Ok(InvalidInputErrorCode::AssessmentTemplateNameAlreadyTaken)
+            }
+            "INVALID_AGENT_ID" => Ok(InvalidInputErrorCode::InvalidAgentId),
+            "INVALID_ASSESSMENT_RUN_ARN" => Ok(InvalidInputErrorCode::InvalidAssessmentRunArn),
+            "INVALID_ASSESSMENT_RUN_COMPLETION_TIME_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentRunCompletionTimeRange)
+            }
+            "INVALID_ASSESSMENT_RUN_DURATION_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentRunDurationRange)
+            }
+            "INVALID_ASSESSMENT_RUN_START_TIME_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentRunStartTimeRange)
+            }
+            "INVALID_ASSESSMENT_RUN_STATE" => Ok(InvalidInputErrorCode::InvalidAssessmentRunState),
+            "INVALID_ASSESSMENT_RUN_STATE_CHANGE_TIME_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentRunStateChangeTimeRange)
+            }
+            "INVALID_ASSESSMENT_TARGET_ARN" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTargetArn)
+            }
+            "INVALID_ASSESSMENT_TARGET_NAME" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTargetName)
+            }
+            "INVALID_ASSESSMENT_TARGET_NAME_PATTERN" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTargetNamePattern)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_ARN" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateArn)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_DURATION" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateDuration)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_DURATION_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateDurationRange)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_NAME" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateName)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_NAME_PATTERN" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateNamePattern)
+            }
+            "INVALID_ATTRIBUTE" => Ok(InvalidInputErrorCode::InvalidAttribute),
+            "INVALID_AUTO_SCALING_GROUP" => Ok(InvalidInputErrorCode::InvalidAutoScalingGroup),
+            "INVALID_EVENT" => Ok(InvalidInputErrorCode::InvalidEvent),
+            "INVALID_FINDING_ARN" => Ok(InvalidInputErrorCode::InvalidFindingArn),
+            "INVALID_IAM_ROLE_ARN" => Ok(InvalidInputErrorCode::InvalidIamRoleArn),
+            "INVALID_LOCALE" => Ok(InvalidInputErrorCode::InvalidLocale),
+            "INVALID_MAX_RESULTS" => Ok(InvalidInputErrorCode::InvalidMaxResults),
+            "INVALID_NUMBER_OF_AGENT_IDS" => Ok(InvalidInputErrorCode::InvalidNumberOfAgentIds),
+            "INVALID_NUMBER_OF_ASSESSMENT_RUN_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAssessmentRunArns)
+            }
+            "INVALID_NUMBER_OF_ASSESSMENT_RUN_STATES" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAssessmentRunStates)
+            }
+            "INVALID_NUMBER_OF_ASSESSMENT_TARGET_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAssessmentTargetArns)
+            }
+            "INVALID_NUMBER_OF_ASSESSMENT_TEMPLATE_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAssessmentTemplateArns)
+            }
+            "INVALID_NUMBER_OF_ATTRIBUTES" => Ok(InvalidInputErrorCode::InvalidNumberOfAttributes),
+            "INVALID_NUMBER_OF_AUTO_SCALING_GROUPS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAutoScalingGroups)
+            }
+            "INVALID_NUMBER_OF_FINDING_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfFindingArns)
+            }
+            "INVALID_NUMBER_OF_RESOURCE_GROUP_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfResourceGroupArns)
+            }
+            "INVALID_NUMBER_OF_RESOURCE_GROUP_TAGS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfResourceGroupTags)
+            }
+            "INVALID_NUMBER_OF_RULES_PACKAGE_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfRulesPackageArns)
+            }
+            "INVALID_NUMBER_OF_RULE_NAMES" => Ok(InvalidInputErrorCode::InvalidNumberOfRuleNames),
+            "INVALID_NUMBER_OF_SEVERITIES" => Ok(InvalidInputErrorCode::InvalidNumberOfSeverities),
+            "INVALID_NUMBER_OF_TAGS" => Ok(InvalidInputErrorCode::InvalidNumberOfTags),
+            "INVALID_NUMBER_OF_USER_ATTRIBUTES" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfUserAttributes)
+            }
+            "INVALID_PAGINATION_TOKEN" => Ok(InvalidInputErrorCode::InvalidPaginationToken),
+            "INVALID_RESOURCE_ARN" => Ok(InvalidInputErrorCode::InvalidResourceArn),
+            "INVALID_RESOURCE_GROUP_ARN" => Ok(InvalidInputErrorCode::InvalidResourceGroupArn),
+            "INVALID_RESOURCE_GROUP_TAG_KEY" => {
+                Ok(InvalidInputErrorCode::InvalidResourceGroupTagKey)
+            }
+            "INVALID_RESOURCE_GROUP_TAG_VALUE" => {
+                Ok(InvalidInputErrorCode::InvalidResourceGroupTagValue)
+            }
+            "INVALID_RULES_PACKAGE_ARN" => Ok(InvalidInputErrorCode::InvalidRulesPackageArn),
+            "INVALID_RULE_NAME" => Ok(InvalidInputErrorCode::InvalidRuleName),
+            "INVALID_SEVERITY" => Ok(InvalidInputErrorCode::InvalidSeverity),
+            "INVALID_SNS_TOPIC_ARN" => Ok(InvalidInputErrorCode::InvalidSnsTopicArn),
+            "INVALID_TAG" => Ok(InvalidInputErrorCode::InvalidTag),
+            "INVALID_TAG_KEY" => Ok(InvalidInputErrorCode::InvalidTagKey),
+            "INVALID_TAG_VALUE" => Ok(InvalidInputErrorCode::InvalidTagValue),
+            "INVALID_USER_ATTRIBUTE" => Ok(InvalidInputErrorCode::InvalidUserAttribute),
+            "INVALID_USER_ATTRIBUTE_KEY" => Ok(InvalidInputErrorCode::InvalidUserAttributeKey),
+            "INVALID_USER_ATTRIBUTE_VALUE" => Ok(InvalidInputErrorCode::InvalidUserAttributeValue),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LimitExceededErrorCode {
+    AssessmentRunLimitExceeded,
+    AssessmentTargetLimitExceeded,
+    AssessmentTemplateLimitExceeded,
+    EventSubscriptionLimitExceeded,
+    ResourceGroupLimitExceeded,
+}
+
+impl Into<String> for LimitExceededErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LimitExceededErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            LimitExceededErrorCode::AssessmentRunLimitExceeded => "ASSESSMENT_RUN_LIMIT_EXCEEDED",
+            LimitExceededErrorCode::AssessmentTargetLimitExceeded => {
+                "ASSESSMENT_TARGET_LIMIT_EXCEEDED"
+            }
+            LimitExceededErrorCode::AssessmentTemplateLimitExceeded => {
+                "ASSESSMENT_TEMPLATE_LIMIT_EXCEEDED"
+            }
+            LimitExceededErrorCode::EventSubscriptionLimitExceeded => {
+                "EVENT_SUBSCRIPTION_LIMIT_EXCEEDED"
+            }
+            LimitExceededErrorCode::ResourceGroupLimitExceeded => "RESOURCE_GROUP_LIMIT_EXCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LimitExceededErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSESSMENT_RUN_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::AssessmentRunLimitExceeded)
+            }
+            "ASSESSMENT_TARGET_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::AssessmentTargetLimitExceeded)
+            }
+            "ASSESSMENT_TEMPLATE_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::AssessmentTemplateLimitExceeded)
+            }
+            "EVENT_SUBSCRIPTION_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::EventSubscriptionLimitExceeded)
+            }
+            "RESOURCE_GROUP_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::ResourceGroupLimitExceeded)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -950,6 +1718,99 @@ pub struct ListTagsForResourceResponse {
     pub tags: Vec<Tag>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Locale {
+    EnUs,
+}
+
+impl Into<String> for Locale {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Locale {
+    fn into(self) -> &'static str {
+        match self {
+            Locale::EnUs => "EN_US",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Locale {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EN_US" => Ok(Locale::EnUs),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NoSuchEntityErrorCode {
+    AssessmentRunDoesNotExist,
+    AssessmentTargetDoesNotExist,
+    AssessmentTemplateDoesNotExist,
+    FindingDoesNotExist,
+    IamRoleDoesNotExist,
+    ResourceGroupDoesNotExist,
+    RulesPackageDoesNotExist,
+    SnsTopicDoesNotExist,
+}
+
+impl Into<String> for NoSuchEntityErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NoSuchEntityErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            NoSuchEntityErrorCode::AssessmentRunDoesNotExist => "ASSESSMENT_RUN_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::AssessmentTargetDoesNotExist => {
+                "ASSESSMENT_TARGET_DOES_NOT_EXIST"
+            }
+            NoSuchEntityErrorCode::AssessmentTemplateDoesNotExist => {
+                "ASSESSMENT_TEMPLATE_DOES_NOT_EXIST"
+            }
+            NoSuchEntityErrorCode::FindingDoesNotExist => "FINDING_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::IamRoleDoesNotExist => "IAM_ROLE_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::ResourceGroupDoesNotExist => "RESOURCE_GROUP_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::RulesPackageDoesNotExist => "RULES_PACKAGE_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::SnsTopicDoesNotExist => "SNS_TOPIC_DOES_NOT_EXIST",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NoSuchEntityErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSESSMENT_RUN_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::AssessmentRunDoesNotExist),
+            "ASSESSMENT_TARGET_DOES_NOT_EXIST" => {
+                Ok(NoSuchEntityErrorCode::AssessmentTargetDoesNotExist)
+            }
+            "ASSESSMENT_TEMPLATE_DOES_NOT_EXIST" => {
+                Ok(NoSuchEntityErrorCode::AssessmentTemplateDoesNotExist)
+            }
+            "FINDING_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::FindingDoesNotExist),
+            "IAM_ROLE_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::IamRoleDoesNotExist),
+            "RESOURCE_GROUP_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::ResourceGroupDoesNotExist),
+            "RULES_PACKAGE_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::RulesPackageDoesNotExist),
+            "SNS_TOPIC_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::SnsTopicDoesNotExist),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PreviewAgentsRequest {
     #[doc="<p>You can use this parameter to indicate the maximum number of items you want in the response. The default value is 10. The maximum value is 500.</p>"]
@@ -998,6 +1859,114 @@ pub struct RemoveAttributesFromFindingsResponse {
     #[doc="<p>Attributes details that cannot be described. An error code is provided for each failed item.</p>"]
     #[serde(rename="failedItems")]
     pub failed_items: ::std::collections::HashMap<String, FailedItemDetails>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportFileFormat {
+    Html,
+    Pdf,
+}
+
+impl Into<String> for ReportFileFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportFileFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ReportFileFormat::Html => "HTML",
+            ReportFileFormat::Pdf => "PDF",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportFileFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HTML" => Ok(ReportFileFormat::Html),
+            "PDF" => Ok(ReportFileFormat::Pdf),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportStatus {
+    Completed,
+    Failed,
+    WorkInProgress,
+}
+
+impl Into<String> for ReportStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReportStatus::Completed => "COMPLETED",
+            ReportStatus::Failed => "FAILED",
+            ReportStatus::WorkInProgress => "WORK_IN_PROGRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETED" => Ok(ReportStatus::Completed),
+            "FAILED" => Ok(ReportStatus::Failed),
+            "WORK_IN_PROGRESS" => Ok(ReportStatus::WorkInProgress),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportType {
+    Finding,
+    Full,
+}
+
+impl Into<String> for ReportType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportType {
+    fn into(self) -> &'static str {
+        match self {
+            ReportType::Finding => "FINDING",
+            ReportType::Full => "FULL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FINDING" => Ok(ReportType::Finding),
+            "FULL" => Ok(ReportType::Full),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains information about a resource group. The resource group defines a set of tags that, when queried, identify the AWS resources that make up the assessment target. This data type is used as the response element in the <a>DescribeResourceGroups</a> action.</p>"]
@@ -1056,6 +2025,50 @@ pub struct SetTagsForResourceRequest {
     #[serde(rename="tags")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Severity {
+    High,
+    Informational,
+    Low,
+    Medium,
+    Undefined,
+}
+
+impl Into<String> for Severity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Severity {
+    fn into(self) -> &'static str {
+        match self {
+            Severity::High => "High",
+            Severity::Informational => "Informational",
+            Severity::Low => "Low",
+            Severity::Medium => "Medium",
+            Severity::Undefined => "Undefined",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Severity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "High" => Ok(Severity::High),
+            "Informational" => Ok(Severity::Informational),
+            "Low" => Ok(Severity::Low),
+            "Medium" => Ok(Severity::Medium),
+            "Undefined" => Ok(Severity::Undefined),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -4477,7 +5490,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddAttributesToFindingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AddAttributesToFindingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4502,7 +5515,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAssessmentTargetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4530,7 +5543,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAssessmentTemplateResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateAssessmentTemplateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4554,7 +5567,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateResourceGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4581,7 +5594,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteAssessmentRunError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -4606,7 +5619,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteAssessmentTargetError::from_body(String::from_utf8_lossy(&response.body)
                                                                .as_ref()))
@@ -4631,7 +5644,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteAssessmentTemplateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4654,7 +5667,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAssessmentRunsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4682,7 +5695,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAssessmentTargetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeAssessmentTargetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4708,7 +5721,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAssessmentTemplatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeAssessmentTemplatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4732,7 +5745,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCrossAccountAccessRoleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeCrossAccountAccessRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4756,7 +5769,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeFindingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4784,7 +5797,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeResourceGroupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4812,7 +5825,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeRulesPackagesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4839,7 +5852,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetAssessmentReportResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4867,7 +5880,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetTelemetryMetadataResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4895,7 +5908,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAssessmentRunAgentsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListAssessmentRunAgentsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4919,7 +5932,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAssessmentRunsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4947,7 +5960,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAssessmentTargetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4975,7 +5988,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAssessmentTemplatesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListAssessmentTemplatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5000,7 +6013,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListEventSubscriptionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5027,7 +6040,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListFindingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5053,7 +6066,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRulesPackagesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5080,7 +6093,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5107,7 +6120,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PreviewAgentsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5134,7 +6147,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RegisterCrossAccountAccessRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -5158,7 +6171,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveAttributesFromFindingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RemoveAttributesFromFindingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5182,7 +6195,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(SetTagsForResourceError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -5207,7 +6220,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartAssessmentRunResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5234,7 +6247,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(StopAssessmentRunError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -5259,7 +6272,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(SubscribeToEventError::from_body(String::from_utf8_lossy(&response.body)
                                                          .as_ref()))
@@ -5284,7 +6297,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UnsubscribeFromEventError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -5309,7 +6322,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateAssessmentTargetError::from_body(String::from_utf8_lossy(&response.body)
                                                                .as_ref()))

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -135,6 +131,41 @@ pub struct AttributePayload {
     pub merge: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoRegistrationStatus {
+    Disable,
+    Enable,
+}
+
+impl Into<String> for AutoRegistrationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoRegistrationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AutoRegistrationStatus::Disable => "DISABLE",
+            AutoRegistrationStatus::Enable => "ENABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoRegistrationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLE" => Ok(AutoRegistrationStatus::Disable),
+            "ENABLE" => Ok(AutoRegistrationStatus::Enable),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A CA certificate.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CACertificate {
@@ -189,12 +220,100 @@ pub struct CACertificateDescription {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CACertificateStatus {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for CACertificateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CACertificateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CACertificateStatus::Active => "ACTIVE",
+            CACertificateStatus::Inactive => "INACTIVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CACertificateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(CACertificateStatus::Active),
+            "INACTIVE" => Ok(CACertificateStatus::Inactive),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The input for the CancelCertificateTransfer operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct CancelCertificateTransferRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
     pub certificate_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CannedAccessControlList {
+    AuthenticatedRead,
+    AwsExecRead,
+    BucketOwnerFullControl,
+    BucketOwnerRead,
+    LogDeliveryWrite,
+    Private,
+    PublicRead,
+    PublicReadWrite,
+}
+
+impl Into<String> for CannedAccessControlList {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CannedAccessControlList {
+    fn into(self) -> &'static str {
+        match self {
+            CannedAccessControlList::AuthenticatedRead => "authenticated-read",
+            CannedAccessControlList::AwsExecRead => "aws-exec-read",
+            CannedAccessControlList::BucketOwnerFullControl => "bucket-owner-full-control",
+            CannedAccessControlList::BucketOwnerRead => "bucket-owner-read",
+            CannedAccessControlList::LogDeliveryWrite => "log-delivery-write",
+            CannedAccessControlList::Private => "private",
+            CannedAccessControlList::PublicRead => "public-read",
+            CannedAccessControlList::PublicReadWrite => "public-read-write",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CannedAccessControlList {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "authenticated-read" => Ok(CannedAccessControlList::AuthenticatedRead),
+            "aws-exec-read" => Ok(CannedAccessControlList::AwsExecRead),
+            "bucket-owner-full-control" => Ok(CannedAccessControlList::BucketOwnerFullControl),
+            "bucket-owner-read" => Ok(CannedAccessControlList::BucketOwnerRead),
+            "log-delivery-write" => Ok(CannedAccessControlList::LogDeliveryWrite),
+            "private" => Ok(CannedAccessControlList::Private),
+            "public-read" => Ok(CannedAccessControlList::PublicRead),
+            "public-read-write" => Ok(CannedAccessControlList::PublicReadWrite),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a certificate.</p>"]
@@ -261,6 +380,53 @@ pub struct CertificateDescription {
     #[serde(rename="transferData")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub transfer_data: Option<TransferData>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CertificateStatus {
+    Active,
+    Inactive,
+    PendingActivation,
+    PendingTransfer,
+    RegisterInactive,
+    Revoked,
+}
+
+impl Into<String> for CertificateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CertificateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CertificateStatus::Active => "ACTIVE",
+            CertificateStatus::Inactive => "INACTIVE",
+            CertificateStatus::PendingActivation => "PENDING_ACTIVATION",
+            CertificateStatus::PendingTransfer => "PENDING_TRANSFER",
+            CertificateStatus::RegisterInactive => "REGISTER_INACTIVE",
+            CertificateStatus::Revoked => "REVOKED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CertificateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(CertificateStatus::Active),
+            "INACTIVE" => Ok(CertificateStatus::Inactive),
+            "PENDING_ACTIVATION" => Ok(CertificateStatus::PendingActivation),
+            "PENDING_TRANSFER" => Ok(CertificateStatus::PendingTransfer),
+            "REGISTER_INACTIVE" => Ok(CertificateStatus::RegisterInactive),
+            "REVOKED" => Ok(CertificateStatus::Revoked),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes an action that updates a CloudWatch alarm.</p>"]
@@ -786,6 +952,41 @@ pub struct DynamoDBv2Action {
     #[serde(rename="roleArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DynamoKeyType {
+    Number,
+    String,
+}
+
+impl Into<String> for DynamoKeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DynamoKeyType {
+    fn into(self) -> &'static str {
+        match self {
+            DynamoKeyType::Number => "NUMBER",
+            DynamoKeyType::String => "STRING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DynamoKeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NUMBER" => Ok(DynamoKeyType::Number),
+            "STRING" => Ok(DynamoKeyType::String),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes an action that writes data to an Amazon Elasticsearch Service domain.</p>"]
@@ -1367,6 +1568,50 @@ pub struct ListTopicRulesResponse {
     pub rules: Option<Vec<TopicRuleListItem>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LogLevel {
+    Debug,
+    Disabled,
+    Error,
+    Info,
+    Warn,
+}
+
+impl Into<String> for LogLevel {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LogLevel {
+    fn into(self) -> &'static str {
+        match self {
+            LogLevel::Debug => "DEBUG",
+            LogLevel::Disabled => "DISABLED",
+            LogLevel::Error => "ERROR",
+            LogLevel::Info => "INFO",
+            LogLevel::Warn => "WARN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LogLevel {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEBUG" => Ok(LogLevel::Debug),
+            "DISABLED" => Ok(LogLevel::Disabled),
+            "ERROR" => Ok(LogLevel::Error),
+            "INFO" => Ok(LogLevel::Info),
+            "WARN" => Ok(LogLevel::Warn),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the logging options payload.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct LoggingOptionsPayload {
@@ -1377,6 +1622,41 @@ pub struct LoggingOptionsPayload {
     #[doc="<p>The ARN of the IAM role that grants access.</p>"]
     #[serde(rename="roleArn")]
     pub role_arn: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MessageFormat {
+    Json,
+    Raw,
+}
+
+impl Into<String> for MessageFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MessageFormat {
+    fn into(self) -> &'static str {
+        match self {
+            MessageFormat::Json => "JSON",
+            MessageFormat::Raw => "RAW",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MessageFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "JSON" => Ok(MessageFormat::Json),
+            "RAW" => Ok(MessageFormat::Raw),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A certificate that has been transfered but not yet accepted.</p>"]
@@ -8174,7 +8454,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8206,7 +8486,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8242,7 +8522,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8287,7 +8567,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8323,7 +8603,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8370,7 +8650,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8412,7 +8692,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8460,7 +8740,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8504,7 +8784,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8546,7 +8826,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8590,7 +8870,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8625,7 +8905,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8670,7 +8950,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8702,7 +8982,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8737,7 +9017,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8771,7 +9051,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8820,7 +9100,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8862,7 +9142,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8906,7 +9186,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8941,7 +9221,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -8987,7 +9267,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9033,7 +9313,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9075,7 +9355,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9119,7 +9399,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9163,7 +9443,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9208,7 +9488,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9244,7 +9524,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9288,7 +9568,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9322,7 +9602,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9354,7 +9634,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9396,7 +9676,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9439,7 +9719,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9482,7 +9762,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9526,7 +9806,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9579,7 +9859,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9633,7 +9913,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9689,7 +9969,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9744,7 +10024,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9796,7 +10076,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9850,7 +10130,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9895,7 +10175,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -9950,7 +10230,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10002,7 +10282,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10047,7 +10327,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10101,7 +10381,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10161,7 +10441,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10215,7 +10495,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10267,7 +10547,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10312,7 +10592,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10357,7 +10637,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10388,7 +10668,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10424,7 +10704,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10455,7 +10735,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10492,7 +10772,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -10544,7 +10824,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10581,7 +10861,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10615,7 +10895,7 @@ impl<P, D> Iot for IotClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -298,6 +294,63 @@ pub struct MergeShardsInput {
     pub stream_name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricsName {
+    All,
+    IncomingBytes,
+    IncomingRecords,
+    IteratorAgeMilliseconds,
+    OutgoingBytes,
+    OutgoingRecords,
+    ReadProvisionedThroughputExceeded,
+    WriteProvisionedThroughputExceeded,
+}
+
+impl Into<String> for MetricsName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricsName {
+    fn into(self) -> &'static str {
+        match self {
+            MetricsName::All => "ALL",
+            MetricsName::IncomingBytes => "IncomingBytes",
+            MetricsName::IncomingRecords => "IncomingRecords",
+            MetricsName::IteratorAgeMilliseconds => "IteratorAgeMilliseconds",
+            MetricsName::OutgoingBytes => "OutgoingBytes",
+            MetricsName::OutgoingRecords => "OutgoingRecords",
+            MetricsName::ReadProvisionedThroughputExceeded => "ReadProvisionedThroughputExceeded",
+            MetricsName::WriteProvisionedThroughputExceeded => "WriteProvisionedThroughputExceeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricsName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(MetricsName::All),
+            "IncomingBytes" => Ok(MetricsName::IncomingBytes),
+            "IncomingRecords" => Ok(MetricsName::IncomingRecords),
+            "IteratorAgeMilliseconds" => Ok(MetricsName::IteratorAgeMilliseconds),
+            "OutgoingBytes" => Ok(MetricsName::OutgoingBytes),
+            "OutgoingRecords" => Ok(MetricsName::OutgoingRecords),
+            "ReadProvisionedThroughputExceeded" => {
+                Ok(MetricsName::ReadProvisionedThroughputExceeded)
+            }
+            "WriteProvisionedThroughputExceeded" => {
+                Ok(MetricsName::WriteProvisionedThroughputExceeded)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input for <code>PutRecord</code>.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutRecordInput {
@@ -434,6 +487,38 @@ pub struct RemoveTagsFromStreamInput {
     pub tag_keys: Vec<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingType {
+    UniformScaling,
+}
+
+impl Into<String> for ScalingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingType {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingType::UniformScaling => "UNIFORM_SCALING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "UNIFORM_SCALING" => Ok(ScalingType::UniformScaling),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The range of possible sequence numbers for the shard.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct SequenceNumberRange {
@@ -466,6 +551,50 @@ pub struct Shard {
     #[doc="<p>The unique identifier of the shard within the stream.</p>"]
     #[serde(rename="ShardId")]
     pub shard_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShardIteratorType {
+    AfterSequenceNumber,
+    AtSequenceNumber,
+    AtTimestamp,
+    Latest,
+    TrimHorizon,
+}
+
+impl Into<String> for ShardIteratorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShardIteratorType {
+    fn into(self) -> &'static str {
+        match self {
+            ShardIteratorType::AfterSequenceNumber => "AFTER_SEQUENCE_NUMBER",
+            ShardIteratorType::AtSequenceNumber => "AT_SEQUENCE_NUMBER",
+            ShardIteratorType::AtTimestamp => "AT_TIMESTAMP",
+            ShardIteratorType::Latest => "LATEST",
+            ShardIteratorType::TrimHorizon => "TRIM_HORIZON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShardIteratorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AFTER_SEQUENCE_NUMBER" => Ok(ShardIteratorType::AfterSequenceNumber),
+            "AT_SEQUENCE_NUMBER" => Ok(ShardIteratorType::AtSequenceNumber),
+            "AT_TIMESTAMP" => Ok(ShardIteratorType::AtTimestamp),
+            "LATEST" => Ok(ShardIteratorType::Latest),
+            "TRIM_HORIZON" => Ok(ShardIteratorType::TrimHorizon),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for <code>SplitShard</code>.</p>"]
@@ -509,6 +638,47 @@ pub struct StreamDescription {
     #[doc="<p>The current status of the stream being described. The stream status is one of the following states:</p> <ul> <li> <p> <code>CREATING</code> - The stream is being created. Amazon Kinesis immediately returns and sets <code>StreamStatus</code> to <code>CREATING</code>.</p> </li> <li> <p> <code>DELETING</code> - The stream is being deleted. The specified stream is in the <code>DELETING</code> state until Amazon Kinesis completes the deletion.</p> </li> <li> <p> <code>ACTIVE</code> - The stream exists and is ready for read and write operations or deletion. You should perform read and write operations only on an <code>ACTIVE</code> stream.</p> </li> <li> <p> <code>UPDATING</code> - Shards in the stream are being merged or split. Read and write operations continue to work while the stream is in the <code>UPDATING</code> state.</p> </li> </ul>"]
     #[serde(rename="StreamStatus")]
     pub stream_status: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StreamStatus {
+    Active,
+    Creating,
+    Deleting,
+    Updating,
+}
+
+impl Into<String> for StreamStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StreamStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StreamStatus::Active => "ACTIVE",
+            StreamStatus::Creating => "CREATING",
+            StreamStatus::Deleting => "DELETING",
+            StreamStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StreamStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(StreamStatus::Active),
+            "CREATING" => Ok(StreamStatus::Creating),
+            "DELETING" => Ok(StreamStatus::Deleting),
+            "UPDATING" => Ok(StreamStatus::Updating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Metadata assigned to the stream, consisting of a key-value pair.</p>"]
@@ -2326,7 +2496,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AddTagsToStreamError::from_body(String::from_utf8_lossy(&response.body)
                                                         .as_ref()))
@@ -2349,7 +2519,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(CreateStreamError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -2374,7 +2544,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DecreaseStreamRetentionPeriodError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -2394,7 +2564,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteStreamError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -2415,7 +2585,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeLimitsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2442,7 +2612,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2470,7 +2640,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<EnhancedMonitoringOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DisableEnhancedMonitoringError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2495,7 +2665,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<EnhancedMonitoringOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(EnableEnhancedMonitoringError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2517,7 +2687,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRecordsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetRecordsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2541,7 +2711,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetShardIteratorOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2569,7 +2739,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(IncreaseStreamRetentionPeriodError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -2591,7 +2761,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListStreamsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListStreamsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2615,7 +2785,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForStreamOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2640,7 +2810,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(MergeShardsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -2660,7 +2830,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<PutRecordOutput>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -2684,7 +2854,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutRecordsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(PutRecordsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2708,7 +2878,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(RemoveTagsFromStreamError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -2731,7 +2901,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(SplitShardError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -2753,7 +2923,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateShardCountOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -144,6 +140,53 @@ pub struct ApplicationDetail {
     #[serde(rename="ReferenceDataSourceDescriptions")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub reference_data_source_descriptions: Option<Vec<ReferenceDataSourceDescription>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApplicationStatus {
+    Deleting,
+    Ready,
+    Running,
+    Starting,
+    Stopping,
+    Updating,
+}
+
+impl Into<String> for ApplicationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApplicationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ApplicationStatus::Deleting => "DELETING",
+            ApplicationStatus::Ready => "READY",
+            ApplicationStatus::Running => "RUNNING",
+            ApplicationStatus::Starting => "STARTING",
+            ApplicationStatus::Stopping => "STOPPING",
+            ApplicationStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApplicationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETING" => Ok(ApplicationStatus::Deleting),
+            "READY" => Ok(ApplicationStatus::Ready),
+            "RUNNING" => Ok(ApplicationStatus::Running),
+            "STARTING" => Ok(ApplicationStatus::Starting),
+            "STOPPING" => Ok(ApplicationStatus::Stopping),
+            "UPDATING" => Ok(ApplicationStatus::Updating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides application summary information, including the application Amazon Resource Name (ARN), name, and status.</p>"]
@@ -500,6 +543,44 @@ pub struct InputSchemaUpdate {
     pub record_format_update: Option<RecordFormat>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InputStartingPosition {
+    LastStoppedPoint,
+    Now,
+    TrimHorizon,
+}
+
+impl Into<String> for InputStartingPosition {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InputStartingPosition {
+    fn into(self) -> &'static str {
+        match self {
+            InputStartingPosition::LastStoppedPoint => "LAST_STOPPED_POINT",
+            InputStartingPosition::Now => "NOW",
+            InputStartingPosition::TrimHorizon => "TRIM_HORIZON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InputStartingPosition {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LAST_STOPPED_POINT" => Ok(InputStartingPosition::LastStoppedPoint),
+            "NOW" => Ok(InputStartingPosition::Now),
+            "TRIM_HORIZON" => Ok(InputStartingPosition::TrimHorizon),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the point at which the application reads from the streaming source.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InputStartingPositionConfiguration {
@@ -820,6 +901,41 @@ pub struct RecordFormat {
     #[doc="<p>The type of record format.</p>"]
     #[serde(rename="RecordFormatType")]
     pub record_format_type: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecordFormatType {
+    Csv,
+    Json,
+}
+
+impl Into<String> for RecordFormatType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecordFormatType {
+    fn into(self) -> &'static str {
+        match self {
+            RecordFormatType::Csv => "CSV",
+            RecordFormatType::Json => "JSON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecordFormatType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CSV" => Ok(RecordFormatType::Csv),
+            "JSON" => Ok(RecordFormatType::Json),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the reference data source by providing the source information (S3 bucket name and object key name), the resulting in-application table name that is created, and the necessary schema to map the data elements in the Amazon S3 object to the in-application table.</p>"]
@@ -2412,7 +2528,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddApplicationCloudWatchLoggingOptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AddApplicationCloudWatchLoggingOptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2437,7 +2553,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddApplicationInputResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2466,7 +2582,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddApplicationOutputResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2496,7 +2612,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddApplicationReferenceDataSourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AddApplicationReferenceDataSourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2521,7 +2637,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2549,7 +2665,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2575,7 +2691,7 @@ fn delete_application_cloud_watch_logging_option(&self, input: &DeleteApplicatio
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteApplicationCloudWatchLoggingOptionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteApplicationCloudWatchLoggingOptionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2601,7 +2717,7 @@ fn delete_application_cloud_watch_logging_option(&self, input: &DeleteApplicatio
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteApplicationOutputResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteApplicationOutputError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2624,7 +2740,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteApplicationReferenceDataSourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteApplicationReferenceDataSourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2649,7 +2765,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2677,7 +2793,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DiscoverInputSchemaResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2704,7 +2820,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListApplicationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2731,7 +2847,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2758,7 +2874,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2786,7 +2902,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateApplicationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -11,21 +11,55 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AlgorithmSpec {
+    RsaesOaepSha1,
+    RsaesOaepSha256,
+    RsaesPkcs1V15,
+}
+
+impl Into<String> for AlgorithmSpec {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AlgorithmSpec {
+    fn into(self) -> &'static str {
+        match self {
+            AlgorithmSpec::RsaesOaepSha1 => "RSAES_OAEP_SHA_1",
+            AlgorithmSpec::RsaesOaepSha256 => "RSAES_OAEP_SHA_256",
+            AlgorithmSpec::RsaesPkcs1V15 => "RSAES_PKCS1_V1_5",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AlgorithmSpec {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RSAES_OAEP_SHA_1" => Ok(AlgorithmSpec::RsaesOaepSha1),
+            "RSAES_OAEP_SHA_256" => Ok(AlgorithmSpec::RsaesOaepSha256),
+            "RSAES_PKCS1_V1_5" => Ok(AlgorithmSpec::RsaesPkcs1V15),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about an alias.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AliasListEntry {
@@ -144,6 +178,41 @@ pub struct CreateKeyResponse {
     #[serde(rename="KeyMetadata")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub key_metadata: Option<KeyMetadata>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DataKeySpec {
+    Aes128,
+    Aes256,
+}
+
+impl Into<String> for DataKeySpec {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DataKeySpec {
+    fn into(self) -> &'static str {
+        match self {
+            DataKeySpec::Aes128 => "AES_128",
+            DataKeySpec::Aes256 => "AES_256",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DataKeySpec {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AES_128" => Ok(DataKeySpec::Aes128),
+            "AES_256" => Ok(DataKeySpec::Aes256),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -280,6 +349,41 @@ pub struct EncryptResponse {
     #[serde(rename="KeyId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub key_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExpirationModelType {
+    KeyMaterialDoesNotExpire,
+    KeyMaterialExpires,
+}
+
+impl Into<String> for ExpirationModelType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExpirationModelType {
+    fn into(self) -> &'static str {
+        match self {
+            ExpirationModelType::KeyMaterialDoesNotExpire => "KEY_MATERIAL_DOES_NOT_EXPIRE",
+            ExpirationModelType::KeyMaterialExpires => "KEY_MATERIAL_EXPIRES",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExpirationModelType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEY_MATERIAL_DOES_NOT_EXPIRE" => Ok(ExpirationModelType::KeyMaterialDoesNotExpire),
+            "KEY_MATERIAL_EXPIRES" => Ok(ExpirationModelType::KeyMaterialExpires),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -516,6 +620,64 @@ pub struct GrantListEntry {
     pub retiring_principal: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GrantOperation {
+    CreateGrant,
+    Decrypt,
+    DescribeKey,
+    Encrypt,
+    GenerateDataKey,
+    GenerateDataKeyWithoutPlaintext,
+    ReEncryptFrom,
+    ReEncryptTo,
+    RetireGrant,
+}
+
+impl Into<String> for GrantOperation {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GrantOperation {
+    fn into(self) -> &'static str {
+        match self {
+            GrantOperation::CreateGrant => "CreateGrant",
+            GrantOperation::Decrypt => "Decrypt",
+            GrantOperation::DescribeKey => "DescribeKey",
+            GrantOperation::Encrypt => "Encrypt",
+            GrantOperation::GenerateDataKey => "GenerateDataKey",
+            GrantOperation::GenerateDataKeyWithoutPlaintext => "GenerateDataKeyWithoutPlaintext",
+            GrantOperation::ReEncryptFrom => "ReEncryptFrom",
+            GrantOperation::ReEncryptTo => "ReEncryptTo",
+            GrantOperation::RetireGrant => "RetireGrant",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GrantOperation {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreateGrant" => Ok(GrantOperation::CreateGrant),
+            "Decrypt" => Ok(GrantOperation::Decrypt),
+            "DescribeKey" => Ok(GrantOperation::DescribeKey),
+            "Encrypt" => Ok(GrantOperation::Encrypt),
+            "GenerateDataKey" => Ok(GrantOperation::GenerateDataKey),
+            "GenerateDataKeyWithoutPlaintext" => {
+                Ok(GrantOperation::GenerateDataKeyWithoutPlaintext)
+            }
+            "ReEncryptFrom" => Ok(GrantOperation::ReEncryptFrom),
+            "ReEncryptTo" => Ok(GrantOperation::ReEncryptTo),
+            "RetireGrant" => Ok(GrantOperation::RetireGrant),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ImportKeyMaterialRequest {
     #[doc="<p>The encrypted key material to import. It must be encrypted with the public key that you received in the response to a previous <a>GetParametersForImport</a> request, using the wrapping algorithm that you specified in that request.</p>"]
@@ -613,6 +775,79 @@ pub struct KeyMetadata {
     #[serde(rename="ValidTo")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub valid_to: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyState {
+    Disabled,
+    Enabled,
+    PendingDeletion,
+    PendingImport,
+}
+
+impl Into<String> for KeyState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyState {
+    fn into(self) -> &'static str {
+        match self {
+            KeyState::Disabled => "Disabled",
+            KeyState::Enabled => "Enabled",
+            KeyState::PendingDeletion => "PendingDeletion",
+            KeyState::PendingImport => "PendingImport",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(KeyState::Disabled),
+            "Enabled" => Ok(KeyState::Enabled),
+            "PendingDeletion" => Ok(KeyState::PendingDeletion),
+            "PendingImport" => Ok(KeyState::PendingImport),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyUsageType {
+    EncryptDecrypt,
+}
+
+impl Into<String> for KeyUsageType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyUsageType {
+    fn into(self) -> &'static str {
+        match self {
+            KeyUsageType::EncryptDecrypt => "ENCRYPT_DECRYPT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyUsageType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ENCRYPT_DECRYPT" => Ok(KeyUsageType::EncryptDecrypt),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -779,6 +1014,41 @@ pub struct ListRetirableGrantsRequest {
     pub retiring_principal: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OriginType {
+    AwsKms,
+    External,
+}
+
+impl Into<String> for OriginType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OriginType {
+    fn into(self) -> &'static str {
+        match self {
+            OriginType::AwsKms => "AWS_KMS",
+            OriginType::External => "EXTERNAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OriginType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS_KMS" => Ok(OriginType::AwsKms),
+            "EXTERNAL" => Ok(OriginType::External),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutKeyPolicyRequest {
     #[doc="<p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent <code>PutKeyPolicy</code> request on the CMK.</p> <p>The default value is false.</p>"]
@@ -941,6 +1211,38 @@ pub struct UpdateKeyDescriptionRequest {
     #[doc="<p>A unique identifier for the CMK. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WrappingKeySpec {
+    Rsa2048,
+}
+
+impl Into<String> for WrappingKeySpec {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WrappingKeySpec {
+    fn into(self) -> &'static str {
+        match self {
+            WrappingKeySpec::Rsa2048 => "RSA_2048",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WrappingKeySpec {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RSA_2048" => Ok(WrappingKeySpec::Rsa2048),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by CancelKeyDeletion
@@ -4734,7 +5036,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CancelKeyDeletionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4759,7 +5061,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(CreateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4781,7 +5083,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateGrantResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateGrantError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4803,7 +5105,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateKeyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4825,7 +5127,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<DecryptResponse>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -4849,7 +5151,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4871,7 +5173,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteImportedKeyMaterialError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4893,7 +5195,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeKeyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4915,7 +5217,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DisableKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4937,7 +5239,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DisableKeyRotationError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -4960,7 +5262,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(EnableKeyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4982,7 +5284,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(EnableKeyRotationError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -5005,7 +5307,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<EncryptResponse>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -5031,7 +5333,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GenerateDataKeyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5060,7 +5362,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GenerateDataKeyWithoutPlaintextResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GenerateDataKeyWithoutPlaintextError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5084,7 +5386,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GenerateRandomResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5111,7 +5413,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetKeyPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5138,7 +5440,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetKeyRotationStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5166,7 +5468,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetParametersForImportResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5193,7 +5495,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ImportKeyMaterialResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5220,7 +5522,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAliasesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListAliasesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5244,7 +5546,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListGrantsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListGrantsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5268,7 +5570,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListKeyPoliciesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5293,7 +5595,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListKeysResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListKeysError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5317,7 +5619,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListResourceTagsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5344,7 +5646,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListGrantsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5369,7 +5671,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutKeyPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -5391,7 +5693,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ReEncryptResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ReEncryptError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5413,7 +5715,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RetireGrantError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -5433,7 +5735,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RevokeGrantError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -5455,7 +5757,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ScheduleKeyDeletionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5480,7 +5782,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -5500,7 +5802,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -5522,7 +5824,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(UpdateAliasError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -5544,7 +5846,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateKeyDescriptionError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -335,6 +331,44 @@ pub struct EventSourceMappingConfiguration {
     pub uuid: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventSourcePosition {
+    AtTimestamp,
+    Latest,
+    TrimHorizon,
+}
+
+impl Into<String> for EventSourcePosition {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventSourcePosition {
+    fn into(self) -> &'static str {
+        match self {
+            EventSourcePosition::AtTimestamp => "AT_TIMESTAMP",
+            EventSourcePosition::Latest => "LATEST",
+            EventSourcePosition::TrimHorizon => "TRIM_HORIZON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventSourcePosition {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AT_TIMESTAMP" => Ok(EventSourcePosition::AtTimestamp),
+            "LATEST" => Ok(EventSourcePosition::Latest),
+            "TRIM_HORIZON" => Ok(EventSourcePosition::TrimHorizon),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The code for the Lambda function.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct FunctionCode {
@@ -582,6 +616,44 @@ pub struct InvocationResponse {
     pub status_code: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvocationType {
+    DryRun,
+    Event,
+    RequestResponse,
+}
+
+impl Into<String> for InvocationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvocationType {
+    fn into(self) -> &'static str {
+        match self {
+            InvocationType::DryRun => "DryRun",
+            InvocationType::Event => "Event",
+            InvocationType::RequestResponse => "RequestResponse",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvocationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DryRun" => Ok(InvocationType::DryRun),
+            "Event" => Ok(InvocationType::Event),
+            "RequestResponse" => Ok(InvocationType::RequestResponse),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct InvokeAsyncRequest {
@@ -742,6 +814,41 @@ pub struct ListVersionsByFunctionResponse {
     pub versions: Option<Vec<FunctionConfiguration>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LogType {
+    None,
+    Tail,
+}
+
+impl Into<String> for LogType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LogType {
+    fn into(self) -> &'static str {
+        match self {
+            LogType::None => "None",
+            LogType::Tail => "Tail",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LogType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "None" => Ok(LogType::None),
+            "Tail" => Ok(LogType::Tail),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PublishVersionRequest {
@@ -773,6 +880,59 @@ pub struct RemovePermissionRequest {
     pub statement_id: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Runtime {
+    Dotnetcore10,
+    Java8,
+    Nodejs,
+    Nodejs43,
+    Nodejs43Edge,
+    Nodejs610,
+    Python27,
+    Python36,
+}
+
+impl Into<String> for Runtime {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Runtime {
+    fn into(self) -> &'static str {
+        match self {
+            Runtime::Dotnetcore10 => "dotnetcore1.0",
+            Runtime::Java8 => "java8",
+            Runtime::Nodejs => "nodejs",
+            Runtime::Nodejs43 => "nodejs4.3",
+            Runtime::Nodejs43Edge => "nodejs4.3-edge",
+            Runtime::Nodejs610 => "nodejs6.10",
+            Runtime::Python27 => "python2.7",
+            Runtime::Python36 => "python3.6",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Runtime {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dotnetcore1.0" => Ok(Runtime::Dotnetcore10),
+            "java8" => Ok(Runtime::Java8),
+            "nodejs" => Ok(Runtime::Nodejs),
+            "nodejs4.3" => Ok(Runtime::Nodejs43),
+            "nodejs4.3-edge" => Ok(Runtime::Nodejs43Edge),
+            "nodejs6.10" => Ok(Runtime::Nodejs610),
+            "python2.7" => Ok(Runtime::Python27),
+            "python3.6" => Ok(Runtime::Python36),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct TagResourceRequest {
     #[doc="<p>The ARN (Amazon Resource Name) of the Lambda function.</p>"]
@@ -781,6 +941,52 @@ pub struct TagResourceRequest {
     #[doc="<p>The list of tags (key-value pairs) you are assigning to the Lambda function.</p>"]
     #[serde(rename="Tags")]
     pub tags: ::std::collections::HashMap<String, String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ThrottleReason {
+    CallerRateLimitExceeded,
+    ConcurrentInvocationLimitExceeded,
+    FunctionInvocationRateLimitExceeded,
+}
+
+impl Into<String> for ThrottleReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ThrottleReason {
+    fn into(self) -> &'static str {
+        match self {
+            ThrottleReason::CallerRateLimitExceeded => "CallerRateLimitExceeded",
+            ThrottleReason::ConcurrentInvocationLimitExceeded => {
+                "ConcurrentInvocationLimitExceeded"
+            }
+            ThrottleReason::FunctionInvocationRateLimitExceeded => {
+                "FunctionInvocationRateLimitExceeded"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ThrottleReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CallerRateLimitExceeded" => Ok(ThrottleReason::CallerRateLimitExceeded),
+            "ConcurrentInvocationLimitExceeded" => {
+                Ok(ThrottleReason::ConcurrentInvocationLimitExceeded)
+            }
+            "FunctionInvocationRateLimitExceeded" => {
+                Ok(ThrottleReason::FunctionInvocationRateLimitExceeded)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The parent object that contains your function's tracing settings.</p>"]
@@ -799,6 +1005,41 @@ pub struct TracingConfigResponse {
     #[serde(rename="Mode")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub mode: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TracingMode {
+    Active,
+    PassThrough,
+}
+
+impl Into<String> for TracingMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TracingMode {
+    fn into(self) -> &'static str {
+        match self {
+            TracingMode::Active => "Active",
+            TracingMode::PassThrough => "PassThrough",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TracingMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(TracingMode::Active),
+            "PassThrough" => Ok(TracingMode::PassThrough),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -3837,7 +4078,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -3881,7 +4122,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -3923,7 +4164,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body = response.body;
 
@@ -3965,7 +4206,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -4009,7 +4250,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4042,7 +4283,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body = response.body;
 
@@ -4087,7 +4328,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4119,7 +4360,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4163,7 +4404,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4206,7 +4447,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4256,7 +4497,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4303,7 +4544,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4347,7 +4588,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4391,7 +4632,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = InvocationResponse::default();
                 result.payload = Some(response.body);
@@ -4404,7 +4645,8 @@ impl<P, D> Lambda for LambdaClient<P, D>
                     let value = log_result.to_owned();
                     result.log_result = Some(value)
                 };
-                result.status_code = Some(StatusCode::to_u16(&response.status) as i64);
+                result.status_code = Some(::hyper::status::StatusCode::to_u16(&response.status) as
+                                          i64);
                 Ok(result)
             }
             _ => Err(InvokeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4433,7 +4675,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body = response.body;
 
@@ -4446,7 +4688,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 let mut result = serde_json::from_slice::<InvokeAsyncResponse>(&body).unwrap();
 
 
-                result.status = Some(StatusCode::to_u16(&response.status) as i64);
+                result.status = Some(::hyper::status::StatusCode::to_u16(&response.status) as i64);
                 Ok(result)
             }
             _ => Err(InvokeAsyncError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4485,7 +4727,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4540,7 +4782,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4589,7 +4831,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4630,7 +4872,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4680,7 +4922,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4726,7 +4968,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body = response.body;
 
@@ -4776,7 +5018,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4808,7 +5050,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4841,7 +5083,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4876,7 +5118,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -4919,7 +5161,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body = response.body;
 
@@ -4962,7 +5204,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -5008,7 +5250,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -11,21 +11,52 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccessDirection {
+    Inbound,
+    Outbound,
+}
+
+impl Into<String> for AccessDirection {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccessDirection {
+    fn into(self) -> &'static str {
+        match self {
+            AccessDirection::Inbound => "inbound",
+            AccessDirection::Outbound => "outbound",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccessDirection {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "inbound" => Ok(AccessDirection::Inbound),
+            "outbound" => Ok(AccessDirection::Outbound),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AllocateStaticIpRequest {
     #[doc="<p>The name of the static IP address.</p>"]
@@ -119,6 +150,41 @@ pub struct Blueprint {
     #[serde(rename="versionCode")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub version_code: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BlueprintType {
+    App,
+    Os,
+}
+
+impl Into<String> for BlueprintType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BlueprintType {
+    fn into(self) -> &'static str {
+        match self {
+            BlueprintType::App => "app",
+            BlueprintType::Os => "os",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BlueprintType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "app" => Ok(BlueprintType::App),
+            "os" => Ok(BlueprintType::Os),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a bundle, which is a set of specs describing your virtual private server (or <i>instance</i>).</p>"]
@@ -1088,6 +1154,41 @@ pub struct InstanceAccessDetails {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceAccessProtocol {
+    Rdp,
+    Ssh,
+}
+
+impl Into<String> for InstanceAccessProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceAccessProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceAccessProtocol::Rdp => "rdp",
+            InstanceAccessProtocol::Ssh => "ssh",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceAccessProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "rdp" => Ok(InstanceAccessProtocol::Rdp),
+            "ssh" => Ok(InstanceAccessProtocol::Ssh),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the hardware for the instance.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceHardware {
@@ -1103,6 +1204,53 @@ pub struct InstanceHardware {
     #[serde(rename="ramSizeInGb")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub ram_size_in_gb: Option<f32>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceMetricName {
+    Cpuutilization,
+    NetworkIn,
+    NetworkOut,
+    StatusCheckFailed,
+    StatusCheckFailedInstance,
+    StatusCheckFailedSystem,
+}
+
+impl Into<String> for InstanceMetricName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceMetricName {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceMetricName::Cpuutilization => "CPUUtilization",
+            InstanceMetricName::NetworkIn => "NetworkIn",
+            InstanceMetricName::NetworkOut => "NetworkOut",
+            InstanceMetricName::StatusCheckFailed => "StatusCheckFailed",
+            InstanceMetricName::StatusCheckFailedInstance => "StatusCheckFailed_Instance",
+            InstanceMetricName::StatusCheckFailedSystem => "StatusCheckFailed_System",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceMetricName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CPUUtilization" => Ok(InstanceMetricName::Cpuutilization),
+            "NetworkIn" => Ok(InstanceMetricName::NetworkIn),
+            "NetworkOut" => Ok(InstanceMetricName::NetworkOut),
+            "StatusCheckFailed" => Ok(InstanceMetricName::StatusCheckFailed),
+            "StatusCheckFailed_Instance" => Ok(InstanceMetricName::StatusCheckFailedInstance),
+            "StatusCheckFailed_System" => Ok(InstanceMetricName::StatusCheckFailedSystem),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes monthly data transfer rates and port information for an instance.</p>"]
@@ -1229,6 +1377,44 @@ pub struct InstanceSnapshot {
     pub support_code: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceSnapshotState {
+    Available,
+    Error,
+    Pending,
+}
+
+impl Into<String> for InstanceSnapshotState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceSnapshotState {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceSnapshotState::Available => "available",
+            InstanceSnapshotState::Error => "error",
+            InstanceSnapshotState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceSnapshotState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(InstanceSnapshotState::Available),
+            "error" => Ok(InstanceSnapshotState::Error),
+            "pending" => Ok(InstanceSnapshotState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the virtual private server (or <i>instance</i>) status.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceState {
@@ -1319,6 +1505,160 @@ pub struct MetricDatapoint {
     pub unit: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricStatistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for MetricStatistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricStatistic {
+    fn into(self) -> &'static str {
+        match self {
+            MetricStatistic::Average => "Average",
+            MetricStatistic::Maximum => "Maximum",
+            MetricStatistic::Minimum => "Minimum",
+            MetricStatistic::SampleCount => "SampleCount",
+            MetricStatistic::Sum => "Sum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricStatistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(MetricStatistic::Average),
+            "Maximum" => Ok(MetricStatistic::Maximum),
+            "Minimum" => Ok(MetricStatistic::Minimum),
+            "SampleCount" => Ok(MetricStatistic::SampleCount),
+            "Sum" => Ok(MetricStatistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricUnit {
+    Bits,
+    BitsSecond,
+    Bytes,
+    BytesSecond,
+    Count,
+    CountSecond,
+    Gigabits,
+    GigabitsSecond,
+    Gigabytes,
+    GigabytesSecond,
+    Kilobits,
+    KilobitsSecond,
+    Kilobytes,
+    KilobytesSecond,
+    Megabits,
+    MegabitsSecond,
+    Megabytes,
+    MegabytesSecond,
+    Microseconds,
+    Milliseconds,
+    None,
+    Percent,
+    Seconds,
+    Terabits,
+    TerabitsSecond,
+    Terabytes,
+    TerabytesSecond,
+}
+
+impl Into<String> for MetricUnit {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricUnit {
+    fn into(self) -> &'static str {
+        match self {
+            MetricUnit::Bits => "Bits",
+            MetricUnit::BitsSecond => "Bits/Second",
+            MetricUnit::Bytes => "Bytes",
+            MetricUnit::BytesSecond => "Bytes/Second",
+            MetricUnit::Count => "Count",
+            MetricUnit::CountSecond => "Count/Second",
+            MetricUnit::Gigabits => "Gigabits",
+            MetricUnit::GigabitsSecond => "Gigabits/Second",
+            MetricUnit::Gigabytes => "Gigabytes",
+            MetricUnit::GigabytesSecond => "Gigabytes/Second",
+            MetricUnit::Kilobits => "Kilobits",
+            MetricUnit::KilobitsSecond => "Kilobits/Second",
+            MetricUnit::Kilobytes => "Kilobytes",
+            MetricUnit::KilobytesSecond => "Kilobytes/Second",
+            MetricUnit::Megabits => "Megabits",
+            MetricUnit::MegabitsSecond => "Megabits/Second",
+            MetricUnit::Megabytes => "Megabytes",
+            MetricUnit::MegabytesSecond => "Megabytes/Second",
+            MetricUnit::Microseconds => "Microseconds",
+            MetricUnit::Milliseconds => "Milliseconds",
+            MetricUnit::None => "None",
+            MetricUnit::Percent => "Percent",
+            MetricUnit::Seconds => "Seconds",
+            MetricUnit::Terabits => "Terabits",
+            MetricUnit::TerabitsSecond => "Terabits/Second",
+            MetricUnit::Terabytes => "Terabytes",
+            MetricUnit::TerabytesSecond => "Terabytes/Second",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricUnit {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bits" => Ok(MetricUnit::Bits),
+            "Bits/Second" => Ok(MetricUnit::BitsSecond),
+            "Bytes" => Ok(MetricUnit::Bytes),
+            "Bytes/Second" => Ok(MetricUnit::BytesSecond),
+            "Count" => Ok(MetricUnit::Count),
+            "Count/Second" => Ok(MetricUnit::CountSecond),
+            "Gigabits" => Ok(MetricUnit::Gigabits),
+            "Gigabits/Second" => Ok(MetricUnit::GigabitsSecond),
+            "Gigabytes" => Ok(MetricUnit::Gigabytes),
+            "Gigabytes/Second" => Ok(MetricUnit::GigabytesSecond),
+            "Kilobits" => Ok(MetricUnit::Kilobits),
+            "Kilobits/Second" => Ok(MetricUnit::KilobitsSecond),
+            "Kilobytes" => Ok(MetricUnit::Kilobytes),
+            "Kilobytes/Second" => Ok(MetricUnit::KilobytesSecond),
+            "Megabits" => Ok(MetricUnit::Megabits),
+            "Megabits/Second" => Ok(MetricUnit::MegabitsSecond),
+            "Megabytes" => Ok(MetricUnit::Megabytes),
+            "Megabytes/Second" => Ok(MetricUnit::MegabytesSecond),
+            "Microseconds" => Ok(MetricUnit::Microseconds),
+            "Milliseconds" => Ok(MetricUnit::Milliseconds),
+            "None" => Ok(MetricUnit::None),
+            "Percent" => Ok(MetricUnit::Percent),
+            "Seconds" => Ok(MetricUnit::Seconds),
+            "Terabits" => Ok(MetricUnit::Terabits),
+            "Terabits/Second" => Ok(MetricUnit::TerabitsSecond),
+            "Terabytes" => Ok(MetricUnit::Terabytes),
+            "Terabytes/Second" => Ok(MetricUnit::TerabytesSecond),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the monthly data transfer in and out of your virtual private server (or <i>instance</i>).</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct MonthlyTransfer {
@@ -1326,6 +1666,44 @@ pub struct MonthlyTransfer {
     #[serde(rename="gbPerMonthAllocated")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub gb_per_month_allocated: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkProtocol {
+    All,
+    Tcp,
+    Udp,
+}
+
+impl Into<String> for NetworkProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkProtocol::All => "all",
+            NetworkProtocol::Tcp => "tcp",
+            NetworkProtocol::Udp => "udp",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(NetworkProtocol::All),
+            "tcp" => Ok(NetworkProtocol::Tcp),
+            "udp" => Ok(NetworkProtocol::Udp),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1399,6 +1777,133 @@ pub struct Operation {
     pub status_changed_at: Option<f64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationStatus {
+    Completed,
+    Failed,
+    NotStarted,
+    Started,
+}
+
+impl Into<String> for OperationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            OperationStatus::Completed => "Completed",
+            OperationStatus::Failed => "Failed",
+            OperationStatus::NotStarted => "NotStarted",
+            OperationStatus::Started => "Started",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Completed" => Ok(OperationStatus::Completed),
+            "Failed" => Ok(OperationStatus::Failed),
+            "NotStarted" => Ok(OperationStatus::NotStarted),
+            "Started" => Ok(OperationStatus::Started),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationType {
+    AllocateStaticIp,
+    AttachStaticIp,
+    CloseInstancePublicPorts,
+    CreateDomain,
+    CreateInstance,
+    CreateInstanceSnapshot,
+    CreateInstancesFromSnapshot,
+    DeleteDomain,
+    DeleteDomainEntry,
+    DeleteInstance,
+    DeleteInstanceSnapshot,
+    DetachStaticIp,
+    OpenInstancePublicPorts,
+    PutInstancePublicPorts,
+    RebootInstance,
+    ReleaseStaticIp,
+    StartInstance,
+    StopInstance,
+    UpdateDomainEntry,
+}
+
+impl Into<String> for OperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationType {
+    fn into(self) -> &'static str {
+        match self {
+            OperationType::AllocateStaticIp => "AllocateStaticIp",
+            OperationType::AttachStaticIp => "AttachStaticIp",
+            OperationType::CloseInstancePublicPorts => "CloseInstancePublicPorts",
+            OperationType::CreateDomain => "CreateDomain",
+            OperationType::CreateInstance => "CreateInstance",
+            OperationType::CreateInstanceSnapshot => "CreateInstanceSnapshot",
+            OperationType::CreateInstancesFromSnapshot => "CreateInstancesFromSnapshot",
+            OperationType::DeleteDomain => "DeleteDomain",
+            OperationType::DeleteDomainEntry => "DeleteDomainEntry",
+            OperationType::DeleteInstance => "DeleteInstance",
+            OperationType::DeleteInstanceSnapshot => "DeleteInstanceSnapshot",
+            OperationType::DetachStaticIp => "DetachStaticIp",
+            OperationType::OpenInstancePublicPorts => "OpenInstancePublicPorts",
+            OperationType::PutInstancePublicPorts => "PutInstancePublicPorts",
+            OperationType::RebootInstance => "RebootInstance",
+            OperationType::ReleaseStaticIp => "ReleaseStaticIp",
+            OperationType::StartInstance => "StartInstance",
+            OperationType::StopInstance => "StopInstance",
+            OperationType::UpdateDomainEntry => "UpdateDomainEntry",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AllocateStaticIp" => Ok(OperationType::AllocateStaticIp),
+            "AttachStaticIp" => Ok(OperationType::AttachStaticIp),
+            "CloseInstancePublicPorts" => Ok(OperationType::CloseInstancePublicPorts),
+            "CreateDomain" => Ok(OperationType::CreateDomain),
+            "CreateInstance" => Ok(OperationType::CreateInstance),
+            "CreateInstanceSnapshot" => Ok(OperationType::CreateInstanceSnapshot),
+            "CreateInstancesFromSnapshot" => Ok(OperationType::CreateInstancesFromSnapshot),
+            "DeleteDomain" => Ok(OperationType::DeleteDomain),
+            "DeleteDomainEntry" => Ok(OperationType::DeleteDomainEntry),
+            "DeleteInstance" => Ok(OperationType::DeleteInstance),
+            "DeleteInstanceSnapshot" => Ok(OperationType::DeleteInstanceSnapshot),
+            "DetachStaticIp" => Ok(OperationType::DetachStaticIp),
+            "OpenInstancePublicPorts" => Ok(OperationType::OpenInstancePublicPorts),
+            "PutInstancePublicPorts" => Ok(OperationType::PutInstancePublicPorts),
+            "RebootInstance" => Ok(OperationType::RebootInstance),
+            "ReleaseStaticIp" => Ok(OperationType::ReleaseStaticIp),
+            "StartInstance" => Ok(OperationType::StartInstance),
+            "StopInstance" => Ok(OperationType::StopInstance),
+            "UpdateDomainEntry" => Ok(OperationType::UpdateDomainEntry),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PeerVpcRequest;
 
@@ -1408,6 +1913,41 @@ pub struct PeerVpcResult {
     #[serde(rename="operation")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub operation: Option<Operation>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PortAccessType {
+    Private,
+    Public,
+}
+
+impl Into<String> for PortAccessType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PortAccessType {
+    fn into(self) -> &'static str {
+        match self {
+            PortAccessType::Private => "Private",
+            PortAccessType::Public => "Public",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PortAccessType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Private" => Ok(PortAccessType::Private),
+            "Public" => Ok(PortAccessType::Public),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes information about the ports on your virtual private server (or <i>instance</i>).</p>"]
@@ -1425,6 +1965,41 @@ pub struct PortInfo {
     #[serde(rename="toPort")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub to_port: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PortState {
+    Closed,
+    Open,
+}
+
+impl Into<String> for PortState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PortState {
+    fn into(self) -> &'static str {
+        match self {
+            PortState::Closed => "closed",
+            PortState::Open => "open",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PortState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "closed" => Ok(PortState::Closed),
+            "open" => Ok(PortState::Open),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1485,6 +2060,68 @@ pub struct Region {
     pub name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RegionName {
+    ApNortheast1,
+    ApNortheast2,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    EuCentral1,
+    EuWest1,
+    UsEast1,
+    UsEast2,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for RegionName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RegionName {
+    fn into(self) -> &'static str {
+        match self {
+            RegionName::ApNortheast1 => "ap-northeast-1",
+            RegionName::ApNortheast2 => "ap-northeast-2",
+            RegionName::ApSouth1 => "ap-south-1",
+            RegionName::ApSoutheast1 => "ap-southeast-1",
+            RegionName::ApSoutheast2 => "ap-southeast-2",
+            RegionName::EuCentral1 => "eu-central-1",
+            RegionName::EuWest1 => "eu-west-1",
+            RegionName::UsEast1 => "us-east-1",
+            RegionName::UsEast2 => "us-east-2",
+            RegionName::UsWest1 => "us-west-1",
+            RegionName::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RegionName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(RegionName::ApNortheast1),
+            "ap-northeast-2" => Ok(RegionName::ApNortheast2),
+            "ap-south-1" => Ok(RegionName::ApSouth1),
+            "ap-southeast-1" => Ok(RegionName::ApSoutheast1),
+            "ap-southeast-2" => Ok(RegionName::ApSoutheast2),
+            "eu-central-1" => Ok(RegionName::EuCentral1),
+            "eu-west-1" => Ok(RegionName::EuWest1),
+            "us-east-1" => Ok(RegionName::UsEast1),
+            "us-east-2" => Ok(RegionName::UsEast2),
+            "us-west-1" => Ok(RegionName::UsWest1),
+            "us-west-2" => Ok(RegionName::UsWest2),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ReleaseStaticIpRequest {
     #[doc="<p>The name of the static IP to delete.</p>"]
@@ -1511,6 +2148,53 @@ pub struct ResourceLocation {
     #[serde(rename="regionName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub region_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    Domain,
+    Instance,
+    InstanceSnapshot,
+    KeyPair,
+    PeeredVpc,
+    StaticIp,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::Domain => "Domain",
+            ResourceType::Instance => "Instance",
+            ResourceType::InstanceSnapshot => "InstanceSnapshot",
+            ResourceType::KeyPair => "KeyPair",
+            ResourceType::PeeredVpc => "PeeredVpc",
+            ResourceType::StaticIp => "StaticIp",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Domain" => Ok(ResourceType::Domain),
+            "Instance" => Ok(ResourceType::Instance),
+            "InstanceSnapshot" => Ok(ResourceType::InstanceSnapshot),
+            "KeyPair" => Ok(ResourceType::KeyPair),
+            "PeeredVpc" => Ok(ResourceType::PeeredVpc),
+            "StaticIp" => Ok(ResourceType::StaticIp),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -7117,7 +7801,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AllocateStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7144,7 +7828,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AttachStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7173,7 +7857,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CloseInstancePublicPortsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CloseInstancePublicPortsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7197,7 +7881,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDomainResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7223,7 +7907,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDomainEntryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7251,7 +7935,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateInstanceSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7278,7 +7962,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateInstancesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7307,7 +7991,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateInstancesFromSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateInstancesFromSnapshotError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7331,7 +8015,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7357,7 +8041,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteDomainResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7383,7 +8067,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteDomainEntryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7410,7 +8094,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7438,7 +8122,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteInstanceSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7465,7 +8149,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7491,7 +8175,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DetachStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7517,7 +8201,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DownloadDefaultKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7544,7 +8228,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetActiveNamesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7571,7 +8255,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetBlueprintsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7595,7 +8279,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetBundlesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetBundlesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7617,7 +8301,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetDomainResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -7641,7 +8325,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDomainsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetDomainsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7665,7 +8349,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7691,7 +8375,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstanceAccessDetailsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetInstanceAccessDetailsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7716,7 +8400,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstanceMetricDataResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7744,7 +8428,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstancePortStatesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7771,7 +8455,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstanceSnapshotResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7798,7 +8482,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstanceSnapshotsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7825,7 +8509,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstanceStateResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7852,7 +8536,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInstancesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7876,7 +8560,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetKeyPairError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7900,7 +8584,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetKeyPairsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetKeyPairsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7924,7 +8608,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetOperationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7950,7 +8634,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetOperationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7978,7 +8662,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetOperationsForResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetOperationsForResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8000,7 +8684,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRegionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetRegionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8024,7 +8708,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetStaticIpError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8048,7 +8732,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetStaticIpsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8074,7 +8758,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ImportKeyPairResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8097,7 +8781,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<IsVpcPeeredResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(IsVpcPeeredError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8122,7 +8806,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<OpenInstancePublicPortsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(OpenInstancePublicPortsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8143,7 +8827,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<PeerVpcResult>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -8170,7 +8854,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutInstancePublicPortsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8197,7 +8881,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RebootInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8224,7 +8908,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ReleaseStaticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8251,7 +8935,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8277,7 +8961,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8300,7 +8984,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<UnpeerVpcResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -8326,7 +9010,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDomainEntryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -362,6 +358,41 @@ pub struct Destination {
     pub target_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Distribution {
+    ByLogStream,
+    Random,
+}
+
+impl Into<String> for Distribution {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Distribution {
+    fn into(self) -> &'static str {
+        match self {
+            Distribution::ByLogStream => "ByLogStream",
+            Distribution::Random => "Random",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Distribution {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ByLogStream" => Ok(Distribution::ByLogStream),
+            "Random" => Ok(Distribution::Random),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents an export task.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ExportTask {
@@ -427,6 +458,53 @@ pub struct ExportTaskStatus {
     #[serde(rename="message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExportTaskStatusCode {
+    Cancelled,
+    Completed,
+    Failed,
+    Pending,
+    PendingCancel,
+    Running,
+}
+
+impl Into<String> for ExportTaskStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExportTaskStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            ExportTaskStatusCode::Cancelled => "CANCELLED",
+            ExportTaskStatusCode::Completed => "COMPLETED",
+            ExportTaskStatusCode::Failed => "FAILED",
+            ExportTaskStatusCode::Pending => "PENDING",
+            ExportTaskStatusCode::PendingCancel => "PENDING_CANCEL",
+            ExportTaskStatusCode::Running => "RUNNING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExportTaskStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(ExportTaskStatusCode::Cancelled),
+            "COMPLETED" => Ok(ExportTaskStatusCode::Completed),
+            "FAILED" => Ok(ExportTaskStatusCode::Failed),
+            "PENDING" => Ok(ExportTaskStatusCode::Pending),
+            "PENDING_CANCEL" => Ok(ExportTaskStatusCode::PendingCancel),
+            "RUNNING" => Ok(ExportTaskStatusCode::Running),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -699,6 +777,41 @@ pub struct MetricTransformation {
     #[doc="<p>The value to publish to the CloudWatch metric when a filter pattern matches a log event.</p>"]
     #[serde(rename="metricValue")]
     pub metric_value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrderBy {
+    LastEventTime,
+    LogStreamName,
+}
+
+impl Into<String> for OrderBy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrderBy {
+    fn into(self) -> &'static str {
+        match self {
+            OrderBy::LastEventTime => "LastEventTime",
+            OrderBy::LogStreamName => "LogStreamName",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrderBy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LastEventTime" => Ok(OrderBy::LastEventTime),
+            "LogStreamName" => Ok(OrderBy::LogStreamName),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a log event.</p>"]
@@ -3630,7 +3743,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(CancelExportTaskError::from_body(String::from_utf8_lossy(&response.body)
                                                          .as_ref()))
@@ -3655,7 +3768,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateExportTaskResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3680,7 +3793,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(CreateLogGroupError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -3705,7 +3818,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(CreateLogStreamError::from_body(String::from_utf8_lossy(&response.body)
                                                         .as_ref()))
@@ -3730,7 +3843,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteDestinationError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -3753,7 +3866,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteLogGroupError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -3778,7 +3891,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteLogStreamError::from_body(String::from_utf8_lossy(&response.body)
                                                         .as_ref()))
@@ -3803,7 +3916,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteMetricFilterError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -3828,7 +3941,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteRetentionPolicyError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))
@@ -3853,7 +3966,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteSubscriptionFilterError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -3875,7 +3988,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDestinationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3902,7 +4015,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeExportTasksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3929,7 +4042,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeLogGroupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3956,7 +4069,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeLogStreamsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3984,7 +4097,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMetricFiltersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4012,7 +4125,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeSubscriptionFiltersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeSubscriptionFiltersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4036,7 +4149,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<FilterLogEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4063,7 +4176,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetLogEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4089,7 +4202,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsLogGroupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4116,7 +4229,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutDestinationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4143,7 +4256,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutDestinationPolicyError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -4168,7 +4281,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutLogEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4194,7 +4307,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutMetricFilterError::from_body(String::from_utf8_lossy(&response.body)
                                                         .as_ref()))
@@ -4219,7 +4332,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutRetentionPolicyError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -4244,7 +4357,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(PutSubscriptionFilterError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))
@@ -4267,7 +4380,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(TagLogGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -4289,7 +4402,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<TestMetricFilterResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4314,7 +4427,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UntagLogGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -50,6 +46,38 @@ pub struct AddTagsOutput {
     #[serde(rename="ResourceType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
+}
+
+#[doc="<p>The function used to train an <code>MLModel</code>. Training choices supported by Amazon ML include the following:</p> <ul> <li> <code>SGD</code> - Stochastic Gradient Descent.</li> <li> <code>RandomForest</code> - Random forest of decision trees.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Algorithm {
+    Sgd,
+}
+
+impl Into<String> for Algorithm {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Algorithm {
+    fn into(self) -> &'static str {
+        match self {
+            Algorithm::Sgd => "sgd",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Algorithm {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "sgd" => Ok(Algorithm::Sgd),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p> Represents the output of a <code>GetBatchPrediction</code> operation.</p> <p> The content consists of the detailed metadata, the status, and the data file information of a <code>Batch Prediction</code>.</p>"]
@@ -114,6 +142,59 @@ pub struct BatchPrediction {
     #[serde(rename="TotalRecordCount")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub total_record_count: Option<i64>,
+}
+
+#[doc="<p>A list of the variables to use in searching or filtering <code>BatchPrediction</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>BatchPrediction</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>BatchPrediction</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>BatchPrediction</code><b> </b> <code>Name</code>.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked the <code>BatchPrediction</code> creation.</li> <li> <code>MLModelId</code> - Sets the search criteria to the <code>MLModel</code> used in the <code>BatchPrediction</code>.</li> <li> <code>DataSourceId</code> - Sets the search criteria to the <code>DataSource</code> used in the <code>BatchPrediction</code>.</li> <li> <code>DataURI</code> - Sets the search criteria to the data file(s) used in the <code>BatchPrediction</code>. The URL can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BatchPredictionFilterVariable {
+    CreatedAt,
+    DataSourceId,
+    DataURI,
+    Iamuser,
+    LastUpdatedAt,
+    MlmodelId,
+    Name,
+    Status,
+}
+
+impl Into<String> for BatchPredictionFilterVariable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BatchPredictionFilterVariable {
+    fn into(self) -> &'static str {
+        match self {
+            BatchPredictionFilterVariable::CreatedAt => "CreatedAt",
+            BatchPredictionFilterVariable::DataSourceId => "DataSourceId",
+            BatchPredictionFilterVariable::DataURI => "DataURI",
+            BatchPredictionFilterVariable::Iamuser => "IAMUser",
+            BatchPredictionFilterVariable::LastUpdatedAt => "LastUpdatedAt",
+            BatchPredictionFilterVariable::MlmodelId => "MLModelId",
+            BatchPredictionFilterVariable::Name => "Name",
+            BatchPredictionFilterVariable::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BatchPredictionFilterVariable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreatedAt" => Ok(BatchPredictionFilterVariable::CreatedAt),
+            "DataSourceId" => Ok(BatchPredictionFilterVariable::DataSourceId),
+            "DataURI" => Ok(BatchPredictionFilterVariable::DataURI),
+            "IAMUser" => Ok(BatchPredictionFilterVariable::Iamuser),
+            "LastUpdatedAt" => Ok(BatchPredictionFilterVariable::LastUpdatedAt),
+            "MLModelId" => Ok(BatchPredictionFilterVariable::MlmodelId),
+            "Name" => Ok(BatchPredictionFilterVariable::Name),
+            "Status" => Ok(BatchPredictionFilterVariable::Status),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -385,6 +466,53 @@ pub struct DataSource {
     #[serde(rename="Status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+#[doc="<p>A list of the variables to use in searching or filtering <code>DataSource</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>DataSource</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>DataSource</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>DataSource</code> <b> </b> <code>Name</code>.</li> <li> <code>DataUri</code> - Sets the search criteria to the URI of data files used to create the <code>DataSource</code>. The URI can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked the <code>DataSource</code> creation.</li> </ul> <note><title>Note</title> <p>The variable names should match the variable names in the <code>DataSource</code>.</p> </note>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DataSourceFilterVariable {
+    CreatedAt,
+    DataLocationS3,
+    Iamuser,
+    LastUpdatedAt,
+    Name,
+    Status,
+}
+
+impl Into<String> for DataSourceFilterVariable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DataSourceFilterVariable {
+    fn into(self) -> &'static str {
+        match self {
+            DataSourceFilterVariable::CreatedAt => "CreatedAt",
+            DataSourceFilterVariable::DataLocationS3 => "DataLocationS3",
+            DataSourceFilterVariable::Iamuser => "IAMUser",
+            DataSourceFilterVariable::LastUpdatedAt => "LastUpdatedAt",
+            DataSourceFilterVariable::Name => "Name",
+            DataSourceFilterVariable::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DataSourceFilterVariable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreatedAt" => Ok(DataSourceFilterVariable::CreatedAt),
+            "DataLocationS3" => Ok(DataSourceFilterVariable::DataLocationS3),
+            "IAMUser" => Ok(DataSourceFilterVariable::Iamuser),
+            "LastUpdatedAt" => Ok(DataSourceFilterVariable::LastUpdatedAt),
+            "Name" => Ok(DataSourceFilterVariable::Name),
+            "Status" => Ok(DataSourceFilterVariable::Status),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -768,6 +896,85 @@ pub struct DescribeTagsOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[doc="Contains the key values of <code>DetailsMap</code>: <code>PredictiveModelType</code> - Indicates the type of the <code>MLModel</code>. <code>Algorithm</code> - Indicates the algorithm that was used for the <code>MLModel</code>."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DetailsAttributes {
+    Algorithm,
+    PredictiveModelType,
+}
+
+impl Into<String> for DetailsAttributes {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DetailsAttributes {
+    fn into(self) -> &'static str {
+        match self {
+            DetailsAttributes::Algorithm => "Algorithm",
+            DetailsAttributes::PredictiveModelType => "PredictiveModelType",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DetailsAttributes {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Algorithm" => Ok(DetailsAttributes::Algorithm),
+            "PredictiveModelType" => Ok(DetailsAttributes::PredictiveModelType),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>Object status with the following possible values:</p> <ul> <li><code>PENDING</code></li> <li><code>INPROGRESS</code></li> <li><code>FAILED</code></li> <li><code>COMPLETED</code></li> <li><code>DELETED</code></li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EntityStatus {
+    Completed,
+    Deleted,
+    Failed,
+    Inprogress,
+    Pending,
+}
+
+impl Into<String> for EntityStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EntityStatus {
+    fn into(self) -> &'static str {
+        match self {
+            EntityStatus::Completed => "COMPLETED",
+            EntityStatus::Deleted => "DELETED",
+            EntityStatus::Failed => "FAILED",
+            EntityStatus::Inprogress => "INPROGRESS",
+            EntityStatus::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EntityStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETED" => Ok(EntityStatus::Completed),
+            "DELETED" => Ok(EntityStatus::Deleted),
+            "FAILED" => Ok(EntityStatus::Failed),
+            "INPROGRESS" => Ok(EntityStatus::Inprogress),
+            "PENDING" => Ok(EntityStatus::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> Represents the output of <code>GetEvaluation</code> operation. </p> <p>The content consists of the detailed metadata and data file information and the current status of the <code>Evaluation</code>.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Evaluation {
@@ -824,6 +1031,59 @@ pub struct Evaluation {
     #[serde(rename="Status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+#[doc="<p>A list of the variables to use in searching or filtering <code>Evaluation</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>Evaluation</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>Evaluation</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>Evaluation</code> <b> </b> <code>Name</code>.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked an evaluation.</li> <li> <code>MLModelId</code> - Sets the search criteria to the <code>Predictor</code> that was evaluated.</li> <li> <code>DataSourceId</code> - Sets the search criteria to the <code>DataSource</code> used in evaluation.</li> <li> <code>DataUri</code> - Sets the search criteria to the data file(s) used in evaluation. The URL can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EvaluationFilterVariable {
+    CreatedAt,
+    DataSourceId,
+    DataURI,
+    Iamuser,
+    LastUpdatedAt,
+    MlmodelId,
+    Name,
+    Status,
+}
+
+impl Into<String> for EvaluationFilterVariable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EvaluationFilterVariable {
+    fn into(self) -> &'static str {
+        match self {
+            EvaluationFilterVariable::CreatedAt => "CreatedAt",
+            EvaluationFilterVariable::DataSourceId => "DataSourceId",
+            EvaluationFilterVariable::DataURI => "DataURI",
+            EvaluationFilterVariable::Iamuser => "IAMUser",
+            EvaluationFilterVariable::LastUpdatedAt => "LastUpdatedAt",
+            EvaluationFilterVariable::MlmodelId => "MLModelId",
+            EvaluationFilterVariable::Name => "Name",
+            EvaluationFilterVariable::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EvaluationFilterVariable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreatedAt" => Ok(EvaluationFilterVariable::CreatedAt),
+            "DataSourceId" => Ok(EvaluationFilterVariable::DataSourceId),
+            "DataURI" => Ok(EvaluationFilterVariable::DataURI),
+            "IAMUser" => Ok(EvaluationFilterVariable::Iamuser),
+            "LastUpdatedAt" => Ok(EvaluationFilterVariable::LastUpdatedAt),
+            "MLModelId" => Ok(EvaluationFilterVariable::MlmodelId),
+            "Name" => Ok(EvaluationFilterVariable::Name),
+            "Status" => Ok(EvaluationFilterVariable::Status),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1246,6 +1506,103 @@ pub struct MLModel {
     pub training_parameters: Option<::std::collections::HashMap<String, String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MLModelFilterVariable {
+    Algorithm,
+    CreatedAt,
+    Iamuser,
+    LastUpdatedAt,
+    MlmodelType,
+    Name,
+    RealtimeEndpointStatus,
+    Status,
+    TrainingDataSourceId,
+    TrainingDataURI,
+}
+
+impl Into<String> for MLModelFilterVariable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MLModelFilterVariable {
+    fn into(self) -> &'static str {
+        match self {
+            MLModelFilterVariable::Algorithm => "Algorithm",
+            MLModelFilterVariable::CreatedAt => "CreatedAt",
+            MLModelFilterVariable::Iamuser => "IAMUser",
+            MLModelFilterVariable::LastUpdatedAt => "LastUpdatedAt",
+            MLModelFilterVariable::MlmodelType => "MLModelType",
+            MLModelFilterVariable::Name => "Name",
+            MLModelFilterVariable::RealtimeEndpointStatus => "RealtimeEndpointStatus",
+            MLModelFilterVariable::Status => "Status",
+            MLModelFilterVariable::TrainingDataSourceId => "TrainingDataSourceId",
+            MLModelFilterVariable::TrainingDataURI => "TrainingDataURI",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MLModelFilterVariable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Algorithm" => Ok(MLModelFilterVariable::Algorithm),
+            "CreatedAt" => Ok(MLModelFilterVariable::CreatedAt),
+            "IAMUser" => Ok(MLModelFilterVariable::Iamuser),
+            "LastUpdatedAt" => Ok(MLModelFilterVariable::LastUpdatedAt),
+            "MLModelType" => Ok(MLModelFilterVariable::MlmodelType),
+            "Name" => Ok(MLModelFilterVariable::Name),
+            "RealtimeEndpointStatus" => Ok(MLModelFilterVariable::RealtimeEndpointStatus),
+            "Status" => Ok(MLModelFilterVariable::Status),
+            "TrainingDataSourceId" => Ok(MLModelFilterVariable::TrainingDataSourceId),
+            "TrainingDataURI" => Ok(MLModelFilterVariable::TrainingDataURI),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MLModelType {
+    Binary,
+    Multiclass,
+    Regression,
+}
+
+impl Into<String> for MLModelType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MLModelType {
+    fn into(self) -> &'static str {
+        match self {
+            MLModelType::Binary => "BINARY",
+            MLModelType::Multiclass => "MULTICLASS",
+            MLModelType::Regression => "REGRESSION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MLModelType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BINARY" => Ok(MLModelType::Binary),
+            "MULTICLASS" => Ok(MLModelType::Multiclass),
+            "REGRESSION" => Ok(MLModelType::Regression),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Measurements of how well the <code>MLModel</code> performed on known observations. One of the following metrics is returned, based on the type of the <code>MLModel</code>: </p> <ul> <li> <p>BinaryAUC: The binary <code>MLModel</code> uses the Area Under the Curve (AUC) technique to measure performance. </p> </li> <li> <p>RegressionRMSE: The regression <code>MLModel</code> uses the Root Mean Square Error (RMSE) technique to measure performance. RMSE measures the difference between predicted and actual values for a single variable.</p> </li> <li> <p>MulticlassAvgFScore: The multiclass <code>MLModel</code> uses the F1 score technique to measure performance. </p> </li> </ul> <p> For more information about performance metrics, please see the <a href=\"http://docs.aws.amazon.com/machine-learning/latest/dg\">Amazon Machine Learning Developer Guide</a>. </p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PerformanceMetrics {
@@ -1400,6 +1757,47 @@ pub struct RealtimeEndpointInfo {
     pub peak_requests_per_second: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RealtimeEndpointStatus {
+    Failed,
+    None,
+    Ready,
+    Updating,
+}
+
+impl Into<String> for RealtimeEndpointStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RealtimeEndpointStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RealtimeEndpointStatus::Failed => "FAILED",
+            RealtimeEndpointStatus::None => "NONE",
+            RealtimeEndpointStatus::Ready => "READY",
+            RealtimeEndpointStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RealtimeEndpointStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(RealtimeEndpointStatus::Failed),
+            "NONE" => Ok(RealtimeEndpointStatus::None),
+            "READY" => Ok(RealtimeEndpointStatus::Ready),
+            "UPDATING" => Ok(RealtimeEndpointStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the data specification of an Amazon Redshift <code>DataSource</code>.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RedshiftDataSpec {
@@ -1482,6 +1880,41 @@ pub struct S3DataSpec {
     pub data_schema_location_s3: Option<String>,
 }
 
+#[doc="<p>The sort order specified in a listing condition. Possible values include the following:</p> <ul> <li> <code>asc</code> - Present the information in ascending order (from A-Z).</li> <li> <code>dsc</code> - Present the information in descending order (from Z-A).</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrder {
+    Asc,
+    Dsc,
+}
+
+impl Into<String> for SortOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrder {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrder::Asc => "asc",
+            SortOrder::Dsc => "dsc",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "asc" => Ok(SortOrder::Asc),
+            "dsc" => Ok(SortOrder::Dsc),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A custom key-value pair associated with an ML object, such as an ML model.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
@@ -1493,6 +1926,47 @@ pub struct Tag {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaggableResourceType {
+    BatchPrediction,
+    DataSource,
+    Evaluation,
+    Mlmodel,
+}
+
+impl Into<String> for TaggableResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaggableResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            TaggableResourceType::BatchPrediction => "BatchPrediction",
+            TaggableResourceType::DataSource => "DataSource",
+            TaggableResourceType::Evaluation => "Evaluation",
+            TaggableResourceType::Mlmodel => "MLModel",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaggableResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BatchPrediction" => Ok(TaggableResourceType::BatchPrediction),
+            "DataSource" => Ok(TaggableResourceType::DataSource),
+            "Evaluation" => Ok(TaggableResourceType::Evaluation),
+            "MLModel" => Ok(TaggableResourceType::Mlmodel),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -4203,7 +4677,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -4230,7 +4704,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateBatchPredictionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4258,7 +4732,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDataSourceFromRDSOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateDataSourceFromRDSError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4284,7 +4758,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDataSourceFromRedshiftOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateDataSourceFromRedshiftError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4309,7 +4783,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDataSourceFromS3Output>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4336,7 +4810,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateEvaluationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4363,7 +4837,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateMLModelOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4390,7 +4864,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateRealtimeEndpointOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4418,7 +4892,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteBatchPredictionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4445,7 +4919,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteDataSourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4472,7 +4946,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteEvaluationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4499,7 +4973,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteMLModelOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4526,7 +5000,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRealtimeEndpointOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4551,7 +5025,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteTagsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4576,7 +5050,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeBatchPredictionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeBatchPredictionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4600,7 +5074,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDataSourcesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4627,7 +5101,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEvaluationsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4654,7 +5128,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMLModelsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4681,7 +5155,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTagsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4707,7 +5181,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetBatchPredictionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4734,7 +5208,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDataSourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4760,7 +5234,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetEvaluationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4784,7 +5258,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetMLModelOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetMLModelError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4806,7 +5280,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<PredictOutput>(String::from_utf8_lossy(&response.body)
                                                              .as_ref())
                            .unwrap())
@@ -4833,7 +5307,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateBatchPredictionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4860,7 +5334,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDataSourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4887,7 +5361,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateEvaluationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4914,7 +5388,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateMLModelOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -11,21 +11,153 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DataSetType {
+    CustomerProfileByGeography,
+    CustomerProfileByIndustry,
+    CustomerProfileByRevenue,
+    CustomerSubscriberAnnualSubscriptions,
+    CustomerSubscriberHourlyMonthlySubscriptions,
+    DailyBusinessCanceledProductSubscribers,
+    DailyBusinessFees,
+    DailyBusinessFreeTrialConversions,
+    DailyBusinessNewInstances,
+    DailyBusinessNewProductSubscribers,
+    DailyBusinessUsageByInstanceType,
+    DisbursedAmountByAgeOfDisbursedFunds,
+    DisbursedAmountByAgeOfUncollectedFunds,
+    DisbursedAmountByCustomerGeo,
+    DisbursedAmountByInstanceHours,
+    DisbursedAmountByProduct,
+    DisbursedAmountByProductWithUncollectedFunds,
+    MonthlyRevenueAnnualSubscriptions,
+    MonthlyRevenueBillingAndRevenueData,
+    SalesCompensationBilledRevenue,
+    UsSalesAndUseTaxRecords,
+}
+
+impl Into<String> for DataSetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DataSetType {
+    fn into(self) -> &'static str {
+        match self {
+            DataSetType::CustomerProfileByGeography => "customer_profile_by_geography",
+            DataSetType::CustomerProfileByIndustry => "customer_profile_by_industry",
+            DataSetType::CustomerProfileByRevenue => "customer_profile_by_revenue",
+            DataSetType::CustomerSubscriberAnnualSubscriptions => {
+                "customer_subscriber_annual_subscriptions"
+            }
+            DataSetType::CustomerSubscriberHourlyMonthlySubscriptions => {
+                "customer_subscriber_hourly_monthly_subscriptions"
+            }
+            DataSetType::DailyBusinessCanceledProductSubscribers => {
+                "daily_business_canceled_product_subscribers"
+            }
+            DataSetType::DailyBusinessFees => "daily_business_fees",
+            DataSetType::DailyBusinessFreeTrialConversions => {
+                "daily_business_free_trial_conversions"
+            }
+            DataSetType::DailyBusinessNewInstances => "daily_business_new_instances",
+            DataSetType::DailyBusinessNewProductSubscribers => {
+                "daily_business_new_product_subscribers"
+            }
+            DataSetType::DailyBusinessUsageByInstanceType => {
+                "daily_business_usage_by_instance_type"
+            }
+            DataSetType::DisbursedAmountByAgeOfDisbursedFunds => {
+                "disbursed_amount_by_age_of_disbursed_funds"
+            }
+            DataSetType::DisbursedAmountByAgeOfUncollectedFunds => {
+                "disbursed_amount_by_age_of_uncollected_funds"
+            }
+            DataSetType::DisbursedAmountByCustomerGeo => "disbursed_amount_by_customer_geo",
+            DataSetType::DisbursedAmountByInstanceHours => "disbursed_amount_by_instance_hours",
+            DataSetType::DisbursedAmountByProduct => "disbursed_amount_by_product",
+            DataSetType::DisbursedAmountByProductWithUncollectedFunds => {
+                "disbursed_amount_by_product_with_uncollected_funds"
+            }
+            DataSetType::MonthlyRevenueAnnualSubscriptions => {
+                "monthly_revenue_annual_subscriptions"
+            }
+            DataSetType::MonthlyRevenueBillingAndRevenueData => {
+                "monthly_revenue_billing_and_revenue_data"
+            }
+            DataSetType::SalesCompensationBilledRevenue => "sales_compensation_billed_revenue",
+            DataSetType::UsSalesAndUseTaxRecords => "us_sales_and_use_tax_records",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DataSetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "customer_profile_by_geography" => Ok(DataSetType::CustomerProfileByGeography),
+            "customer_profile_by_industry" => Ok(DataSetType::CustomerProfileByIndustry),
+            "customer_profile_by_revenue" => Ok(DataSetType::CustomerProfileByRevenue),
+            "customer_subscriber_annual_subscriptions" => {
+                Ok(DataSetType::CustomerSubscriberAnnualSubscriptions)
+            }
+            "customer_subscriber_hourly_monthly_subscriptions" => {
+                Ok(DataSetType::CustomerSubscriberHourlyMonthlySubscriptions)
+            }
+            "daily_business_canceled_product_subscribers" => {
+                Ok(DataSetType::DailyBusinessCanceledProductSubscribers)
+            }
+            "daily_business_fees" => Ok(DataSetType::DailyBusinessFees),
+            "daily_business_free_trial_conversions" => {
+                Ok(DataSetType::DailyBusinessFreeTrialConversions)
+            }
+            "daily_business_new_instances" => Ok(DataSetType::DailyBusinessNewInstances),
+            "daily_business_new_product_subscribers" => {
+                Ok(DataSetType::DailyBusinessNewProductSubscribers)
+            }
+            "daily_business_usage_by_instance_type" => {
+                Ok(DataSetType::DailyBusinessUsageByInstanceType)
+            }
+            "disbursed_amount_by_age_of_disbursed_funds" => {
+                Ok(DataSetType::DisbursedAmountByAgeOfDisbursedFunds)
+            }
+            "disbursed_amount_by_age_of_uncollected_funds" => {
+                Ok(DataSetType::DisbursedAmountByAgeOfUncollectedFunds)
+            }
+            "disbursed_amount_by_customer_geo" => Ok(DataSetType::DisbursedAmountByCustomerGeo),
+            "disbursed_amount_by_instance_hours" => Ok(DataSetType::DisbursedAmountByInstanceHours),
+            "disbursed_amount_by_product" => Ok(DataSetType::DisbursedAmountByProduct),
+            "disbursed_amount_by_product_with_uncollected_funds" => {
+                Ok(DataSetType::DisbursedAmountByProductWithUncollectedFunds)
+            }
+            "monthly_revenue_annual_subscriptions" => {
+                Ok(DataSetType::MonthlyRevenueAnnualSubscriptions)
+            }
+            "monthly_revenue_billing_and_revenue_data" => {
+                Ok(DataSetType::MonthlyRevenueBillingAndRevenueData)
+            }
+            "sales_compensation_billed_revenue" => Ok(DataSetType::SalesCompensationBilledRevenue),
+            "us_sales_and_use_tax_records" => Ok(DataSetType::UsSalesAndUseTaxRecords),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Container for the parameters to the GenerateDataSet operation."]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GenerateDataSetRequest {
@@ -98,6 +230,45 @@ pub struct StartSupportDataExportResult {
     #[serde(rename="dataSetRequestId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub data_set_request_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SupportDataSetType {
+    CustomerSupportContactsData,
+    TestCustomerSupportContactsData,
+}
+
+impl Into<String> for SupportDataSetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SupportDataSetType {
+    fn into(self) -> &'static str {
+        match self {
+            SupportDataSetType::CustomerSupportContactsData => "customer_support_contacts_data",
+            SupportDataSetType::TestCustomerSupportContactsData => {
+                "test_customer_support_contacts_data"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for SupportDataSetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "customer_support_contacts_data" => Ok(SupportDataSetType::CustomerSupportContactsData),
+            "test_customer_support_contacts_data" => {
+                Ok(SupportDataSetType::TestCustomerSupportContactsData)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by GenerateDataSet
@@ -305,7 +476,7 @@ impl<P, D> MarketplaceCommerceAnalytics for MarketplaceCommerceAnalyticsClient<P
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GenerateDataSetResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -335,7 +506,7 @@ impl<P, D> MarketplaceCommerceAnalytics for MarketplaceCommerceAnalyticsClient<P
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartSupportDataExportResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -129,6 +125,44 @@ pub struct UsageRecordResult {
     #[serde(rename="UsageRecord")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub usage_record: Option<UsageRecord>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UsageRecordResultStatus {
+    CustomerNotSubscribed,
+    DuplicateRecord,
+    Success,
+}
+
+impl Into<String> for UsageRecordResultStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UsageRecordResultStatus {
+    fn into(self) -> &'static str {
+        match self {
+            UsageRecordResultStatus::CustomerNotSubscribed => "CustomerNotSubscribed",
+            UsageRecordResultStatus::DuplicateRecord => "DuplicateRecord",
+            UsageRecordResultStatus::Success => "Success",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UsageRecordResultStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CustomerNotSubscribed" => Ok(UsageRecordResultStatus::CustomerNotSubscribed),
+            "DuplicateRecord" => Ok(UsageRecordResultStatus::DuplicateRecord),
+            "Success" => Ok(UsageRecordResultStatus::Success),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by BatchMeterUsage
@@ -495,7 +529,7 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<BatchMeterUsageResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -520,7 +554,7 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<MeterUsageResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(MeterUsageError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -544,7 +578,7 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ResolveCustomerResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -111,6 +107,44 @@ pub struct Assignment {
     pub worker_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssignmentStatus {
+    Approved,
+    Rejected,
+    Submitted,
+}
+
+impl Into<String> for AssignmentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssignmentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AssignmentStatus::Approved => "Approved",
+            AssignmentStatus::Rejected => "Rejected",
+            AssignmentStatus::Submitted => "Submitted",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssignmentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Approved" => Ok(AssignmentStatus::Approved),
+            "Rejected" => Ok(AssignmentStatus::Rejected),
+            "Submitted" => Ok(AssignmentStatus::Submitted),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AssociateQualificationWithWorkerRequest {
     #[doc="<p>The value of the Qualification to assign.</p>"]
@@ -154,6 +188,65 @@ pub struct BonusPayment {
     #[serde(rename="WorkerId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub worker_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Comparator {
+    DoesNotExist,
+    EqualTo,
+    Exists,
+    GreaterThan,
+    GreaterThanOrEqualTo,
+    In,
+    LessThan,
+    LessThanOrEqualTo,
+    NotEqualTo,
+    NotIn,
+}
+
+impl Into<String> for Comparator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Comparator {
+    fn into(self) -> &'static str {
+        match self {
+            Comparator::DoesNotExist => "DoesNotExist",
+            Comparator::EqualTo => "EqualTo",
+            Comparator::Exists => "Exists",
+            Comparator::GreaterThan => "GreaterThan",
+            Comparator::GreaterThanOrEqualTo => "GreaterThanOrEqualTo",
+            Comparator::In => "In",
+            Comparator::LessThan => "LessThan",
+            Comparator::LessThanOrEqualTo => "LessThanOrEqualTo",
+            Comparator::NotEqualTo => "NotEqualTo",
+            Comparator::NotIn => "NotIn",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Comparator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DoesNotExist" => Ok(Comparator::DoesNotExist),
+            "EqualTo" => Ok(Comparator::EqualTo),
+            "Exists" => Ok(Comparator::Exists),
+            "GreaterThan" => Ok(Comparator::GreaterThan),
+            "GreaterThanOrEqualTo" => Ok(Comparator::GreaterThanOrEqualTo),
+            "In" => Ok(Comparator::In),
+            "LessThan" => Ok(Comparator::LessThan),
+            "LessThanOrEqualTo" => Ok(Comparator::LessThanOrEqualTo),
+            "NotEqualTo" => Ok(Comparator::NotEqualTo),
+            "NotIn" => Ok(Comparator::NotIn),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -444,6 +537,71 @@ pub struct DisassociateQualificationFromWorkerRequest {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DisassociateQualificationFromWorkerResponse;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    AssignmentAbandoned,
+    AssignmentAccepted,
+    AssignmentApproved,
+    AssignmentRejected,
+    AssignmentReturned,
+    AssignmentSubmitted,
+    Hitcreated,
+    Hitdisposed,
+    Hitexpired,
+    Hitextended,
+    Hitreviewable,
+    Ping,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::AssignmentAbandoned => "AssignmentAbandoned",
+            EventType::AssignmentAccepted => "AssignmentAccepted",
+            EventType::AssignmentApproved => "AssignmentApproved",
+            EventType::AssignmentRejected => "AssignmentRejected",
+            EventType::AssignmentReturned => "AssignmentReturned",
+            EventType::AssignmentSubmitted => "AssignmentSubmitted",
+            EventType::Hitcreated => "HITCreated",
+            EventType::Hitdisposed => "HITDisposed",
+            EventType::Hitexpired => "HITExpired",
+            EventType::Hitextended => "HITExtended",
+            EventType::Hitreviewable => "HITReviewable",
+            EventType::Ping => "Ping",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AssignmentAbandoned" => Ok(EventType::AssignmentAbandoned),
+            "AssignmentAccepted" => Ok(EventType::AssignmentAccepted),
+            "AssignmentApproved" => Ok(EventType::AssignmentApproved),
+            "AssignmentRejected" => Ok(EventType::AssignmentRejected),
+            "AssignmentReturned" => Ok(EventType::AssignmentReturned),
+            "AssignmentSubmitted" => Ok(EventType::AssignmentSubmitted),
+            "HITCreated" => Ok(EventType::Hitcreated),
+            "HITDisposed" => Ok(EventType::Hitdisposed),
+            "HITExpired" => Ok(EventType::Hitexpired),
+            "HITExtended" => Ok(EventType::Hitextended),
+            "HITReviewable" => Ok(EventType::Hitreviewable),
+            "Ping" => Ok(EventType::Ping),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GetAccountBalanceRequest;
 
@@ -641,6 +799,91 @@ pub struct HITLayoutParameter {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HITReviewStatus {
+    MarkedForReview,
+    NotReviewed,
+    ReviewedAppropriate,
+    ReviewedInappropriate,
+}
+
+impl Into<String> for HITReviewStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HITReviewStatus {
+    fn into(self) -> &'static str {
+        match self {
+            HITReviewStatus::MarkedForReview => "MarkedForReview",
+            HITReviewStatus::NotReviewed => "NotReviewed",
+            HITReviewStatus::ReviewedAppropriate => "ReviewedAppropriate",
+            HITReviewStatus::ReviewedInappropriate => "ReviewedInappropriate",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HITReviewStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MarkedForReview" => Ok(HITReviewStatus::MarkedForReview),
+            "NotReviewed" => Ok(HITReviewStatus::NotReviewed),
+            "ReviewedAppropriate" => Ok(HITReviewStatus::ReviewedAppropriate),
+            "ReviewedInappropriate" => Ok(HITReviewStatus::ReviewedInappropriate),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HITStatus {
+    Assignable,
+    Disposed,
+    Reviewable,
+    Reviewing,
+    Unassignable,
+}
+
+impl Into<String> for HITStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HITStatus {
+    fn into(self) -> &'static str {
+        match self {
+            HITStatus::Assignable => "Assignable",
+            HITStatus::Disposed => "Disposed",
+            HITStatus::Reviewable => "Reviewable",
+            HITStatus::Reviewing => "Reviewing",
+            HITStatus::Unassignable => "Unassignable",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HITStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Assignable" => Ok(HITStatus::Assignable),
+            "Disposed" => Ok(HITStatus::Disposed),
+            "Reviewable" => Ok(HITStatus::Reviewable),
+            "Reviewing" => Ok(HITStatus::Reviewing),
+            "Unassignable" => Ok(HITStatus::Unassignable),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1013,6 +1256,76 @@ pub struct NotificationSpecification {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotificationTransport {
+    Email,
+    Sqs,
+}
+
+impl Into<String> for NotificationTransport {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotificationTransport {
+    fn into(self) -> &'static str {
+        match self {
+            NotificationTransport::Email => "Email",
+            NotificationTransport::Sqs => "SQS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotificationTransport {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Email" => Ok(NotificationTransport::Email),
+            "SQS" => Ok(NotificationTransport::Sqs),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotifyWorkersFailureCode {
+    HardFailure,
+    SoftFailure,
+}
+
+impl Into<String> for NotifyWorkersFailureCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotifyWorkersFailureCode {
+    fn into(self) -> &'static str {
+        match self {
+            NotifyWorkersFailureCode::HardFailure => "HardFailure",
+            NotifyWorkersFailureCode::SoftFailure => "SoftFailure",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotifyWorkersFailureCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HardFailure" => Ok(NotifyWorkersFailureCode::HardFailure),
+            "SoftFailure" => Ok(NotifyWorkersFailureCode::SoftFailure),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> When MTurk encounters an issue with notifying the Workers you specified, it returns back this object with failure details. </p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct NotifyWorkersFailureStatus {
@@ -1161,6 +1474,41 @@ pub struct QualificationRequirement {
     pub required_to_preview: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QualificationStatus {
+    Granted,
+    Revoked,
+}
+
+impl Into<String> for QualificationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QualificationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            QualificationStatus::Granted => "Granted",
+            QualificationStatus::Revoked => "Revoked",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QualificationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Granted" => Ok(QualificationStatus::Granted),
+            "Revoked" => Ok(QualificationStatus::Revoked),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> The QualificationType data structure represents a Qualification type, a description of a property of a Worker that must match the requirements of a HIT for the Worker to be able to accept the HIT. The type also describes how a Worker can obtain a Qualification of that type, such as through a Qualification test. </p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct QualificationType {
@@ -1216,6 +1564,41 @@ pub struct QualificationType {
     #[serde(rename="TestDurationInSeconds")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub test_duration_in_seconds: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QualificationTypeStatus {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for QualificationTypeStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QualificationTypeStatus {
+    fn into(self) -> &'static str {
+        match self {
+            QualificationTypeStatus::Active => "Active",
+            QualificationTypeStatus::Inactive => "Inactive",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QualificationTypeStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(QualificationTypeStatus::Active),
+            "Inactive" => Ok(QualificationTypeStatus::Inactive),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1283,6 +1666,47 @@ pub struct ReviewActionDetail {
     pub target_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReviewActionStatus {
+    Cancelled,
+    Failed,
+    Intended,
+    Succeeded,
+}
+
+impl Into<String> for ReviewActionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReviewActionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReviewActionStatus::Cancelled => "Cancelled",
+            ReviewActionStatus::Failed => "Failed",
+            ReviewActionStatus::Intended => "Intended",
+            ReviewActionStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReviewActionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(ReviewActionStatus::Cancelled),
+            "Failed" => Ok(ReviewActionStatus::Failed),
+            "Intended" => Ok(ReviewActionStatus::Intended),
+            "Succeeded" => Ok(ReviewActionStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> HIT Review Policy data structures represent HIT review policies, which you specify when you create a HIT. </p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReviewPolicy {
@@ -1294,6 +1718,41 @@ pub struct ReviewPolicy {
     #[serde(rename="PolicyName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReviewPolicyLevel {
+    Assignment,
+    Hit,
+}
+
+impl Into<String> for ReviewPolicyLevel {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReviewPolicyLevel {
+    fn into(self) -> &'static str {
+        match self {
+            ReviewPolicyLevel::Assignment => "Assignment",
+            ReviewPolicyLevel::Hit => "HIT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReviewPolicyLevel {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Assignment" => Ok(ReviewPolicyLevel::Assignment),
+            "HIT" => Ok(ReviewPolicyLevel::Hit),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p> Contains both ReviewResult and ReviewAction elements for a particular HIT. </p>"]
@@ -1336,6 +1795,41 @@ pub struct ReviewResultDetail {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReviewableHITStatus {
+    Reviewable,
+    Reviewing,
+}
+
+impl Into<String> for ReviewableHITStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReviewableHITStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReviewableHITStatus::Reviewable => "Reviewable",
+            ReviewableHITStatus::Reviewing => "Reviewing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReviewableHITStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Reviewable" => Ok(ReviewableHITStatus::Reviewable),
+            "Reviewing" => Ok(ReviewableHITStatus::Reviewing),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -4901,7 +5395,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AcceptQualificationRequestResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AcceptQualificationRequestError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4926,7 +5420,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ApproveAssignmentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -4955,7 +5449,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AssociateQualificationWithWorkerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AssociateQualificationWithWorkerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -4982,7 +5476,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAdditionalAssignmentsForHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateAdditionalAssignmentsForHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5004,7 +5498,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5029,7 +5523,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateHITTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5057,7 +5551,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateHITWithHITTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5086,7 +5580,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5111,7 +5605,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateWorkerBlockResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5136,7 +5630,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5162,7 +5656,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5187,7 +5681,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteWorkerBlockResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5217,7 +5711,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisassociateQualificationFromWorkerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DisassociateQualificationFromWorkerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5239,7 +5733,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetAccountBalanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5267,7 +5761,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetAssignmentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5294,7 +5788,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetFileUploadURLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5319,7 +5813,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetHITResponse>(String::from_utf8_lossy(&response.body)
                                                               .as_ref())
                            .unwrap())
@@ -5347,7 +5841,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetQualificationScoreResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5376,7 +5870,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5405,7 +5899,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAssignmentsForHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5433,7 +5927,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListBonusPaymentsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5458,7 +5952,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListHITsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListHITsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5484,7 +5978,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListHITsForQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListHITsForQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5510,7 +6004,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListQualificationRequestsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListQualificationRequestsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5536,7 +6030,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListQualificationTypesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5565,7 +6059,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListReviewPolicyResultsForHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListReviewPolicyResultsForHITError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5590,7 +6084,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListReviewableHITsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5618,7 +6112,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListWorkerBlocksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5647,7 +6141,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListWorkersWithQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListWorkersWithQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5672,7 +6166,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<NotifyWorkersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5699,7 +6193,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RejectAssignmentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5728,7 +6222,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RejectQualificationRequestResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RejectQualificationRequestError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5750,7 +6244,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SendBonusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(SendBonusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5776,7 +6270,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SendTestEventNotificationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(SendTestEventNotificationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5802,7 +6296,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateExpirationForHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5831,7 +6325,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateHITReviewStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5859,7 +6353,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateHITTypeOfHITResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5888,7 +6382,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateNotificationSettingsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateNotificationSettingsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5914,7 +6408,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateQualificationTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateQualificationTypeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -100,6 +96,132 @@ pub struct App {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AppAttributesKeys {
+    AutoBundleOnDeploy,
+    AwsFlowRubySettings,
+    DocumentRoot,
+    RailsEnv,
+}
+
+impl Into<String> for AppAttributesKeys {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AppAttributesKeys {
+    fn into(self) -> &'static str {
+        match self {
+            AppAttributesKeys::AutoBundleOnDeploy => "AutoBundleOnDeploy",
+            AppAttributesKeys::AwsFlowRubySettings => "AwsFlowRubySettings",
+            AppAttributesKeys::DocumentRoot => "DocumentRoot",
+            AppAttributesKeys::RailsEnv => "RailsEnv",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AppAttributesKeys {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AutoBundleOnDeploy" => Ok(AppAttributesKeys::AutoBundleOnDeploy),
+            "AwsFlowRubySettings" => Ok(AppAttributesKeys::AwsFlowRubySettings),
+            "DocumentRoot" => Ok(AppAttributesKeys::DocumentRoot),
+            "RailsEnv" => Ok(AppAttributesKeys::RailsEnv),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AppType {
+    AwsFlowRuby,
+    Java,
+    Nodejs,
+    Other,
+    Php,
+    Rails,
+    Static,
+}
+
+impl Into<String> for AppType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AppType {
+    fn into(self) -> &'static str {
+        match self {
+            AppType::AwsFlowRuby => "aws-flow-ruby",
+            AppType::Java => "java",
+            AppType::Nodejs => "nodejs",
+            AppType::Other => "other",
+            AppType::Php => "php",
+            AppType::Rails => "rails",
+            AppType::Static => "static",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AppType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "aws-flow-ruby" => Ok(AppType::AwsFlowRuby),
+            "java" => Ok(AppType::Java),
+            "nodejs" => Ok(AppType::Nodejs),
+            "other" => Ok(AppType::Other),
+            "php" => Ok(AppType::Php),
+            "rails" => Ok(AppType::Rails),
+            "static" => Ok(AppType::Static),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Architecture {
+    I386,
+    X8664,
+}
+
+impl Into<String> for Architecture {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Architecture {
+    fn into(self) -> &'static str {
+        match self {
+            Architecture::I386 => "i386",
+            Architecture::X8664 => "x86_64",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Architecture {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "i386" => Ok(Architecture::I386),
+            "x86_64" => Ok(Architecture::X8664),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AssignInstanceRequest {
     #[doc="<p>The instance ID.</p>"]
@@ -173,6 +295,41 @@ pub struct AutoScalingThresholds {
     #[serde(rename="ThresholdsWaitTime")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub thresholds_wait_time: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoScalingType {
+    Load,
+    Timer,
+}
+
+impl Into<String> for AutoScalingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoScalingType {
+    fn into(self) -> &'static str {
+        match self {
+            AutoScalingType::Load => "load",
+            AutoScalingType::Timer => "timer",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoScalingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "load" => Ok(AutoScalingType::Load),
+            "timer" => Ok(AutoScalingType::Timer),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a block device mapping. This data type maps directly to the Amazon EC2 <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html\">BlockDeviceMapping</a> data type. </p>"]
@@ -320,6 +477,346 @@ pub struct CloudWatchLogsConfiguration {
     pub log_streams: Option<Vec<CloudWatchLogsLogStream>>,
 }
 
+#[doc="<p>Specifies the encoding of the log file so that the file can be read correctly. The default is <code>utf_8</code>. Encodings supported by Python <code>codecs.decode()</code> can be used here.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudWatchLogsEncoding {
+    Ascii,
+    Big5,
+    Big5Hkscs,
+    Cp037,
+    Cp1006,
+    Cp1026,
+    Cp1140,
+    Cp1250,
+    Cp1251,
+    Cp1252,
+    Cp1253,
+    Cp1254,
+    Cp1255,
+    Cp1256,
+    Cp1257,
+    Cp1258,
+    Cp424,
+    Cp437,
+    Cp500,
+    Cp720,
+    Cp737,
+    Cp775,
+    Cp850,
+    Cp852,
+    Cp855,
+    Cp856,
+    Cp857,
+    Cp858,
+    Cp860,
+    Cp861,
+    Cp862,
+    Cp863,
+    Cp864,
+    Cp865,
+    Cp866,
+    Cp869,
+    Cp874,
+    Cp875,
+    Cp932,
+    Cp949,
+    Cp950,
+    EucJis2004,
+    EucJisx0213,
+    EucJp,
+    EucKr,
+    Gb18030,
+    Gb2312,
+    Gbk,
+    Hz,
+    Iso2022Jp,
+    Iso2022Jp1,
+    Iso2022Jp2,
+    Iso2022Jp2004,
+    Iso2022Jp3,
+    Iso2022JpExt,
+    Iso2022Kr,
+    Iso885910,
+    Iso885913,
+    Iso885914,
+    Iso885915,
+    Iso885916,
+    Iso88592,
+    Iso88593,
+    Iso88594,
+    Iso88595,
+    Iso88596,
+    Iso88597,
+    Iso88598,
+    Iso88599,
+    Johab,
+    Koi8R,
+    Koi8U,
+    Latin1,
+    MacCyrillic,
+    MacGreek,
+    MacIceland,
+    MacLatin2,
+    MacRoman,
+    MacTurkish,
+    Ptcp154,
+    ShiftJis,
+    ShiftJis2004,
+    ShiftJisx0213,
+    Utf16,
+    Utf16Be,
+    Utf16Le,
+    Utf32,
+    Utf32Be,
+    Utf32Le,
+    Utf7,
+    Utf8,
+    Utf8Sig,
+}
+
+impl Into<String> for CloudWatchLogsEncoding {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudWatchLogsEncoding {
+    fn into(self) -> &'static str {
+        match self {
+            CloudWatchLogsEncoding::Ascii => "ascii",
+            CloudWatchLogsEncoding::Big5 => "big5",
+            CloudWatchLogsEncoding::Big5Hkscs => "big5hkscs",
+            CloudWatchLogsEncoding::Cp037 => "cp037",
+            CloudWatchLogsEncoding::Cp1006 => "cp1006",
+            CloudWatchLogsEncoding::Cp1026 => "cp1026",
+            CloudWatchLogsEncoding::Cp1140 => "cp1140",
+            CloudWatchLogsEncoding::Cp1250 => "cp1250",
+            CloudWatchLogsEncoding::Cp1251 => "cp1251",
+            CloudWatchLogsEncoding::Cp1252 => "cp1252",
+            CloudWatchLogsEncoding::Cp1253 => "cp1253",
+            CloudWatchLogsEncoding::Cp1254 => "cp1254",
+            CloudWatchLogsEncoding::Cp1255 => "cp1255",
+            CloudWatchLogsEncoding::Cp1256 => "cp1256",
+            CloudWatchLogsEncoding::Cp1257 => "cp1257",
+            CloudWatchLogsEncoding::Cp1258 => "cp1258",
+            CloudWatchLogsEncoding::Cp424 => "cp424",
+            CloudWatchLogsEncoding::Cp437 => "cp437",
+            CloudWatchLogsEncoding::Cp500 => "cp500",
+            CloudWatchLogsEncoding::Cp720 => "cp720",
+            CloudWatchLogsEncoding::Cp737 => "cp737",
+            CloudWatchLogsEncoding::Cp775 => "cp775",
+            CloudWatchLogsEncoding::Cp850 => "cp850",
+            CloudWatchLogsEncoding::Cp852 => "cp852",
+            CloudWatchLogsEncoding::Cp855 => "cp855",
+            CloudWatchLogsEncoding::Cp856 => "cp856",
+            CloudWatchLogsEncoding::Cp857 => "cp857",
+            CloudWatchLogsEncoding::Cp858 => "cp858",
+            CloudWatchLogsEncoding::Cp860 => "cp860",
+            CloudWatchLogsEncoding::Cp861 => "cp861",
+            CloudWatchLogsEncoding::Cp862 => "cp862",
+            CloudWatchLogsEncoding::Cp863 => "cp863",
+            CloudWatchLogsEncoding::Cp864 => "cp864",
+            CloudWatchLogsEncoding::Cp865 => "cp865",
+            CloudWatchLogsEncoding::Cp866 => "cp866",
+            CloudWatchLogsEncoding::Cp869 => "cp869",
+            CloudWatchLogsEncoding::Cp874 => "cp874",
+            CloudWatchLogsEncoding::Cp875 => "cp875",
+            CloudWatchLogsEncoding::Cp932 => "cp932",
+            CloudWatchLogsEncoding::Cp949 => "cp949",
+            CloudWatchLogsEncoding::Cp950 => "cp950",
+            CloudWatchLogsEncoding::EucJis2004 => "euc_jis_2004",
+            CloudWatchLogsEncoding::EucJisx0213 => "euc_jisx0213",
+            CloudWatchLogsEncoding::EucJp => "euc_jp",
+            CloudWatchLogsEncoding::EucKr => "euc_kr",
+            CloudWatchLogsEncoding::Gb18030 => "gb18030",
+            CloudWatchLogsEncoding::Gb2312 => "gb2312",
+            CloudWatchLogsEncoding::Gbk => "gbk",
+            CloudWatchLogsEncoding::Hz => "hz",
+            CloudWatchLogsEncoding::Iso2022Jp => "iso2022_jp",
+            CloudWatchLogsEncoding::Iso2022Jp1 => "iso2022_jp_1",
+            CloudWatchLogsEncoding::Iso2022Jp2 => "iso2022_jp_2",
+            CloudWatchLogsEncoding::Iso2022Jp2004 => "iso2022_jp_2004",
+            CloudWatchLogsEncoding::Iso2022Jp3 => "iso2022_jp_3",
+            CloudWatchLogsEncoding::Iso2022JpExt => "iso2022_jp_ext",
+            CloudWatchLogsEncoding::Iso2022Kr => "iso2022_kr",
+            CloudWatchLogsEncoding::Iso885910 => "iso8859_10",
+            CloudWatchLogsEncoding::Iso885913 => "iso8859_13",
+            CloudWatchLogsEncoding::Iso885914 => "iso8859_14",
+            CloudWatchLogsEncoding::Iso885915 => "iso8859_15",
+            CloudWatchLogsEncoding::Iso885916 => "iso8859_16",
+            CloudWatchLogsEncoding::Iso88592 => "iso8859_2",
+            CloudWatchLogsEncoding::Iso88593 => "iso8859_3",
+            CloudWatchLogsEncoding::Iso88594 => "iso8859_4",
+            CloudWatchLogsEncoding::Iso88595 => "iso8859_5",
+            CloudWatchLogsEncoding::Iso88596 => "iso8859_6",
+            CloudWatchLogsEncoding::Iso88597 => "iso8859_7",
+            CloudWatchLogsEncoding::Iso88598 => "iso8859_8",
+            CloudWatchLogsEncoding::Iso88599 => "iso8859_9",
+            CloudWatchLogsEncoding::Johab => "johab",
+            CloudWatchLogsEncoding::Koi8R => "koi8_r",
+            CloudWatchLogsEncoding::Koi8U => "koi8_u",
+            CloudWatchLogsEncoding::Latin1 => "latin_1",
+            CloudWatchLogsEncoding::MacCyrillic => "mac_cyrillic",
+            CloudWatchLogsEncoding::MacGreek => "mac_greek",
+            CloudWatchLogsEncoding::MacIceland => "mac_iceland",
+            CloudWatchLogsEncoding::MacLatin2 => "mac_latin2",
+            CloudWatchLogsEncoding::MacRoman => "mac_roman",
+            CloudWatchLogsEncoding::MacTurkish => "mac_turkish",
+            CloudWatchLogsEncoding::Ptcp154 => "ptcp154",
+            CloudWatchLogsEncoding::ShiftJis => "shift_jis",
+            CloudWatchLogsEncoding::ShiftJis2004 => "shift_jis_2004",
+            CloudWatchLogsEncoding::ShiftJisx0213 => "shift_jisx0213",
+            CloudWatchLogsEncoding::Utf16 => "utf_16",
+            CloudWatchLogsEncoding::Utf16Be => "utf_16_be",
+            CloudWatchLogsEncoding::Utf16Le => "utf_16_le",
+            CloudWatchLogsEncoding::Utf32 => "utf_32",
+            CloudWatchLogsEncoding::Utf32Be => "utf_32_be",
+            CloudWatchLogsEncoding::Utf32Le => "utf_32_le",
+            CloudWatchLogsEncoding::Utf7 => "utf_7",
+            CloudWatchLogsEncoding::Utf8 => "utf_8",
+            CloudWatchLogsEncoding::Utf8Sig => "utf_8_sig",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudWatchLogsEncoding {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ascii" => Ok(CloudWatchLogsEncoding::Ascii),
+            "big5" => Ok(CloudWatchLogsEncoding::Big5),
+            "big5hkscs" => Ok(CloudWatchLogsEncoding::Big5Hkscs),
+            "cp037" => Ok(CloudWatchLogsEncoding::Cp037),
+            "cp1006" => Ok(CloudWatchLogsEncoding::Cp1006),
+            "cp1026" => Ok(CloudWatchLogsEncoding::Cp1026),
+            "cp1140" => Ok(CloudWatchLogsEncoding::Cp1140),
+            "cp1250" => Ok(CloudWatchLogsEncoding::Cp1250),
+            "cp1251" => Ok(CloudWatchLogsEncoding::Cp1251),
+            "cp1252" => Ok(CloudWatchLogsEncoding::Cp1252),
+            "cp1253" => Ok(CloudWatchLogsEncoding::Cp1253),
+            "cp1254" => Ok(CloudWatchLogsEncoding::Cp1254),
+            "cp1255" => Ok(CloudWatchLogsEncoding::Cp1255),
+            "cp1256" => Ok(CloudWatchLogsEncoding::Cp1256),
+            "cp1257" => Ok(CloudWatchLogsEncoding::Cp1257),
+            "cp1258" => Ok(CloudWatchLogsEncoding::Cp1258),
+            "cp424" => Ok(CloudWatchLogsEncoding::Cp424),
+            "cp437" => Ok(CloudWatchLogsEncoding::Cp437),
+            "cp500" => Ok(CloudWatchLogsEncoding::Cp500),
+            "cp720" => Ok(CloudWatchLogsEncoding::Cp720),
+            "cp737" => Ok(CloudWatchLogsEncoding::Cp737),
+            "cp775" => Ok(CloudWatchLogsEncoding::Cp775),
+            "cp850" => Ok(CloudWatchLogsEncoding::Cp850),
+            "cp852" => Ok(CloudWatchLogsEncoding::Cp852),
+            "cp855" => Ok(CloudWatchLogsEncoding::Cp855),
+            "cp856" => Ok(CloudWatchLogsEncoding::Cp856),
+            "cp857" => Ok(CloudWatchLogsEncoding::Cp857),
+            "cp858" => Ok(CloudWatchLogsEncoding::Cp858),
+            "cp860" => Ok(CloudWatchLogsEncoding::Cp860),
+            "cp861" => Ok(CloudWatchLogsEncoding::Cp861),
+            "cp862" => Ok(CloudWatchLogsEncoding::Cp862),
+            "cp863" => Ok(CloudWatchLogsEncoding::Cp863),
+            "cp864" => Ok(CloudWatchLogsEncoding::Cp864),
+            "cp865" => Ok(CloudWatchLogsEncoding::Cp865),
+            "cp866" => Ok(CloudWatchLogsEncoding::Cp866),
+            "cp869" => Ok(CloudWatchLogsEncoding::Cp869),
+            "cp874" => Ok(CloudWatchLogsEncoding::Cp874),
+            "cp875" => Ok(CloudWatchLogsEncoding::Cp875),
+            "cp932" => Ok(CloudWatchLogsEncoding::Cp932),
+            "cp949" => Ok(CloudWatchLogsEncoding::Cp949),
+            "cp950" => Ok(CloudWatchLogsEncoding::Cp950),
+            "euc_jis_2004" => Ok(CloudWatchLogsEncoding::EucJis2004),
+            "euc_jisx0213" => Ok(CloudWatchLogsEncoding::EucJisx0213),
+            "euc_jp" => Ok(CloudWatchLogsEncoding::EucJp),
+            "euc_kr" => Ok(CloudWatchLogsEncoding::EucKr),
+            "gb18030" => Ok(CloudWatchLogsEncoding::Gb18030),
+            "gb2312" => Ok(CloudWatchLogsEncoding::Gb2312),
+            "gbk" => Ok(CloudWatchLogsEncoding::Gbk),
+            "hz" => Ok(CloudWatchLogsEncoding::Hz),
+            "iso2022_jp" => Ok(CloudWatchLogsEncoding::Iso2022Jp),
+            "iso2022_jp_1" => Ok(CloudWatchLogsEncoding::Iso2022Jp1),
+            "iso2022_jp_2" => Ok(CloudWatchLogsEncoding::Iso2022Jp2),
+            "iso2022_jp_2004" => Ok(CloudWatchLogsEncoding::Iso2022Jp2004),
+            "iso2022_jp_3" => Ok(CloudWatchLogsEncoding::Iso2022Jp3),
+            "iso2022_jp_ext" => Ok(CloudWatchLogsEncoding::Iso2022JpExt),
+            "iso2022_kr" => Ok(CloudWatchLogsEncoding::Iso2022Kr),
+            "iso8859_10" => Ok(CloudWatchLogsEncoding::Iso885910),
+            "iso8859_13" => Ok(CloudWatchLogsEncoding::Iso885913),
+            "iso8859_14" => Ok(CloudWatchLogsEncoding::Iso885914),
+            "iso8859_15" => Ok(CloudWatchLogsEncoding::Iso885915),
+            "iso8859_16" => Ok(CloudWatchLogsEncoding::Iso885916),
+            "iso8859_2" => Ok(CloudWatchLogsEncoding::Iso88592),
+            "iso8859_3" => Ok(CloudWatchLogsEncoding::Iso88593),
+            "iso8859_4" => Ok(CloudWatchLogsEncoding::Iso88594),
+            "iso8859_5" => Ok(CloudWatchLogsEncoding::Iso88595),
+            "iso8859_6" => Ok(CloudWatchLogsEncoding::Iso88596),
+            "iso8859_7" => Ok(CloudWatchLogsEncoding::Iso88597),
+            "iso8859_8" => Ok(CloudWatchLogsEncoding::Iso88598),
+            "iso8859_9" => Ok(CloudWatchLogsEncoding::Iso88599),
+            "johab" => Ok(CloudWatchLogsEncoding::Johab),
+            "koi8_r" => Ok(CloudWatchLogsEncoding::Koi8R),
+            "koi8_u" => Ok(CloudWatchLogsEncoding::Koi8U),
+            "latin_1" => Ok(CloudWatchLogsEncoding::Latin1),
+            "mac_cyrillic" => Ok(CloudWatchLogsEncoding::MacCyrillic),
+            "mac_greek" => Ok(CloudWatchLogsEncoding::MacGreek),
+            "mac_iceland" => Ok(CloudWatchLogsEncoding::MacIceland),
+            "mac_latin2" => Ok(CloudWatchLogsEncoding::MacLatin2),
+            "mac_roman" => Ok(CloudWatchLogsEncoding::MacRoman),
+            "mac_turkish" => Ok(CloudWatchLogsEncoding::MacTurkish),
+            "ptcp154" => Ok(CloudWatchLogsEncoding::Ptcp154),
+            "shift_jis" => Ok(CloudWatchLogsEncoding::ShiftJis),
+            "shift_jis_2004" => Ok(CloudWatchLogsEncoding::ShiftJis2004),
+            "shift_jisx0213" => Ok(CloudWatchLogsEncoding::ShiftJisx0213),
+            "utf_16" => Ok(CloudWatchLogsEncoding::Utf16),
+            "utf_16_be" => Ok(CloudWatchLogsEncoding::Utf16Be),
+            "utf_16_le" => Ok(CloudWatchLogsEncoding::Utf16Le),
+            "utf_32" => Ok(CloudWatchLogsEncoding::Utf32),
+            "utf_32_be" => Ok(CloudWatchLogsEncoding::Utf32Be),
+            "utf_32_le" => Ok(CloudWatchLogsEncoding::Utf32Le),
+            "utf_7" => Ok(CloudWatchLogsEncoding::Utf7),
+            "utf_8" => Ok(CloudWatchLogsEncoding::Utf8),
+            "utf_8_sig" => Ok(CloudWatchLogsEncoding::Utf8Sig),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>Specifies where to start to read data (start_of_file or end_of_file). The default is start_of_file. It's only used if there is no state persisted for that log stream.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudWatchLogsInitialPosition {
+    EndOfFile,
+    StartOfFile,
+}
+
+impl Into<String> for CloudWatchLogsInitialPosition {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudWatchLogsInitialPosition {
+    fn into(self) -> &'static str {
+        match self {
+            CloudWatchLogsInitialPosition::EndOfFile => "end_of_file",
+            CloudWatchLogsInitialPosition::StartOfFile => "start_of_file",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudWatchLogsInitialPosition {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "end_of_file" => Ok(CloudWatchLogsInitialPosition::EndOfFile),
+            "start_of_file" => Ok(CloudWatchLogsInitialPosition::StartOfFile),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the Amazon CloudWatch logs configuration for a layer. For detailed information about members of this data type, see the <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html\">CloudWatch Logs Agent Reference</a>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloudWatchLogsLogStream {
@@ -367,6 +864,41 @@ pub struct CloudWatchLogsLogStream {
     #[serde(rename="TimeZone")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub time_zone: Option<String>,
+}
+
+#[doc="<p>The preferred time zone for logs streamed to CloudWatch Logs. Valid values are <code>LOCAL</code> and <code>UTC</code>, for Coordinated Universal Time.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudWatchLogsTimeZone {
+    Local,
+    Utc,
+}
+
+impl Into<String> for CloudWatchLogsTimeZone {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudWatchLogsTimeZone {
+    fn into(self) -> &'static str {
+        match self {
+            CloudWatchLogsTimeZone::Local => "LOCAL",
+            CloudWatchLogsTimeZone::Utc => "UTC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudWatchLogsTimeZone {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LOCAL" => Ok(CloudWatchLogsTimeZone::Local),
+            "UTC" => Ok(CloudWatchLogsTimeZone::Utc),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a command.</p>"]
@@ -908,6 +1440,71 @@ pub struct DeploymentCommand {
     #[doc="<p>Specifies the operation. You can specify only one command.</p> <p>For stacks, the following commands are available:</p> <ul> <li> <p> <code>execute_recipes</code>: Execute one or more recipes. To specify the recipes, set an <code>Args</code> parameter named <code>recipes</code> to the list of recipes to be executed. For example, to execute <code>phpapp::appsetup</code>, set <code>Args</code> to <code>{\"recipes\":[\"phpapp::appsetup\"]}</code>.</p> </li> <li> <p> <code>install_dependencies</code>: Install the stack's dependencies.</p> </li> <li> <p> <code>update_custom_cookbooks</code>: Update the stack's custom cookbooks.</p> </li> <li> <p> <code>update_dependencies</code>: Update the stack's dependencies.</p> </li> </ul> <note> <p>The update_dependencies and install_dependencies commands are supported only for Linux instances. You can run the commands successfully on Windows instances, but they do nothing.</p> </note> <p>For apps, the following commands are available:</p> <ul> <li> <p> <code>deploy</code>: Deploy an app. Ruby on Rails apps have an optional <code>Args</code> parameter named <code>migrate</code>. Set <code>Args</code> to {\"migrate\":[\"true\"]} to migrate the database. The default setting is {\"migrate\":[\"false\"]}.</p> </li> <li> <p> <code>rollback</code> Roll the app back to the previous version. When you update an app, AWS OpsWorks Stacks stores the previous version, up to a maximum of five versions. You can use this command to roll an app back as many as four versions.</p> </li> <li> <p> <code>start</code>: Start the app's web or application server.</p> </li> <li> <p> <code>stop</code>: Stop the app's web or application server.</p> </li> <li> <p> <code>restart</code>: Restart the app's web or application server.</p> </li> <li> <p> <code>undeploy</code>: Undeploy the app.</p> </li> </ul>"]
     #[serde(rename="Name")]
     pub name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentCommandName {
+    Configure,
+    Deploy,
+    ExecuteRecipes,
+    InstallDependencies,
+    Restart,
+    Rollback,
+    Setup,
+    Start,
+    Stop,
+    Undeploy,
+    UpdateCustomCookbooks,
+    UpdateDependencies,
+}
+
+impl Into<String> for DeploymentCommandName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentCommandName {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentCommandName::Configure => "configure",
+            DeploymentCommandName::Deploy => "deploy",
+            DeploymentCommandName::ExecuteRecipes => "execute_recipes",
+            DeploymentCommandName::InstallDependencies => "install_dependencies",
+            DeploymentCommandName::Restart => "restart",
+            DeploymentCommandName::Rollback => "rollback",
+            DeploymentCommandName::Setup => "setup",
+            DeploymentCommandName::Start => "start",
+            DeploymentCommandName::Stop => "stop",
+            DeploymentCommandName::Undeploy => "undeploy",
+            DeploymentCommandName::UpdateCustomCookbooks => "update_custom_cookbooks",
+            DeploymentCommandName::UpdateDependencies => "update_dependencies",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentCommandName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "configure" => Ok(DeploymentCommandName::Configure),
+            "deploy" => Ok(DeploymentCommandName::Deploy),
+            "execute_recipes" => Ok(DeploymentCommandName::ExecuteRecipes),
+            "install_dependencies" => Ok(DeploymentCommandName::InstallDependencies),
+            "restart" => Ok(DeploymentCommandName::Restart),
+            "rollback" => Ok(DeploymentCommandName::Rollback),
+            "setup" => Ok(DeploymentCommandName::Setup),
+            "start" => Ok(DeploymentCommandName::Start),
+            "stop" => Ok(DeploymentCommandName::Stop),
+            "undeploy" => Ok(DeploymentCommandName::Undeploy),
+            "update_custom_cookbooks" => Ok(DeploymentCommandName::UpdateCustomCookbooks),
+            "update_dependencies" => Ok(DeploymentCommandName::UpdateDependencies),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1934,6 +2531,175 @@ pub struct Layer {
     pub volume_configurations: Option<Vec<VolumeConfiguration>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LayerAttributesKeys {
+    BundlerVersion,
+    EcsClusterArn,
+    EnableHaproxyStats,
+    GangliaPassword,
+    GangliaUrl,
+    GangliaUser,
+    HaproxyHealthCheckMethod,
+    HaproxyHealthCheckUrl,
+    HaproxyStatsPassword,
+    HaproxyStatsUrl,
+    HaproxyStatsUser,
+    JavaAppServer,
+    JavaAppServerVersion,
+    Jvm,
+    JvmOptions,
+    JvmVersion,
+    ManageBundler,
+    MemcachedMemory,
+    MysqlRootPassword,
+    MysqlRootPasswordUbiquitous,
+    NodejsVersion,
+    PassengerVersion,
+    RailsStack,
+    RubyVersion,
+    RubygemsVersion,
+}
+
+impl Into<String> for LayerAttributesKeys {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LayerAttributesKeys {
+    fn into(self) -> &'static str {
+        match self {
+            LayerAttributesKeys::BundlerVersion => "BundlerVersion",
+            LayerAttributesKeys::EcsClusterArn => "EcsClusterArn",
+            LayerAttributesKeys::EnableHaproxyStats => "EnableHaproxyStats",
+            LayerAttributesKeys::GangliaPassword => "GangliaPassword",
+            LayerAttributesKeys::GangliaUrl => "GangliaUrl",
+            LayerAttributesKeys::GangliaUser => "GangliaUser",
+            LayerAttributesKeys::HaproxyHealthCheckMethod => "HaproxyHealthCheckMethod",
+            LayerAttributesKeys::HaproxyHealthCheckUrl => "HaproxyHealthCheckUrl",
+            LayerAttributesKeys::HaproxyStatsPassword => "HaproxyStatsPassword",
+            LayerAttributesKeys::HaproxyStatsUrl => "HaproxyStatsUrl",
+            LayerAttributesKeys::HaproxyStatsUser => "HaproxyStatsUser",
+            LayerAttributesKeys::JavaAppServer => "JavaAppServer",
+            LayerAttributesKeys::JavaAppServerVersion => "JavaAppServerVersion",
+            LayerAttributesKeys::Jvm => "Jvm",
+            LayerAttributesKeys::JvmOptions => "JvmOptions",
+            LayerAttributesKeys::JvmVersion => "JvmVersion",
+            LayerAttributesKeys::ManageBundler => "ManageBundler",
+            LayerAttributesKeys::MemcachedMemory => "MemcachedMemory",
+            LayerAttributesKeys::MysqlRootPassword => "MysqlRootPassword",
+            LayerAttributesKeys::MysqlRootPasswordUbiquitous => "MysqlRootPasswordUbiquitous",
+            LayerAttributesKeys::NodejsVersion => "NodejsVersion",
+            LayerAttributesKeys::PassengerVersion => "PassengerVersion",
+            LayerAttributesKeys::RailsStack => "RailsStack",
+            LayerAttributesKeys::RubyVersion => "RubyVersion",
+            LayerAttributesKeys::RubygemsVersion => "RubygemsVersion",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LayerAttributesKeys {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BundlerVersion" => Ok(LayerAttributesKeys::BundlerVersion),
+            "EcsClusterArn" => Ok(LayerAttributesKeys::EcsClusterArn),
+            "EnableHaproxyStats" => Ok(LayerAttributesKeys::EnableHaproxyStats),
+            "GangliaPassword" => Ok(LayerAttributesKeys::GangliaPassword),
+            "GangliaUrl" => Ok(LayerAttributesKeys::GangliaUrl),
+            "GangliaUser" => Ok(LayerAttributesKeys::GangliaUser),
+            "HaproxyHealthCheckMethod" => Ok(LayerAttributesKeys::HaproxyHealthCheckMethod),
+            "HaproxyHealthCheckUrl" => Ok(LayerAttributesKeys::HaproxyHealthCheckUrl),
+            "HaproxyStatsPassword" => Ok(LayerAttributesKeys::HaproxyStatsPassword),
+            "HaproxyStatsUrl" => Ok(LayerAttributesKeys::HaproxyStatsUrl),
+            "HaproxyStatsUser" => Ok(LayerAttributesKeys::HaproxyStatsUser),
+            "JavaAppServer" => Ok(LayerAttributesKeys::JavaAppServer),
+            "JavaAppServerVersion" => Ok(LayerAttributesKeys::JavaAppServerVersion),
+            "Jvm" => Ok(LayerAttributesKeys::Jvm),
+            "JvmOptions" => Ok(LayerAttributesKeys::JvmOptions),
+            "JvmVersion" => Ok(LayerAttributesKeys::JvmVersion),
+            "ManageBundler" => Ok(LayerAttributesKeys::ManageBundler),
+            "MemcachedMemory" => Ok(LayerAttributesKeys::MemcachedMemory),
+            "MysqlRootPassword" => Ok(LayerAttributesKeys::MysqlRootPassword),
+            "MysqlRootPasswordUbiquitous" => Ok(LayerAttributesKeys::MysqlRootPasswordUbiquitous),
+            "NodejsVersion" => Ok(LayerAttributesKeys::NodejsVersion),
+            "PassengerVersion" => Ok(LayerAttributesKeys::PassengerVersion),
+            "RailsStack" => Ok(LayerAttributesKeys::RailsStack),
+            "RubyVersion" => Ok(LayerAttributesKeys::RubyVersion),
+            "RubygemsVersion" => Ok(LayerAttributesKeys::RubygemsVersion),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LayerType {
+    AwsFlowRuby,
+    Custom,
+    DbMaster,
+    EcsCluster,
+    JavaApp,
+    Lb,
+    Memcached,
+    MonitoringMaster,
+    NodejsApp,
+    PhpApp,
+    RailsApp,
+    Web,
+}
+
+impl Into<String> for LayerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LayerType {
+    fn into(self) -> &'static str {
+        match self {
+            LayerType::AwsFlowRuby => "aws-flow-ruby",
+            LayerType::Custom => "custom",
+            LayerType::DbMaster => "db-master",
+            LayerType::EcsCluster => "ecs-cluster",
+            LayerType::JavaApp => "java-app",
+            LayerType::Lb => "lb",
+            LayerType::Memcached => "memcached",
+            LayerType::MonitoringMaster => "monitoring-master",
+            LayerType::NodejsApp => "nodejs-app",
+            LayerType::PhpApp => "php-app",
+            LayerType::RailsApp => "rails-app",
+            LayerType::Web => "web",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LayerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "aws-flow-ruby" => Ok(LayerType::AwsFlowRuby),
+            "custom" => Ok(LayerType::Custom),
+            "db-master" => Ok(LayerType::DbMaster),
+            "ecs-cluster" => Ok(LayerType::EcsCluster),
+            "java-app" => Ok(LayerType::JavaApp),
+            "lb" => Ok(LayerType::Lb),
+            "memcached" => Ok(LayerType::Memcached),
+            "monitoring-master" => Ok(LayerType::MonitoringMaster),
+            "nodejs-app" => Ok(LayerType::NodejsApp),
+            "php-app" => Ok(LayerType::PhpApp),
+            "rails-app" => Ok(LayerType::RailsApp),
+            "web" => Ok(LayerType::Web),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the lifecycle event configuration</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LifecycleEventConfiguration {
@@ -2278,6 +3044,41 @@ pub struct ReportedOs {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RootDeviceType {
+    Ebs,
+    InstanceStore,
+}
+
+impl Into<String> for RootDeviceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RootDeviceType {
+    fn into(self) -> &'static str {
+        match self {
+            RootDeviceType::Ebs => "ebs",
+            RootDeviceType::InstanceStore => "instance-store",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RootDeviceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ebs" => Ok(RootDeviceType::Ebs),
+            "instance-store" => Ok(RootDeviceType::InstanceStore),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes a user's SSH information.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct SelfUserProfile {
@@ -2422,6 +3223,47 @@ pub struct Source {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    Archive,
+    Git,
+    S3,
+    Svn,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::Archive => "archive",
+            SourceType::Git => "git",
+            SourceType::S3 => "s3",
+            SourceType::Svn => "svn",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "archive" => Ok(SourceType::Archive),
+            "git" => Ok(SourceType::Git),
+            "s3" => Ok(SourceType::S3),
+            "svn" => Ok(SourceType::Svn),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an app's SSL configuration.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SslConfiguration {
@@ -2527,6 +3369,38 @@ pub struct Stack {
     #[serde(rename="VpcId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackAttributesKeys {
+    Color,
+}
+
+impl Into<String> for StackAttributesKeys {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackAttributesKeys {
+    fn into(self) -> &'static str {
+        match self {
+            StackAttributesKeys::Color => "Color",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackAttributesKeys {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Color" => Ok(StackAttributesKeys::Color),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the configuration manager.</p>"]
@@ -3003,6 +3877,41 @@ pub struct UserProfile {
     pub ssh_username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VirtualizationType {
+    Hvm,
+    Paravirtual,
+}
+
+impl Into<String> for VirtualizationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VirtualizationType {
+    fn into(self) -> &'static str {
+        match self {
+            VirtualizationType::Hvm => "hvm",
+            VirtualizationType::Paravirtual => "paravirtual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VirtualizationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hvm" => Ok(VirtualizationType::Hvm),
+            "paravirtual" => Ok(VirtualizationType::Paravirtual),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an instance's Amazon EBS volume.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Volume {
@@ -3084,6 +3993,44 @@ pub struct VolumeConfiguration {
     #[serde(rename="VolumeType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub volume_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeType {
+    Gp2,
+    Io1,
+    Standard,
+}
+
+impl Into<String> for VolumeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeType {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeType::Gp2 => "gp2",
+            VolumeType::Io1 => "io1",
+            VolumeType::Standard => "standard",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gp2" => Ok(VolumeType::Gp2),
+            "io1" => Ok(VolumeType::Io1),
+            "standard" => Ok(VolumeType::Standard),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a time-based instance's auto scaling schedule. The schedule consists of a set of key-value pairs.</p> <ul> <li> <p>The key is the time period (a UTC hour) and must be an integer from 0 - 23.</p> </li> <li> <p>The value indicates whether the instance should be online or offline for the specified period, and must be set to \"on\" or \"off\"</p> </li> </ul> <p>The default setting for all time periods is off, so you use the following parameters primarily to specify the online periods. You don't have to explicitly specify offline periods unless you want to change an online period to an offline period.</p> <p>The following example specifies that the instance should be online for four hours, from UTC 1200 - 1600. It will be off for the remainder of the day.</p> <p> <code> { \"12\":\"on\", \"13\":\"on\", \"14\":\"on\", \"15\":\"on\" } </code> </p>"]
@@ -8985,7 +9932,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AssignInstanceError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -9008,7 +9955,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AssignVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -9032,7 +9979,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AssociateElasticIpError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -9058,7 +10005,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(AttachElasticLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -9078,7 +10025,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CloneStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CloneStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -9100,7 +10047,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<CreateAppResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -9126,7 +10073,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDeploymentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9153,7 +10100,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9180,7 +10127,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateLayerResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateLayerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -9204,7 +10151,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateStackResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -9228,7 +10175,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateUserProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9253,7 +10200,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteAppError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -9273,7 +10220,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteInstanceError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -9296,7 +10243,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteLayerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -9316,7 +10263,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -9338,7 +10285,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteUserProfileError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -9363,7 +10310,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeregisterEcsClusterError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -9388,7 +10335,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeregisterElasticIpError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -9413,7 +10360,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeregisterInstanceError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -9438,7 +10385,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeregisterRdsDbInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -9460,7 +10407,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeregisterVolumeError::from_body(String::from_utf8_lossy(&response.body)
                                                          .as_ref()))
@@ -9486,7 +10433,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAgentVersionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9513,7 +10460,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAppsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9539,7 +10486,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCommandsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9566,7 +10513,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDeploymentsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9593,7 +10540,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEcsClustersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9620,7 +10567,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeElasticIpsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9649,7 +10596,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeElasticLoadBalancersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeElasticLoadBalancersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -9673,7 +10620,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeInstancesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9700,7 +10647,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeLayersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9729,7 +10676,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeLoadBasedAutoScalingResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeLoadBasedAutoScalingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -9752,7 +10699,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMyUserProfileResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9779,7 +10726,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribePermissionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9806,7 +10753,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeRaidArraysResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9834,7 +10781,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeRdsDbInstancesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9862,7 +10809,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeServiceErrorsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9892,7 +10839,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStackProvisioningParametersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeStackProvisioningParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -9916,7 +10863,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStackSummaryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9943,7 +10890,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStacksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -9972,7 +10919,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTimeBasedAutoScalingResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeTimeBasedAutoScalingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -9996,7 +10943,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeUserProfilesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -10023,7 +10970,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeVolumesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -10051,7 +10998,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DetachElasticLoadBalancerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10073,7 +11020,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DisassociateElasticIpError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))
@@ -10099,7 +11046,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetHostnameSuggestionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -10126,7 +11073,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GrantAccessResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GrantAccessError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -10148,7 +11095,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ListTagsResult>(String::from_utf8_lossy(&response.body)
                                                               .as_ref())
                            .unwrap())
@@ -10172,7 +11119,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(RebootInstanceError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -10197,7 +11144,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterEcsClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -10224,7 +11171,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterElasticIpResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -10251,7 +11198,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -10278,7 +11225,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(RegisterRdsDbInstanceError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))
@@ -10303,7 +11250,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterVolumeResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -10330,7 +11277,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(SetLoadBasedAutoScalingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10350,7 +11297,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(SetPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -10374,7 +11321,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(SetTimeBasedAutoScalingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10394,7 +11341,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(StartInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -10416,7 +11363,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(StartStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10436,7 +11383,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(StopInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -10458,7 +11405,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(StopStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10478,7 +11425,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(TagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10500,7 +11447,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UnassignInstanceError::from_body(String::from_utf8_lossy(&response.body)
                                                          .as_ref()))
@@ -10523,7 +11470,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UnassignVolumeError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -10546,7 +11493,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UntagResourceError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -10568,7 +11515,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(UpdateAppError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10590,7 +11537,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateElasticIpError::from_body(String::from_utf8_lossy(&response.body)
                                                         .as_ref()))
@@ -10613,7 +11560,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateInstanceError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -10636,7 +11583,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(UpdateLayerError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10658,7 +11605,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateMyUserProfileError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -10683,7 +11630,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateRdsDbInstanceError::from_body(String::from_utf8_lossy(&response.body)
                                                             .as_ref()))
@@ -10706,7 +11653,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(UpdateStackError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -10728,7 +11675,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateUserProfileError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -10751,7 +11698,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(UpdateVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -155,6 +151,82 @@ pub struct Backup {
     #[serde(rename="UserArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub user_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BackupStatus {
+    Deleting,
+    Failed,
+    InProgress,
+    Ok,
+}
+
+impl Into<String> for BackupStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BackupStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BackupStatus::Deleting => "DELETING",
+            BackupStatus::Failed => "FAILED",
+            BackupStatus::InProgress => "IN_PROGRESS",
+            BackupStatus::Ok => "OK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BackupStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETING" => Ok(BackupStatus::Deleting),
+            "FAILED" => Ok(BackupStatus::Failed),
+            "IN_PROGRESS" => Ok(BackupStatus::InProgress),
+            "OK" => Ok(BackupStatus::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BackupType {
+    Automated,
+    Manual,
+}
+
+impl Into<String> for BackupType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BackupType {
+    fn into(self) -> &'static str {
+        match self {
+            BackupType::Automated => "AUTOMATED",
+            BackupType::Manual => "MANUAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BackupType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AUTOMATED" => Ok(BackupType::Automated),
+            "MANUAL" => Ok(BackupType::Manual),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -422,6 +494,79 @@ pub struct EngineAttribute {
     pub value: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaintenanceStatus {
+    Failed,
+    Success,
+}
+
+impl Into<String> for MaintenanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaintenanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MaintenanceStatus::Failed => "FAILED",
+            MaintenanceStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaintenanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(MaintenanceStatus::Failed),
+            "SUCCESS" => Ok(MaintenanceStatus::Success),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>The status of the association or disassociation request. </p> <p class=\"title\"> <b>Possible values:</b> </p> <ul> <li> <p> <code>SUCCESS</code>: The association or disassociation succeeded. </p> </li> <li> <p> <code>FAILED</code>: The association or disassociation failed. </p> </li> <li> <p> <code>IN_PROGRESS</code>: The association or disassociation is still in progress. </p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NodeAssociationStatus {
+    Failed,
+    InProgress,
+    Success,
+}
+
+impl Into<String> for NodeAssociationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NodeAssociationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            NodeAssociationStatus::Failed => "FAILED",
+            NodeAssociationStatus::InProgress => "IN_PROGRESS",
+            NodeAssociationStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NodeAssociationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(NodeAssociationStatus::Failed),
+            "IN_PROGRESS" => Ok(NodeAssociationStatus::InProgress),
+            "SUCCESS" => Ok(NodeAssociationStatus::Success),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RestoreServerRequest {
     #[doc="<p> The ID of the backup that you want to use to restore a server. </p>"]
@@ -559,6 +704,74 @@ pub struct ServerEvent {
     #[serde(rename="ServerName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub server_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServerStatus {
+    BackingUp,
+    ConnectionLost,
+    Creating,
+    Deleting,
+    Failed,
+    Healthy,
+    Modifying,
+    Restoring,
+    Running,
+    Setup,
+    Terminated,
+    UnderMaintenance,
+    Unhealthy,
+}
+
+impl Into<String> for ServerStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServerStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ServerStatus::BackingUp => "BACKING_UP",
+            ServerStatus::ConnectionLost => "CONNECTION_LOST",
+            ServerStatus::Creating => "CREATING",
+            ServerStatus::Deleting => "DELETING",
+            ServerStatus::Failed => "FAILED",
+            ServerStatus::Healthy => "HEALTHY",
+            ServerStatus::Modifying => "MODIFYING",
+            ServerStatus::Restoring => "RESTORING",
+            ServerStatus::Running => "RUNNING",
+            ServerStatus::Setup => "SETUP",
+            ServerStatus::Terminated => "TERMINATED",
+            ServerStatus::UnderMaintenance => "UNDER_MAINTENANCE",
+            ServerStatus::Unhealthy => "UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServerStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BACKING_UP" => Ok(ServerStatus::BackingUp),
+            "CONNECTION_LOST" => Ok(ServerStatus::ConnectionLost),
+            "CREATING" => Ok(ServerStatus::Creating),
+            "DELETING" => Ok(ServerStatus::Deleting),
+            "FAILED" => Ok(ServerStatus::Failed),
+            "HEALTHY" => Ok(ServerStatus::Healthy),
+            "MODIFYING" => Ok(ServerStatus::Modifying),
+            "RESTORING" => Ok(ServerStatus::Restoring),
+            "RUNNING" => Ok(ServerStatus::Running),
+            "SETUP" => Ok(ServerStatus::Setup),
+            "TERMINATED" => Ok(ServerStatus::Terminated),
+            "UNDER_MAINTENANCE" => Ok(ServerStatus::UnderMaintenance),
+            "UNHEALTHY" => Ok(ServerStatus::Unhealthy),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1959,7 +2172,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AssociateNodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1985,7 +2198,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateBackupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2011,7 +2224,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateServerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2037,7 +2250,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteBackupResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2063,7 +2276,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteServerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2089,7 +2302,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAccountAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeAccountAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2113,7 +2326,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeBackupsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2140,7 +2353,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2169,7 +2382,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeNodeAssociationStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeNodeAssociationStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2193,7 +2406,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeServersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2220,7 +2433,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisassociateNodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2247,7 +2460,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RestoreServerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2273,7 +2486,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartMaintenanceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2300,7 +2513,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateServerResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2328,7 +2541,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateServerEngineAttributesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateServerEngineAttributesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -74,6 +70,114 @@ pub struct Account {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccountJoinedMethod {
+    Created,
+    Invited,
+}
+
+impl Into<String> for AccountJoinedMethod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccountJoinedMethod {
+    fn into(self) -> &'static str {
+        match self {
+            AccountJoinedMethod::Created => "CREATED",
+            AccountJoinedMethod::Invited => "INVITED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccountJoinedMethod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATED" => Ok(AccountJoinedMethod::Created),
+            "INVITED" => Ok(AccountJoinedMethod::Invited),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccountStatus {
+    Active,
+    Suspended,
+}
+
+impl Into<String> for AccountStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccountStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AccountStatus::Active => "ACTIVE",
+            AccountStatus::Suspended => "SUSPENDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccountStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(AccountStatus::Active),
+            "SUSPENDED" => Ok(AccountStatus::Suspended),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionType {
+    ApproveAllFeatures,
+    EnableAllFeatures,
+    Invite,
+}
+
+impl Into<String> for ActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionType {
+    fn into(self) -> &'static str {
+        match self {
+            ActionType::ApproveAllFeatures => "APPROVE_ALL_FEATURES",
+            ActionType::EnableAllFeatures => "ENABLE_ALL_FEATURES",
+            ActionType::Invite => "INVITE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPROVE_ALL_FEATURES" => Ok(ActionType::ApproveAllFeatures),
+            "ENABLE_ALL_FEATURES" => Ok(ActionType::EnableAllFeatures),
+            "INVITE" => Ok(ActionType::Invite),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AttachPolicyRequest {
     #[doc="<p>The unique identifier (ID) of the policy that you want to attach to the target. You can get the ID for the policy by calling the <a>ListPolicies</a> operation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a policy ID string requires \"p-\" followed by from 8 to 128 lower-case letters or digits.</p>"]
@@ -112,6 +216,208 @@ pub struct Child {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChildType {
+    Account,
+    OrganizationalUnit,
+}
+
+impl Into<String> for ChildType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChildType {
+    fn into(self) -> &'static str {
+        match self {
+            ChildType::Account => "ACCOUNT",
+            ChildType::OrganizationalUnit => "ORGANIZATIONAL_UNIT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChildType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(ChildType::Account),
+            "ORGANIZATIONAL_UNIT" => Ok(ChildType::OrganizationalUnit),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConstraintViolationExceptionReason {
+    AccountCannotLeaveOrganization,
+    AccountCannotLeaveWithoutEula,
+    AccountCannotLeaveWithoutPhoneVerification,
+    AccountCreationRateLimitExceeded,
+    AccountNumberLimitExceeded,
+    HandshakeRateLimitExceeded,
+    MasterAccountAddressDoesNotMatchMarketplace,
+    MasterAccountPaymentInstrumentRequired,
+    MaxPolicyTypeAttachmentLimitExceeded,
+    MemberAccountPaymentInstrumentRequired,
+    MinPolicyTypeAttachmentLimitExceeded,
+    OuDepthLimitExceeded,
+    OuNumberLimitExceeded,
+    PolicyNumberLimitExceeded,
+}
+
+impl Into<String> for ConstraintViolationExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConstraintViolationExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            ConstraintViolationExceptionReason::AccountCannotLeaveOrganization => {
+                "ACCOUNT_CANNOT_LEAVE_ORGANIZATION"
+            }
+            ConstraintViolationExceptionReason::AccountCannotLeaveWithoutEula => {
+                "ACCOUNT_CANNOT_LEAVE_WITHOUT_EULA"
+            }
+            ConstraintViolationExceptionReason::AccountCannotLeaveWithoutPhoneVerification => {
+                "ACCOUNT_CANNOT_LEAVE_WITHOUT_PHONE_VERIFICATION"
+            }
+            ConstraintViolationExceptionReason::AccountCreationRateLimitExceeded => {
+                "ACCOUNT_CREATION_RATE_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::AccountNumberLimitExceeded => {
+                "ACCOUNT_NUMBER_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::HandshakeRateLimitExceeded => {
+                "HANDSHAKE_RATE_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::MasterAccountAddressDoesNotMatchMarketplace => {
+                "MASTER_ACCOUNT_ADDRESS_DOES_NOT_MATCH_MARKETPLACE"
+            }
+            ConstraintViolationExceptionReason::MasterAccountPaymentInstrumentRequired => {
+                "MASTER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED"
+            }
+            ConstraintViolationExceptionReason::MaxPolicyTypeAttachmentLimitExceeded => {
+                "MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::MemberAccountPaymentInstrumentRequired => {
+                "MEMBER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED"
+            }
+            ConstraintViolationExceptionReason::MinPolicyTypeAttachmentLimitExceeded => {
+                "MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::OuDepthLimitExceeded => "OU_DEPTH_LIMIT_EXCEEDED",
+            ConstraintViolationExceptionReason::OuNumberLimitExceeded => "OU_NUMBER_LIMIT_EXCEEDED",
+            ConstraintViolationExceptionReason::PolicyNumberLimitExceeded => {
+                "POLICY_NUMBER_LIMIT_EXCEEDED"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConstraintViolationExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT_CANNOT_LEAVE_ORGANIZATION" => {
+                Ok(ConstraintViolationExceptionReason::AccountCannotLeaveOrganization)
+            }
+            "ACCOUNT_CANNOT_LEAVE_WITHOUT_EULA" => {
+                Ok(ConstraintViolationExceptionReason::AccountCannotLeaveWithoutEula)
+            }
+            "ACCOUNT_CANNOT_LEAVE_WITHOUT_PHONE_VERIFICATION" => {
+                Ok(ConstraintViolationExceptionReason::AccountCannotLeaveWithoutPhoneVerification)
+            }
+            "ACCOUNT_CREATION_RATE_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::AccountCreationRateLimitExceeded)
+            }
+            "ACCOUNT_NUMBER_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::AccountNumberLimitExceeded)
+            }
+            "HANDSHAKE_RATE_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::HandshakeRateLimitExceeded)
+            }
+            "MASTER_ACCOUNT_ADDRESS_DOES_NOT_MATCH_MARKETPLACE" => {
+                Ok(ConstraintViolationExceptionReason::MasterAccountAddressDoesNotMatchMarketplace)
+            }
+            "MASTER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED" => {
+                Ok(ConstraintViolationExceptionReason::MasterAccountPaymentInstrumentRequired)
+            }
+            "MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::MaxPolicyTypeAttachmentLimitExceeded)
+            }
+            "MEMBER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED" => {
+                Ok(ConstraintViolationExceptionReason::MemberAccountPaymentInstrumentRequired)
+            }
+            "MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::MinPolicyTypeAttachmentLimitExceeded)
+            }
+            "OU_DEPTH_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::OuDepthLimitExceeded)
+            }
+            "OU_NUMBER_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::OuNumberLimitExceeded)
+            }
+            "POLICY_NUMBER_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::PolicyNumberLimitExceeded)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CreateAccountFailureReason {
+    AccountLimitExceeded,
+    EmailAlreadyExists,
+    InternalFailure,
+    InvalidAddress,
+    InvalidEmail,
+}
+
+impl Into<String> for CreateAccountFailureReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CreateAccountFailureReason {
+    fn into(self) -> &'static str {
+        match self {
+            CreateAccountFailureReason::AccountLimitExceeded => "ACCOUNT_LIMIT_EXCEEDED",
+            CreateAccountFailureReason::EmailAlreadyExists => "EMAIL_ALREADY_EXISTS",
+            CreateAccountFailureReason::InternalFailure => "INTERNAL_FAILURE",
+            CreateAccountFailureReason::InvalidAddress => "INVALID_ADDRESS",
+            CreateAccountFailureReason::InvalidEmail => "INVALID_EMAIL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CreateAccountFailureReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT_LIMIT_EXCEEDED" => Ok(CreateAccountFailureReason::AccountLimitExceeded),
+            "EMAIL_ALREADY_EXISTS" => Ok(CreateAccountFailureReason::EmailAlreadyExists),
+            "INTERNAL_FAILURE" => Ok(CreateAccountFailureReason::InternalFailure),
+            "INVALID_ADDRESS" => Ok(CreateAccountFailureReason::InvalidAddress),
+            "INVALID_EMAIL" => Ok(CreateAccountFailureReason::InvalidEmail),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct CreateAccountRequest {
     #[doc="<p>The friendly name of the member account.</p>"]
@@ -136,6 +442,44 @@ pub struct CreateAccountResponse {
     #[serde(rename="CreateAccountStatus")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub create_account_status: Option<CreateAccountStatus>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CreateAccountState {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for CreateAccountState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CreateAccountState {
+    fn into(self) -> &'static str {
+        match self {
+            CreateAccountState::Failed => "FAILED",
+            CreateAccountState::InProgress => "IN_PROGRESS",
+            CreateAccountState::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CreateAccountState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(CreateAccountState::Failed),
+            "IN_PROGRESS" => Ok(CreateAccountState::InProgress),
+            "SUCCEEDED" => Ok(CreateAccountState::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the status about a <a>CreateAccount</a> request to create an AWS account in an organization.</p>"]
@@ -435,6 +779,81 @@ pub struct Handshake {
     pub state: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HandshakeConstraintViolationExceptionReason {
+    AccountNumberLimitExceeded,
+    AlreadyInAnOrganization,
+    HandshakeRateLimitExceeded,
+    InviteDisabledDuringEnableAllFeatures,
+    OrganizationAlreadyHasAllFeatures,
+    OrganizationFromDifferentSellerOfRecord,
+    OrganizationMembershipChangeRateLimitExceeded,
+    PaymentInstrumentRequired,
+}
+
+impl Into<String> for HandshakeConstraintViolationExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HandshakeConstraintViolationExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            HandshakeConstraintViolationExceptionReason::AccountNumberLimitExceeded => {
+                "ACCOUNT_NUMBER_LIMIT_EXCEEDED"
+            }
+            HandshakeConstraintViolationExceptionReason::AlreadyInAnOrganization => {
+                "ALREADY_IN_AN_ORGANIZATION"
+            }
+            HandshakeConstraintViolationExceptionReason::HandshakeRateLimitExceeded => {
+                "HANDSHAKE_RATE_LIMIT_EXCEEDED"
+            }
+            HandshakeConstraintViolationExceptionReason::InviteDisabledDuringEnableAllFeatures => {
+                "INVITE_DISABLED_DURING_ENABLE_ALL_FEATURES"
+            }
+            HandshakeConstraintViolationExceptionReason::OrganizationAlreadyHasAllFeatures => {
+                "ORGANIZATION_ALREADY_HAS_ALL_FEATURES"
+            }
+            HandshakeConstraintViolationExceptionReason::OrganizationFromDifferentSellerOfRecord => "ORGANIZATION_FROM_DIFFERENT_SELLER_OF_RECORD",
+            HandshakeConstraintViolationExceptionReason::OrganizationMembershipChangeRateLimitExceeded => "ORGANIZATION_MEMBERSHIP_CHANGE_RATE_LIMIT_EXCEEDED",
+            HandshakeConstraintViolationExceptionReason::PaymentInstrumentRequired => {
+                "PAYMENT_INSTRUMENT_REQUIRED"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for HandshakeConstraintViolationExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT_NUMBER_LIMIT_EXCEEDED" => {
+                Ok(HandshakeConstraintViolationExceptionReason::AccountNumberLimitExceeded)
+            }
+            "ALREADY_IN_AN_ORGANIZATION" => {
+                Ok(HandshakeConstraintViolationExceptionReason::AlreadyInAnOrganization)
+            }
+            "HANDSHAKE_RATE_LIMIT_EXCEEDED" => {
+                Ok(HandshakeConstraintViolationExceptionReason::HandshakeRateLimitExceeded)
+            }
+            "INVITE_DISABLED_DURING_ENABLE_ALL_FEATURES" => Ok(HandshakeConstraintViolationExceptionReason::InviteDisabledDuringEnableAllFeatures),
+            "ORGANIZATION_ALREADY_HAS_ALL_FEATURES" => {
+                Ok(HandshakeConstraintViolationExceptionReason::OrganizationAlreadyHasAllFeatures)
+            }
+            "ORGANIZATION_FROM_DIFFERENT_SELLER_OF_RECORD" => Ok(HandshakeConstraintViolationExceptionReason::OrganizationFromDifferentSellerOfRecord),
+            "ORGANIZATION_MEMBERSHIP_CHANGE_RATE_LIMIT_EXCEEDED" => Ok(HandshakeConstraintViolationExceptionReason::OrganizationMembershipChangeRateLimitExceeded),
+            "PAYMENT_INSTRUMENT_REQUIRED" => {
+                Ok(HandshakeConstraintViolationExceptionReason::PaymentInstrumentRequired)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the criteria that are used to select the handshakes for the operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct HandshakeFilter {
@@ -461,6 +880,44 @@ pub struct HandshakeParty {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HandshakePartyType {
+    Account,
+    Email,
+    Organization,
+}
+
+impl Into<String> for HandshakePartyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HandshakePartyType {
+    fn into(self) -> &'static str {
+        match self {
+            HandshakePartyType::Account => "ACCOUNT",
+            HandshakePartyType::Email => "EMAIL",
+            HandshakePartyType::Organization => "ORGANIZATION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HandshakePartyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(HandshakePartyType::Account),
+            "EMAIL" => Ok(HandshakePartyType::Email),
+            "ORGANIZATION" => Ok(HandshakePartyType::Organization),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains additional data that is needed to process a handshake.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct HandshakeResource {
@@ -476,6 +933,229 @@ pub struct HandshakeResource {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HandshakeResourceType {
+    Account,
+    Email,
+    MasterEmail,
+    MasterName,
+    Notes,
+    Organization,
+    OrganizationFeatureSet,
+    ParentHandshake,
+}
+
+impl Into<String> for HandshakeResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HandshakeResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            HandshakeResourceType::Account => "ACCOUNT",
+            HandshakeResourceType::Email => "EMAIL",
+            HandshakeResourceType::MasterEmail => "MASTER_EMAIL",
+            HandshakeResourceType::MasterName => "MASTER_NAME",
+            HandshakeResourceType::Notes => "NOTES",
+            HandshakeResourceType::Organization => "ORGANIZATION",
+            HandshakeResourceType::OrganizationFeatureSet => "ORGANIZATION_FEATURE_SET",
+            HandshakeResourceType::ParentHandshake => "PARENT_HANDSHAKE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HandshakeResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(HandshakeResourceType::Account),
+            "EMAIL" => Ok(HandshakeResourceType::Email),
+            "MASTER_EMAIL" => Ok(HandshakeResourceType::MasterEmail),
+            "MASTER_NAME" => Ok(HandshakeResourceType::MasterName),
+            "NOTES" => Ok(HandshakeResourceType::Notes),
+            "ORGANIZATION" => Ok(HandshakeResourceType::Organization),
+            "ORGANIZATION_FEATURE_SET" => Ok(HandshakeResourceType::OrganizationFeatureSet),
+            "PARENT_HANDSHAKE" => Ok(HandshakeResourceType::ParentHandshake),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HandshakeState {
+    Accepted,
+    Canceled,
+    Declined,
+    Expired,
+    Open,
+    Requested,
+}
+
+impl Into<String> for HandshakeState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HandshakeState {
+    fn into(self) -> &'static str {
+        match self {
+            HandshakeState::Accepted => "ACCEPTED",
+            HandshakeState::Canceled => "CANCELED",
+            HandshakeState::Declined => "DECLINED",
+            HandshakeState::Expired => "EXPIRED",
+            HandshakeState::Open => "OPEN",
+            HandshakeState::Requested => "REQUESTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HandshakeState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCEPTED" => Ok(HandshakeState::Accepted),
+            "CANCELED" => Ok(HandshakeState::Canceled),
+            "DECLINED" => Ok(HandshakeState::Declined),
+            "EXPIRED" => Ok(HandshakeState::Expired),
+            "OPEN" => Ok(HandshakeState::Open),
+            "REQUESTED" => Ok(HandshakeState::Requested),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IAMUserAccessToBilling {
+    Allow,
+    Deny,
+}
+
+impl Into<String> for IAMUserAccessToBilling {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IAMUserAccessToBilling {
+    fn into(self) -> &'static str {
+        match self {
+            IAMUserAccessToBilling::Allow => "ALLOW",
+            IAMUserAccessToBilling::Deny => "DENY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IAMUserAccessToBilling {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALLOW" => Ok(IAMUserAccessToBilling::Allow),
+            "DENY" => Ok(IAMUserAccessToBilling::Deny),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvalidInputExceptionReason {
+    ImmutablePolicy,
+    InputRequired,
+    InvalidEnum,
+    InvalidFullNameTarget,
+    InvalidListMember,
+    InvalidNextToken,
+    InvalidPartyTypeTarget,
+    InvalidPattern,
+    InvalidPatternTargetId,
+    InvalidSyntaxOrganizationArn,
+    InvalidSyntaxPolicyId,
+    MaxLengthExceeded,
+    MaxLimitExceededFilter,
+    MaxValueExceeded,
+    MinLengthExceeded,
+    MinValueExceeded,
+    MovingAccountBetweenDifferentRoots,
+}
+
+impl Into<String> for InvalidInputExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvalidInputExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            InvalidInputExceptionReason::ImmutablePolicy => "IMMUTABLE_POLICY",
+            InvalidInputExceptionReason::InputRequired => "INPUT_REQUIRED",
+            InvalidInputExceptionReason::InvalidEnum => "INVALID_ENUM",
+            InvalidInputExceptionReason::InvalidFullNameTarget => "INVALID_FULL_NAME_TARGET",
+            InvalidInputExceptionReason::InvalidListMember => "INVALID_LIST_MEMBER",
+            InvalidInputExceptionReason::InvalidNextToken => "INVALID_NEXT_TOKEN",
+            InvalidInputExceptionReason::InvalidPartyTypeTarget => "INVALID_PARTY_TYPE_TARGET",
+            InvalidInputExceptionReason::InvalidPattern => "INVALID_PATTERN",
+            InvalidInputExceptionReason::InvalidPatternTargetId => "INVALID_PATTERN_TARGET_ID",
+            InvalidInputExceptionReason::InvalidSyntaxOrganizationArn => {
+                "INVALID_SYNTAX_ORGANIZATION_ARN"
+            }
+            InvalidInputExceptionReason::InvalidSyntaxPolicyId => "INVALID_SYNTAX_POLICY_ID",
+            InvalidInputExceptionReason::MaxLengthExceeded => "MAX_LENGTH_EXCEEDED",
+            InvalidInputExceptionReason::MaxLimitExceededFilter => "MAX_LIMIT_EXCEEDED_FILTER",
+            InvalidInputExceptionReason::MaxValueExceeded => "MAX_VALUE_EXCEEDED",
+            InvalidInputExceptionReason::MinLengthExceeded => "MIN_LENGTH_EXCEEDED",
+            InvalidInputExceptionReason::MinValueExceeded => "MIN_VALUE_EXCEEDED",
+            InvalidInputExceptionReason::MovingAccountBetweenDifferentRoots => {
+                "MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvalidInputExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IMMUTABLE_POLICY" => Ok(InvalidInputExceptionReason::ImmutablePolicy),
+            "INPUT_REQUIRED" => Ok(InvalidInputExceptionReason::InputRequired),
+            "INVALID_ENUM" => Ok(InvalidInputExceptionReason::InvalidEnum),
+            "INVALID_FULL_NAME_TARGET" => Ok(InvalidInputExceptionReason::InvalidFullNameTarget),
+            "INVALID_LIST_MEMBER" => Ok(InvalidInputExceptionReason::InvalidListMember),
+            "INVALID_NEXT_TOKEN" => Ok(InvalidInputExceptionReason::InvalidNextToken),
+            "INVALID_PARTY_TYPE_TARGET" => Ok(InvalidInputExceptionReason::InvalidPartyTypeTarget),
+            "INVALID_PATTERN" => Ok(InvalidInputExceptionReason::InvalidPattern),
+            "INVALID_PATTERN_TARGET_ID" => Ok(InvalidInputExceptionReason::InvalidPatternTargetId),
+            "INVALID_SYNTAX_ORGANIZATION_ARN" => {
+                Ok(InvalidInputExceptionReason::InvalidSyntaxOrganizationArn)
+            }
+            "INVALID_SYNTAX_POLICY_ID" => Ok(InvalidInputExceptionReason::InvalidSyntaxPolicyId),
+            "MAX_LENGTH_EXCEEDED" => Ok(InvalidInputExceptionReason::MaxLengthExceeded),
+            "MAX_LIMIT_EXCEEDED_FILTER" => Ok(InvalidInputExceptionReason::MaxLimitExceededFilter),
+            "MAX_VALUE_EXCEEDED" => Ok(InvalidInputExceptionReason::MaxValueExceeded),
+            "MIN_LENGTH_EXCEEDED" => Ok(InvalidInputExceptionReason::MinLengthExceeded),
+            "MIN_VALUE_EXCEEDED" => Ok(InvalidInputExceptionReason::MinValueExceeded),
+            "MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS" => {
+                Ok(InvalidInputExceptionReason::MovingAccountBetweenDifferentRoots)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -870,6 +1550,41 @@ pub struct Organization {
     pub master_account_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrganizationFeatureSet {
+    All,
+    ConsolidatedBilling,
+}
+
+impl Into<String> for OrganizationFeatureSet {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrganizationFeatureSet {
+    fn into(self) -> &'static str {
+        match self {
+            OrganizationFeatureSet::All => "ALL",
+            OrganizationFeatureSet::ConsolidatedBilling => "CONSOLIDATED_BILLING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrganizationFeatureSet {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(OrganizationFeatureSet::All),
+            "CONSOLIDATED_BILLING" => Ok(OrganizationFeatureSet::ConsolidatedBilling),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains details about an organizational unit (OU). An OU is a container of AWS accounts within a root of an organization. Policies that are attached to an OU apply to all accounts contained in that OU and in any child OUs.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct OrganizationalUnit {
@@ -898,6 +1613,41 @@ pub struct Parent {
     #[serde(rename="Type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParentType {
+    OrganizationalUnit,
+    Root,
+}
+
+impl Into<String> for ParentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParentType {
+    fn into(self) -> &'static str {
+        match self {
+            ParentType::OrganizationalUnit => "ORGANIZATIONAL_UNIT",
+            ParentType::Root => "ROOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ORGANIZATIONAL_UNIT" => Ok(ParentType::OrganizationalUnit),
+            "ROOT" => Ok(ParentType::Root),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains rules to be applied to the affected accounts. Policies can be attached directly to accounts, or to roots and OUs to affect all accounts in those hierarchies.</p>"]
@@ -963,6 +1713,76 @@ pub struct PolicyTargetSummary {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyType {
+    ServiceControlPolicy,
+}
+
+impl Into<String> for PolicyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyType::ServiceControlPolicy => "SERVICE_CONTROL_POLICY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SERVICE_CONTROL_POLICY" => Ok(PolicyType::ServiceControlPolicy),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyTypeStatus {
+    Enabled,
+    PendingDisable,
+    PendingEnable,
+}
+
+impl Into<String> for PolicyTypeStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyTypeStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyTypeStatus::Enabled => "ENABLED",
+            PolicyTypeStatus::PendingDisable => "PENDING_DISABLE",
+            PolicyTypeStatus::PendingEnable => "PENDING_ENABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyTypeStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ENABLED" => Ok(PolicyTypeStatus::Enabled),
+            "PENDING_DISABLE" => Ok(PolicyTypeStatus::PendingDisable),
+            "PENDING_ENABLE" => Ok(PolicyTypeStatus::PendingEnable),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about a policy type and its status in the associated root.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PolicyTypeSummary {
@@ -1002,6 +1822,44 @@ pub struct Root {
     #[serde(rename="PolicyTypes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub policy_types: Option<Vec<PolicyTypeSummary>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TargetType {
+    Account,
+    OrganizationalUnit,
+    Root,
+}
+
+impl Into<String> for TargetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TargetType {
+    fn into(self) -> &'static str {
+        match self {
+            TargetType::Account => "ACCOUNT",
+            TargetType::OrganizationalUnit => "ORGANIZATIONAL_UNIT",
+            TargetType::Root => "ROOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TargetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(TargetType::Account),
+            "ORGANIZATIONAL_UNIT" => Ok(TargetType::OrganizationalUnit),
+            "ROOT" => Ok(TargetType::Root),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -5589,7 +6447,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AcceptHandshakeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5614,7 +6472,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(AttachPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -5638,7 +6496,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CancelHandshakeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5665,7 +6523,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAccountResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5692,7 +6550,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateOrganizationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5721,7 +6579,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateOrganizationalUnitResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateOrganizationalUnitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5745,7 +6603,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreatePolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5771,7 +6629,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeclineHandshakeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5796,7 +6654,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeleteOrganizationError::from_body(String::from_utf8_lossy(&response.body)
                                                            .as_ref()))
@@ -5822,7 +6680,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(DeleteOrganizationalUnitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -5842,7 +6700,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeletePolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -5866,7 +6724,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAccountResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5895,7 +6753,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCreateAccountStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeCreateAccountStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5920,7 +6778,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeHandshakeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5946,7 +6804,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeOrganizationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5975,7 +6833,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeOrganizationalUnitResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeOrganizationalUnitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5999,7 +6857,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribePolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6024,7 +6882,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DetachPolicyError::from_body(String::from_utf8_lossy(&response.body).as_ref()))
             }
@@ -6049,7 +6907,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisablePolicyTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6074,7 +6932,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<EnableAllFeaturesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6101,7 +6959,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<EnablePolicyTypeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6130,7 +6988,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<InviteAccountToOrganizationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(InviteAccountToOrganizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6152,7 +7010,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(LeaveOrganizationError::from_body(String::from_utf8_lossy(&response.body)
                                                           .as_ref()))
@@ -6177,7 +7035,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAccountsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6205,7 +7063,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAccountsForParentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6232,7 +7090,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListChildrenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6260,7 +7118,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListCreateAccountStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListCreateAccountStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6286,7 +7144,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListHandshakesForAccountResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListHandshakesForAccountError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6312,7 +7170,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListHandshakesForOrganizationResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListHandshakesForOrganizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6338,7 +7196,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListOrganizationalUnitsForParentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListOrganizationalUnitsForParentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6362,7 +7220,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListParentsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListParentsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6386,7 +7244,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPoliciesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6414,7 +7272,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPoliciesForTargetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6439,7 +7297,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRootsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListRootsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6465,7 +7323,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTargetsForPolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6490,7 +7348,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(MoveAccountError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6513,7 +7371,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RemoveAccountFromOrganizationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6537,7 +7395,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateOrganizationalUnitResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateOrganizationalUnitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6561,7 +7419,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdatePolicyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -61,6 +57,41 @@ pub struct DescribeVoicesOutput {
     pub voices: Option<Vec<Voice>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Gender {
+    Female,
+    Male,
+}
+
+impl Into<String> for Gender {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Gender {
+    fn into(self) -> &'static str {
+        match self {
+            Gender::Female => "Female",
+            Gender::Male => "Male",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Gender {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Female" => Ok(Gender::Female),
+            "Male" => Ok(Gender::Male),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GetLexiconInput {
     #[doc="<p>Name of the lexicon.</p>"]
@@ -78,6 +109,107 @@ pub struct GetLexiconOutput {
     #[serde(rename="LexiconAttributes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub lexicon_attributes: Option<LexiconAttributes>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LanguageCode {
+    CyGB,
+    DaDK,
+    DeDE,
+    EnAU,
+    EnGB,
+    EnGBWLS,
+    EnIN,
+    EnUS,
+    EsES,
+    EsUS,
+    FrCA,
+    FrFR,
+    IsIS,
+    ItIT,
+    JaJP,
+    NbNO,
+    NlNL,
+    PlPL,
+    PtBR,
+    PtPT,
+    RoRO,
+    RuRU,
+    SvSE,
+    TrTR,
+}
+
+impl Into<String> for LanguageCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LanguageCode {
+    fn into(self) -> &'static str {
+        match self {
+            LanguageCode::CyGB => "cy-GB",
+            LanguageCode::DaDK => "da-DK",
+            LanguageCode::DeDE => "de-DE",
+            LanguageCode::EnAU => "en-AU",
+            LanguageCode::EnGB => "en-GB",
+            LanguageCode::EnGBWLS => "en-GB-WLS",
+            LanguageCode::EnIN => "en-IN",
+            LanguageCode::EnUS => "en-US",
+            LanguageCode::EsES => "es-ES",
+            LanguageCode::EsUS => "es-US",
+            LanguageCode::FrCA => "fr-CA",
+            LanguageCode::FrFR => "fr-FR",
+            LanguageCode::IsIS => "is-IS",
+            LanguageCode::ItIT => "it-IT",
+            LanguageCode::JaJP => "ja-JP",
+            LanguageCode::NbNO => "nb-NO",
+            LanguageCode::NlNL => "nl-NL",
+            LanguageCode::PlPL => "pl-PL",
+            LanguageCode::PtBR => "pt-BR",
+            LanguageCode::PtPT => "pt-PT",
+            LanguageCode::RoRO => "ro-RO",
+            LanguageCode::RuRU => "ru-RU",
+            LanguageCode::SvSE => "sv-SE",
+            LanguageCode::TrTR => "tr-TR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LanguageCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cy-GB" => Ok(LanguageCode::CyGB),
+            "da-DK" => Ok(LanguageCode::DaDK),
+            "de-DE" => Ok(LanguageCode::DeDE),
+            "en-AU" => Ok(LanguageCode::EnAU),
+            "en-GB" => Ok(LanguageCode::EnGB),
+            "en-GB-WLS" => Ok(LanguageCode::EnGBWLS),
+            "en-IN" => Ok(LanguageCode::EnIN),
+            "en-US" => Ok(LanguageCode::EnUS),
+            "es-ES" => Ok(LanguageCode::EsES),
+            "es-US" => Ok(LanguageCode::EsUS),
+            "fr-CA" => Ok(LanguageCode::FrCA),
+            "fr-FR" => Ok(LanguageCode::FrFR),
+            "is-IS" => Ok(LanguageCode::IsIS),
+            "it-IT" => Ok(LanguageCode::ItIT),
+            "ja-JP" => Ok(LanguageCode::JaJP),
+            "nb-NO" => Ok(LanguageCode::NbNO),
+            "nl-NL" => Ok(LanguageCode::NlNL),
+            "pl-PL" => Ok(LanguageCode::PlPL),
+            "pt-BR" => Ok(LanguageCode::PtBR),
+            "pt-PT" => Ok(LanguageCode::PtPT),
+            "ro-RO" => Ok(LanguageCode::RoRO),
+            "ru-RU" => Ok(LanguageCode::RuRU),
+            "sv-SE" => Ok(LanguageCode::SvSE),
+            "tr-TR" => Ok(LanguageCode::TrTR),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides lexicon name and lexicon content in string format. For more information, see <a href=\"https://www.w3.org/TR/pronunciation-lexicon/\">Pronunciation Lexicon Specification (PLS) Version 1.0</a>.</p>"]
@@ -155,6 +287,47 @@ pub struct ListLexiconsOutput {
     pub next_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OutputFormat {
+    Json,
+    Mp3,
+    OggVorbis,
+    Pcm,
+}
+
+impl Into<String> for OutputFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OutputFormat {
+    fn into(self) -> &'static str {
+        match self {
+            OutputFormat::Json => "json",
+            OutputFormat::Mp3 => "mp3",
+            OutputFormat::OggVorbis => "ogg_vorbis",
+            OutputFormat::Pcm => "pcm",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OutputFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "json" => Ok(OutputFormat::Json),
+            "mp3" => Ok(OutputFormat::Mp3),
+            "ogg_vorbis" => Ok(OutputFormat::OggVorbis),
+            "pcm" => Ok(OutputFormat::Pcm),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutLexiconInput {
     #[doc="<p>Content of the PLS lexicon as string data.</p>"]
@@ -167,6 +340,47 @@ pub struct PutLexiconInput {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PutLexiconOutput;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SpeechMarkType {
+    Sentence,
+    Ssml,
+    Viseme,
+    Word,
+}
+
+impl Into<String> for SpeechMarkType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SpeechMarkType {
+    fn into(self) -> &'static str {
+        match self {
+            SpeechMarkType::Sentence => "sentence",
+            SpeechMarkType::Ssml => "ssml",
+            SpeechMarkType::Viseme => "viseme",
+            SpeechMarkType::Word => "word",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SpeechMarkType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "sentence" => Ok(SpeechMarkType::Sentence),
+            "ssml" => Ok(SpeechMarkType::Ssml),
+            "viseme" => Ok(SpeechMarkType::Viseme),
+            "word" => Ok(SpeechMarkType::Word),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct SynthesizeSpeechInput {
@@ -207,6 +421,41 @@ pub struct SynthesizeSpeechOutput {
     pub request_characters: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TextType {
+    Ssml,
+    Text,
+}
+
+impl Into<String> for TextType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TextType {
+    fn into(self) -> &'static str {
+        match self {
+            TextType::Ssml => "ssml",
+            TextType::Text => "text",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TextType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ssml" => Ok(TextType::Ssml),
+            "text" => Ok(TextType::Text),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Description of the voice.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Voice {
@@ -230,6 +479,179 @@ pub struct Voice {
     #[serde(rename="Name")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VoiceId {
+    Amy,
+    Astrid,
+    Brian,
+    Carla,
+    Carmen,
+    Celine,
+    Chantal,
+    Conchita,
+    Cristiano,
+    Dora,
+    Emma,
+    Enrique,
+    Ewa,
+    Filiz,
+    Geraint,
+    Giorgio,
+    Gwyneth,
+    Hans,
+    Ines,
+    Ivy,
+    Jacek,
+    Jan,
+    Joanna,
+    Joey,
+    Justin,
+    Karl,
+    Kendra,
+    Kimberly,
+    Liv,
+    Lotte,
+    Mads,
+    Maja,
+    Marlene,
+    Mathieu,
+    Maxim,
+    Miguel,
+    Mizuki,
+    Naja,
+    Nicole,
+    Penelope,
+    Raveena,
+    Ricardo,
+    Ruben,
+    Russell,
+    Salli,
+    Tatyana,
+    Vicki,
+    Vitoria,
+}
+
+impl Into<String> for VoiceId {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VoiceId {
+    fn into(self) -> &'static str {
+        match self {
+            VoiceId::Amy => "Amy",
+            VoiceId::Astrid => "Astrid",
+            VoiceId::Brian => "Brian",
+            VoiceId::Carla => "Carla",
+            VoiceId::Carmen => "Carmen",
+            VoiceId::Celine => "Celine",
+            VoiceId::Chantal => "Chantal",
+            VoiceId::Conchita => "Conchita",
+            VoiceId::Cristiano => "Cristiano",
+            VoiceId::Dora => "Dora",
+            VoiceId::Emma => "Emma",
+            VoiceId::Enrique => "Enrique",
+            VoiceId::Ewa => "Ewa",
+            VoiceId::Filiz => "Filiz",
+            VoiceId::Geraint => "Geraint",
+            VoiceId::Giorgio => "Giorgio",
+            VoiceId::Gwyneth => "Gwyneth",
+            VoiceId::Hans => "Hans",
+            VoiceId::Ines => "Ines",
+            VoiceId::Ivy => "Ivy",
+            VoiceId::Jacek => "Jacek",
+            VoiceId::Jan => "Jan",
+            VoiceId::Joanna => "Joanna",
+            VoiceId::Joey => "Joey",
+            VoiceId::Justin => "Justin",
+            VoiceId::Karl => "Karl",
+            VoiceId::Kendra => "Kendra",
+            VoiceId::Kimberly => "Kimberly",
+            VoiceId::Liv => "Liv",
+            VoiceId::Lotte => "Lotte",
+            VoiceId::Mads => "Mads",
+            VoiceId::Maja => "Maja",
+            VoiceId::Marlene => "Marlene",
+            VoiceId::Mathieu => "Mathieu",
+            VoiceId::Maxim => "Maxim",
+            VoiceId::Miguel => "Miguel",
+            VoiceId::Mizuki => "Mizuki",
+            VoiceId::Naja => "Naja",
+            VoiceId::Nicole => "Nicole",
+            VoiceId::Penelope => "Penelope",
+            VoiceId::Raveena => "Raveena",
+            VoiceId::Ricardo => "Ricardo",
+            VoiceId::Ruben => "Ruben",
+            VoiceId::Russell => "Russell",
+            VoiceId::Salli => "Salli",
+            VoiceId::Tatyana => "Tatyana",
+            VoiceId::Vicki => "Vicki",
+            VoiceId::Vitoria => "Vitoria",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VoiceId {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Amy" => Ok(VoiceId::Amy),
+            "Astrid" => Ok(VoiceId::Astrid),
+            "Brian" => Ok(VoiceId::Brian),
+            "Carla" => Ok(VoiceId::Carla),
+            "Carmen" => Ok(VoiceId::Carmen),
+            "Celine" => Ok(VoiceId::Celine),
+            "Chantal" => Ok(VoiceId::Chantal),
+            "Conchita" => Ok(VoiceId::Conchita),
+            "Cristiano" => Ok(VoiceId::Cristiano),
+            "Dora" => Ok(VoiceId::Dora),
+            "Emma" => Ok(VoiceId::Emma),
+            "Enrique" => Ok(VoiceId::Enrique),
+            "Ewa" => Ok(VoiceId::Ewa),
+            "Filiz" => Ok(VoiceId::Filiz),
+            "Geraint" => Ok(VoiceId::Geraint),
+            "Giorgio" => Ok(VoiceId::Giorgio),
+            "Gwyneth" => Ok(VoiceId::Gwyneth),
+            "Hans" => Ok(VoiceId::Hans),
+            "Ines" => Ok(VoiceId::Ines),
+            "Ivy" => Ok(VoiceId::Ivy),
+            "Jacek" => Ok(VoiceId::Jacek),
+            "Jan" => Ok(VoiceId::Jan),
+            "Joanna" => Ok(VoiceId::Joanna),
+            "Joey" => Ok(VoiceId::Joey),
+            "Justin" => Ok(VoiceId::Justin),
+            "Karl" => Ok(VoiceId::Karl),
+            "Kendra" => Ok(VoiceId::Kendra),
+            "Kimberly" => Ok(VoiceId::Kimberly),
+            "Liv" => Ok(VoiceId::Liv),
+            "Lotte" => Ok(VoiceId::Lotte),
+            "Mads" => Ok(VoiceId::Mads),
+            "Maja" => Ok(VoiceId::Maja),
+            "Marlene" => Ok(VoiceId::Marlene),
+            "Mathieu" => Ok(VoiceId::Mathieu),
+            "Maxim" => Ok(VoiceId::Maxim),
+            "Miguel" => Ok(VoiceId::Miguel),
+            "Mizuki" => Ok(VoiceId::Mizuki),
+            "Naja" => Ok(VoiceId::Naja),
+            "Nicole" => Ok(VoiceId::Nicole),
+            "Penelope" => Ok(VoiceId::Penelope),
+            "Raveena" => Ok(VoiceId::Raveena),
+            "Ricardo" => Ok(VoiceId::Ricardo),
+            "Ruben" => Ok(VoiceId::Ruben),
+            "Russell" => Ok(VoiceId::Russell),
+            "Salli" => Ok(VoiceId::Salli),
+            "Tatyana" => Ok(VoiceId::Tatyana),
+            "Vicki" => Ok(VoiceId::Vicki),
+            "Vitoria" => Ok(VoiceId::Vitoria),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by DeleteLexicon
@@ -844,7 +1266,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -894,7 +1316,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -936,7 +1358,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -981,7 +1403,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -1022,7 +1444,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body = response.body;
 
@@ -1063,7 +1485,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = SynthesizeSpeechOutput::default();
                 result.audio_stream = Some(response.body);

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -401,7 +396,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -415,7 +410,7 @@ impl BooleanOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4645,7 +4640,7 @@ impl DoubleDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4659,7 +4654,7 @@ impl DoubleOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6390,7 +6385,7 @@ impl IntegerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6404,7 +6399,7 @@ impl IntegerOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6501,7 +6496,7 @@ impl LongDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6515,7 +6510,7 @@ impl LongOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7373,6 +7368,41 @@ impl ParameterSerializer {
             params.put(&format!("{}{}", prefix, "Source"), &field_value);
         }
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterApplyType {
+    Dynamic,
+    Static,
+}
+
+impl Into<String> for ParameterApplyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterApplyType {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterApplyType::Dynamic => "dynamic",
+            ParameterApplyType::Static => "static",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterApplyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dynamic" => Ok(ParameterApplyType::Dynamic),
+            "static" => Ok(ParameterApplyType::Static),
+            _ => Err(()),
+        }
     }
 }
 
@@ -9615,6 +9645,47 @@ impl SourceIdsListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    Cluster,
+    ClusterParameterGroup,
+    ClusterSecurityGroup,
+    ClusterSnapshot,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::Cluster => "cluster",
+            SourceType::ClusterParameterGroup => "cluster-parameter-group",
+            SourceType::ClusterSecurityGroup => "cluster-security-group",
+            SourceType::ClusterSnapshot => "cluster-snapshot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cluster" => Ok(SourceType::Cluster),
+            "cluster-parameter-group" => Ok(SourceType::ClusterParameterGroup),
+            "cluster-security-group" => Ok(SourceType::ClusterSecurityGroup),
+            "cluster-snapshot" => Ok(SourceType::ClusterSnapshot),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -10007,6 +10078,50 @@ impl TableRestoreStatusMessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TableRestoreStatusType {
+    Canceled,
+    Failed,
+    InProgress,
+    Pending,
+    Succeeded,
+}
+
+impl Into<String> for TableRestoreStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TableRestoreStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            TableRestoreStatusType::Canceled => "CANCELED",
+            TableRestoreStatusType::Failed => "FAILED",
+            TableRestoreStatusType::InProgress => "IN_PROGRESS",
+            TableRestoreStatusType::Pending => "PENDING",
+            TableRestoreStatusType::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TableRestoreStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELED" => Ok(TableRestoreStatusType::Canceled),
+            "FAILED" => Ok(TableRestoreStatusType::Failed),
+            "IN_PROGRESS" => Ok(TableRestoreStatusType::InProgress),
+            "PENDING" => Ok(TableRestoreStatusType::Pending),
+            "SUCCEEDED" => Ok(TableRestoreStatusType::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TableRestoreStatusTypeDeserializer;
 impl TableRestoreStatusTypeDeserializer {
     #[allow(unused_variables)]
@@ -15956,7 +16071,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -15999,7 +16114,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16043,7 +16158,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16087,7 +16202,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16131,7 +16246,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16174,7 +16289,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16219,7 +16334,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16264,7 +16379,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16309,7 +16424,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16354,7 +16469,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16399,7 +16514,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16445,7 +16560,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16487,7 +16602,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16511,7 +16626,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16554,7 +16669,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16580,7 +16695,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16607,7 +16722,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16651,7 +16766,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16677,7 +16792,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16703,7 +16818,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16729,7 +16844,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16756,7 +16871,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16780,7 +16895,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16805,7 +16920,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16850,7 +16965,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16895,7 +17010,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16938,7 +17053,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -16982,7 +17097,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17026,7 +17141,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17069,7 +17184,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17114,7 +17229,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17157,7 +17272,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17201,7 +17316,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17244,7 +17359,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17289,7 +17404,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17333,7 +17448,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17376,7 +17491,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17421,7 +17536,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17466,7 +17581,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17510,7 +17625,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17554,7 +17669,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17599,7 +17714,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17643,7 +17758,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17686,7 +17801,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17729,7 +17844,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17773,7 +17888,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17817,7 +17932,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17860,7 +17975,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17904,7 +18019,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17948,7 +18063,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -17992,7 +18107,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18037,7 +18152,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18082,7 +18197,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18127,7 +18242,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18172,7 +18287,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18215,7 +18330,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18257,7 +18372,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18301,7 +18416,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18346,7 +18461,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18391,7 +18506,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18434,7 +18549,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18476,7 +18591,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -18520,7 +18635,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -37,6 +33,41 @@ pub struct AgeRange {
     #[serde(rename="Low")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub low: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Attribute {
+    All,
+    Default,
+}
+
+impl Into<String> for Attribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Attribute {
+    fn into(self) -> &'static str {
+        match self {
+            Attribute::All => "ALL",
+            Attribute::Default => "DEFAULT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Attribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(Attribute::All),
+            "DEFAULT" => Ok(Attribute::Default),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Indicates whether or not the face has a beard, and the confidence level in the determination.</p>"]
@@ -321,6 +352,59 @@ pub struct Emotion {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EmotionName {
+    Angry,
+    Calm,
+    Confused,
+    Disgusted,
+    Happy,
+    Sad,
+    Surprised,
+    Unknown,
+}
+
+impl Into<String> for EmotionName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EmotionName {
+    fn into(self) -> &'static str {
+        match self {
+            EmotionName::Angry => "ANGRY",
+            EmotionName::Calm => "CALM",
+            EmotionName::Confused => "CONFUSED",
+            EmotionName::Disgusted => "DISGUSTED",
+            EmotionName::Happy => "HAPPY",
+            EmotionName::Sad => "SAD",
+            EmotionName::Surprised => "SURPRISED",
+            EmotionName::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EmotionName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ANGRY" => Ok(EmotionName::Angry),
+            "CALM" => Ok(EmotionName::Calm),
+            "CONFUSED" => Ok(EmotionName::Confused),
+            "DISGUSTED" => Ok(EmotionName::Disgusted),
+            "HAPPY" => Ok(EmotionName::Happy),
+            "SAD" => Ok(EmotionName::Sad),
+            "SURPRISED" => Ok(EmotionName::Surprised),
+            "UNKNOWN" => Ok(EmotionName::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Indicates whether or not the eyes on the face are open, and the confidence level in the determination.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct EyeOpen {
@@ -476,6 +560,41 @@ pub struct Gender {
     pub value: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GenderType {
+    Female,
+    Male,
+}
+
+impl Into<String> for GenderType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GenderType {
+    fn into(self) -> &'static str {
+        match self {
+            GenderType::Female => "FEMALE",
+            GenderType::Male => "MALE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GenderType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FEMALE" => Ok(GenderType::Female),
+            "MALE" => Ok(GenderType::Male),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GetCelebrityInfoRequest {
     #[doc="<p>The ID for the celebrity. You get the celebrity ID from a call to the operation, which recognizes celebrities in an image. </p>"]
@@ -585,6 +704,110 @@ pub struct Landmark {
     pub y: Option<f32>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LandmarkType {
+    EyeLeft,
+    EyeRight,
+    LeftEyebrowLeft,
+    LeftEyebrowRight,
+    LeftEyebrowUp,
+    LeftEyeDown,
+    LeftEyeLeft,
+    LeftEyeRight,
+    LeftEyeUp,
+    LeftPupil,
+    MouthDown,
+    MouthLeft,
+    MouthRight,
+    MouthUp,
+    Nose,
+    NoseLeft,
+    NoseRight,
+    RightEyebrowLeft,
+    RightEyebrowRight,
+    RightEyebrowUp,
+    RightEyeDown,
+    RightEyeLeft,
+    RightEyeRight,
+    RightEyeUp,
+    RightPupil,
+}
+
+impl Into<String> for LandmarkType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LandmarkType {
+    fn into(self) -> &'static str {
+        match self {
+            LandmarkType::EyeLeft => "EYE_LEFT",
+            LandmarkType::EyeRight => "EYE_RIGHT",
+            LandmarkType::LeftEyebrowLeft => "LEFT_EYEBROW_LEFT",
+            LandmarkType::LeftEyebrowRight => "LEFT_EYEBROW_RIGHT",
+            LandmarkType::LeftEyebrowUp => "LEFT_EYEBROW_UP",
+            LandmarkType::LeftEyeDown => "LEFT_EYE_DOWN",
+            LandmarkType::LeftEyeLeft => "LEFT_EYE_LEFT",
+            LandmarkType::LeftEyeRight => "LEFT_EYE_RIGHT",
+            LandmarkType::LeftEyeUp => "LEFT_EYE_UP",
+            LandmarkType::LeftPupil => "LEFT_PUPIL",
+            LandmarkType::MouthDown => "MOUTH_DOWN",
+            LandmarkType::MouthLeft => "MOUTH_LEFT",
+            LandmarkType::MouthRight => "MOUTH_RIGHT",
+            LandmarkType::MouthUp => "MOUTH_UP",
+            LandmarkType::Nose => "NOSE",
+            LandmarkType::NoseLeft => "NOSE_LEFT",
+            LandmarkType::NoseRight => "NOSE_RIGHT",
+            LandmarkType::RightEyebrowLeft => "RIGHT_EYEBROW_LEFT",
+            LandmarkType::RightEyebrowRight => "RIGHT_EYEBROW_RIGHT",
+            LandmarkType::RightEyebrowUp => "RIGHT_EYEBROW_UP",
+            LandmarkType::RightEyeDown => "RIGHT_EYE_DOWN",
+            LandmarkType::RightEyeLeft => "RIGHT_EYE_LEFT",
+            LandmarkType::RightEyeRight => "RIGHT_EYE_RIGHT",
+            LandmarkType::RightEyeUp => "RIGHT_EYE_UP",
+            LandmarkType::RightPupil => "RIGHT_PUPIL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LandmarkType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EYE_LEFT" => Ok(LandmarkType::EyeLeft),
+            "EYE_RIGHT" => Ok(LandmarkType::EyeRight),
+            "LEFT_EYEBROW_LEFT" => Ok(LandmarkType::LeftEyebrowLeft),
+            "LEFT_EYEBROW_RIGHT" => Ok(LandmarkType::LeftEyebrowRight),
+            "LEFT_EYEBROW_UP" => Ok(LandmarkType::LeftEyebrowUp),
+            "LEFT_EYE_DOWN" => Ok(LandmarkType::LeftEyeDown),
+            "LEFT_EYE_LEFT" => Ok(LandmarkType::LeftEyeLeft),
+            "LEFT_EYE_RIGHT" => Ok(LandmarkType::LeftEyeRight),
+            "LEFT_EYE_UP" => Ok(LandmarkType::LeftEyeUp),
+            "LEFT_PUPIL" => Ok(LandmarkType::LeftPupil),
+            "MOUTH_DOWN" => Ok(LandmarkType::MouthDown),
+            "MOUTH_LEFT" => Ok(LandmarkType::MouthLeft),
+            "MOUTH_RIGHT" => Ok(LandmarkType::MouthRight),
+            "MOUTH_UP" => Ok(LandmarkType::MouthUp),
+            "NOSE" => Ok(LandmarkType::Nose),
+            "NOSE_LEFT" => Ok(LandmarkType::NoseLeft),
+            "NOSE_RIGHT" => Ok(LandmarkType::NoseRight),
+            "RIGHT_EYEBROW_LEFT" => Ok(LandmarkType::RightEyebrowLeft),
+            "RIGHT_EYEBROW_RIGHT" => Ok(LandmarkType::RightEyebrowRight),
+            "RIGHT_EYEBROW_UP" => Ok(LandmarkType::RightEyebrowUp),
+            "RIGHT_EYE_DOWN" => Ok(LandmarkType::RightEyeDown),
+            "RIGHT_EYE_LEFT" => Ok(LandmarkType::RightEyeLeft),
+            "RIGHT_EYE_RIGHT" => Ok(LandmarkType::RightEyeRight),
+            "RIGHT_EYE_UP" => Ok(LandmarkType::RightEyeUp),
+            "RIGHT_PUPIL" => Ok(LandmarkType::RightPupil),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListCollectionsRequest {
     #[doc="<p>Maximum number of collection IDs to return.</p>"]
@@ -677,6 +900,47 @@ pub struct Mustache {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<bool>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrientationCorrection {
+    Rotate0,
+    Rotate180,
+    Rotate270,
+    Rotate90,
+}
+
+impl Into<String> for OrientationCorrection {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrientationCorrection {
+    fn into(self) -> &'static str {
+        match self {
+            OrientationCorrection::Rotate0 => "ROTATE_0",
+            OrientationCorrection::Rotate180 => "ROTATE_180",
+            OrientationCorrection::Rotate270 => "ROTATE_270",
+            OrientationCorrection::Rotate90 => "ROTATE_90",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrientationCorrection {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ROTATE_0" => Ok(OrientationCorrection::Rotate0),
+            "ROTATE_180" => Ok(OrientationCorrection::Rotate180),
+            "ROTATE_270" => Ok(OrientationCorrection::Rotate270),
+            "ROTATE_90" => Ok(OrientationCorrection::Rotate90),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Indicates the pose of the face as determined by its pitch, roll, and yaw.</p>"]
@@ -2499,7 +2763,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CompareFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2525,7 +2789,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateCollectionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2552,7 +2816,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteCollectionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2579,7 +2843,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2603,7 +2867,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DetectFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DetectFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2627,7 +2891,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DetectLabelsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2654,7 +2918,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DetectModerationLabelsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2681,7 +2945,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetCelebrityInfoResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2708,7 +2972,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<IndexFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(IndexFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2732,7 +2996,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListCollectionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2757,7 +3021,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2781,7 +3045,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RecognizeCelebritiesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2808,7 +3072,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SearchFacesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(SearchFacesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2832,7 +3096,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SearchFacesByImageResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -11,19 +11,14 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 
-use std::str::FromStr;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
@@ -136,7 +131,7 @@ impl AliasHealthEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -327,6 +322,44 @@ impl ChangeSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeAction {
+    Create,
+    Delete,
+    Upsert,
+}
+
+impl Into<String> for ChangeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeAction {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeAction::Create => "CREATE",
+            ChangeAction::Delete => "DELETE",
+            ChangeAction::Upsert => "UPSERT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE" => Ok(ChangeAction::Create),
+            "DELETE" => Ok(ChangeAction::Delete),
+            "UPSERT" => Ok(ChangeAction::Upsert),
+            _ => Err(()),
+        }
+    }
+}
+
+
 pub struct ChangeActionSerializer;
 impl ChangeActionSerializer {
     #[allow(unused_variables, warnings)]
@@ -487,6 +520,41 @@ impl ChangeResourceRecordSetsResponseDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeStatus {
+    Insync,
+    Pending,
+}
+
+impl Into<String> for ChangeStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeStatus::Insync => "INSYNC",
+            ChangeStatus::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSYNC" => Ok(ChangeStatus::Insync),
+            "PENDING" => Ok(ChangeStatus::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeStatusDeserializer;
 impl ChangeStatusDeserializer {
     #[allow(unused_variables)]
@@ -740,6 +808,77 @@ impl CloudWatchAlarmConfigurationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudWatchRegion {
+    ApNortheast1,
+    ApNortheast2,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    CaCentral1,
+    EuCentral1,
+    EuWest1,
+    EuWest2,
+    SaEast1,
+    UsEast1,
+    UsEast2,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for CloudWatchRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudWatchRegion {
+    fn into(self) -> &'static str {
+        match self {
+            CloudWatchRegion::ApNortheast1 => "ap-northeast-1",
+            CloudWatchRegion::ApNortheast2 => "ap-northeast-2",
+            CloudWatchRegion::ApSouth1 => "ap-south-1",
+            CloudWatchRegion::ApSoutheast1 => "ap-southeast-1",
+            CloudWatchRegion::ApSoutheast2 => "ap-southeast-2",
+            CloudWatchRegion::CaCentral1 => "ca-central-1",
+            CloudWatchRegion::EuCentral1 => "eu-central-1",
+            CloudWatchRegion::EuWest1 => "eu-west-1",
+            CloudWatchRegion::EuWest2 => "eu-west-2",
+            CloudWatchRegion::SaEast1 => "sa-east-1",
+            CloudWatchRegion::UsEast1 => "us-east-1",
+            CloudWatchRegion::UsEast2 => "us-east-2",
+            CloudWatchRegion::UsWest1 => "us-west-1",
+            CloudWatchRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudWatchRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(CloudWatchRegion::ApNortheast1),
+            "ap-northeast-2" => Ok(CloudWatchRegion::ApNortheast2),
+            "ap-south-1" => Ok(CloudWatchRegion::ApSouth1),
+            "ap-southeast-1" => Ok(CloudWatchRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(CloudWatchRegion::ApSoutheast2),
+            "ca-central-1" => Ok(CloudWatchRegion::CaCentral1),
+            "eu-central-1" => Ok(CloudWatchRegion::EuCentral1),
+            "eu-west-1" => Ok(CloudWatchRegion::EuWest1),
+            "eu-west-2" => Ok(CloudWatchRegion::EuWest2),
+            "sa-east-1" => Ok(CloudWatchRegion::SaEast1),
+            "us-east-1" => Ok(CloudWatchRegion::UsEast1),
+            "us-east-2" => Ok(CloudWatchRegion::UsEast2),
+            "us-west-1" => Ok(CloudWatchRegion::UsWest1),
+            "us-west-2" => Ok(CloudWatchRegion::UsWest2),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CloudWatchRegionDeserializer;
 impl CloudWatchRegionDeserializer {
     #[allow(unused_variables)]
@@ -762,6 +901,49 @@ impl CloudWatchRegionSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    GreaterThanOrEqualToThreshold,
+    GreaterThanThreshold,
+    LessThanOrEqualToThreshold,
+    LessThanThreshold,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::GreaterThanOrEqualToThreshold => "GreaterThanOrEqualToThreshold",
+            ComparisonOperator::GreaterThanThreshold => "GreaterThanThreshold",
+            ComparisonOperator::LessThanOrEqualToThreshold => "LessThanOrEqualToThreshold",
+            ComparisonOperator::LessThanThreshold => "LessThanThreshold",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GreaterThanOrEqualToThreshold" => {
+                Ok(ComparisonOperator::GreaterThanOrEqualToThreshold)
+            }
+            "GreaterThanThreshold" => Ok(ComparisonOperator::GreaterThanThreshold),
+            "LessThanOrEqualToThreshold" => Ok(ComparisonOperator::LessThanOrEqualToThreshold),
+            "LessThanThreshold" => Ok(ComparisonOperator::LessThanThreshold),
+            _ => Err(()),
+        }
     }
 }
 
@@ -1812,7 +1994,7 @@ impl EnableSNIDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1837,7 +2019,7 @@ impl EvaluationPeriodsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1851,7 +2033,7 @@ impl FailureThresholdDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3240,7 +3422,7 @@ impl HealthCheckCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3401,6 +3583,59 @@ impl HealthCheckObservationsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HealthCheckRegion {
+    ApNortheast1,
+    ApSoutheast1,
+    ApSoutheast2,
+    EuWest1,
+    SaEast1,
+    UsEast1,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for HealthCheckRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HealthCheckRegion {
+    fn into(self) -> &'static str {
+        match self {
+            HealthCheckRegion::ApNortheast1 => "ap-northeast-1",
+            HealthCheckRegion::ApSoutheast1 => "ap-southeast-1",
+            HealthCheckRegion::ApSoutheast2 => "ap-southeast-2",
+            HealthCheckRegion::EuWest1 => "eu-west-1",
+            HealthCheckRegion::SaEast1 => "sa-east-1",
+            HealthCheckRegion::UsEast1 => "us-east-1",
+            HealthCheckRegion::UsWest1 => "us-west-1",
+            HealthCheckRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HealthCheckRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(HealthCheckRegion::ApNortheast1),
+            "ap-southeast-1" => Ok(HealthCheckRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(HealthCheckRegion::ApSoutheast2),
+            "eu-west-1" => Ok(HealthCheckRegion::EuWest1),
+            "sa-east-1" => Ok(HealthCheckRegion::SaEast1),
+            "us-east-1" => Ok(HealthCheckRegion::UsEast1),
+            "us-west-1" => Ok(HealthCheckRegion::UsWest1),
+            "us-west-2" => Ok(HealthCheckRegion::UsWest2),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HealthCheckRegionDeserializer;
 impl HealthCheckRegionDeserializer {
     #[allow(unused_variables)]
@@ -3482,6 +3717,56 @@ impl HealthCheckRegionListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HealthCheckType {
+    Calculated,
+    CloudwatchMetric,
+    Http,
+    Https,
+    HttpsStrMatch,
+    HttpStrMatch,
+    Tcp,
+}
+
+impl Into<String> for HealthCheckType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HealthCheckType {
+    fn into(self) -> &'static str {
+        match self {
+            HealthCheckType::Calculated => "CALCULATED",
+            HealthCheckType::CloudwatchMetric => "CLOUDWATCH_METRIC",
+            HealthCheckType::Http => "HTTP",
+            HealthCheckType::Https => "HTTPS",
+            HealthCheckType::HttpsStrMatch => "HTTPS_STR_MATCH",
+            HealthCheckType::HttpStrMatch => "HTTP_STR_MATCH",
+            HealthCheckType::Tcp => "TCP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HealthCheckType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CALCULATED" => Ok(HealthCheckType::Calculated),
+            "CLOUDWATCH_METRIC" => Ok(HealthCheckType::CloudwatchMetric),
+            "HTTP" => Ok(HealthCheckType::Http),
+            "HTTPS" => Ok(HealthCheckType::Https),
+            "HTTPS_STR_MATCH" => Ok(HealthCheckType::HttpsStrMatch),
+            "HTTP_STR_MATCH" => Ok(HealthCheckType::HttpStrMatch),
+            "TCP" => Ok(HealthCheckType::Tcp),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HealthCheckTypeDeserializer;
 impl HealthCheckTypeDeserializer {
     #[allow(unused_variables)]
@@ -3514,7 +3799,7 @@ impl HealthCheckVersionDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3580,7 +3865,7 @@ impl HealthThresholdDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3752,7 +4037,7 @@ impl HostedZoneCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3766,7 +4051,7 @@ impl HostedZoneRRSetCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3853,6 +4138,44 @@ impl IPAddressCidrDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InsufficientDataHealthStatus {
+    Healthy,
+    LastKnownStatus,
+    Unhealthy,
+}
+
+impl Into<String> for InsufficientDataHealthStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InsufficientDataHealthStatus {
+    fn into(self) -> &'static str {
+        match self {
+            InsufficientDataHealthStatus::Healthy => "Healthy",
+            InsufficientDataHealthStatus::LastKnownStatus => "LastKnownStatus",
+            InsufficientDataHealthStatus::Unhealthy => "Unhealthy",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InsufficientDataHealthStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Healthy" => Ok(InsufficientDataHealthStatus::Healthy),
+            "LastKnownStatus" => Ok(InsufficientDataHealthStatus::LastKnownStatus),
+            "Unhealthy" => Ok(InsufficientDataHealthStatus::Unhealthy),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InsufficientDataHealthStatusDeserializer;
 impl InsufficientDataHealthStatusDeserializer {
     #[allow(unused_variables)]
@@ -3885,7 +4208,7 @@ impl InvertedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3910,7 +4233,7 @@ impl IsPrivateZoneDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5119,7 +5442,7 @@ impl MeasureLatencyDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5275,7 +5598,7 @@ impl PageTruncatedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5314,7 +5637,7 @@ impl PeriodDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5328,7 +5651,7 @@ impl PortDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5368,6 +5691,68 @@ impl RDataSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RRType {
+    A,
+    Aaaa,
+    Cname,
+    Mx,
+    Naptr,
+    Ns,
+    Ptr,
+    Soa,
+    Spf,
+    Srv,
+    Txt,
+}
+
+impl Into<String> for RRType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RRType {
+    fn into(self) -> &'static str {
+        match self {
+            RRType::A => "A",
+            RRType::Aaaa => "AAAA",
+            RRType::Cname => "CNAME",
+            RRType::Mx => "MX",
+            RRType::Naptr => "NAPTR",
+            RRType::Ns => "NS",
+            RRType::Ptr => "PTR",
+            RRType::Soa => "SOA",
+            RRType::Spf => "SPF",
+            RRType::Srv => "SRV",
+            RRType::Txt => "TXT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RRType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "A" => Ok(RRType::A),
+            "AAAA" => Ok(RRType::Aaaa),
+            "CNAME" => Ok(RRType::Cname),
+            "MX" => Ok(RRType::Mx),
+            "NAPTR" => Ok(RRType::Naptr),
+            "NS" => Ok(RRType::Ns),
+            "PTR" => Ok(RRType::Ptr),
+            "SOA" => Ok(RRType::Soa),
+            "SPF" => Ok(RRType::Spf),
+            "SRV" => Ok(RRType::Srv),
+            "TXT" => Ok(RRType::Txt),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5459,7 +5844,7 @@ impl RequestIntervalDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5782,6 +6167,41 @@ impl ResourceRecordSetSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceRecordSetFailover {
+    Primary,
+    Secondary,
+}
+
+impl Into<String> for ResourceRecordSetFailover {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceRecordSetFailover {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceRecordSetFailover::Primary => "PRIMARY",
+            ResourceRecordSetFailover::Secondary => "SECONDARY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceRecordSetFailover {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PRIMARY" => Ok(ResourceRecordSetFailover::Primary),
+            "SECONDARY" => Ok(ResourceRecordSetFailover::Secondary),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ResourceRecordSetFailoverDeserializer;
 impl ResourceRecordSetFailoverDeserializer {
     #[allow(unused_variables)]
@@ -5839,7 +6259,7 @@ impl ResourceRecordSetMultiValueAnswerDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5854,6 +6274,80 @@ impl ResourceRecordSetMultiValueAnswerSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceRecordSetRegion {
+    ApNortheast1,
+    ApNortheast2,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    CaCentral1,
+    CnNorth1,
+    EuCentral1,
+    EuWest1,
+    EuWest2,
+    SaEast1,
+    UsEast1,
+    UsEast2,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for ResourceRecordSetRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceRecordSetRegion {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceRecordSetRegion::ApNortheast1 => "ap-northeast-1",
+            ResourceRecordSetRegion::ApNortheast2 => "ap-northeast-2",
+            ResourceRecordSetRegion::ApSouth1 => "ap-south-1",
+            ResourceRecordSetRegion::ApSoutheast1 => "ap-southeast-1",
+            ResourceRecordSetRegion::ApSoutheast2 => "ap-southeast-2",
+            ResourceRecordSetRegion::CaCentral1 => "ca-central-1",
+            ResourceRecordSetRegion::CnNorth1 => "cn-north-1",
+            ResourceRecordSetRegion::EuCentral1 => "eu-central-1",
+            ResourceRecordSetRegion::EuWest1 => "eu-west-1",
+            ResourceRecordSetRegion::EuWest2 => "eu-west-2",
+            ResourceRecordSetRegion::SaEast1 => "sa-east-1",
+            ResourceRecordSetRegion::UsEast1 => "us-east-1",
+            ResourceRecordSetRegion::UsEast2 => "us-east-2",
+            ResourceRecordSetRegion::UsWest1 => "us-west-1",
+            ResourceRecordSetRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceRecordSetRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(ResourceRecordSetRegion::ApNortheast1),
+            "ap-northeast-2" => Ok(ResourceRecordSetRegion::ApNortheast2),
+            "ap-south-1" => Ok(ResourceRecordSetRegion::ApSouth1),
+            "ap-southeast-1" => Ok(ResourceRecordSetRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(ResourceRecordSetRegion::ApSoutheast2),
+            "ca-central-1" => Ok(ResourceRecordSetRegion::CaCentral1),
+            "cn-north-1" => Ok(ResourceRecordSetRegion::CnNorth1),
+            "eu-central-1" => Ok(ResourceRecordSetRegion::EuCentral1),
+            "eu-west-1" => Ok(ResourceRecordSetRegion::EuWest1),
+            "eu-west-2" => Ok(ResourceRecordSetRegion::EuWest2),
+            "sa-east-1" => Ok(ResourceRecordSetRegion::SaEast1),
+            "us-east-1" => Ok(ResourceRecordSetRegion::UsEast1),
+            "us-east-2" => Ok(ResourceRecordSetRegion::UsEast2),
+            "us-west-1" => Ok(ResourceRecordSetRegion::UsWest1),
+            "us-west-2" => Ok(ResourceRecordSetRegion::UsWest2),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5889,7 +6383,7 @@ impl ResourceRecordSetWeightDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6134,6 +6628,50 @@ impl SearchStringSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Statistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for Statistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Statistic {
+    fn into(self) -> &'static str {
+        match self {
+            Statistic::Average => "Average",
+            Statistic::Maximum => "Maximum",
+            Statistic::Minimum => "Minimum",
+            Statistic::SampleCount => "SampleCount",
+            Statistic::Sum => "Sum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Statistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(Statistic::Average),
+            "Maximum" => Ok(Statistic::Maximum),
+            "Minimum" => Ok(Statistic::Minimum),
+            "SampleCount" => Ok(Statistic::SampleCount),
+            "Sum" => Ok(Statistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatisticDeserializer;
 impl StatisticDeserializer {
     #[allow(unused_variables)]
@@ -6236,7 +6774,7 @@ impl TTLDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6461,6 +6999,41 @@ impl TagResourceIdListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TagResourceType {
+    Healthcheck,
+    Hostedzone,
+}
+
+impl Into<String> for TagResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TagResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            TagResourceType::Healthcheck => "healthcheck",
+            TagResourceType::Hostedzone => "hostedzone",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TagResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "healthcheck" => Ok(TagResourceType::Healthcheck),
+            "hostedzone" => Ok(TagResourceType::Hostedzone),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TagResourceTypeDeserializer;
 impl TagResourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -6614,7 +7187,7 @@ impl ThresholdDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6936,7 +7509,7 @@ impl TrafficPolicyInstanceCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7169,7 +7742,7 @@ impl TrafficPolicyVersionDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7583,6 +8156,80 @@ impl VPCIdSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VPCRegion {
+    ApNortheast1,
+    ApNortheast2,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    CaCentral1,
+    CnNorth1,
+    EuCentral1,
+    EuWest1,
+    EuWest2,
+    SaEast1,
+    UsEast1,
+    UsEast2,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for VPCRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VPCRegion {
+    fn into(self) -> &'static str {
+        match self {
+            VPCRegion::ApNortheast1 => "ap-northeast-1",
+            VPCRegion::ApNortheast2 => "ap-northeast-2",
+            VPCRegion::ApSouth1 => "ap-south-1",
+            VPCRegion::ApSoutheast1 => "ap-southeast-1",
+            VPCRegion::ApSoutheast2 => "ap-southeast-2",
+            VPCRegion::CaCentral1 => "ca-central-1",
+            VPCRegion::CnNorth1 => "cn-north-1",
+            VPCRegion::EuCentral1 => "eu-central-1",
+            VPCRegion::EuWest1 => "eu-west-1",
+            VPCRegion::EuWest2 => "eu-west-2",
+            VPCRegion::SaEast1 => "sa-east-1",
+            VPCRegion::UsEast1 => "us-east-1",
+            VPCRegion::UsEast2 => "us-east-2",
+            VPCRegion::UsWest1 => "us-west-1",
+            VPCRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VPCRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(VPCRegion::ApNortheast1),
+            "ap-northeast-2" => Ok(VPCRegion::ApNortheast2),
+            "ap-south-1" => Ok(VPCRegion::ApSouth1),
+            "ap-southeast-1" => Ok(VPCRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(VPCRegion::ApSoutheast2),
+            "ca-central-1" => Ok(VPCRegion::CaCentral1),
+            "cn-north-1" => Ok(VPCRegion::CnNorth1),
+            "eu-central-1" => Ok(VPCRegion::EuCentral1),
+            "eu-west-1" => Ok(VPCRegion::EuWest1),
+            "eu-west-2" => Ok(VPCRegion::EuWest2),
+            "sa-east-1" => Ok(VPCRegion::SaEast1),
+            "us-east-1" => Ok(VPCRegion::UsEast1),
+            "us-east-2" => Ok(VPCRegion::UsEast2),
+            "us-west-1" => Ok(VPCRegion::UsWest1),
+            "us-west-2" => Ok(VPCRegion::UsWest2),
+            _ => Err(()),
+        }
     }
 }
 
@@ -11834,9 +12481,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11882,9 +12529,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11931,9 +12578,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -11981,9 +12628,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12034,9 +12681,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12088,9 +12735,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12136,9 +12783,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12188,9 +12835,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12237,9 +12884,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12287,9 +12934,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12334,9 +12981,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12386,9 +13033,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12439,9 +13086,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12487,9 +13134,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12538,9 +13185,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12587,9 +13234,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12635,9 +13282,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12680,9 +13327,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12728,9 +13375,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12791,9 +13438,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12843,9 +13490,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12895,9 +13542,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12947,9 +13594,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -12995,9 +13642,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13045,9 +13692,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13095,9 +13742,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13148,9 +13795,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13196,9 +13843,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13249,9 +13896,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13297,9 +13944,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13359,9 +14006,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13418,9 +14065,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13481,9 +14128,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13545,9 +14192,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13611,9 +14258,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13669,9 +14316,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13717,9 +14364,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13768,9 +14415,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13825,9 +14472,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13895,9 +14542,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -13956,9 +14603,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -14026,9 +14673,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -14081,9 +14728,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -14136,9 +14783,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -14197,9 +14844,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -14247,9 +14894,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -14300,9 +14947,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -14349,9 +14996,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -14397,9 +15044,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -132,6 +128,766 @@ pub struct ContactDetail {
     pub zip_code: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContactType {
+    Association,
+    Company,
+    Person,
+    PublicBody,
+    Reseller,
+}
+
+impl Into<String> for ContactType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContactType {
+    fn into(self) -> &'static str {
+        match self {
+            ContactType::Association => "ASSOCIATION",
+            ContactType::Company => "COMPANY",
+            ContactType::Person => "PERSON",
+            ContactType::PublicBody => "PUBLIC_BODY",
+            ContactType::Reseller => "RESELLER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContactType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSOCIATION" => Ok(ContactType::Association),
+            "COMPANY" => Ok(ContactType::Company),
+            "PERSON" => Ok(ContactType::Person),
+            "PUBLIC_BODY" => Ok(ContactType::PublicBody),
+            "RESELLER" => Ok(ContactType::Reseller),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CountryCode {
+    Ad,
+    Ae,
+    Af,
+    Ag,
+    Ai,
+    Al,
+    Am,
+    An,
+    Ao,
+    Aq,
+    Ar,
+    As,
+    At,
+    Au,
+    Aw,
+    Az,
+    Ba,
+    Bb,
+    Bd,
+    Be,
+    Bf,
+    Bg,
+    Bh,
+    Bi,
+    Bj,
+    Bl,
+    Bm,
+    Bn,
+    Bo,
+    Br,
+    Bs,
+    Bt,
+    Bw,
+    By,
+    Bz,
+    Ca,
+    Cc,
+    Cd,
+    Cf,
+    Cg,
+    Ch,
+    Ci,
+    Ck,
+    Cl,
+    Cm,
+    Cn,
+    Co,
+    Cr,
+    Cu,
+    Cv,
+    Cx,
+    Cy,
+    Cz,
+    De,
+    Dj,
+    Dk,
+    Dm,
+    Do,
+    Dz,
+    Ec,
+    Ee,
+    Eg,
+    Er,
+    Es,
+    Et,
+    Fi,
+    Fj,
+    Fk,
+    Fm,
+    Fo,
+    Fr,
+    Ga,
+    Gb,
+    Gd,
+    Ge,
+    Gh,
+    Gi,
+    Gl,
+    Gm,
+    Gn,
+    Gq,
+    Gr,
+    Gt,
+    Gu,
+    Gw,
+    Gy,
+    Hk,
+    Hn,
+    Hr,
+    Ht,
+    Hu,
+    Id,
+    Ie,
+    Il,
+    Im,
+    In,
+    Iq,
+    Ir,
+    Is,
+    It,
+    Jm,
+    Jo,
+    Jp,
+    Ke,
+    Kg,
+    Kh,
+    Ki,
+    Km,
+    Kn,
+    Kp,
+    Kr,
+    Kw,
+    Ky,
+    Kz,
+    La,
+    Lb,
+    Lc,
+    Li,
+    Lk,
+    Lr,
+    Ls,
+    Lt,
+    Lu,
+    Lv,
+    Ly,
+    Ma,
+    Mc,
+    Md,
+    Me,
+    Mf,
+    Mg,
+    Mh,
+    Mk,
+    Ml,
+    Mm,
+    Mn,
+    Mo,
+    Mp,
+    Mr,
+    Ms,
+    Mt,
+    Mu,
+    Mv,
+    Mw,
+    Mx,
+    My,
+    Mz,
+    Na,
+    Nc,
+    Ne,
+    Ng,
+    Ni,
+    Nl,
+    No,
+    Np,
+    Nr,
+    Nu,
+    Nz,
+    Om,
+    Pa,
+    Pe,
+    Pf,
+    Pg,
+    Ph,
+    Pk,
+    Pl,
+    Pm,
+    Pn,
+    Pr,
+    Pt,
+    Pw,
+    Py,
+    Qa,
+    Ro,
+    Rs,
+    Ru,
+    Rw,
+    Sa,
+    Sb,
+    Sc,
+    Sd,
+    Se,
+    Sg,
+    Sh,
+    Si,
+    Sk,
+    Sl,
+    Sm,
+    Sn,
+    So,
+    Sr,
+    St,
+    Sv,
+    Sy,
+    Sz,
+    Tc,
+    Td,
+    Tg,
+    Th,
+    Tj,
+    Tk,
+    Tl,
+    Tm,
+    Tn,
+    To,
+    Tr,
+    Tt,
+    Tv,
+    Tw,
+    Tz,
+    Ua,
+    Ug,
+    Us,
+    Uy,
+    Uz,
+    Va,
+    Vc,
+    Ve,
+    Vg,
+    Vi,
+    Vn,
+    Vu,
+    Wf,
+    Ws,
+    Ye,
+    Yt,
+    Za,
+    Zm,
+    Zw,
+}
+
+impl Into<String> for CountryCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CountryCode {
+    fn into(self) -> &'static str {
+        match self {
+            CountryCode::Ad => "AD",
+            CountryCode::Ae => "AE",
+            CountryCode::Af => "AF",
+            CountryCode::Ag => "AG",
+            CountryCode::Ai => "AI",
+            CountryCode::Al => "AL",
+            CountryCode::Am => "AM",
+            CountryCode::An => "AN",
+            CountryCode::Ao => "AO",
+            CountryCode::Aq => "AQ",
+            CountryCode::Ar => "AR",
+            CountryCode::As => "AS",
+            CountryCode::At => "AT",
+            CountryCode::Au => "AU",
+            CountryCode::Aw => "AW",
+            CountryCode::Az => "AZ",
+            CountryCode::Ba => "BA",
+            CountryCode::Bb => "BB",
+            CountryCode::Bd => "BD",
+            CountryCode::Be => "BE",
+            CountryCode::Bf => "BF",
+            CountryCode::Bg => "BG",
+            CountryCode::Bh => "BH",
+            CountryCode::Bi => "BI",
+            CountryCode::Bj => "BJ",
+            CountryCode::Bl => "BL",
+            CountryCode::Bm => "BM",
+            CountryCode::Bn => "BN",
+            CountryCode::Bo => "BO",
+            CountryCode::Br => "BR",
+            CountryCode::Bs => "BS",
+            CountryCode::Bt => "BT",
+            CountryCode::Bw => "BW",
+            CountryCode::By => "BY",
+            CountryCode::Bz => "BZ",
+            CountryCode::Ca => "CA",
+            CountryCode::Cc => "CC",
+            CountryCode::Cd => "CD",
+            CountryCode::Cf => "CF",
+            CountryCode::Cg => "CG",
+            CountryCode::Ch => "CH",
+            CountryCode::Ci => "CI",
+            CountryCode::Ck => "CK",
+            CountryCode::Cl => "CL",
+            CountryCode::Cm => "CM",
+            CountryCode::Cn => "CN",
+            CountryCode::Co => "CO",
+            CountryCode::Cr => "CR",
+            CountryCode::Cu => "CU",
+            CountryCode::Cv => "CV",
+            CountryCode::Cx => "CX",
+            CountryCode::Cy => "CY",
+            CountryCode::Cz => "CZ",
+            CountryCode::De => "DE",
+            CountryCode::Dj => "DJ",
+            CountryCode::Dk => "DK",
+            CountryCode::Dm => "DM",
+            CountryCode::Do => "DO",
+            CountryCode::Dz => "DZ",
+            CountryCode::Ec => "EC",
+            CountryCode::Ee => "EE",
+            CountryCode::Eg => "EG",
+            CountryCode::Er => "ER",
+            CountryCode::Es => "ES",
+            CountryCode::Et => "ET",
+            CountryCode::Fi => "FI",
+            CountryCode::Fj => "FJ",
+            CountryCode::Fk => "FK",
+            CountryCode::Fm => "FM",
+            CountryCode::Fo => "FO",
+            CountryCode::Fr => "FR",
+            CountryCode::Ga => "GA",
+            CountryCode::Gb => "GB",
+            CountryCode::Gd => "GD",
+            CountryCode::Ge => "GE",
+            CountryCode::Gh => "GH",
+            CountryCode::Gi => "GI",
+            CountryCode::Gl => "GL",
+            CountryCode::Gm => "GM",
+            CountryCode::Gn => "GN",
+            CountryCode::Gq => "GQ",
+            CountryCode::Gr => "GR",
+            CountryCode::Gt => "GT",
+            CountryCode::Gu => "GU",
+            CountryCode::Gw => "GW",
+            CountryCode::Gy => "GY",
+            CountryCode::Hk => "HK",
+            CountryCode::Hn => "HN",
+            CountryCode::Hr => "HR",
+            CountryCode::Ht => "HT",
+            CountryCode::Hu => "HU",
+            CountryCode::Id => "ID",
+            CountryCode::Ie => "IE",
+            CountryCode::Il => "IL",
+            CountryCode::Im => "IM",
+            CountryCode::In => "IN",
+            CountryCode::Iq => "IQ",
+            CountryCode::Ir => "IR",
+            CountryCode::Is => "IS",
+            CountryCode::It => "IT",
+            CountryCode::Jm => "JM",
+            CountryCode::Jo => "JO",
+            CountryCode::Jp => "JP",
+            CountryCode::Ke => "KE",
+            CountryCode::Kg => "KG",
+            CountryCode::Kh => "KH",
+            CountryCode::Ki => "KI",
+            CountryCode::Km => "KM",
+            CountryCode::Kn => "KN",
+            CountryCode::Kp => "KP",
+            CountryCode::Kr => "KR",
+            CountryCode::Kw => "KW",
+            CountryCode::Ky => "KY",
+            CountryCode::Kz => "KZ",
+            CountryCode::La => "LA",
+            CountryCode::Lb => "LB",
+            CountryCode::Lc => "LC",
+            CountryCode::Li => "LI",
+            CountryCode::Lk => "LK",
+            CountryCode::Lr => "LR",
+            CountryCode::Ls => "LS",
+            CountryCode::Lt => "LT",
+            CountryCode::Lu => "LU",
+            CountryCode::Lv => "LV",
+            CountryCode::Ly => "LY",
+            CountryCode::Ma => "MA",
+            CountryCode::Mc => "MC",
+            CountryCode::Md => "MD",
+            CountryCode::Me => "ME",
+            CountryCode::Mf => "MF",
+            CountryCode::Mg => "MG",
+            CountryCode::Mh => "MH",
+            CountryCode::Mk => "MK",
+            CountryCode::Ml => "ML",
+            CountryCode::Mm => "MM",
+            CountryCode::Mn => "MN",
+            CountryCode::Mo => "MO",
+            CountryCode::Mp => "MP",
+            CountryCode::Mr => "MR",
+            CountryCode::Ms => "MS",
+            CountryCode::Mt => "MT",
+            CountryCode::Mu => "MU",
+            CountryCode::Mv => "MV",
+            CountryCode::Mw => "MW",
+            CountryCode::Mx => "MX",
+            CountryCode::My => "MY",
+            CountryCode::Mz => "MZ",
+            CountryCode::Na => "NA",
+            CountryCode::Nc => "NC",
+            CountryCode::Ne => "NE",
+            CountryCode::Ng => "NG",
+            CountryCode::Ni => "NI",
+            CountryCode::Nl => "NL",
+            CountryCode::No => "NO",
+            CountryCode::Np => "NP",
+            CountryCode::Nr => "NR",
+            CountryCode::Nu => "NU",
+            CountryCode::Nz => "NZ",
+            CountryCode::Om => "OM",
+            CountryCode::Pa => "PA",
+            CountryCode::Pe => "PE",
+            CountryCode::Pf => "PF",
+            CountryCode::Pg => "PG",
+            CountryCode::Ph => "PH",
+            CountryCode::Pk => "PK",
+            CountryCode::Pl => "PL",
+            CountryCode::Pm => "PM",
+            CountryCode::Pn => "PN",
+            CountryCode::Pr => "PR",
+            CountryCode::Pt => "PT",
+            CountryCode::Pw => "PW",
+            CountryCode::Py => "PY",
+            CountryCode::Qa => "QA",
+            CountryCode::Ro => "RO",
+            CountryCode::Rs => "RS",
+            CountryCode::Ru => "RU",
+            CountryCode::Rw => "RW",
+            CountryCode::Sa => "SA",
+            CountryCode::Sb => "SB",
+            CountryCode::Sc => "SC",
+            CountryCode::Sd => "SD",
+            CountryCode::Se => "SE",
+            CountryCode::Sg => "SG",
+            CountryCode::Sh => "SH",
+            CountryCode::Si => "SI",
+            CountryCode::Sk => "SK",
+            CountryCode::Sl => "SL",
+            CountryCode::Sm => "SM",
+            CountryCode::Sn => "SN",
+            CountryCode::So => "SO",
+            CountryCode::Sr => "SR",
+            CountryCode::St => "ST",
+            CountryCode::Sv => "SV",
+            CountryCode::Sy => "SY",
+            CountryCode::Sz => "SZ",
+            CountryCode::Tc => "TC",
+            CountryCode::Td => "TD",
+            CountryCode::Tg => "TG",
+            CountryCode::Th => "TH",
+            CountryCode::Tj => "TJ",
+            CountryCode::Tk => "TK",
+            CountryCode::Tl => "TL",
+            CountryCode::Tm => "TM",
+            CountryCode::Tn => "TN",
+            CountryCode::To => "TO",
+            CountryCode::Tr => "TR",
+            CountryCode::Tt => "TT",
+            CountryCode::Tv => "TV",
+            CountryCode::Tw => "TW",
+            CountryCode::Tz => "TZ",
+            CountryCode::Ua => "UA",
+            CountryCode::Ug => "UG",
+            CountryCode::Us => "US",
+            CountryCode::Uy => "UY",
+            CountryCode::Uz => "UZ",
+            CountryCode::Va => "VA",
+            CountryCode::Vc => "VC",
+            CountryCode::Ve => "VE",
+            CountryCode::Vg => "VG",
+            CountryCode::Vi => "VI",
+            CountryCode::Vn => "VN",
+            CountryCode::Vu => "VU",
+            CountryCode::Wf => "WF",
+            CountryCode::Ws => "WS",
+            CountryCode::Ye => "YE",
+            CountryCode::Yt => "YT",
+            CountryCode::Za => "ZA",
+            CountryCode::Zm => "ZM",
+            CountryCode::Zw => "ZW",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CountryCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AD" => Ok(CountryCode::Ad),
+            "AE" => Ok(CountryCode::Ae),
+            "AF" => Ok(CountryCode::Af),
+            "AG" => Ok(CountryCode::Ag),
+            "AI" => Ok(CountryCode::Ai),
+            "AL" => Ok(CountryCode::Al),
+            "AM" => Ok(CountryCode::Am),
+            "AN" => Ok(CountryCode::An),
+            "AO" => Ok(CountryCode::Ao),
+            "AQ" => Ok(CountryCode::Aq),
+            "AR" => Ok(CountryCode::Ar),
+            "AS" => Ok(CountryCode::As),
+            "AT" => Ok(CountryCode::At),
+            "AU" => Ok(CountryCode::Au),
+            "AW" => Ok(CountryCode::Aw),
+            "AZ" => Ok(CountryCode::Az),
+            "BA" => Ok(CountryCode::Ba),
+            "BB" => Ok(CountryCode::Bb),
+            "BD" => Ok(CountryCode::Bd),
+            "BE" => Ok(CountryCode::Be),
+            "BF" => Ok(CountryCode::Bf),
+            "BG" => Ok(CountryCode::Bg),
+            "BH" => Ok(CountryCode::Bh),
+            "BI" => Ok(CountryCode::Bi),
+            "BJ" => Ok(CountryCode::Bj),
+            "BL" => Ok(CountryCode::Bl),
+            "BM" => Ok(CountryCode::Bm),
+            "BN" => Ok(CountryCode::Bn),
+            "BO" => Ok(CountryCode::Bo),
+            "BR" => Ok(CountryCode::Br),
+            "BS" => Ok(CountryCode::Bs),
+            "BT" => Ok(CountryCode::Bt),
+            "BW" => Ok(CountryCode::Bw),
+            "BY" => Ok(CountryCode::By),
+            "BZ" => Ok(CountryCode::Bz),
+            "CA" => Ok(CountryCode::Ca),
+            "CC" => Ok(CountryCode::Cc),
+            "CD" => Ok(CountryCode::Cd),
+            "CF" => Ok(CountryCode::Cf),
+            "CG" => Ok(CountryCode::Cg),
+            "CH" => Ok(CountryCode::Ch),
+            "CI" => Ok(CountryCode::Ci),
+            "CK" => Ok(CountryCode::Ck),
+            "CL" => Ok(CountryCode::Cl),
+            "CM" => Ok(CountryCode::Cm),
+            "CN" => Ok(CountryCode::Cn),
+            "CO" => Ok(CountryCode::Co),
+            "CR" => Ok(CountryCode::Cr),
+            "CU" => Ok(CountryCode::Cu),
+            "CV" => Ok(CountryCode::Cv),
+            "CX" => Ok(CountryCode::Cx),
+            "CY" => Ok(CountryCode::Cy),
+            "CZ" => Ok(CountryCode::Cz),
+            "DE" => Ok(CountryCode::De),
+            "DJ" => Ok(CountryCode::Dj),
+            "DK" => Ok(CountryCode::Dk),
+            "DM" => Ok(CountryCode::Dm),
+            "DO" => Ok(CountryCode::Do),
+            "DZ" => Ok(CountryCode::Dz),
+            "EC" => Ok(CountryCode::Ec),
+            "EE" => Ok(CountryCode::Ee),
+            "EG" => Ok(CountryCode::Eg),
+            "ER" => Ok(CountryCode::Er),
+            "ES" => Ok(CountryCode::Es),
+            "ET" => Ok(CountryCode::Et),
+            "FI" => Ok(CountryCode::Fi),
+            "FJ" => Ok(CountryCode::Fj),
+            "FK" => Ok(CountryCode::Fk),
+            "FM" => Ok(CountryCode::Fm),
+            "FO" => Ok(CountryCode::Fo),
+            "FR" => Ok(CountryCode::Fr),
+            "GA" => Ok(CountryCode::Ga),
+            "GB" => Ok(CountryCode::Gb),
+            "GD" => Ok(CountryCode::Gd),
+            "GE" => Ok(CountryCode::Ge),
+            "GH" => Ok(CountryCode::Gh),
+            "GI" => Ok(CountryCode::Gi),
+            "GL" => Ok(CountryCode::Gl),
+            "GM" => Ok(CountryCode::Gm),
+            "GN" => Ok(CountryCode::Gn),
+            "GQ" => Ok(CountryCode::Gq),
+            "GR" => Ok(CountryCode::Gr),
+            "GT" => Ok(CountryCode::Gt),
+            "GU" => Ok(CountryCode::Gu),
+            "GW" => Ok(CountryCode::Gw),
+            "GY" => Ok(CountryCode::Gy),
+            "HK" => Ok(CountryCode::Hk),
+            "HN" => Ok(CountryCode::Hn),
+            "HR" => Ok(CountryCode::Hr),
+            "HT" => Ok(CountryCode::Ht),
+            "HU" => Ok(CountryCode::Hu),
+            "ID" => Ok(CountryCode::Id),
+            "IE" => Ok(CountryCode::Ie),
+            "IL" => Ok(CountryCode::Il),
+            "IM" => Ok(CountryCode::Im),
+            "IN" => Ok(CountryCode::In),
+            "IQ" => Ok(CountryCode::Iq),
+            "IR" => Ok(CountryCode::Ir),
+            "IS" => Ok(CountryCode::Is),
+            "IT" => Ok(CountryCode::It),
+            "JM" => Ok(CountryCode::Jm),
+            "JO" => Ok(CountryCode::Jo),
+            "JP" => Ok(CountryCode::Jp),
+            "KE" => Ok(CountryCode::Ke),
+            "KG" => Ok(CountryCode::Kg),
+            "KH" => Ok(CountryCode::Kh),
+            "KI" => Ok(CountryCode::Ki),
+            "KM" => Ok(CountryCode::Km),
+            "KN" => Ok(CountryCode::Kn),
+            "KP" => Ok(CountryCode::Kp),
+            "KR" => Ok(CountryCode::Kr),
+            "KW" => Ok(CountryCode::Kw),
+            "KY" => Ok(CountryCode::Ky),
+            "KZ" => Ok(CountryCode::Kz),
+            "LA" => Ok(CountryCode::La),
+            "LB" => Ok(CountryCode::Lb),
+            "LC" => Ok(CountryCode::Lc),
+            "LI" => Ok(CountryCode::Li),
+            "LK" => Ok(CountryCode::Lk),
+            "LR" => Ok(CountryCode::Lr),
+            "LS" => Ok(CountryCode::Ls),
+            "LT" => Ok(CountryCode::Lt),
+            "LU" => Ok(CountryCode::Lu),
+            "LV" => Ok(CountryCode::Lv),
+            "LY" => Ok(CountryCode::Ly),
+            "MA" => Ok(CountryCode::Ma),
+            "MC" => Ok(CountryCode::Mc),
+            "MD" => Ok(CountryCode::Md),
+            "ME" => Ok(CountryCode::Me),
+            "MF" => Ok(CountryCode::Mf),
+            "MG" => Ok(CountryCode::Mg),
+            "MH" => Ok(CountryCode::Mh),
+            "MK" => Ok(CountryCode::Mk),
+            "ML" => Ok(CountryCode::Ml),
+            "MM" => Ok(CountryCode::Mm),
+            "MN" => Ok(CountryCode::Mn),
+            "MO" => Ok(CountryCode::Mo),
+            "MP" => Ok(CountryCode::Mp),
+            "MR" => Ok(CountryCode::Mr),
+            "MS" => Ok(CountryCode::Ms),
+            "MT" => Ok(CountryCode::Mt),
+            "MU" => Ok(CountryCode::Mu),
+            "MV" => Ok(CountryCode::Mv),
+            "MW" => Ok(CountryCode::Mw),
+            "MX" => Ok(CountryCode::Mx),
+            "MY" => Ok(CountryCode::My),
+            "MZ" => Ok(CountryCode::Mz),
+            "NA" => Ok(CountryCode::Na),
+            "NC" => Ok(CountryCode::Nc),
+            "NE" => Ok(CountryCode::Ne),
+            "NG" => Ok(CountryCode::Ng),
+            "NI" => Ok(CountryCode::Ni),
+            "NL" => Ok(CountryCode::Nl),
+            "NO" => Ok(CountryCode::No),
+            "NP" => Ok(CountryCode::Np),
+            "NR" => Ok(CountryCode::Nr),
+            "NU" => Ok(CountryCode::Nu),
+            "NZ" => Ok(CountryCode::Nz),
+            "OM" => Ok(CountryCode::Om),
+            "PA" => Ok(CountryCode::Pa),
+            "PE" => Ok(CountryCode::Pe),
+            "PF" => Ok(CountryCode::Pf),
+            "PG" => Ok(CountryCode::Pg),
+            "PH" => Ok(CountryCode::Ph),
+            "PK" => Ok(CountryCode::Pk),
+            "PL" => Ok(CountryCode::Pl),
+            "PM" => Ok(CountryCode::Pm),
+            "PN" => Ok(CountryCode::Pn),
+            "PR" => Ok(CountryCode::Pr),
+            "PT" => Ok(CountryCode::Pt),
+            "PW" => Ok(CountryCode::Pw),
+            "PY" => Ok(CountryCode::Py),
+            "QA" => Ok(CountryCode::Qa),
+            "RO" => Ok(CountryCode::Ro),
+            "RS" => Ok(CountryCode::Rs),
+            "RU" => Ok(CountryCode::Ru),
+            "RW" => Ok(CountryCode::Rw),
+            "SA" => Ok(CountryCode::Sa),
+            "SB" => Ok(CountryCode::Sb),
+            "SC" => Ok(CountryCode::Sc),
+            "SD" => Ok(CountryCode::Sd),
+            "SE" => Ok(CountryCode::Se),
+            "SG" => Ok(CountryCode::Sg),
+            "SH" => Ok(CountryCode::Sh),
+            "SI" => Ok(CountryCode::Si),
+            "SK" => Ok(CountryCode::Sk),
+            "SL" => Ok(CountryCode::Sl),
+            "SM" => Ok(CountryCode::Sm),
+            "SN" => Ok(CountryCode::Sn),
+            "SO" => Ok(CountryCode::So),
+            "SR" => Ok(CountryCode::Sr),
+            "ST" => Ok(CountryCode::St),
+            "SV" => Ok(CountryCode::Sv),
+            "SY" => Ok(CountryCode::Sy),
+            "SZ" => Ok(CountryCode::Sz),
+            "TC" => Ok(CountryCode::Tc),
+            "TD" => Ok(CountryCode::Td),
+            "TG" => Ok(CountryCode::Tg),
+            "TH" => Ok(CountryCode::Th),
+            "TJ" => Ok(CountryCode::Tj),
+            "TK" => Ok(CountryCode::Tk),
+            "TL" => Ok(CountryCode::Tl),
+            "TM" => Ok(CountryCode::Tm),
+            "TN" => Ok(CountryCode::Tn),
+            "TO" => Ok(CountryCode::To),
+            "TR" => Ok(CountryCode::Tr),
+            "TT" => Ok(CountryCode::Tt),
+            "TV" => Ok(CountryCode::Tv),
+            "TW" => Ok(CountryCode::Tw),
+            "TZ" => Ok(CountryCode::Tz),
+            "UA" => Ok(CountryCode::Ua),
+            "UG" => Ok(CountryCode::Ug),
+            "US" => Ok(CountryCode::Us),
+            "UY" => Ok(CountryCode::Uy),
+            "UZ" => Ok(CountryCode::Uz),
+            "VA" => Ok(CountryCode::Va),
+            "VC" => Ok(CountryCode::Vc),
+            "VE" => Ok(CountryCode::Ve),
+            "VG" => Ok(CountryCode::Vg),
+            "VI" => Ok(CountryCode::Vi),
+            "VN" => Ok(CountryCode::Vn),
+            "VU" => Ok(CountryCode::Vu),
+            "WF" => Ok(CountryCode::Wf),
+            "WS" => Ok(CountryCode::Ws),
+            "YE" => Ok(CountryCode::Ye),
+            "YT" => Ok(CountryCode::Yt),
+            "ZA" => Ok(CountryCode::Za),
+            "ZM" => Ok(CountryCode::Zm),
+            "ZW" => Ok(CountryCode::Zw),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The DeleteTagsForDomainRequest includes the following elements.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeleteTagsForDomainRequest {
@@ -170,6 +926,59 @@ pub struct DisableDomainTransferLockResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>"]
     #[serde(rename="OperationId")]
     pub operation_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainAvailability {
+    Available,
+    AvailablePreorder,
+    AvailableReserved,
+    DontKnow,
+    Reserved,
+    Unavailable,
+    UnavailablePremium,
+    UnavailableRestricted,
+}
+
+impl Into<String> for DomainAvailability {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainAvailability {
+    fn into(self) -> &'static str {
+        match self {
+            DomainAvailability::Available => "AVAILABLE",
+            DomainAvailability::AvailablePreorder => "AVAILABLE_PREORDER",
+            DomainAvailability::AvailableReserved => "AVAILABLE_RESERVED",
+            DomainAvailability::DontKnow => "DONT_KNOW",
+            DomainAvailability::Reserved => "RESERVED",
+            DomainAvailability::Unavailable => "UNAVAILABLE",
+            DomainAvailability::UnavailablePremium => "UNAVAILABLE_PREMIUM",
+            DomainAvailability::UnavailableRestricted => "UNAVAILABLE_RESTRICTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainAvailability {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(DomainAvailability::Available),
+            "AVAILABLE_PREORDER" => Ok(DomainAvailability::AvailablePreorder),
+            "AVAILABLE_RESERVED" => Ok(DomainAvailability::AvailableReserved),
+            "DONT_KNOW" => Ok(DomainAvailability::DontKnow),
+            "RESERVED" => Ok(DomainAvailability::Reserved),
+            "UNAVAILABLE" => Ok(DomainAvailability::Unavailable),
+            "UNAVAILABLE_PREMIUM" => Ok(DomainAvailability::UnavailablePremium),
+            "UNAVAILABLE_RESTRICTED" => Ok(DomainAvailability::UnavailableRestricted),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about one suggested domain name.</p>"]
@@ -240,6 +1049,98 @@ pub struct ExtraParam {
     #[doc="<p>Values corresponding to the additional parameter names required by some top-level domains.</p>"]
     #[serde(rename="Value")]
     pub value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExtraParamName {
+    AuIdNumber,
+    AuIdType,
+    BirthCity,
+    BirthCountry,
+    BirthDateInYyyyMmDd,
+    BirthDepartment,
+    BrandNumber,
+    CaBusinessEntityType,
+    CaLegalType,
+    DocumentNumber,
+    DunsNumber,
+    EsIdentification,
+    EsIdentificationType,
+    EsLegalForm,
+    FiBusinessNumber,
+    FiIdNumber,
+    ItPin,
+    RuPassportData,
+    SeIdNumber,
+    SgIdNumber,
+    VatNumber,
+}
+
+impl Into<String> for ExtraParamName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExtraParamName {
+    fn into(self) -> &'static str {
+        match self {
+            ExtraParamName::AuIdNumber => "AU_ID_NUMBER",
+            ExtraParamName::AuIdType => "AU_ID_TYPE",
+            ExtraParamName::BirthCity => "BIRTH_CITY",
+            ExtraParamName::BirthCountry => "BIRTH_COUNTRY",
+            ExtraParamName::BirthDateInYyyyMmDd => "BIRTH_DATE_IN_YYYY_MM_DD",
+            ExtraParamName::BirthDepartment => "BIRTH_DEPARTMENT",
+            ExtraParamName::BrandNumber => "BRAND_NUMBER",
+            ExtraParamName::CaBusinessEntityType => "CA_BUSINESS_ENTITY_TYPE",
+            ExtraParamName::CaLegalType => "CA_LEGAL_TYPE",
+            ExtraParamName::DocumentNumber => "DOCUMENT_NUMBER",
+            ExtraParamName::DunsNumber => "DUNS_NUMBER",
+            ExtraParamName::EsIdentification => "ES_IDENTIFICATION",
+            ExtraParamName::EsIdentificationType => "ES_IDENTIFICATION_TYPE",
+            ExtraParamName::EsLegalForm => "ES_LEGAL_FORM",
+            ExtraParamName::FiBusinessNumber => "FI_BUSINESS_NUMBER",
+            ExtraParamName::FiIdNumber => "FI_ID_NUMBER",
+            ExtraParamName::ItPin => "IT_PIN",
+            ExtraParamName::RuPassportData => "RU_PASSPORT_DATA",
+            ExtraParamName::SeIdNumber => "SE_ID_NUMBER",
+            ExtraParamName::SgIdNumber => "SG_ID_NUMBER",
+            ExtraParamName::VatNumber => "VAT_NUMBER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExtraParamName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AU_ID_NUMBER" => Ok(ExtraParamName::AuIdNumber),
+            "AU_ID_TYPE" => Ok(ExtraParamName::AuIdType),
+            "BIRTH_CITY" => Ok(ExtraParamName::BirthCity),
+            "BIRTH_COUNTRY" => Ok(ExtraParamName::BirthCountry),
+            "BIRTH_DATE_IN_YYYY_MM_DD" => Ok(ExtraParamName::BirthDateInYyyyMmDd),
+            "BIRTH_DEPARTMENT" => Ok(ExtraParamName::BirthDepartment),
+            "BRAND_NUMBER" => Ok(ExtraParamName::BrandNumber),
+            "CA_BUSINESS_ENTITY_TYPE" => Ok(ExtraParamName::CaBusinessEntityType),
+            "CA_LEGAL_TYPE" => Ok(ExtraParamName::CaLegalType),
+            "DOCUMENT_NUMBER" => Ok(ExtraParamName::DocumentNumber),
+            "DUNS_NUMBER" => Ok(ExtraParamName::DunsNumber),
+            "ES_IDENTIFICATION" => Ok(ExtraParamName::EsIdentification),
+            "ES_IDENTIFICATION_TYPE" => Ok(ExtraParamName::EsIdentificationType),
+            "ES_LEGAL_FORM" => Ok(ExtraParamName::EsLegalForm),
+            "FI_BUSINESS_NUMBER" => Ok(ExtraParamName::FiBusinessNumber),
+            "FI_ID_NUMBER" => Ok(ExtraParamName::FiIdNumber),
+            "IT_PIN" => Ok(ExtraParamName::ItPin),
+            "RU_PASSPORT_DATA" => Ok(ExtraParamName::RuPassportData),
+            "SE_ID_NUMBER" => Ok(ExtraParamName::SeIdNumber),
+            "SG_ID_NUMBER" => Ok(ExtraParamName::SgIdNumber),
+            "VAT_NUMBER" => Ok(ExtraParamName::VatNumber),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -490,6 +1391,50 @@ pub struct Nameserver {
     pub name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationStatus {
+    Error,
+    Failed,
+    InProgress,
+    Submitted,
+    Successful,
+}
+
+impl Into<String> for OperationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            OperationStatus::Error => "ERROR",
+            OperationStatus::Failed => "FAILED",
+            OperationStatus::InProgress => "IN_PROGRESS",
+            OperationStatus::Submitted => "SUBMITTED",
+            OperationStatus::Successful => "SUCCESSFUL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ERROR" => Ok(OperationStatus::Error),
+            "FAILED" => Ok(OperationStatus::Failed),
+            "IN_PROGRESS" => Ok(OperationStatus::InProgress),
+            "SUBMITTED" => Ok(OperationStatus::Submitted),
+            "SUCCESSFUL" => Ok(OperationStatus::Successful),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>OperationSummary includes the following elements.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct OperationSummary {
@@ -505,6 +1450,94 @@ pub struct OperationSummary {
     #[doc="<p>Type of the action requested.</p>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationType {
+    ChangePrivacyProtection,
+    DeleteDomain,
+    DomainLock,
+    RegisterDomain,
+    TransferInDomain,
+    UpdateDomainContact,
+    UpdateNameserver,
+}
+
+impl Into<String> for OperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationType {
+    fn into(self) -> &'static str {
+        match self {
+            OperationType::ChangePrivacyProtection => "CHANGE_PRIVACY_PROTECTION",
+            OperationType::DeleteDomain => "DELETE_DOMAIN",
+            OperationType::DomainLock => "DOMAIN_LOCK",
+            OperationType::RegisterDomain => "REGISTER_DOMAIN",
+            OperationType::TransferInDomain => "TRANSFER_IN_DOMAIN",
+            OperationType::UpdateDomainContact => "UPDATE_DOMAIN_CONTACT",
+            OperationType::UpdateNameserver => "UPDATE_NAMESERVER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHANGE_PRIVACY_PROTECTION" => Ok(OperationType::ChangePrivacyProtection),
+            "DELETE_DOMAIN" => Ok(OperationType::DeleteDomain),
+            "DOMAIN_LOCK" => Ok(OperationType::DomainLock),
+            "REGISTER_DOMAIN" => Ok(OperationType::RegisterDomain),
+            "TRANSFER_IN_DOMAIN" => Ok(OperationType::TransferInDomain),
+            "UPDATE_DOMAIN_CONTACT" => Ok(OperationType::UpdateDomainContact),
+            "UPDATE_NAMESERVER" => Ok(OperationType::UpdateNameserver),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReachabilityStatus {
+    Done,
+    Expired,
+    Pending,
+}
+
+impl Into<String> for ReachabilityStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReachabilityStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReachabilityStatus::Done => "DONE",
+            ReachabilityStatus::Expired => "EXPIRED",
+            ReachabilityStatus::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReachabilityStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DONE" => Ok(ReachabilityStatus::Done),
+            "EXPIRED" => Ok(ReachabilityStatus::Expired),
+            "PENDING" => Ok(ReachabilityStatus::Pending),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The RegisterDomain request includes the following elements.</p>"]
@@ -3009,7 +4042,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CheckDomainAvailabilityResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CheckDomainAvailabilityError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3034,7 +4067,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteTagsForDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3063,7 +4096,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisableDomainAutoRenewResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3092,7 +4125,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisableDomainTransferLockResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DisableDomainTransferLockError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3118,7 +4151,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<EnableDomainAutoRenewResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3147,7 +4180,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<EnableDomainTransferLockResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(EnableDomainTransferLockError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3173,7 +4206,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetContactReachabilityStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetContactReachabilityStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3197,7 +4230,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDomainDetailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3226,7 +4259,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDomainSuggestionsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3254,7 +4287,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetOperationDetailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3281,7 +4314,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDomainsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListDomainsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3305,7 +4338,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListOperationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3332,7 +4365,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3359,7 +4392,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3386,7 +4419,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RenewDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RenewDomainError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3412,7 +4445,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ResendContactReachabilityEmailResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ResendContactReachabilityEmailError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3438,7 +4471,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RetrieveDomainAuthCodeResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3465,7 +4498,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<TransferDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3493,7 +4526,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDomainContactResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3522,7 +4555,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDomainContactPrivacyResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateDomainContactPrivacyError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3548,7 +4581,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDomainNameserversResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateDomainNameserversError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -3573,7 +4606,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateTagsForDomainResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -3600,7 +4633,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ViewBillingResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ViewBillingError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -11,19 +11,14 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 
-use std::str::FromStr;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
@@ -830,6 +825,38 @@ impl AnalyticsS3BucketDestinationSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AnalyticsS3ExportFileFormat {
+    Csv,
+}
+
+impl Into<String> for AnalyticsS3ExportFileFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AnalyticsS3ExportFileFormat {
+    fn into(self) -> &'static str {
+        match self {
+            AnalyticsS3ExportFileFormat::Csv => "CSV",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AnalyticsS3ExportFileFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CSV" => Ok(AnalyticsS3ExportFileFormat::Csv),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AnalyticsS3ExportFileFormatDeserializer;
 impl AnalyticsS3ExportFileFormatDeserializer {
     #[allow(unused_variables)]
@@ -921,6 +948,41 @@ impl BucketDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketAccelerateStatus {
+    Enabled,
+    Suspended,
+}
+
+impl Into<String> for BucketAccelerateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketAccelerateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BucketAccelerateStatus::Enabled => "Enabled",
+            BucketAccelerateStatus::Suspended => "Suspended",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketAccelerateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Enabled" => Ok(BucketAccelerateStatus::Enabled),
+            "Suspended" => Ok(BucketAccelerateStatus::Suspended),
+            _ => Err(()),
+        }
+    }
+}
+
 struct BucketAccelerateStatusDeserializer;
 impl BucketAccelerateStatusDeserializer {
     #[allow(unused_variables)]
@@ -946,6 +1008,47 @@ impl BucketAccelerateStatusSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketCannedACL {
+    AuthenticatedRead,
+    Private,
+    PublicRead,
+    PublicReadWrite,
+}
+
+impl Into<String> for BucketCannedACL {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketCannedACL {
+    fn into(self) -> &'static str {
+        match self {
+            BucketCannedACL::AuthenticatedRead => "authenticated-read",
+            BucketCannedACL::Private => "private",
+            BucketCannedACL::PublicRead => "public-read",
+            BucketCannedACL::PublicReadWrite => "public-read-write",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketCannedACL {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "authenticated-read" => Ok(BucketCannedACL::AuthenticatedRead),
+            "private" => Ok(BucketCannedACL::Private),
+            "public-read" => Ok(BucketCannedACL::PublicRead),
+            "public-read-write" => Ok(BucketCannedACL::PublicReadWrite),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Clone,Debug)]
 pub struct BucketLifecycleConfiguration {
     pub rules: Vec<LifecycleRule>,
@@ -960,6 +1063,68 @@ impl BucketLifecycleConfigurationSerializer {
         serialized += &LifecycleRulesSerializer::serialize("Rule", &obj.rules);
         serialized += &format!("</{name}>", name = name);
         serialized
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketLocationConstraint {
+    Eu,
+    ApNortheast1,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    CnNorth1,
+    EuCentral1,
+    EuWest1,
+    SaEast1,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for BucketLocationConstraint {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketLocationConstraint {
+    fn into(self) -> &'static str {
+        match self {
+            BucketLocationConstraint::Eu => "EU",
+            BucketLocationConstraint::ApNortheast1 => "ap-northeast-1",
+            BucketLocationConstraint::ApSouth1 => "ap-south-1",
+            BucketLocationConstraint::ApSoutheast1 => "ap-southeast-1",
+            BucketLocationConstraint::ApSoutheast2 => "ap-southeast-2",
+            BucketLocationConstraint::CnNorth1 => "cn-north-1",
+            BucketLocationConstraint::EuCentral1 => "eu-central-1",
+            BucketLocationConstraint::EuWest1 => "eu-west-1",
+            BucketLocationConstraint::SaEast1 => "sa-east-1",
+            BucketLocationConstraint::UsWest1 => "us-west-1",
+            BucketLocationConstraint::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketLocationConstraint {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EU" => Ok(BucketLocationConstraint::Eu),
+            "ap-northeast-1" => Ok(BucketLocationConstraint::ApNortheast1),
+            "ap-south-1" => Ok(BucketLocationConstraint::ApSouth1),
+            "ap-southeast-1" => Ok(BucketLocationConstraint::ApSoutheast1),
+            "ap-southeast-2" => Ok(BucketLocationConstraint::ApSoutheast2),
+            "cn-north-1" => Ok(BucketLocationConstraint::CnNorth1),
+            "eu-central-1" => Ok(BucketLocationConstraint::EuCentral1),
+            "eu-west-1" => Ok(BucketLocationConstraint::EuWest1),
+            "sa-east-1" => Ok(BucketLocationConstraint::SaEast1),
+            "us-west-1" => Ok(BucketLocationConstraint::UsWest1),
+            "us-west-2" => Ok(BucketLocationConstraint::UsWest2),
+            _ => Err(()),
+        }
     }
 }
 
@@ -1004,6 +1169,44 @@ impl BucketLoggingStatusSerializer {
         }
         serialized += &format!("</{name}>", name = name);
         serialized
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketLogsPermission {
+    FullControl,
+    Read,
+    Write,
+}
+
+impl Into<String> for BucketLogsPermission {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketLogsPermission {
+    fn into(self) -> &'static str {
+        match self {
+            BucketLogsPermission::FullControl => "FULL_CONTROL",
+            BucketLogsPermission::Read => "READ",
+            BucketLogsPermission::Write => "WRITE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketLogsPermission {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FULL_CONTROL" => Ok(BucketLogsPermission::FullControl),
+            "READ" => Ok(BucketLogsPermission::Read),
+            "WRITE" => Ok(BucketLogsPermission::Write),
+            _ => Err(()),
+        }
     }
 }
 
@@ -1054,6 +1257,41 @@ impl BucketNameSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketVersioningStatus {
+    Enabled,
+    Suspended,
+}
+
+impl Into<String> for BucketVersioningStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketVersioningStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BucketVersioningStatus::Enabled => "Enabled",
+            BucketVersioningStatus::Suspended => "Suspended",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketVersioningStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Enabled" => Ok(BucketVersioningStatus::Enabled),
+            "Suspended" => Ok(BucketVersioningStatus::Suspended),
+            _ => Err(()),
+        }
     }
 }
 
@@ -2171,7 +2409,7 @@ impl DaysDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2196,7 +2434,7 @@ impl DaysAfterInitiationDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2302,7 +2540,7 @@ impl DeleteMarkerDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2812,6 +3050,38 @@ impl EmailAddressSerializer {
     }
 }
 
+#[doc="Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EncodingType {
+    Url,
+}
+
+impl Into<String> for EncodingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EncodingType {
+    fn into(self) -> &'static str {
+        match self {
+            EncodingType::Url => "url",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EncodingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "url" => Ok(EncodingType::Url),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EncodingTypeDeserializer;
 impl EncodingTypeDeserializer {
     #[allow(unused_variables)]
@@ -2985,6 +3255,66 @@ impl ErrorsDeserializer {
 
     }
 }
+#[doc="Bucket event for which to send notifications."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Event {
+    S3ObjectCreated,
+    S3ObjectCreatedCompleteMultipartUpload,
+    S3ObjectCreatedCopy,
+    S3ObjectCreatedPost,
+    S3ObjectCreatedPut,
+    S3ObjectRemoved,
+    S3ObjectRemovedDelete,
+    S3ObjectRemovedDeleteMarkerCreated,
+    S3ReducedRedundancyLostObject,
+}
+
+impl Into<String> for Event {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Event {
+    fn into(self) -> &'static str {
+        match self {
+            Event::S3ObjectCreated => "s3:ObjectCreated:*",
+            Event::S3ObjectCreatedCompleteMultipartUpload => {
+                "s3:ObjectCreated:CompleteMultipartUpload"
+            }
+            Event::S3ObjectCreatedCopy => "s3:ObjectCreated:Copy",
+            Event::S3ObjectCreatedPost => "s3:ObjectCreated:Post",
+            Event::S3ObjectCreatedPut => "s3:ObjectCreated:Put",
+            Event::S3ObjectRemoved => "s3:ObjectRemoved:*",
+            Event::S3ObjectRemovedDelete => "s3:ObjectRemoved:Delete",
+            Event::S3ObjectRemovedDeleteMarkerCreated => "s3:ObjectRemoved:DeleteMarkerCreated",
+            Event::S3ReducedRedundancyLostObject => "s3:ReducedRedundancyLostObject",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Event {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "s3:ObjectCreated:*" => Ok(Event::S3ObjectCreated),
+            "s3:ObjectCreated:CompleteMultipartUpload" => {
+                Ok(Event::S3ObjectCreatedCompleteMultipartUpload)
+            }
+            "s3:ObjectCreated:Copy" => Ok(Event::S3ObjectCreatedCopy),
+            "s3:ObjectCreated:Post" => Ok(Event::S3ObjectCreatedPost),
+            "s3:ObjectCreated:Put" => Ok(Event::S3ObjectCreatedPut),
+            "s3:ObjectRemoved:*" => Ok(Event::S3ObjectRemoved),
+            "s3:ObjectRemoved:Delete" => Ok(Event::S3ObjectRemovedDelete),
+            "s3:ObjectRemoved:DeleteMarkerCreated" => Ok(Event::S3ObjectRemovedDeleteMarkerCreated),
+            "s3:ReducedRedundancyLostObject" => Ok(Event::S3ReducedRedundancyLostObject),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventDeserializer;
 impl EventDeserializer {
     #[allow(unused_variables)]
@@ -3051,6 +3381,41 @@ impl EventListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExpirationStatus {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for ExpirationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExpirationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExpirationStatus::Disabled => "Disabled",
+            ExpirationStatus::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExpirationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(ExpirationStatus::Disabled),
+            "Enabled" => Ok(ExpirationStatus::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ExpirationStatusDeserializer;
 impl ExpirationStatusDeserializer {
     #[allow(unused_variables)]
@@ -3083,7 +3448,7 @@ impl ExpiredObjectDeleteMarkerDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3287,6 +3652,41 @@ impl FilterRuleListSerializer {
             parts.push(FilterRuleSerializer::serialize(name, element));
         }
         parts.join("")
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FilterRuleName {
+    Prefix,
+    Suffix,
+}
+
+impl Into<String> for FilterRuleName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FilterRuleName {
+    fn into(self) -> &'static str {
+        match self {
+            FilterRuleName::Prefix => "prefix",
+            FilterRuleName::Suffix => "suffix",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FilterRuleName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "prefix" => Ok(FilterRuleName::Prefix),
+            "suffix" => Ok(FilterRuleName::Suffix),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5208,6 +5608,38 @@ impl InventoryFilterSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryFormat {
+    Csv,
+}
+
+impl Into<String> for InventoryFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryFormat {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryFormat::Csv => "CSV",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CSV" => Ok(InventoryFormat::Csv),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InventoryFormatDeserializer;
 impl InventoryFormatDeserializer {
     #[allow(unused_variables)]
@@ -5230,6 +5662,41 @@ impl InventoryFormatSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryFrequency {
+    Daily,
+    Weekly,
+}
+
+impl Into<String> for InventoryFrequency {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryFrequency {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryFrequency::Daily => "Daily",
+            InventoryFrequency::Weekly => "Weekly",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryFrequency {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Daily" => Ok(InventoryFrequency::Daily),
+            "Weekly" => Ok(InventoryFrequency::Weekly),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5283,6 +5750,41 @@ impl InventoryIdSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryIncludedObjectVersions {
+    All,
+    Current,
+}
+
+impl Into<String> for InventoryIncludedObjectVersions {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryIncludedObjectVersions {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryIncludedObjectVersions::All => "All",
+            InventoryIncludedObjectVersions::Current => "Current",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryIncludedObjectVersions {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(InventoryIncludedObjectVersions::All),
+            "Current" => Ok(InventoryIncludedObjectVersions::Current),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InventoryIncludedObjectVersionsDeserializer;
 impl InventoryIncludedObjectVersionsDeserializer {
     #[allow(unused_variables)]
@@ -5305,6 +5807,53 @@ impl InventoryIncludedObjectVersionsSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryOptionalField {
+    Etag,
+    IsMultipartUploaded,
+    LastModifiedDate,
+    ReplicationStatus,
+    Size,
+    StorageClass,
+}
+
+impl Into<String> for InventoryOptionalField {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryOptionalField {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryOptionalField::Etag => "ETag",
+            InventoryOptionalField::IsMultipartUploaded => "IsMultipartUploaded",
+            InventoryOptionalField::LastModifiedDate => "LastModifiedDate",
+            InventoryOptionalField::ReplicationStatus => "ReplicationStatus",
+            InventoryOptionalField::Size => "Size",
+            InventoryOptionalField::StorageClass => "StorageClass",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryOptionalField {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ETag" => Ok(InventoryOptionalField::Etag),
+            "IsMultipartUploaded" => Ok(InventoryOptionalField::IsMultipartUploaded),
+            "LastModifiedDate" => Ok(InventoryOptionalField::LastModifiedDate),
+            "ReplicationStatus" => Ok(InventoryOptionalField::ReplicationStatus),
+            "Size" => Ok(InventoryOptionalField::Size),
+            "StorageClass" => Ok(InventoryOptionalField::StorageClass),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5542,7 +6091,7 @@ impl IsEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5567,7 +6116,7 @@ impl IsLatestDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5581,7 +6130,7 @@ impl IsTruncatedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5595,7 +6144,7 @@ impl KeyCountDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7253,6 +7802,41 @@ impl LoggingEnabledSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MFADelete {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for MFADelete {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MFADelete {
+    fn into(self) -> &'static str {
+        match self {
+            MFADelete::Disabled => "Disabled",
+            MFADelete::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MFADelete {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(MFADelete::Disabled),
+            "Enabled" => Ok(MFADelete::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
 pub struct MFADeleteSerializer;
 impl MFADeleteSerializer {
     #[allow(unused_variables, warnings)]
@@ -7260,6 +7844,41 @@ impl MFADeleteSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MFADeleteStatus {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for MFADeleteStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MFADeleteStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MFADeleteStatus::Disabled => "Disabled",
+            MFADeleteStatus::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MFADeleteStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(MFADeleteStatus::Disabled),
+            "Enabled" => Ok(MFADeleteStatus::Enabled),
+            _ => Err(()),
+        }
     }
 }
 
@@ -7309,7 +7928,7 @@ impl MaxAgeSecondsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7334,7 +7953,7 @@ impl MaxKeysDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7359,7 +7978,7 @@ impl MaxPartsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7384,7 +8003,7 @@ impl MaxUploadsDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7416,6 +8035,41 @@ impl MessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetadataDirective {
+    Copy,
+    Replace,
+}
+
+impl Into<String> for MetadataDirective {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetadataDirective {
+    fn into(self) -> &'static str {
+        match self {
+            MetadataDirective::Copy => "COPY",
+            MetadataDirective::Replace => "REPLACE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetadataDirective {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COPY" => Ok(MetadataDirective::Copy),
+            "REPLACE" => Ok(MetadataDirective::Replace),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Clone,Debug)]
 pub struct MetricsAndOperator {
     #[doc="The prefix used when evaluating an AND predicate."]
@@ -7852,7 +8506,7 @@ impl NextPartNumberMarkerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -8397,6 +9051,56 @@ impl ObjectDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ObjectCannedACL {
+    AuthenticatedRead,
+    AwsExecRead,
+    BucketOwnerFullControl,
+    BucketOwnerRead,
+    Private,
+    PublicRead,
+    PublicReadWrite,
+}
+
+impl Into<String> for ObjectCannedACL {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ObjectCannedACL {
+    fn into(self) -> &'static str {
+        match self {
+            ObjectCannedACL::AuthenticatedRead => "authenticated-read",
+            ObjectCannedACL::AwsExecRead => "aws-exec-read",
+            ObjectCannedACL::BucketOwnerFullControl => "bucket-owner-full-control",
+            ObjectCannedACL::BucketOwnerRead => "bucket-owner-read",
+            ObjectCannedACL::Private => "private",
+            ObjectCannedACL::PublicRead => "public-read",
+            ObjectCannedACL::PublicReadWrite => "public-read-write",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ObjectCannedACL {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "authenticated-read" => Ok(ObjectCannedACL::AuthenticatedRead),
+            "aws-exec-read" => Ok(ObjectCannedACL::AwsExecRead),
+            "bucket-owner-full-control" => Ok(ObjectCannedACL::BucketOwnerFullControl),
+            "bucket-owner-read" => Ok(ObjectCannedACL::BucketOwnerRead),
+            "private" => Ok(ObjectCannedACL::Private),
+            "public-read" => Ok(ObjectCannedACL::PublicRead),
+            "public-read-write" => Ok(ObjectCannedACL::PublicReadWrite),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Clone,Debug)]
 pub struct ObjectIdentifier {
     #[doc="Key name of the object to delete."]
@@ -8486,6 +9190,44 @@ impl ObjectListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ObjectStorageClass {
+    Glacier,
+    ReducedRedundancy,
+    Standard,
+}
+
+impl Into<String> for ObjectStorageClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ObjectStorageClass {
+    fn into(self) -> &'static str {
+        match self {
+            ObjectStorageClass::Glacier => "GLACIER",
+            ObjectStorageClass::ReducedRedundancy => "REDUCED_REDUNDANCY",
+            ObjectStorageClass::Standard => "STANDARD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ObjectStorageClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GLACIER" => Ok(ObjectStorageClass::Glacier),
+            "REDUCED_REDUNDANCY" => Ok(ObjectStorageClass::ReducedRedundancy),
+            "STANDARD" => Ok(ObjectStorageClass::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ObjectStorageClassDeserializer;
 impl ObjectStorageClassDeserializer {
     #[allow(unused_variables)]
@@ -8638,6 +9380,38 @@ impl ObjectVersionListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ObjectVersionStorageClass {
+    Standard,
+}
+
+impl Into<String> for ObjectVersionStorageClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ObjectVersionStorageClass {
+    fn into(self) -> &'static str {
+        match self {
+            ObjectVersionStorageClass::Standard => "STANDARD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ObjectVersionStorageClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "STANDARD" => Ok(ObjectVersionStorageClass::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ObjectVersionStorageClassDeserializer;
 impl ObjectVersionStorageClassDeserializer {
     #[allow(unused_variables)]
@@ -8794,7 +9568,7 @@ impl PartNumberDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -8819,7 +9593,7 @@ impl PartNumberMarkerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -8865,6 +9639,41 @@ impl PartsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Payer {
+    BucketOwner,
+    Requester,
+}
+
+impl Into<String> for Payer {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Payer {
+    fn into(self) -> &'static str {
+        match self {
+            Payer::BucketOwner => "BucketOwner",
+            Payer::Requester => "Requester",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Payer {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BucketOwner" => Ok(Payer::BucketOwner),
+            "Requester" => Ok(Payer::Requester),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PayerDeserializer;
 impl PayerDeserializer {
     #[allow(unused_variables)]
@@ -8887,6 +9696,50 @@ impl PayerSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Permission {
+    FullControl,
+    Read,
+    ReadAcp,
+    Write,
+    WriteAcp,
+}
+
+impl Into<String> for Permission {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Permission {
+    fn into(self) -> &'static str {
+        match self {
+            Permission::FullControl => "FULL_CONTROL",
+            Permission::Read => "READ",
+            Permission::ReadAcp => "READ_ACP",
+            Permission::Write => "WRITE",
+            Permission::WriteAcp => "WRITE_ACP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Permission {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FULL_CONTROL" => Ok(Permission::FullControl),
+            "READ" => Ok(Permission::Read),
+            "READ_ACP" => Ok(Permission::ReadAcp),
+            "WRITE" => Ok(Permission::Write),
+            "WRITE_ACP" => Ok(Permission::WriteAcp),
+            _ => Err(()),
+        }
     }
 }
 
@@ -8948,6 +9801,41 @@ impl PrefixSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Protocol {
+    Http,
+    Https,
+}
+
+impl Into<String> for Protocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Protocol {
+    fn into(self) -> &'static str {
+        match self {
+            Protocol::Http => "http",
+            Protocol::Https => "https",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Protocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http" => Ok(Protocol::Http),
+            "https" => Ok(Protocol::Https),
+            _ => Err(()),
+        }
     }
 }
 
@@ -9886,6 +10774,41 @@ impl ReplicationRuleSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationRuleStatus {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for ReplicationRuleStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationRuleStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationRuleStatus::Disabled => "Disabled",
+            ReplicationRuleStatus::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationRuleStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(ReplicationRuleStatus::Disabled),
+            "Enabled" => Ok(ReplicationRuleStatus::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReplicationRuleStatusDeserializer;
 impl ReplicationRuleStatusDeserializer {
     #[allow(unused_variables)]
@@ -9949,6 +10872,111 @@ impl ReplicationRulesSerializer {
             parts.push(ReplicationRuleSerializer::serialize(name, element));
         }
         parts.join("")
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationStatus {
+    Complete,
+    Failed,
+    Pending,
+    Replica,
+}
+
+impl Into<String> for ReplicationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationStatus::Complete => "COMPLETE",
+            ReplicationStatus::Failed => "FAILED",
+            ReplicationStatus::Pending => "PENDING",
+            ReplicationStatus::Replica => "REPLICA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETE" => Ok(ReplicationStatus::Complete),
+            "FAILED" => Ok(ReplicationStatus::Failed),
+            "PENDING" => Ok(ReplicationStatus::Pending),
+            "REPLICA" => Ok(ReplicationStatus::Replica),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="If present, indicates that the requester was successfully charged for the request."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequestCharged {
+    Requester,
+}
+
+impl Into<String> for RequestCharged {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequestCharged {
+    fn into(self) -> &'static str {
+        match self {
+            RequestCharged::Requester => "requester",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequestCharged {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "requester" => Ok(RequestCharged::Requester),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Confirms that the requester knows that she or he will be charged for the request. Bucket owners need not specify this parameter in their requests. Documentation on downloading objects from requester pays buckets can be found at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequestPayer {
+    Requester,
+}
+
+impl Into<String> for RequestPayer {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequestPayer {
+    fn into(self) -> &'static str {
+        match self {
+            RequestPayer::Requester => "requester",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequestPayer {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "requester" => Ok(RequestPayer::Requester),
+            _ => Err(()),
+        }
     }
 }
 
@@ -10458,6 +11486,41 @@ impl S3KeyFilterSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServerSideEncryption {
+    Aes256,
+    AwsKms,
+}
+
+impl Into<String> for ServerSideEncryption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServerSideEncryption {
+    fn into(self) -> &'static str {
+        match self {
+            ServerSideEncryption::Aes256 => "AES256",
+            ServerSideEncryption::AwsKms => "aws:kms",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServerSideEncryption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AES256" => Ok(ServerSideEncryption::Aes256),
+            "aws:kms" => Ok(ServerSideEncryption::AwsKms),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SizeDeserializer;
 impl SizeDeserializer {
     #[allow(unused_variables)]
@@ -10465,7 +11528,7 @@ impl SizeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -10494,6 +11557,44 @@ impl StartAfterSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StorageClass {
+    ReducedRedundancy,
+    Standard,
+    StandardIa,
+}
+
+impl Into<String> for StorageClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StorageClass {
+    fn into(self) -> &'static str {
+        match self {
+            StorageClass::ReducedRedundancy => "REDUCED_REDUNDANCY",
+            StorageClass::Standard => "STANDARD",
+            StorageClass::StandardIa => "STANDARD_IA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StorageClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "REDUCED_REDUNDANCY" => Ok(StorageClass::ReducedRedundancy),
+            "STANDARD" => Ok(StorageClass::Standard),
+            "STANDARD_IA" => Ok(StorageClass::StandardIa),
+            _ => Err(()),
+        }
     }
 }
 
@@ -10649,6 +11750,38 @@ impl StorageClassAnalysisDataExportSerializer {
                 value = obj.output_schema_version);
         serialized += &format!("</{name}>", name = name);
         serialized
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StorageClassAnalysisSchemaVersion {
+    V1,
+}
+
+impl Into<String> for StorageClassAnalysisSchemaVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StorageClassAnalysisSchemaVersion {
+    fn into(self) -> &'static str {
+        match self {
+            StorageClassAnalysisSchemaVersion::V1 => "V_1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StorageClassAnalysisSchemaVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "V_1" => Ok(StorageClassAnalysisSchemaVersion::V1),
+            _ => Err(()),
+        }
     }
 }
 
@@ -10840,6 +11973,41 @@ impl TaggingSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaggingDirective {
+    Copy,
+    Replace,
+}
+
+impl Into<String> for TaggingDirective {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaggingDirective {
+    fn into(self) -> &'static str {
+        match self {
+            TaggingDirective::Copy => "COPY",
+            TaggingDirective::Replace => "REPLACE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaggingDirective {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COPY" => Ok(TaggingDirective::Copy),
+            "REPLACE" => Ok(TaggingDirective::Replace),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TargetBucketDeserializer;
 impl TargetBucketDeserializer {
     #[allow(unused_variables)]
@@ -11014,6 +12182,44 @@ impl TargetPrefixSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Tier {
+    Bulk,
+    Expedited,
+    Standard,
+}
+
+impl Into<String> for Tier {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Tier {
+    fn into(self) -> &'static str {
+        match self {
+            Tier::Bulk => "Bulk",
+            Tier::Expedited => "Expedited",
+            Tier::Standard => "Standard",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Tier {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bulk" => Ok(Tier::Bulk),
+            "Expedited" => Ok(Tier::Expedited),
+            "Standard" => Ok(Tier::Standard),
+            _ => Err(()),
+        }
     }
 }
 
@@ -11397,6 +12603,41 @@ impl TransitionListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TransitionStorageClass {
+    Glacier,
+    StandardIa,
+}
+
+impl Into<String> for TransitionStorageClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TransitionStorageClass {
+    fn into(self) -> &'static str {
+        match self {
+            TransitionStorageClass::Glacier => "GLACIER",
+            TransitionStorageClass::StandardIa => "STANDARD_IA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TransitionStorageClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GLACIER" => Ok(TransitionStorageClass::Glacier),
+            "STANDARD_IA" => Ok(TransitionStorageClass::StandardIa),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TransitionStorageClassDeserializer;
 impl TransitionStorageClassDeserializer {
     #[allow(unused_variables)]
@@ -11419,6 +12660,44 @@ impl TransitionStorageClassSerializer {
         format!("<{name}>{value}</{name}>",
                 name = name,
                 value = obj.to_string())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Type {
+    AmazonCustomerByEmail,
+    CanonicalUser,
+    Group,
+}
+
+impl Into<String> for Type {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Type {
+    fn into(self) -> &'static str {
+        match self {
+            Type::AmazonCustomerByEmail => "AmazonCustomerByEmail",
+            Type::CanonicalUser => "CanonicalUser",
+            Type::Group => "Group",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Type {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AmazonCustomerByEmail" => Ok(Type::AmazonCustomerByEmail),
+            "CanonicalUser" => Ok(Type::CanonicalUser),
+            "Group" => Ok(Type::Group),
+            _ => Err(()),
+        }
     }
 }
 
@@ -16973,9 +18252,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -17045,9 +18324,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -17244,9 +18523,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -17364,9 +18643,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -17500,9 +18779,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -17585,9 +18864,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17622,9 +18901,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17656,9 +18935,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17694,9 +18973,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17728,9 +19007,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17765,9 +19044,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17799,9 +19078,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17836,9 +19115,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17870,9 +19149,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17907,9 +19186,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -17955,9 +19234,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18020,9 +19299,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18092,9 +19371,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18146,9 +19425,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18193,9 +19472,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18244,9 +19523,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18291,9 +19570,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18342,9 +19621,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18389,9 +19668,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18442,9 +19721,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18489,9 +19768,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18541,9 +19820,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18594,9 +19873,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18642,9 +19921,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18693,9 +19972,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18742,9 +20021,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result = GetBucketPolicyOutput::default();
                 result.policy = Some(String::from_utf8_lossy(&response.body).into_owned());
@@ -18782,9 +20061,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18835,9 +20114,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18882,9 +20161,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18934,9 +20213,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -18986,9 +20265,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19106,9 +20385,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result = GetObjectOutput::default();
                 result.body = Some(response.body);
@@ -19272,9 +20551,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19329,9 +20608,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19388,9 +20667,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result = GetObjectTorrentOutput::default();
                 result.body = Some(response.body);
@@ -19429,9 +20708,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19507,9 +20786,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19673,9 +20952,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19724,9 +21003,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19775,9 +21054,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19820,9 +21099,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19891,9 +21170,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -19966,9 +21245,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -20040,9 +21319,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -20118,9 +21397,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -20178,9 +21457,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -20242,9 +21521,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20313,9 +21592,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20354,9 +21633,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20401,9 +21680,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20442,9 +21721,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20498,9 +21777,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20555,9 +21834,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20597,9 +21876,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20639,9 +21918,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20679,9 +21958,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20723,9 +22002,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20763,9 +22042,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20816,9 +22095,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20859,9 +22138,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20906,9 +22185,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -20955,9 +22234,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -21000,9 +22279,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -21132,9 +22411,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -21268,9 +22547,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -21331,9 +22610,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -21402,9 +22681,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -21484,9 +22763,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 
@@ -21626,9 +22905,9 @@ impl<P, D> S3 for S3Client<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
 

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -581,7 +576,7 @@ impl IntegerDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -768,7 +763,7 @@ impl LongDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1953,7 +1948,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -1980,7 +1975,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2005,7 +2000,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2031,7 +2026,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2056,7 +2051,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2082,7 +2077,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2126,7 +2121,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2169,7 +2164,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2208,7 +2203,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2232,7 +2227,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -51,6 +47,44 @@ pub struct AccessLevelFilter {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccessLevelFilterKey {
+    Account,
+    Role,
+    User,
+}
+
+impl Into<String> for AccessLevelFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccessLevelFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            AccessLevelFilterKey::Account => "Account",
+            AccessLevelFilterKey::Role => "Role",
+            AccessLevelFilterKey::User => "User",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccessLevelFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Account" => Ok(AccessLevelFilterKey::Account),
+            "Role" => Ok(AccessLevelFilterKey::Role),
+            "User" => Ok(AccessLevelFilterKey::User),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1027,6 +1061,105 @@ pub struct Principal {
     pub principal_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PrincipalType {
+    Iam,
+}
+
+impl Into<String> for PrincipalType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PrincipalType {
+    fn into(self) -> &'static str {
+        match self {
+            PrincipalType::Iam => "IAM",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PrincipalType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IAM" => Ok(PrincipalType::Iam),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductSource {
+    Account,
+}
+
+impl Into<String> for ProductSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductSource {
+    fn into(self) -> &'static str {
+        match self {
+            ProductSource::Account => "ACCOUNT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(ProductSource::Account),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductType {
+    CloudFormationTemplate,
+    Marketplace,
+}
+
+impl Into<String> for ProductType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductType {
+    fn into(self) -> &'static str {
+        match self {
+            ProductType::CloudFormationTemplate => "CLOUD_FORMATION_TEMPLATE",
+            ProductType::Marketplace => "MARKETPLACE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLOUD_FORMATION_TEMPLATE" => Ok(ProductType::CloudFormationTemplate),
+            "MARKETPLACE" => Ok(ProductType::Marketplace),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A single product view aggregation value/count pair, containing metadata about each product to which the calling user has access.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ProductViewAggregationValue {
@@ -1059,6 +1192,85 @@ pub struct ProductViewDetail {
     #[serde(rename="Status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductViewFilterBy {
+    FullTextSearch,
+    Owner,
+    ProductType,
+    SourceProductId,
+}
+
+impl Into<String> for ProductViewFilterBy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductViewFilterBy {
+    fn into(self) -> &'static str {
+        match self {
+            ProductViewFilterBy::FullTextSearch => "FullTextSearch",
+            ProductViewFilterBy::Owner => "Owner",
+            ProductViewFilterBy::ProductType => "ProductType",
+            ProductViewFilterBy::SourceProductId => "SourceProductId",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductViewFilterBy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FullTextSearch" => Ok(ProductViewFilterBy::FullTextSearch),
+            "Owner" => Ok(ProductViewFilterBy::Owner),
+            "ProductType" => Ok(ProductViewFilterBy::ProductType),
+            "SourceProductId" => Ok(ProductViewFilterBy::SourceProductId),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductViewSortBy {
+    CreationDate,
+    Title,
+    VersionCount,
+}
+
+impl Into<String> for ProductViewSortBy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductViewSortBy {
+    fn into(self) -> &'static str {
+        match self {
+            ProductViewSortBy::CreationDate => "CreationDate",
+            ProductViewSortBy::Title => "Title",
+            ProductViewSortBy::VersionCount => "VersionCount",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductViewSortBy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreationDate" => Ok(ProductViewSortBy::CreationDate),
+            "Title" => Ok(ProductViewSortBy::Title),
+            "VersionCount" => Ok(ProductViewSortBy::VersionCount),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The summary metadata about the specified product.</p>"]
@@ -1195,6 +1407,47 @@ pub struct ProvisionedProductDetail {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProvisionedProductStatus {
+    Available,
+    Error,
+    Tainted,
+    UnderChange,
+}
+
+impl Into<String> for ProvisionedProductStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProvisionedProductStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ProvisionedProductStatus::Available => "AVAILABLE",
+            ProvisionedProductStatus::Error => "ERROR",
+            ProvisionedProductStatus::Tainted => "TAINTED",
+            ProvisionedProductStatus::UnderChange => "UNDER_CHANGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProvisionedProductStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(ProvisionedProductStatus::Available),
+            "ERROR" => Ok(ProvisionedProductStatus::Error),
+            "TAINTED" => Ok(ProvisionedProductStatus::Tainted),
+            "UNDER_CHANGE" => Ok(ProvisionedProductStatus::UnderChange),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information indicating the ways in which a product can be provisioned.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ProvisioningArtifact {
@@ -1315,6 +1568,44 @@ pub struct ProvisioningArtifactSummary {
     pub provisioning_artifact_metadata: Option<::std::collections::HashMap<String, String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProvisioningArtifactType {
+    CloudFormationTemplate,
+    MarketplaceAmi,
+    MarketplaceCar,
+}
+
+impl Into<String> for ProvisioningArtifactType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProvisioningArtifactType {
+    fn into(self) -> &'static str {
+        match self {
+            ProvisioningArtifactType::CloudFormationTemplate => "CLOUD_FORMATION_TEMPLATE",
+            ProvisioningArtifactType::MarketplaceAmi => "MARKETPLACE_AMI",
+            ProvisioningArtifactType::MarketplaceCar => "MARKETPLACE_CAR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProvisioningArtifactType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLOUD_FORMATION_TEMPLATE" => Ok(ProvisioningArtifactType::CloudFormationTemplate),
+            "MARKETPLACE_AMI" => Ok(ProvisioningArtifactType::MarketplaceAmi),
+            "MARKETPLACE_CAR" => Ok(ProvisioningArtifactType::MarketplaceCar),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The parameter key-value pairs used to provision a product.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ProvisioningParameter {
@@ -1413,6 +1704,50 @@ pub struct RecordOutput {
     #[serde(rename="OutputValue")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub output_value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecordStatus {
+    Created,
+    Failed,
+    InProgress,
+    InProgressInError,
+    Succeeded,
+}
+
+impl Into<String> for RecordStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecordStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RecordStatus::Created => "CREATED",
+            RecordStatus::Failed => "FAILED",
+            RecordStatus::InProgress => "IN_PROGRESS",
+            RecordStatus::InProgressInError => "IN_PROGRESS_IN_ERROR",
+            RecordStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecordStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATED" => Ok(RecordStatus::Created),
+            "FAILED" => Ok(RecordStatus::Failed),
+            "IN_PROGRESS" => Ok(RecordStatus::InProgress),
+            "IN_PROGRESS_IN_ERROR" => Ok(RecordStatus::InProgressInError),
+            "SUCCEEDED" => Ok(RecordStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A tag associated with the record, stored as a key-value pair.</p>"]
@@ -1565,6 +1900,79 @@ pub struct SearchProductsOutput {
     #[serde(rename="ProductViewSummaries")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub product_view_summaries: Option<Vec<ProductViewSummary>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+impl Into<String> for SortOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrder {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrder::Ascending => "ASCENDING",
+            SortOrder::Descending => "DESCENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASCENDING" => Ok(SortOrder::Ascending),
+            "DESCENDING" => Ok(SortOrder::Descending),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Status {
+    Available,
+    Creating,
+    Failed,
+}
+
+impl Into<String> for Status {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Status {
+    fn into(self) -> &'static str {
+        match self {
+            Status::Available => "AVAILABLE",
+            Status::Creating => "CREATING",
+            Status::Failed => "FAILED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Status {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(Status::Available),
+            "CREATING" => Ok(Status::Creating),
+            "FAILED" => Ok(Status::Failed),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Key/value pairs to associate with this provisioning. These tags are entirely discretionary and are propagated to the resources created in the provisioning.</p>"]
@@ -5684,7 +6092,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AcceptPortfolioShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5713,7 +6121,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AssociatePrincipalWithPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AssociatePrincipalWithPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5739,7 +6147,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AssociateProductWithPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(AssociateProductWithPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5764,7 +6172,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateConstraintOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5792,7 +6200,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreatePortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5820,7 +6228,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreatePortfolioShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5847,7 +6255,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5875,7 +6283,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateProvisioningArtifactOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateProvisioningArtifactError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5900,7 +6308,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteConstraintOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5928,7 +6336,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeletePortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5956,7 +6364,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeletePortfolioShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5983,7 +6391,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6011,7 +6419,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteProvisioningArtifactOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteProvisioningArtifactError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6036,7 +6444,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeConstraintOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6064,7 +6472,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribePortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6092,7 +6500,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6121,7 +6529,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeProductAsAdminOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6149,7 +6557,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeProductViewOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6178,7 +6586,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeProvisionedProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeProvisionedProductError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6204,7 +6612,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeProvisioningArtifactOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeProvisioningArtifactError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6230,7 +6638,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeProvisioningParametersOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeProvisioningParametersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6254,7 +6662,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeRecordOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6284,7 +6692,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisassociatePrincipalFromPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DisassociatePrincipalFromPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6310,7 +6718,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisassociateProductFromPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DisassociateProductFromPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6336,7 +6744,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAcceptedPortfolioSharesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListAcceptedPortfolioSharesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6362,7 +6770,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListConstraintsForPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListConstraintsForPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6387,7 +6795,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListLaunchPathsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6415,7 +6823,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPortfolioAccessOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6442,7 +6850,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPortfoliosOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6471,7 +6879,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPortfoliosForProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListPortfoliosForProductError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6497,7 +6905,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListPrincipalsForPortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListPrincipalsForPortfolioError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6523,7 +6931,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListProvisioningArtifactsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListProvisioningArtifactsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6548,7 +6956,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRecordHistoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6576,7 +6984,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ProvisionProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6604,7 +7012,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RejectPortfolioShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6633,7 +7041,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ScanProvisionedProductsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ScanProvisionedProductsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6657,7 +7065,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SearchProductsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6686,7 +7094,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SearchProductsAsAdminOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6715,7 +7123,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<TerminateProvisionedProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(TerminateProvisionedProductError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6740,7 +7148,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateConstraintOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6768,7 +7176,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdatePortfolioOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6795,7 +7203,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6823,7 +7231,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateProvisionedProductOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateProvisionedProductError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6849,7 +7257,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateProvisioningArtifactOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateProvisioningArtifactError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -189,6 +184,41 @@ impl AmazonResourceNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BehaviorOnMXFailure {
+    RejectMessage,
+    UseDefaultValue,
+}
+
+impl Into<String> for BehaviorOnMXFailure {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BehaviorOnMXFailure {
+    fn into(self) -> &'static str {
+        match self {
+            BehaviorOnMXFailure::RejectMessage => "RejectMessage",
+            BehaviorOnMXFailure::UseDefaultValue => "UseDefaultValue",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BehaviorOnMXFailure {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RejectMessage" => Ok(BehaviorOnMXFailure::RejectMessage),
+            "UseDefaultValue" => Ok(BehaviorOnMXFailure::UseDefaultValue),
+            _ => Err(()),
+        }
+    }
+}
+
 struct BehaviorOnMXFailureDeserializer;
 impl BehaviorOnMXFailureDeserializer {
     #[allow(unused_variables)]
@@ -373,6 +403,53 @@ impl BounceStatusCodeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BounceType {
+    ContentRejected,
+    DoesNotExist,
+    ExceededQuota,
+    MessageTooLarge,
+    TemporaryFailure,
+    Undefined,
+}
+
+impl Into<String> for BounceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BounceType {
+    fn into(self) -> &'static str {
+        match self {
+            BounceType::ContentRejected => "ContentRejected",
+            BounceType::DoesNotExist => "DoesNotExist",
+            BounceType::ExceededQuota => "ExceededQuota",
+            BounceType::MessageTooLarge => "MessageTooLarge",
+            BounceType::TemporaryFailure => "TemporaryFailure",
+            BounceType::Undefined => "Undefined",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BounceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ContentRejected" => Ok(BounceType::ContentRejected),
+            "DoesNotExist" => Ok(BounceType::DoesNotExist),
+            "ExceededQuota" => Ok(BounceType::ExceededQuota),
+            "MessageTooLarge" => Ok(BounceType::MessageTooLarge),
+            "TemporaryFailure" => Ok(BounceType::TemporaryFailure),
+            "Undefined" => Ok(BounceType::Undefined),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\">Amazon SES Developer Guide</a>.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct BouncedRecipientInfo {
@@ -755,6 +832,38 @@ impl ConfigurationSetSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigurationSetAttribute {
+    EventDestinations,
+}
+
+impl Into<String> for ConfigurationSetAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigurationSetAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigurationSetAttribute::EventDestinations => "eventDestinations",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigurationSetAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "eventDestinations" => Ok(ConfigurationSetAttribute::EventDestinations),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `ConfigurationSetAttributeList` contents to a `SignedRequest`.
 struct ConfigurationSetAttributeListSerializer;
 impl ConfigurationSetAttributeListSerializer {
@@ -855,7 +964,7 @@ impl CounterDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1091,6 +1200,47 @@ impl CreateReceiptRuleSetResponseDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CustomMailFromStatus {
+    Failed,
+    Pending,
+    Success,
+    TemporaryFailure,
+}
+
+impl Into<String> for CustomMailFromStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CustomMailFromStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CustomMailFromStatus::Failed => "Failed",
+            CustomMailFromStatus::Pending => "Pending",
+            CustomMailFromStatus::Success => "Success",
+            CustomMailFromStatus::TemporaryFailure => "TemporaryFailure",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CustomMailFromStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(CustomMailFromStatus::Failed),
+            "Pending" => Ok(CustomMailFromStatus::Pending),
+            "Success" => Ok(CustomMailFromStatus::Success),
+            "TemporaryFailure" => Ok(CustomMailFromStatus::TemporaryFailure),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CustomMailFromStatusDeserializer;
 impl CustomMailFromStatusDeserializer {
     #[allow(unused_variables)]
@@ -1824,6 +1974,41 @@ impl DimensionNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DimensionValueSource {
+    EmailHeader,
+    MessageTag,
+}
+
+impl Into<String> for DimensionValueSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DimensionValueSource {
+    fn into(self) -> &'static str {
+        match self {
+            DimensionValueSource::EmailHeader => "emailHeader",
+            DimensionValueSource::MessageTag => "messageTag",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DimensionValueSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "emailHeader" => Ok(DimensionValueSource::EmailHeader),
+            "messageTag" => Ok(DimensionValueSource::MessageTag),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DimensionValueSourceDeserializer;
 impl DimensionValueSourceDeserializer {
     #[allow(unused_variables)]
@@ -1862,6 +2047,50 @@ impl DkimAttributesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DsnAction {
+    Delayed,
+    Delivered,
+    Expanded,
+    Failed,
+    Relayed,
+}
+
+impl Into<String> for DsnAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DsnAction {
+    fn into(self) -> &'static str {
+        match self {
+            DsnAction::Delayed => "delayed",
+            DsnAction::Delivered => "delivered",
+            DsnAction::Expanded => "expanded",
+            DsnAction::Failed => "failed",
+            DsnAction::Relayed => "relayed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DsnAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "delayed" => Ok(DsnAction::Delayed),
+            "delivered" => Ok(DsnAction::Delivered),
+            "expanded" => Ok(DsnAction::Expanded),
+            "failed" => Ok(DsnAction::Failed),
+            "relayed" => Ok(DsnAction::Relayed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EnabledDeserializer;
 impl EnabledDeserializer {
     #[allow(unused_variables)]
@@ -1869,7 +2098,7 @@ impl EnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2041,6 +2270,50 @@ impl EventDestinationsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    Bounce,
+    Complaint,
+    Delivery,
+    Reject,
+    Send,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::Bounce => "bounce",
+            EventType::Complaint => "complaint",
+            EventType::Delivery => "delivery",
+            EventType::Reject => "reject",
+            EventType::Send => "send",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bounce" => Ok(EventType::Bounce),
+            "complaint" => Ok(EventType::Complaint),
+            "delivery" => Ok(EventType::Delivery),
+            "reject" => Ok(EventType::Reject),
+            "send" => Ok(EventType::Send),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventTypeDeserializer;
 impl EventTypeDeserializer {
     #[allow(unused_variables)]
@@ -2954,6 +3227,41 @@ impl IdentityNotificationAttributesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IdentityType {
+    Domain,
+    EmailAddress,
+}
+
+impl Into<String> for IdentityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IdentityType {
+    fn into(self) -> &'static str {
+        match self {
+            IdentityType::Domain => "Domain",
+            IdentityType::EmailAddress => "EmailAddress",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IdentityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Domain" => Ok(IdentityType::Domain),
+            "EmailAddress" => Ok(IdentityType::EmailAddress),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the verification attributes of a single identity.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct IdentityVerificationAttributes {
@@ -3011,6 +3319,41 @@ impl IdentityVerificationAttributesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvocationType {
+    Event,
+    RequestResponse,
+}
+
+impl Into<String> for InvocationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvocationType {
+    fn into(self) -> &'static str {
+        match self {
+            InvocationType::Event => "Event",
+            InvocationType::RequestResponse => "RequestResponse",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvocationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Event" => Ok(InvocationType::Event),
+            "RequestResponse" => Ok(InvocationType::RequestResponse),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InvocationTypeDeserializer;
 impl InvocationTypeDeserializer {
     #[allow(unused_variables)]
@@ -3678,7 +4021,7 @@ impl Max24HourSendDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3692,7 +4035,7 @@ impl MaxSendRateDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3863,6 +4206,44 @@ impl NotificationTopicDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotificationType {
+    Bounce,
+    Complaint,
+    Delivery,
+}
+
+impl Into<String> for NotificationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotificationType {
+    fn into(self) -> &'static str {
+        match self {
+            NotificationType::Bounce => "Bounce",
+            NotificationType::Complaint => "Complaint",
+            NotificationType::Delivery => "Delivery",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotificationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bounce" => Ok(NotificationType::Bounce),
+            "Complaint" => Ok(NotificationType::Complaint),
+            "Delivery" => Ok(NotificationType::Delivery),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PolicyDeserializer;
 impl PolicyDeserializer {
     #[allow(unused_variables)]
@@ -4359,6 +4740,41 @@ impl ReceiptFilterNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReceiptFilterPolicy {
+    Allow,
+    Block,
+}
+
+impl Into<String> for ReceiptFilterPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReceiptFilterPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ReceiptFilterPolicy::Allow => "Allow",
+            ReceiptFilterPolicy::Block => "Block",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReceiptFilterPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Allow" => Ok(ReceiptFilterPolicy::Allow),
+            "Block" => Ok(ReceiptFilterPolicy::Block),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReceiptFilterPolicyDeserializer;
 impl ReceiptFilterPolicyDeserializer {
     #[allow(unused_variables)]
@@ -5103,6 +5519,41 @@ impl SNSActionSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SNSActionEncoding {
+    Base64,
+    Utf8,
+}
+
+impl Into<String> for SNSActionEncoding {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SNSActionEncoding {
+    fn into(self) -> &'static str {
+        match self {
+            SNSActionEncoding::Base64 => "Base64",
+            SNSActionEncoding::Utf8 => "UTF-8",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SNSActionEncoding {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Base64" => Ok(SNSActionEncoding::Base64),
+            "UTF-8" => Ok(SNSActionEncoding::Utf8),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SNSActionEncodingDeserializer;
 impl SNSActionEncodingDeserializer {
     #[allow(unused_variables)]
@@ -5565,7 +6016,7 @@ impl SentLast24HoursDeserializer {
                                        stack: &mut T)
                                        -> Result<f64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = f64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<f64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5994,6 +6445,38 @@ impl StopActionSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StopScope {
+    RuleSet,
+}
+
+impl Into<String> for StopScope {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StopScope {
+    fn into(self) -> &'static str {
+        match self {
+            StopScope::RuleSet => "RuleSet",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StopScope {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RuleSet" => Ok(StopScope::RuleSet),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StopScopeDeserializer;
 impl StopScopeDeserializer {
     #[allow(unused_variables)]
@@ -6022,6 +6505,41 @@ impl TimestampDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TlsPolicy {
+    Optional,
+    Require,
+}
+
+impl Into<String> for TlsPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TlsPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            TlsPolicy::Optional => "Optional",
+            TlsPolicy::Require => "Require",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TlsPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Optional" => Ok(TlsPolicy::Optional),
+            "Require" => Ok(TlsPolicy::Require),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TlsPolicyDeserializer;
 impl TlsPolicyDeserializer {
     #[allow(unused_variables)]
@@ -6158,6 +6676,50 @@ impl VerificationAttributesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VerificationStatus {
+    Failed,
+    NotStarted,
+    Pending,
+    Success,
+    TemporaryFailure,
+}
+
+impl Into<String> for VerificationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VerificationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            VerificationStatus::Failed => "Failed",
+            VerificationStatus::NotStarted => "NotStarted",
+            VerificationStatus::Pending => "Pending",
+            VerificationStatus::Success => "Success",
+            VerificationStatus::TemporaryFailure => "TemporaryFailure",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VerificationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(VerificationStatus::Failed),
+            "NotStarted" => Ok(VerificationStatus::NotStarted),
+            "Pending" => Ok(VerificationStatus::Pending),
+            "Success" => Ok(VerificationStatus::Success),
+            "TemporaryFailure" => Ok(VerificationStatus::TemporaryFailure),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VerificationStatusDeserializer;
 impl VerificationStatusDeserializer {
     #[allow(unused_variables)]
@@ -10236,7 +10798,7 @@ impl<P, D> Ses for SesClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10281,7 +10843,7 @@ impl<P, D> Ses for SesClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10324,7 +10886,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10366,7 +10928,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10410,7 +10972,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10455,7 +11017,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10501,7 +11063,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10544,7 +11106,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10586,7 +11148,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10631,7 +11193,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10676,7 +11238,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10720,7 +11282,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10765,7 +11327,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10810,7 +11372,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -10837,7 +11399,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10880,7 +11442,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10924,7 +11486,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -10969,7 +11531,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11015,7 +11577,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11059,7 +11621,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11103,7 +11665,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11145,7 +11707,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11191,7 +11753,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11231,7 +11793,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11272,7 +11834,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11317,7 +11879,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11362,7 +11924,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11407,7 +11969,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11452,7 +12014,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11496,7 +12058,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11540,7 +12102,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11582,7 +12144,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11627,7 +12189,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11672,7 +12234,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11711,7 +12273,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11752,7 +12314,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11796,7 +12358,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11841,7 +12403,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11884,7 +12446,7 @@ fn set_identity_feedback_forwarding_enabled(&self, input: &SetIdentityFeedbackFo
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11926,7 +12488,7 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -11969,7 +12531,7 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12012,7 +12574,7 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12055,7 +12617,7 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12098,7 +12660,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12140,7 +12702,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12184,7 +12746,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12229,7 +12791,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -12274,7 +12836,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12301,7 +12863,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -59,6 +55,73 @@ pub struct Connector {
     #[serde(rename="vmManagerType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vm_manager_type: Option<String>,
+}
+
+#[doc="Capabilities for a Connector"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectorCapability {
+    Vsphere,
+}
+
+impl Into<String> for ConnectorCapability {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectorCapability {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectorCapability::Vsphere => "VSPHERE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectorCapability {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "VSPHERE" => Ok(ConnectorCapability::Vsphere),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Status of on-premise Connector"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectorStatus {
+    Healthy,
+    Unhealthy,
+}
+
+impl Into<String> for ConnectorStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectorStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectorStatus::Healthy => "HEALTHY",
+            ConnectorStatus::Unhealthy => "UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectorStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HEALTHY" => Ok(ConnectorStatus::Healthy),
+            "UNHEALTHY" => Ok(ConnectorStatus::Unhealthy),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -211,6 +274,41 @@ pub struct ImportServerCatalogRequest;
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ImportServerCatalogResponse;
 
+#[doc="The license type to be used for the Amazon Machine Image (AMI) created after a successful ReplicationRun."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LicenseType {
+    Aws,
+    Byol,
+}
+
+impl Into<String> for LicenseType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LicenseType {
+    fn into(self) -> &'static str {
+        match self {
+            LicenseType::Aws => "AWS",
+            LicenseType::Byol => "BYOL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LicenseType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(LicenseType::Aws),
+            "BYOL" => Ok(LicenseType::Byol),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Object representing a Replication Job"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ReplicationJob {
@@ -258,6 +356,50 @@ pub struct ReplicationJob {
     pub vm_server: Option<VmServer>,
 }
 
+#[doc="Current state of Replication Job"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationJobState {
+    Active,
+    Deleted,
+    Deleting,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for ReplicationJobState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationJobState {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationJobState::Active => "ACTIVE",
+            ReplicationJobState::Deleted => "DELETED",
+            ReplicationJobState::Deleting => "DELETING",
+            ReplicationJobState::Failed => "FAILED",
+            ReplicationJobState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationJobState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ReplicationJobState::Active),
+            "DELETED" => Ok(ReplicationJobState::Deleted),
+            "DELETING" => Ok(ReplicationJobState::Deleting),
+            "FAILED" => Ok(ReplicationJobState::Failed),
+            "PENDING" => Ok(ReplicationJobState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Object representing a Replication Run"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ReplicationRun {
@@ -287,6 +429,91 @@ pub struct ReplicationRun {
     pub type_: Option<String>,
 }
 
+#[doc="Current state of Replication Run"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationRunState {
+    Active,
+    Completed,
+    Deleted,
+    Deleting,
+    Failed,
+    Missed,
+    Pending,
+}
+
+impl Into<String> for ReplicationRunState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationRunState {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationRunState::Active => "ACTIVE",
+            ReplicationRunState::Completed => "COMPLETED",
+            ReplicationRunState::Deleted => "DELETED",
+            ReplicationRunState::Deleting => "DELETING",
+            ReplicationRunState::Failed => "FAILED",
+            ReplicationRunState::Missed => "MISSED",
+            ReplicationRunState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationRunState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ReplicationRunState::Active),
+            "COMPLETED" => Ok(ReplicationRunState::Completed),
+            "DELETED" => Ok(ReplicationRunState::Deleted),
+            "DELETING" => Ok(ReplicationRunState::Deleting),
+            "FAILED" => Ok(ReplicationRunState::Failed),
+            "MISSED" => Ok(ReplicationRunState::Missed),
+            "PENDING" => Ok(ReplicationRunState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Type of Replication Run"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationRunType {
+    Automatic,
+    OnDemand,
+}
+
+impl Into<String> for ReplicationRunType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationRunType {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationRunType::Automatic => "AUTOMATIC",
+            ReplicationRunType::OnDemand => "ON_DEMAND",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationRunType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AUTOMATIC" => Ok(ReplicationRunType::Automatic),
+            "ON_DEMAND" => Ok(ReplicationRunType::OnDemand),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Object representing a server"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Server {
@@ -305,6 +532,82 @@ pub struct Server {
     #[serde(rename="vmServer")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vm_server: Option<VmServer>,
+}
+
+#[doc="Status of Server catalog"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServerCatalogStatus {
+    Available,
+    Deleted,
+    Expired,
+    Importing,
+    NotImported,
+}
+
+impl Into<String> for ServerCatalogStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServerCatalogStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ServerCatalogStatus::Available => "AVAILABLE",
+            ServerCatalogStatus::Deleted => "DELETED",
+            ServerCatalogStatus::Expired => "EXPIRED",
+            ServerCatalogStatus::Importing => "IMPORTING",
+            ServerCatalogStatus::NotImported => "NOT_IMPORTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServerCatalogStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(ServerCatalogStatus::Available),
+            "DELETED" => Ok(ServerCatalogStatus::Deleted),
+            "EXPIRED" => Ok(ServerCatalogStatus::Expired),
+            "IMPORTING" => Ok(ServerCatalogStatus::Importing),
+            "NOT_IMPORTED" => Ok(ServerCatalogStatus::NotImported),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Type of server."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServerType {
+    VirtualMachine,
+}
+
+impl Into<String> for ServerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServerType {
+    fn into(self) -> &'static str {
+        match self {
+            ServerType::VirtualMachine => "VIRTUAL_MACHINE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "VIRTUAL_MACHINE" => Ok(ServerType::VirtualMachine),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -346,6 +649,38 @@ pub struct UpdateReplicationJobRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UpdateReplicationJobResponse;
+
+#[doc="VM Management Product"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VmManagerType {
+    Vsphere,
+}
+
+impl Into<String> for VmManagerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VmManagerType {
+    fn into(self) -> &'static str {
+        match self {
+            VmManagerType::Vsphere => "VSPHERE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VmManagerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "VSPHERE" => Ok(VmManagerType::Vsphere),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="Object representing a VM server"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -1479,7 +1814,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateReplicationJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1508,7 +1843,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteReplicationJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1534,7 +1869,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteServerCatalogResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1563,7 +1898,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisassociateConnectorResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1591,7 +1926,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetConnectorsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1618,7 +1953,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetReplicationJobsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1646,7 +1981,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetReplicationRunsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1674,7 +2009,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetServersResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetServersError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1697,7 +2032,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ImportServerCatalogResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1726,7 +2061,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartOnDemandReplicationRunResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StartOnDemandReplicationRunError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1752,7 +2087,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateReplicationJobResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -183,6 +179,50 @@ pub struct ClusterMetadata {
     #[serde(rename="SnowballType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub snowball_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClusterState {
+    AwaitingQuorum,
+    Cancelled,
+    Complete,
+    InUse,
+    Pending,
+}
+
+impl Into<String> for ClusterState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClusterState {
+    fn into(self) -> &'static str {
+        match self {
+            ClusterState::AwaitingQuorum => "AwaitingQuorum",
+            ClusterState::Cancelled => "Cancelled",
+            ClusterState::Complete => "Complete",
+            ClusterState::InUse => "InUse",
+            ClusterState::Pending => "Pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClusterState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AwaitingQuorum" => Ok(ClusterState::AwaitingQuorum),
+            "Cancelled" => Ok(ClusterState::Cancelled),
+            "Complete" => Ok(ClusterState::Complete),
+            "InUse" => Ok(ClusterState::InUse),
+            "Pending" => Ok(ClusterState::Pending),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -591,6 +631,109 @@ pub struct JobResource {
     pub s3_resources: Option<Vec<S3Resource>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobState {
+    Cancelled,
+    Complete,
+    InProgress,
+    InTransitToAWS,
+    InTransitToCustomer,
+    Listing,
+    New,
+    Pending,
+    PreparingAppliance,
+    PreparingShipment,
+    WithAWS,
+    WithCustomer,
+}
+
+impl Into<String> for JobState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobState {
+    fn into(self) -> &'static str {
+        match self {
+            JobState::Cancelled => "Cancelled",
+            JobState::Complete => "Complete",
+            JobState::InProgress => "InProgress",
+            JobState::InTransitToAWS => "InTransitToAWS",
+            JobState::InTransitToCustomer => "InTransitToCustomer",
+            JobState::Listing => "Listing",
+            JobState::New => "New",
+            JobState::Pending => "Pending",
+            JobState::PreparingAppliance => "PreparingAppliance",
+            JobState::PreparingShipment => "PreparingShipment",
+            JobState::WithAWS => "WithAWS",
+            JobState::WithCustomer => "WithCustomer",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(JobState::Cancelled),
+            "Complete" => Ok(JobState::Complete),
+            "InProgress" => Ok(JobState::InProgress),
+            "InTransitToAWS" => Ok(JobState::InTransitToAWS),
+            "InTransitToCustomer" => Ok(JobState::InTransitToCustomer),
+            "Listing" => Ok(JobState::Listing),
+            "New" => Ok(JobState::New),
+            "Pending" => Ok(JobState::Pending),
+            "PreparingAppliance" => Ok(JobState::PreparingAppliance),
+            "PreparingShipment" => Ok(JobState::PreparingShipment),
+            "WithAWS" => Ok(JobState::WithAWS),
+            "WithCustomer" => Ok(JobState::WithCustomer),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobType {
+    Export,
+    Import,
+    LocalUse,
+}
+
+impl Into<String> for JobType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobType {
+    fn into(self) -> &'static str {
+        match self {
+            JobType::Export => "EXPORT",
+            JobType::Import => "IMPORT",
+            JobType::LocalUse => "LOCAL_USE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EXPORT" => Ok(JobType::Export),
+            "IMPORT" => Ok(JobType::Import),
+            "LOCAL_USE" => Ok(JobType::LocalUse),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains a key range. For export jobs, a <code>S3Resource</code> object can have an optional <code>KeyRange</code> value. The length of the range is defined at job creation, and has either an inclusive <code>BeginMarker</code>, an inclusive <code>EndMarker</code>, or both. Ranges are UTF-8 binary sorted.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeyRange {
@@ -750,6 +893,123 @@ pub struct ShippingDetails {
     #[serde(rename="ShippingOption")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub shipping_option: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShippingOption {
+    Express,
+    NextDay,
+    SecondDay,
+    Standard,
+}
+
+impl Into<String> for ShippingOption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShippingOption {
+    fn into(self) -> &'static str {
+        match self {
+            ShippingOption::Express => "EXPRESS",
+            ShippingOption::NextDay => "NEXT_DAY",
+            ShippingOption::SecondDay => "SECOND_DAY",
+            ShippingOption::Standard => "STANDARD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShippingOption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EXPRESS" => Ok(ShippingOption::Express),
+            "NEXT_DAY" => Ok(ShippingOption::NextDay),
+            "SECOND_DAY" => Ok(ShippingOption::SecondDay),
+            "STANDARD" => Ok(ShippingOption::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnowballCapacity {
+    NoPreference,
+    T100,
+    T50,
+    T80,
+}
+
+impl Into<String> for SnowballCapacity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnowballCapacity {
+    fn into(self) -> &'static str {
+        match self {
+            SnowballCapacity::NoPreference => "NoPreference",
+            SnowballCapacity::T100 => "T100",
+            SnowballCapacity::T50 => "T50",
+            SnowballCapacity::T80 => "T80",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnowballCapacity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NoPreference" => Ok(SnowballCapacity::NoPreference),
+            "T100" => Ok(SnowballCapacity::T100),
+            "T50" => Ok(SnowballCapacity::T50),
+            "T80" => Ok(SnowballCapacity::T80),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnowballType {
+    Edge,
+    Standard,
+}
+
+impl Into<String> for SnowballType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnowballType {
+    fn into(self) -> &'static str {
+        match self {
+            SnowballType::Edge => "EDGE",
+            SnowballType::Standard => "STANDARD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnowballType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EDGE" => Ok(SnowballType::Edge),
+            "STANDARD" => Ok(SnowballType::Standard),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2341,7 +2601,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CancelClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2366,7 +2626,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<CancelJobResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -2393,7 +2653,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAddressResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2420,7 +2680,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2445,7 +2705,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<CreateJobResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -2472,7 +2732,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAddressResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2500,7 +2760,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAddressesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2528,7 +2788,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2556,7 +2816,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeJobResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeJobError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2581,7 +2841,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetJobManifestResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2609,7 +2869,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetJobUnlockCodeResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2634,7 +2894,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetSnowballUsageResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2662,7 +2922,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListClusterJobsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2690,7 +2950,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListClustersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2714,7 +2974,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ListJobsResult>(String::from_utf8_lossy(&response.body)
                                                               .as_ref())
                            .unwrap())
@@ -2741,7 +3001,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateClusterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2766,7 +3026,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<UpdateJobResult>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -132,7 +127,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5251,7 +5246,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -5278,7 +5273,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5320,7 +5315,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5365,7 +5360,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5407,7 +5402,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5451,7 +5446,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5490,7 +5485,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -5517,7 +5512,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -5541,7 +5536,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -5566,7 +5561,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5612,7 +5607,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5654,7 +5649,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5699,7 +5694,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5741,7 +5736,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5787,7 +5782,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5830,7 +5825,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5875,7 +5870,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5919,7 +5914,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -5964,7 +5959,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -6006,7 +6001,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -6047,7 +6042,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -6089,7 +6084,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -6130,7 +6125,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6157,7 +6152,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6184,7 +6179,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6210,7 +6205,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -6254,7 +6249,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6280,7 +6275,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6305,7 +6300,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -6344,7 +6339,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -275,7 +270,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1439,6 +1434,60 @@ impl MessageSystemAttributeMapDeserializer {
         Ok(obj)
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MessageSystemAttributeName {
+    ApproximateFirstReceiveTimestamp,
+    ApproximateReceiveCount,
+    MessageDeduplicationId,
+    MessageGroupId,
+    SenderId,
+    SentTimestamp,
+    SequenceNumber,
+}
+
+impl Into<String> for MessageSystemAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MessageSystemAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            MessageSystemAttributeName::ApproximateFirstReceiveTimestamp => {
+                "ApproximateFirstReceiveTimestamp"
+            }
+            MessageSystemAttributeName::ApproximateReceiveCount => "ApproximateReceiveCount",
+            MessageSystemAttributeName::MessageDeduplicationId => "MessageDeduplicationId",
+            MessageSystemAttributeName::MessageGroupId => "MessageGroupId",
+            MessageSystemAttributeName::SenderId => "SenderId",
+            MessageSystemAttributeName::SentTimestamp => "SentTimestamp",
+            MessageSystemAttributeName::SequenceNumber => "SequenceNumber",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MessageSystemAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ApproximateFirstReceiveTimestamp" => {
+                Ok(MessageSystemAttributeName::ApproximateFirstReceiveTimestamp)
+            }
+            "ApproximateReceiveCount" => Ok(MessageSystemAttributeName::ApproximateReceiveCount),
+            "MessageDeduplicationId" => Ok(MessageSystemAttributeName::MessageDeduplicationId),
+            "MessageGroupId" => Ok(MessageSystemAttributeName::MessageGroupId),
+            "SenderId" => Ok(MessageSystemAttributeName::SenderId),
+            "SentTimestamp" => Ok(MessageSystemAttributeName::SentTimestamp),
+            "SequenceNumber" => Ok(MessageSystemAttributeName::SequenceNumber),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MessageSystemAttributeNameDeserializer;
 impl MessageSystemAttributeNameDeserializer {
     #[allow(unused_variables)]
@@ -1507,6 +1556,99 @@ impl QueueAttributeMapSerializer {
             let prefix = format!("{}.{}", name, index + 1);
             params.put(&format!("{}.{}", prefix, "Name"), &key);
             params.put(&key, &value);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QueueAttributeName {
+    All,
+    ApproximateNumberOfMessages,
+    ApproximateNumberOfMessagesDelayed,
+    ApproximateNumberOfMessagesNotVisible,
+    ContentBasedDeduplication,
+    CreatedTimestamp,
+    DelaySeconds,
+    FifoQueue,
+    KmsDataKeyReusePeriodSeconds,
+    KmsMasterKeyId,
+    LastModifiedTimestamp,
+    MaximumMessageSize,
+    MessageRetentionPeriod,
+    Policy,
+    QueueArn,
+    ReceiveMessageWaitTimeSeconds,
+    RedrivePolicy,
+    VisibilityTimeout,
+}
+
+impl Into<String> for QueueAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QueueAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            QueueAttributeName::All => "All",
+            QueueAttributeName::ApproximateNumberOfMessages => "ApproximateNumberOfMessages",
+            QueueAttributeName::ApproximateNumberOfMessagesDelayed => {
+                "ApproximateNumberOfMessagesDelayed"
+            }
+            QueueAttributeName::ApproximateNumberOfMessagesNotVisible => {
+                "ApproximateNumberOfMessagesNotVisible"
+            }
+            QueueAttributeName::ContentBasedDeduplication => "ContentBasedDeduplication",
+            QueueAttributeName::CreatedTimestamp => "CreatedTimestamp",
+            QueueAttributeName::DelaySeconds => "DelaySeconds",
+            QueueAttributeName::FifoQueue => "FifoQueue",
+            QueueAttributeName::KmsDataKeyReusePeriodSeconds => "KmsDataKeyReusePeriodSeconds",
+            QueueAttributeName::KmsMasterKeyId => "KmsMasterKeyId",
+            QueueAttributeName::LastModifiedTimestamp => "LastModifiedTimestamp",
+            QueueAttributeName::MaximumMessageSize => "MaximumMessageSize",
+            QueueAttributeName::MessageRetentionPeriod => "MessageRetentionPeriod",
+            QueueAttributeName::Policy => "Policy",
+            QueueAttributeName::QueueArn => "QueueArn",
+            QueueAttributeName::ReceiveMessageWaitTimeSeconds => "ReceiveMessageWaitTimeSeconds",
+            QueueAttributeName::RedrivePolicy => "RedrivePolicy",
+            QueueAttributeName::VisibilityTimeout => "VisibilityTimeout",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QueueAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(QueueAttributeName::All),
+            "ApproximateNumberOfMessages" => Ok(QueueAttributeName::ApproximateNumberOfMessages),
+            "ApproximateNumberOfMessagesDelayed" => {
+                Ok(QueueAttributeName::ApproximateNumberOfMessagesDelayed)
+            }
+            "ApproximateNumberOfMessagesNotVisible" => {
+                Ok(QueueAttributeName::ApproximateNumberOfMessagesNotVisible)
+            }
+            "ContentBasedDeduplication" => Ok(QueueAttributeName::ContentBasedDeduplication),
+            "CreatedTimestamp" => Ok(QueueAttributeName::CreatedTimestamp),
+            "DelaySeconds" => Ok(QueueAttributeName::DelaySeconds),
+            "FifoQueue" => Ok(QueueAttributeName::FifoQueue),
+            "KmsDataKeyReusePeriodSeconds" => Ok(QueueAttributeName::KmsDataKeyReusePeriodSeconds),
+            "KmsMasterKeyId" => Ok(QueueAttributeName::KmsMasterKeyId),
+            "LastModifiedTimestamp" => Ok(QueueAttributeName::LastModifiedTimestamp),
+            "MaximumMessageSize" => Ok(QueueAttributeName::MaximumMessageSize),
+            "MessageRetentionPeriod" => Ok(QueueAttributeName::MessageRetentionPeriod),
+            "Policy" => Ok(QueueAttributeName::Policy),
+            "QueueArn" => Ok(QueueAttributeName::QueueArn),
+            "ReceiveMessageWaitTimeSeconds" => {
+                Ok(QueueAttributeName::ReceiveMessageWaitTimeSeconds)
+            }
+            "RedrivePolicy" => Ok(QueueAttributeName::RedrivePolicy),
+            "VisibilityTimeout" => Ok(QueueAttributeName::VisibilityTimeout),
+            _ => Err(()),
         }
     }
 }
@@ -3496,7 +3638,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3522,7 +3664,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3549,7 +3691,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3591,7 +3733,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3630,7 +3772,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3656,7 +3798,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3698,7 +3840,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3722,7 +3864,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3766,7 +3908,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3808,7 +3950,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3850,7 +3992,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3889,7 +4031,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3913,7 +4055,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -3957,7 +4099,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3984,7 +4126,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -4025,7 +4167,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -4069,7 +4211,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -192,6 +188,53 @@ pub struct AssociationFilter {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssociationFilterKey {
+    AssociationId,
+    AssociationStatusName,
+    InstanceId,
+    LastExecutedAfter,
+    LastExecutedBefore,
+    Name,
+}
+
+impl Into<String> for AssociationFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssociationFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            AssociationFilterKey::AssociationId => "AssociationId",
+            AssociationFilterKey::AssociationStatusName => "AssociationStatusName",
+            AssociationFilterKey::InstanceId => "InstanceId",
+            AssociationFilterKey::LastExecutedAfter => "LastExecutedAfter",
+            AssociationFilterKey::LastExecutedBefore => "LastExecutedBefore",
+            AssociationFilterKey::Name => "Name",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssociationFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AssociationId" => Ok(AssociationFilterKey::AssociationId),
+            "AssociationStatusName" => Ok(AssociationFilterKey::AssociationStatusName),
+            "InstanceId" => Ok(AssociationFilterKey::InstanceId),
+            "LastExecutedAfter" => Ok(AssociationFilterKey::LastExecutedAfter),
+            "LastExecutedBefore" => Ok(AssociationFilterKey::LastExecutedBefore),
+            "Name" => Ok(AssociationFilterKey::Name),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the association.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AssociationOverview {
@@ -225,6 +268,44 @@ pub struct AssociationStatus {
     #[doc="<p>The status.</p>"]
     #[serde(rename="Name")]
     pub name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssociationStatusName {
+    Failed,
+    Pending,
+    Success,
+}
+
+impl Into<String> for AssociationStatusName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssociationStatusName {
+    fn into(self) -> &'static str {
+        match self {
+            AssociationStatusName::Failed => "Failed",
+            AssociationStatusName::Pending => "Pending",
+            AssociationStatusName::Success => "Success",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssociationStatusName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(AssociationStatusName::Failed),
+            "Pending" => Ok(AssociationStatusName::Pending),
+            "Success" => Ok(AssociationStatusName::Success),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Detailed information about the current state of an individual Automation execution.</p>"]
@@ -283,6 +364,41 @@ pub struct AutomationExecutionFilter {
     pub values: Vec<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutomationExecutionFilterKey {
+    DocumentNamePrefix,
+    ExecutionStatus,
+}
+
+impl Into<String> for AutomationExecutionFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutomationExecutionFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            AutomationExecutionFilterKey::DocumentNamePrefix => "DocumentNamePrefix",
+            AutomationExecutionFilterKey::ExecutionStatus => "ExecutionStatus",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutomationExecutionFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DocumentNamePrefix" => Ok(AutomationExecutionFilterKey::DocumentNamePrefix),
+            "ExecutionStatus" => Ok(AutomationExecutionFilterKey::ExecutionStatus),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Details about a specific Automation execution.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AutomationExecutionMetadata {
@@ -322,6 +438,53 @@ pub struct AutomationExecutionMetadata {
     #[serde(rename="Outputs")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub outputs: Option<::std::collections::HashMap<String, Vec<String>>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutomationExecutionStatus {
+    Cancelled,
+    Failed,
+    InProgress,
+    Pending,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for AutomationExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutomationExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AutomationExecutionStatus::Cancelled => "Cancelled",
+            AutomationExecutionStatus::Failed => "Failed",
+            AutomationExecutionStatus::InProgress => "InProgress",
+            AutomationExecutionStatus::Pending => "Pending",
+            AutomationExecutionStatus::Success => "Success",
+            AutomationExecutionStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutomationExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(AutomationExecutionStatus::Cancelled),
+            "Failed" => Ok(AutomationExecutionStatus::Failed),
+            "InProgress" => Ok(AutomationExecutionStatus::InProgress),
+            "Pending" => Ok(AutomationExecutionStatus::Pending),
+            "Success" => Ok(AutomationExecutionStatus::Success),
+            "TimedOut" => Ok(AutomationExecutionStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -436,6 +599,44 @@ pub struct CommandFilter {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommandFilterKey {
+    InvokedAfter,
+    InvokedBefore,
+    Status,
+}
+
+impl Into<String> for CommandFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommandFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            CommandFilterKey::InvokedAfter => "InvokedAfter",
+            CommandFilterKey::InvokedBefore => "InvokedBefore",
+            CommandFilterKey::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommandFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InvokedAfter" => Ok(CommandFilterKey::InvokedAfter),
+            "InvokedBefore" => Ok(CommandFilterKey::InvokedBefore),
+            "Status" => Ok(CommandFilterKey::Status),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An invocation is copy of a command sent to a specific instance. A command can apply to one or more instances. A command invocation applies to one instance. For example, if a user executes SendCommand against three instances, then a command invocation is created for each requested instance ID. A command invocation returns status and detail information about a command you executed. </p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CommandInvocation {
@@ -496,6 +697,59 @@ pub struct CommandInvocation {
     pub trace_output: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommandInvocationStatus {
+    Cancelled,
+    Cancelling,
+    Delayed,
+    Failed,
+    InProgress,
+    Pending,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for CommandInvocationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommandInvocationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CommandInvocationStatus::Cancelled => "Cancelled",
+            CommandInvocationStatus::Cancelling => "Cancelling",
+            CommandInvocationStatus::Delayed => "Delayed",
+            CommandInvocationStatus::Failed => "Failed",
+            CommandInvocationStatus::InProgress => "InProgress",
+            CommandInvocationStatus::Pending => "Pending",
+            CommandInvocationStatus::Success => "Success",
+            CommandInvocationStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommandInvocationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(CommandInvocationStatus::Cancelled),
+            "Cancelling" => Ok(CommandInvocationStatus::Cancelling),
+            "Delayed" => Ok(CommandInvocationStatus::Delayed),
+            "Failed" => Ok(CommandInvocationStatus::Failed),
+            "InProgress" => Ok(CommandInvocationStatus::InProgress),
+            "Pending" => Ok(CommandInvocationStatus::Pending),
+            "Success" => Ok(CommandInvocationStatus::Success),
+            "TimedOut" => Ok(CommandInvocationStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes plugin details.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CommandPlugin {
@@ -547,6 +801,103 @@ pub struct CommandPlugin {
     #[serde(rename="StatusDetails")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status_details: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommandPluginStatus {
+    Cancelled,
+    Failed,
+    InProgress,
+    Pending,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for CommandPluginStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommandPluginStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CommandPluginStatus::Cancelled => "Cancelled",
+            CommandPluginStatus::Failed => "Failed",
+            CommandPluginStatus::InProgress => "InProgress",
+            CommandPluginStatus::Pending => "Pending",
+            CommandPluginStatus::Success => "Success",
+            CommandPluginStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommandPluginStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(CommandPluginStatus::Cancelled),
+            "Failed" => Ok(CommandPluginStatus::Failed),
+            "InProgress" => Ok(CommandPluginStatus::InProgress),
+            "Pending" => Ok(CommandPluginStatus::Pending),
+            "Success" => Ok(CommandPluginStatus::Success),
+            "TimedOut" => Ok(CommandPluginStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommandStatus {
+    Cancelled,
+    Cancelling,
+    Failed,
+    InProgress,
+    Pending,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for CommandStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommandStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CommandStatus::Cancelled => "Cancelled",
+            CommandStatus::Cancelling => "Cancelling",
+            CommandStatus::Failed => "Failed",
+            CommandStatus::InProgress => "InProgress",
+            CommandStatus::Pending => "Pending",
+            CommandStatus::Success => "Success",
+            CommandStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommandStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(CommandStatus::Cancelled),
+            "Cancelling" => Ok(CommandStatus::Cancelling),
+            "Failed" => Ok(CommandStatus::Failed),
+            "InProgress" => Ok(CommandStatus::InProgress),
+            "Pending" => Ok(CommandStatus::Pending),
+            "Success" => Ok(CommandStatus::Success),
+            "TimedOut" => Ok(CommandStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -951,6 +1302,44 @@ pub struct DescribeActivationsFilter {
     #[serde(rename="FilterValues")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub filter_values: Option<Vec<String>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DescribeActivationsFilterKeys {
+    ActivationIds,
+    DefaultInstanceName,
+    IamRole,
+}
+
+impl Into<String> for DescribeActivationsFilterKeys {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DescribeActivationsFilterKeys {
+    fn into(self) -> &'static str {
+        match self {
+            DescribeActivationsFilterKeys::ActivationIds => "ActivationIds",
+            DescribeActivationsFilterKeys::DefaultInstanceName => "DefaultInstanceName",
+            DescribeActivationsFilterKeys::IamRole => "IamRole",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DescribeActivationsFilterKeys {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivationIds" => Ok(DescribeActivationsFilterKeys::ActivationIds),
+            "DefaultInstanceName" => Ok(DescribeActivationsFilterKeys::DefaultInstanceName),
+            "IamRole" => Ok(DescribeActivationsFilterKeys::IamRole),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1695,6 +2084,82 @@ pub struct DocumentFilter {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentFilterKey {
+    DocumentType,
+    Name,
+    Owner,
+    PlatformTypes,
+}
+
+impl Into<String> for DocumentFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentFilterKey::DocumentType => "DocumentType",
+            DocumentFilterKey::Name => "Name",
+            DocumentFilterKey::Owner => "Owner",
+            DocumentFilterKey::PlatformTypes => "PlatformTypes",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DocumentType" => Ok(DocumentFilterKey::DocumentType),
+            "Name" => Ok(DocumentFilterKey::Name),
+            "Owner" => Ok(DocumentFilterKey::Owner),
+            "PlatformTypes" => Ok(DocumentFilterKey::PlatformTypes),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentHashType {
+    Sha1,
+    Sha256,
+}
+
+impl Into<String> for DocumentHashType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentHashType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentHashType::Sha1 => "Sha1",
+            DocumentHashType::Sha256 => "Sha256",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentHashType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Sha1" => Ok(DocumentHashType::Sha1),
+            "Sha256" => Ok(DocumentHashType::Sha256),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the name of an SSM document.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DocumentIdentifier {
@@ -1743,6 +2208,152 @@ pub struct DocumentParameter {
     #[serde(rename="Type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentParameterType {
+    String,
+    StringList,
+}
+
+impl Into<String> for DocumentParameterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentParameterType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentParameterType::String => "String",
+            DocumentParameterType::StringList => "StringList",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentParameterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "String" => Ok(DocumentParameterType::String),
+            "StringList" => Ok(DocumentParameterType::StringList),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentPermissionType {
+    Share,
+}
+
+impl Into<String> for DocumentPermissionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentPermissionType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentPermissionType::Share => "Share",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentPermissionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Share" => Ok(DocumentPermissionType::Share),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentStatus {
+    Active,
+    Creating,
+    Deleting,
+    Updating,
+}
+
+impl Into<String> for DocumentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentStatus::Active => "Active",
+            DocumentStatus::Creating => "Creating",
+            DocumentStatus::Deleting => "Deleting",
+            DocumentStatus::Updating => "Updating",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(DocumentStatus::Active),
+            "Creating" => Ok(DocumentStatus::Creating),
+            "Deleting" => Ok(DocumentStatus::Deleting),
+            "Updating" => Ok(DocumentStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentType {
+    Automation,
+    Command,
+    Policy,
+}
+
+impl Into<String> for DocumentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentType::Automation => "Automation",
+            DocumentType::Command => "Command",
+            DocumentType::Policy => "Policy",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Automation" => Ok(DocumentType::Automation),
+            "Command" => Ok(DocumentType::Command),
+            "Policy" => Ok(DocumentType::Policy),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Version information about the document.</p>"]
@@ -1811,6 +2422,44 @@ pub struct FailureDetails {
     #[serde(rename="FailureType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub failure_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Fault {
+    Client,
+    Server,
+    Unknown,
+}
+
+impl Into<String> for Fault {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Fault {
+    fn into(self) -> &'static str {
+        match self {
+            Fault::Client => "Client",
+            Fault::Server => "Server",
+            Fault::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Fault {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Client" => Ok(Fault::Client),
+            "Server" => Ok(Fault::Server),
+            "Unknown" => Ok(Fault::Unknown),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2552,6 +3201,59 @@ pub struct InstanceInformationFilter {
     pub value_set: Vec<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceInformationFilterKey {
+    ActivationIds,
+    AgentVersion,
+    AssociationStatus,
+    IamRole,
+    InstanceIds,
+    PingStatus,
+    PlatformTypes,
+    ResourceType,
+}
+
+impl Into<String> for InstanceInformationFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceInformationFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceInformationFilterKey::ActivationIds => "ActivationIds",
+            InstanceInformationFilterKey::AgentVersion => "AgentVersion",
+            InstanceInformationFilterKey::AssociationStatus => "AssociationStatus",
+            InstanceInformationFilterKey::IamRole => "IamRole",
+            InstanceInformationFilterKey::InstanceIds => "InstanceIds",
+            InstanceInformationFilterKey::PingStatus => "PingStatus",
+            InstanceInformationFilterKey::PlatformTypes => "PlatformTypes",
+            InstanceInformationFilterKey::ResourceType => "ResourceType",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceInformationFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivationIds" => Ok(InstanceInformationFilterKey::ActivationIds),
+            "AgentVersion" => Ok(InstanceInformationFilterKey::AgentVersion),
+            "AssociationStatus" => Ok(InstanceInformationFilterKey::AssociationStatus),
+            "IamRole" => Ok(InstanceInformationFilterKey::IamRole),
+            "InstanceIds" => Ok(InstanceInformationFilterKey::InstanceIds),
+            "PingStatus" => Ok(InstanceInformationFilterKey::PingStatus),
+            "PlatformTypes" => Ok(InstanceInformationFilterKey::PlatformTypes),
+            "ResourceType" => Ok(InstanceInformationFilterKey::ResourceType),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The filters to describe or get information about your managed instances.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct InstanceInformationStringFilter {
@@ -2628,6 +3330,82 @@ pub struct InstancePatchStateFilter {
     pub values: Vec<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstancePatchStateOperatorType {
+    Equal,
+    GreaterThan,
+    LessThan,
+    NotEqual,
+}
+
+impl Into<String> for InstancePatchStateOperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstancePatchStateOperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            InstancePatchStateOperatorType::Equal => "Equal",
+            InstancePatchStateOperatorType::GreaterThan => "GreaterThan",
+            InstancePatchStateOperatorType::LessThan => "LessThan",
+            InstancePatchStateOperatorType::NotEqual => "NotEqual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstancePatchStateOperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Equal" => Ok(InstancePatchStateOperatorType::Equal),
+            "GreaterThan" => Ok(InstancePatchStateOperatorType::GreaterThan),
+            "LessThan" => Ok(InstancePatchStateOperatorType::LessThan),
+            "NotEqual" => Ok(InstancePatchStateOperatorType::NotEqual),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryAttributeDataType {
+    Number,
+    String,
+}
+
+impl Into<String> for InventoryAttributeDataType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryAttributeDataType {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryAttributeDataType::Number => "number",
+            InventoryAttributeDataType::String => "string",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryAttributeDataType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "number" => Ok(InventoryAttributeDataType::Number),
+            "string" => Ok(InventoryAttributeDataType::String),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct InventoryFilter {
@@ -2689,6 +3467,50 @@ pub struct InventoryItemSchema {
     #[serde(rename="Version")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryQueryOperatorType {
+    BeginWith,
+    Equal,
+    GreaterThan,
+    LessThan,
+    NotEqual,
+}
+
+impl Into<String> for InventoryQueryOperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryQueryOperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryQueryOperatorType::BeginWith => "BeginWith",
+            InventoryQueryOperatorType::Equal => "Equal",
+            InventoryQueryOperatorType::GreaterThan => "GreaterThan",
+            InventoryQueryOperatorType::LessThan => "LessThan",
+            InventoryQueryOperatorType::NotEqual => "NotEqual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryQueryOperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BeginWith" => Ok(InventoryQueryOperatorType::BeginWith),
+            "Equal" => Ok(InventoryQueryOperatorType::Equal),
+            "GreaterThan" => Ok(InventoryQueryOperatorType::GreaterThan),
+            "LessThan" => Ok(InventoryQueryOperatorType::LessThan),
+            "NotEqual" => Ok(InventoryQueryOperatorType::NotEqual),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Inventory query results.</p>"]
@@ -2997,6 +3819,59 @@ pub struct MaintenanceWindowExecution {
     pub window_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaintenanceWindowExecutionStatus {
+    Cancelled,
+    Cancelling,
+    Failed,
+    InProgress,
+    Pending,
+    SkippedOverlapping,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for MaintenanceWindowExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaintenanceWindowExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MaintenanceWindowExecutionStatus::Cancelled => "CANCELLED",
+            MaintenanceWindowExecutionStatus::Cancelling => "CANCELLING",
+            MaintenanceWindowExecutionStatus::Failed => "FAILED",
+            MaintenanceWindowExecutionStatus::InProgress => "IN_PROGRESS",
+            MaintenanceWindowExecutionStatus::Pending => "PENDING",
+            MaintenanceWindowExecutionStatus::SkippedOverlapping => "SKIPPED_OVERLAPPING",
+            MaintenanceWindowExecutionStatus::Success => "SUCCESS",
+            MaintenanceWindowExecutionStatus::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaintenanceWindowExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(MaintenanceWindowExecutionStatus::Cancelled),
+            "CANCELLING" => Ok(MaintenanceWindowExecutionStatus::Cancelling),
+            "FAILED" => Ok(MaintenanceWindowExecutionStatus::Failed),
+            "IN_PROGRESS" => Ok(MaintenanceWindowExecutionStatus::InProgress),
+            "PENDING" => Ok(MaintenanceWindowExecutionStatus::Pending),
+            "SKIPPED_OVERLAPPING" => Ok(MaintenanceWindowExecutionStatus::SkippedOverlapping),
+            "SUCCESS" => Ok(MaintenanceWindowExecutionStatus::Success),
+            "TIMED_OUT" => Ok(MaintenanceWindowExecutionStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a task execution performed as part of a Maintenance Window execution.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct MaintenanceWindowExecutionTaskIdentity {
@@ -3121,6 +3996,38 @@ pub struct MaintenanceWindowIdentity {
     pub window_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaintenanceWindowResourceType {
+    Instance,
+}
+
+impl Into<String> for MaintenanceWindowResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaintenanceWindowResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            MaintenanceWindowResourceType::Instance => "INSTANCE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaintenanceWindowResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSTANCE" => Ok(MaintenanceWindowResourceType::Instance),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The target registered with the Maintenance Window.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct MaintenanceWindowTarget {
@@ -3205,6 +4112,38 @@ pub struct MaintenanceWindowTaskParameterValueExpression {
     pub values: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaintenanceWindowTaskType {
+    RunCommand,
+}
+
+impl Into<String> for MaintenanceWindowTaskType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaintenanceWindowTaskType {
+    fn into(self) -> &'static str {
+        match self {
+            MaintenanceWindowTaskType::RunCommand => "RUN_COMMAND",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaintenanceWindowTaskType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RUN_COMMAND" => Ok(MaintenanceWindowTaskType::RunCommand),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ModifyDocumentPermissionRequest {
     #[doc="<p>The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or <i>All</i>.</p>"]
@@ -3241,6 +4180,88 @@ pub struct NotificationConfig {
     #[serde(rename="NotificationType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub notification_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotificationEvent {
+    All,
+    Cancelled,
+    Failed,
+    InProgress,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for NotificationEvent {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotificationEvent {
+    fn into(self) -> &'static str {
+        match self {
+            NotificationEvent::All => "All",
+            NotificationEvent::Cancelled => "Cancelled",
+            NotificationEvent::Failed => "Failed",
+            NotificationEvent::InProgress => "InProgress",
+            NotificationEvent::Success => "Success",
+            NotificationEvent::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotificationEvent {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(NotificationEvent::All),
+            "Cancelled" => Ok(NotificationEvent::Cancelled),
+            "Failed" => Ok(NotificationEvent::Failed),
+            "InProgress" => Ok(NotificationEvent::InProgress),
+            "Success" => Ok(NotificationEvent::Success),
+            "TimedOut" => Ok(NotificationEvent::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotificationType {
+    Command,
+    Invocation,
+}
+
+impl Into<String> for NotificationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotificationType {
+    fn into(self) -> &'static str {
+        match self {
+            NotificationType::Command => "Command",
+            NotificationType::Invocation => "Invocation",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotificationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Command" => Ok(NotificationType::Command),
+            "Invocation" => Ok(NotificationType::Invocation),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An Amazon EC2 Systems Manager parameter in Parameter Store.</p>"]
@@ -3346,6 +4367,44 @@ pub struct ParameterStringFilter {
     pub values: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterType {
+    SecureString,
+    String,
+    StringList,
+}
+
+impl Into<String> for ParameterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterType {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterType::SecureString => "SecureString",
+            ParameterType::String => "String",
+            ParameterType::StringList => "StringList",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SecureString" => Ok(ParameterType::SecureString),
+            "String" => Ok(ParameterType::String),
+            "StringList" => Ok(ParameterType::StringList),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ParametersFilter {
@@ -3355,6 +4414,44 @@ pub struct ParametersFilter {
     #[doc="<p>The filter values.</p>"]
     #[serde(rename="Values")]
     pub values: Vec<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParametersFilterKey {
+    KeyId,
+    Name,
+    Type,
+}
+
+impl Into<String> for ParametersFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParametersFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            ParametersFilterKey::KeyId => "KeyId",
+            ParametersFilterKey::Name => "Name",
+            ParametersFilterKey::Type => "Type",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParametersFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KeyId" => Ok(ParametersFilterKey::KeyId),
+            "Name" => Ok(ParametersFilterKey::Name),
+            "Type" => Ok(ParametersFilterKey::Type),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents metadata about a patch.</p>"]
@@ -3458,6 +4555,91 @@ pub struct PatchComplianceData {
     pub title: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchComplianceDataState {
+    Failed,
+    Installed,
+    InstalledOther,
+    Missing,
+    NotApplicable,
+}
+
+impl Into<String> for PatchComplianceDataState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchComplianceDataState {
+    fn into(self) -> &'static str {
+        match self {
+            PatchComplianceDataState::Failed => "FAILED",
+            PatchComplianceDataState::Installed => "INSTALLED",
+            PatchComplianceDataState::InstalledOther => "INSTALLED_OTHER",
+            PatchComplianceDataState::Missing => "MISSING",
+            PatchComplianceDataState::NotApplicable => "NOT_APPLICABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchComplianceDataState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(PatchComplianceDataState::Failed),
+            "INSTALLED" => Ok(PatchComplianceDataState::Installed),
+            "INSTALLED_OTHER" => Ok(PatchComplianceDataState::InstalledOther),
+            "MISSING" => Ok(PatchComplianceDataState::Missing),
+            "NOT_APPLICABLE" => Ok(PatchComplianceDataState::NotApplicable),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchDeploymentStatus {
+    Approved,
+    ExplicitApproved,
+    ExplicitRejected,
+    PendingApproval,
+}
+
+impl Into<String> for PatchDeploymentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchDeploymentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PatchDeploymentStatus::Approved => "APPROVED",
+            PatchDeploymentStatus::ExplicitApproved => "EXPLICIT_APPROVED",
+            PatchDeploymentStatus::ExplicitRejected => "EXPLICIT_REJECTED",
+            PatchDeploymentStatus::PendingApproval => "PENDING_APPROVAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchDeploymentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPROVED" => Ok(PatchDeploymentStatus::Approved),
+            "EXPLICIT_APPROVED" => Ok(PatchDeploymentStatus::ExplicitApproved),
+            "EXPLICIT_REJECTED" => Ok(PatchDeploymentStatus::ExplicitRejected),
+            "PENDING_APPROVAL" => Ok(PatchDeploymentStatus::PendingApproval),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Defines a patch filter.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PatchFilter {
@@ -3477,6 +4659,47 @@ pub struct PatchFilterGroup {
     pub patch_filters: Vec<PatchFilter>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchFilterKey {
+    Classification,
+    MsrcSeverity,
+    PatchId,
+    Product,
+}
+
+impl Into<String> for PatchFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            PatchFilterKey::Classification => "CLASSIFICATION",
+            PatchFilterKey::MsrcSeverity => "MSRC_SEVERITY",
+            PatchFilterKey::PatchId => "PATCH_ID",
+            PatchFilterKey::Product => "PRODUCT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLASSIFICATION" => Ok(PatchFilterKey::Classification),
+            "MSRC_SEVERITY" => Ok(PatchFilterKey::MsrcSeverity),
+            "PATCH_ID" => Ok(PatchFilterKey::PatchId),
+            "PRODUCT" => Ok(PatchFilterKey::Product),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The mapping between a patch group and the patch baseline the patch group is registered with.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PatchGroupPatchBaselineMapping {
@@ -3488,6 +4711,41 @@ pub struct PatchGroupPatchBaselineMapping {
     #[serde(rename="PatchGroup")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub patch_group: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchOperationType {
+    Install,
+    Scan,
+}
+
+impl Into<String> for PatchOperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchOperationType {
+    fn into(self) -> &'static str {
+        match self {
+            PatchOperationType::Install => "Install",
+            PatchOperationType::Scan => "Scan",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchOperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Install" => Ok(PatchOperationType::Install),
+            "Scan" => Ok(PatchOperationType::Scan),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Defines a filter used in Patch Manager APIs.</p>"]
@@ -3533,6 +4791,79 @@ pub struct PatchStatus {
     #[serde(rename="DeploymentStatus")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub deployment_status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PingStatus {
+    ConnectionLost,
+    Inactive,
+    Online,
+}
+
+impl Into<String> for PingStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PingStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PingStatus::ConnectionLost => "ConnectionLost",
+            PingStatus::Inactive => "Inactive",
+            PingStatus::Online => "Online",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PingStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ConnectionLost" => Ok(PingStatus::ConnectionLost),
+            "Inactive" => Ok(PingStatus::Inactive),
+            "Online" => Ok(PingStatus::Online),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformType {
+    Linux,
+    Windows,
+}
+
+impl Into<String> for PlatformType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformType {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformType::Linux => "Linux",
+            PlatformType::Windows => "Windows",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Linux" => Ok(PlatformType::Linux),
+            "Windows" => Ok(PlatformType::Windows),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -3711,6 +5042,82 @@ pub struct RemoveTagsFromResourceRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoveTagsFromResourceResult;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    Document,
+    Ec2Instance,
+    ManagedInstance,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::Document => "Document",
+            ResourceType::Ec2Instance => "EC2Instance",
+            ResourceType::ManagedInstance => "ManagedInstance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Document" => Ok(ResourceType::Document),
+            "EC2Instance" => Ok(ResourceType::Ec2Instance),
+            "ManagedInstance" => Ok(ResourceType::ManagedInstance),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceTypeForTagging {
+    MaintenanceWindow,
+    ManagedInstance,
+    Parameter,
+}
+
+impl Into<String> for ResourceTypeForTagging {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceTypeForTagging {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceTypeForTagging::MaintenanceWindow => "MaintenanceWindow",
+            ResourceTypeForTagging::ManagedInstance => "ManagedInstance",
+            ResourceTypeForTagging::Parameter => "Parameter",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceTypeForTagging {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MaintenanceWindow" => Ok(ResourceTypeForTagging::MaintenanceWindow),
+            "ManagedInstance" => Ok(ResourceTypeForTagging::ManagedInstance),
+            "Parameter" => Ok(ResourceTypeForTagging::Parameter),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p>The inventory item result attribute.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
@@ -12045,7 +13452,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddTagsToResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12072,7 +13479,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CancelCommandResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12098,7 +13505,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateActivationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12125,7 +13532,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAssociationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12153,7 +13560,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateAssociationBatchResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12180,7 +13587,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12208,7 +13615,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12232,7 +13639,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreatePatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12259,7 +13666,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteActivationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12286,7 +13693,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteAssociationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12313,7 +13720,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12341,7 +13748,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12365,7 +13772,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteParameterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12392,7 +13799,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteParametersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12419,7 +13826,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeletePatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12447,7 +13854,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeregisterManagedInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeregisterManagedInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12474,7 +13881,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeregisterPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeregisterPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12497,7 +13904,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeregisterTargetFromMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeregisterTargetFromMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12524,7 +13931,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeregisterTaskFromMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeregisterTaskFromMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12548,7 +13955,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeActivationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12575,7 +13982,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAssociationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12603,7 +14010,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAutomationExecutionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeAutomationExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12628,7 +14035,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAvailablePatchesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeAvailablePatchesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12652,7 +14059,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -12680,7 +14087,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeDocumentPermissionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeDocumentPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12703,7 +14110,7 @@ fn describe_effective_instance_associations(&self, input: &DescribeEffectiveInst
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEffectiveInstanceAssociationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeEffectiveInstanceAssociationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12726,7 +14133,7 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeEffectivePatchesForPatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeEffectivePatchesForPatchBaselineError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12753,7 +14160,7 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeInstanceAssociationsStatusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeInstanceAssociationsStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12778,7 +14185,7 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeInstanceInformationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeInstanceInformationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12803,7 +14210,7 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeInstancePatchStatesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeInstancePatchStatesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12826,7 +14233,7 @@ fn describe_instance_patch_states_for_patch_group(&self, input: &DescribeInstanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeInstancePatchStatesForPatchGroupResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeInstancePatchStatesForPatchGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12851,7 +14258,7 @@ fn describe_instance_patch_states_for_patch_group(&self, input: &DescribeInstanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeInstancePatchesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeInstancePatchesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12874,7 +14281,7 @@ fn describe_maintenance_window_execution_task_invocations(&self, input: &Describ
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionTaskInvocationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeMaintenanceWindowExecutionTaskInvocationsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12897,7 +14304,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionTasksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeMaintenanceWindowExecutionTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12924,7 +14331,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeMaintenanceWindowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12949,7 +14356,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMaintenanceWindowTargetsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeMaintenanceWindowTargetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12974,7 +14381,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMaintenanceWindowTasksResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeMaintenanceWindowTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -12999,7 +14406,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMaintenanceWindowsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeMaintenanceWindowsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13023,7 +14430,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeParametersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13051,7 +14458,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribePatchBaselinesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13079,7 +14486,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribePatchGroupStateResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribePatchGroupStateError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13103,7 +14510,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribePatchGroupsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13131,7 +14538,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetAutomationExecutionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13158,7 +14565,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetCommandInvocationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13184,7 +14591,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDefaultPatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetDefaultPatchBaselineError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13207,7 +14614,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDeployablePatchSnapshotForInstanceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetDeployablePatchSnapshotForInstanceError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13231,7 +14638,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetDocumentError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13255,7 +14662,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInventoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13281,7 +14688,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetInventorySchemaResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13308,7 +14715,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13336,7 +14743,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetMaintenanceWindowExecutionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetMaintenanceWindowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13362,7 +14769,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetMaintenanceWindowExecutionTaskResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetMaintenanceWindowExecutionTaskError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13386,7 +14793,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetParameterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13412,7 +14819,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetParameterHistoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13439,7 +14846,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetParametersResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13465,7 +14872,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetParametersByPathResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13492,7 +14899,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetPatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13520,7 +14927,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13544,7 +14951,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListAssociationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13572,7 +14979,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListCommandInvocationsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13599,7 +15006,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListCommandsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13625,7 +15032,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDocumentVersionsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13652,7 +15059,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListDocumentsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13678,7 +15085,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListInventoryEntriesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13705,7 +15112,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13733,7 +15140,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyDocumentPermissionResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ModifyDocumentPermissionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13757,7 +15164,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutInventoryResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13783,7 +15190,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PutParameterResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13810,7 +15217,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterDefaultPatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RegisterDefaultPatchBaselineError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13837,7 +15244,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RegisterPatchBaselineForPatchGroupError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13864,7 +15271,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterTargetWithMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RegisterTargetWithMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13890,7 +15297,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RegisterTaskWithMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RegisterTaskWithMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13915,7 +15322,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTagsFromResourceResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -13942,7 +15349,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SendCommandResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(SendCommandError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13967,7 +15374,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartAutomationExecutionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StartAutomationExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -13992,7 +15399,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopAutomationExecutionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(StopAutomationExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -14016,7 +15423,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateAssociationResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -14044,7 +15451,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateAssociationStatusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateAssociationStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -14068,7 +15475,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDocumentResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -14096,7 +15503,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateDocumentDefaultVersionResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateDocumentDefaultVersionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -14121,7 +15528,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateMaintenanceWindowResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateMaintenanceWindowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -14146,7 +15553,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateManagedInstanceRoleResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateManagedInstanceRoleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -14170,7 +15577,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdatePatchBaselineResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -317,6 +313,50 @@ pub struct ExecutionStartedEventDetails {
     pub role_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionStatus {
+    Aborted,
+    Failed,
+    Running,
+    Succeeded,
+    TimedOut,
+}
+
+impl Into<String> for ExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionStatus::Aborted => "ABORTED",
+            ExecutionStatus::Failed => "FAILED",
+            ExecutionStatus::Running => "RUNNING",
+            ExecutionStatus::Succeeded => "SUCCEEDED",
+            ExecutionStatus::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ABORTED" => Ok(ExecutionStatus::Aborted),
+            "FAILED" => Ok(ExecutionStatus::Failed),
+            "RUNNING" => Ok(ExecutionStatus::Running),
+            "SUCCEEDED" => Ok(ExecutionStatus::Succeeded),
+            "TIMED_OUT" => Ok(ExecutionStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ExecutionSucceededEventDetails {
     #[doc="<p>The JSON data output by the execution.</p>"]
@@ -464,6 +504,128 @@ pub struct HistoryEvent {
     #[doc="<p>The type of the event.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HistoryEventType {
+    ActivityFailed,
+    ActivityScheduleFailed,
+    ActivityScheduled,
+    ActivityStarted,
+    ActivitySucceeded,
+    ActivityTimedOut,
+    ChoiceStateEntered,
+    ChoiceStateExited,
+    ExecutionAborted,
+    ExecutionFailed,
+    ExecutionStarted,
+    ExecutionSucceeded,
+    ExecutionTimedOut,
+    FailStateEntered,
+    LambdaFunctionFailed,
+    LambdaFunctionScheduleFailed,
+    LambdaFunctionScheduled,
+    LambdaFunctionStartFailed,
+    LambdaFunctionStarted,
+    LambdaFunctionSucceeded,
+    LambdaFunctionTimedOut,
+    ParallelStateEntered,
+    ParallelStateExited,
+    PassStateEntered,
+    PassStateExited,
+    SucceedStateEntered,
+    SucceedStateExited,
+    TaskStateEntered,
+    TaskStateExited,
+    WaitStateEntered,
+    WaitStateExited,
+}
+
+impl Into<String> for HistoryEventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HistoryEventType {
+    fn into(self) -> &'static str {
+        match self {
+            HistoryEventType::ActivityFailed => "ActivityFailed",
+            HistoryEventType::ActivityScheduleFailed => "ActivityScheduleFailed",
+            HistoryEventType::ActivityScheduled => "ActivityScheduled",
+            HistoryEventType::ActivityStarted => "ActivityStarted",
+            HistoryEventType::ActivitySucceeded => "ActivitySucceeded",
+            HistoryEventType::ActivityTimedOut => "ActivityTimedOut",
+            HistoryEventType::ChoiceStateEntered => "ChoiceStateEntered",
+            HistoryEventType::ChoiceStateExited => "ChoiceStateExited",
+            HistoryEventType::ExecutionAborted => "ExecutionAborted",
+            HistoryEventType::ExecutionFailed => "ExecutionFailed",
+            HistoryEventType::ExecutionStarted => "ExecutionStarted",
+            HistoryEventType::ExecutionSucceeded => "ExecutionSucceeded",
+            HistoryEventType::ExecutionTimedOut => "ExecutionTimedOut",
+            HistoryEventType::FailStateEntered => "FailStateEntered",
+            HistoryEventType::LambdaFunctionFailed => "LambdaFunctionFailed",
+            HistoryEventType::LambdaFunctionScheduleFailed => "LambdaFunctionScheduleFailed",
+            HistoryEventType::LambdaFunctionScheduled => "LambdaFunctionScheduled",
+            HistoryEventType::LambdaFunctionStartFailed => "LambdaFunctionStartFailed",
+            HistoryEventType::LambdaFunctionStarted => "LambdaFunctionStarted",
+            HistoryEventType::LambdaFunctionSucceeded => "LambdaFunctionSucceeded",
+            HistoryEventType::LambdaFunctionTimedOut => "LambdaFunctionTimedOut",
+            HistoryEventType::ParallelStateEntered => "ParallelStateEntered",
+            HistoryEventType::ParallelStateExited => "ParallelStateExited",
+            HistoryEventType::PassStateEntered => "PassStateEntered",
+            HistoryEventType::PassStateExited => "PassStateExited",
+            HistoryEventType::SucceedStateEntered => "SucceedStateEntered",
+            HistoryEventType::SucceedStateExited => "SucceedStateExited",
+            HistoryEventType::TaskStateEntered => "TaskStateEntered",
+            HistoryEventType::TaskStateExited => "TaskStateExited",
+            HistoryEventType::WaitStateEntered => "WaitStateEntered",
+            HistoryEventType::WaitStateExited => "WaitStateExited",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HistoryEventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivityFailed" => Ok(HistoryEventType::ActivityFailed),
+            "ActivityScheduleFailed" => Ok(HistoryEventType::ActivityScheduleFailed),
+            "ActivityScheduled" => Ok(HistoryEventType::ActivityScheduled),
+            "ActivityStarted" => Ok(HistoryEventType::ActivityStarted),
+            "ActivitySucceeded" => Ok(HistoryEventType::ActivitySucceeded),
+            "ActivityTimedOut" => Ok(HistoryEventType::ActivityTimedOut),
+            "ChoiceStateEntered" => Ok(HistoryEventType::ChoiceStateEntered),
+            "ChoiceStateExited" => Ok(HistoryEventType::ChoiceStateExited),
+            "ExecutionAborted" => Ok(HistoryEventType::ExecutionAborted),
+            "ExecutionFailed" => Ok(HistoryEventType::ExecutionFailed),
+            "ExecutionStarted" => Ok(HistoryEventType::ExecutionStarted),
+            "ExecutionSucceeded" => Ok(HistoryEventType::ExecutionSucceeded),
+            "ExecutionTimedOut" => Ok(HistoryEventType::ExecutionTimedOut),
+            "FailStateEntered" => Ok(HistoryEventType::FailStateEntered),
+            "LambdaFunctionFailed" => Ok(HistoryEventType::LambdaFunctionFailed),
+            "LambdaFunctionScheduleFailed" => Ok(HistoryEventType::LambdaFunctionScheduleFailed),
+            "LambdaFunctionScheduled" => Ok(HistoryEventType::LambdaFunctionScheduled),
+            "LambdaFunctionStartFailed" => Ok(HistoryEventType::LambdaFunctionStartFailed),
+            "LambdaFunctionStarted" => Ok(HistoryEventType::LambdaFunctionStarted),
+            "LambdaFunctionSucceeded" => Ok(HistoryEventType::LambdaFunctionSucceeded),
+            "LambdaFunctionTimedOut" => Ok(HistoryEventType::LambdaFunctionTimedOut),
+            "ParallelStateEntered" => Ok(HistoryEventType::ParallelStateEntered),
+            "ParallelStateExited" => Ok(HistoryEventType::ParallelStateExited),
+            "PassStateEntered" => Ok(HistoryEventType::PassStateEntered),
+            "PassStateExited" => Ok(HistoryEventType::PassStateExited),
+            "SucceedStateEntered" => Ok(HistoryEventType::SucceedStateEntered),
+            "SucceedStateExited" => Ok(HistoryEventType::SucceedStateExited),
+            "TaskStateEntered" => Ok(HistoryEventType::TaskStateEntered),
+            "TaskStateExited" => Ok(HistoryEventType::TaskStateExited),
+            "WaitStateEntered" => Ok(HistoryEventType::WaitStateEntered),
+            "WaitStateExited" => Ok(HistoryEventType::WaitStateExited),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -711,6 +873,41 @@ pub struct StateMachineListItem {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the state machine.</p>"]
     #[serde(rename="stateMachineArn")]
     pub state_machine_arn: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StateMachineStatus {
+    Active,
+    Deleting,
+}
+
+impl Into<String> for StateMachineStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StateMachineStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StateMachineStatus::Active => "ACTIVE",
+            StateMachineStatus::Deleting => "DELETING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StateMachineStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(StateMachineStatus::Active),
+            "DELETING" => Ok(StateMachineStatus::Deleting),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2301,7 +2498,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateActivityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2328,7 +2525,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateStateMachineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2355,7 +2552,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteActivityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2382,7 +2579,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteStateMachineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2409,7 +2606,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeActivityOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2436,7 +2633,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2463,7 +2660,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStateMachineOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2490,7 +2687,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetActivityTaskOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2517,7 +2714,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetExecutionHistoryOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2544,7 +2741,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListActivitiesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2571,7 +2768,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListExecutionsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2598,7 +2795,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListStateMachinesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2625,7 +2822,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SendTaskFailureOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2652,7 +2849,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SendTaskHeartbeatOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2679,7 +2876,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SendTaskSuccessOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2706,7 +2903,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2733,7 +2930,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopExecutionOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -1053,6 +1049,218 @@ pub struct Disk {
     #[serde(rename="DiskStatus")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub disk_status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ErrorCode {
+    ActivationKeyExpired,
+    ActivationKeyInvalid,
+    ActivationKeyNotFound,
+    AuthenticationFailure,
+    BandwidthThrottleScheduleNotFound,
+    Blocked,
+    CannotExportSnapshot,
+    ChapCredentialNotFound,
+    DiskAlreadyAllocated,
+    DiskDoesNotExist,
+    DiskSizeGreaterThanVolumeMaxSize,
+    DiskSizeLessThanVolumeSize,
+    DiskSizeNotGigAligned,
+    DuplicateCertificateInfo,
+    DuplicateSchedule,
+    EndpointNotFound,
+    GatewayInternalError,
+    GatewayNotConnected,
+    GatewayNotFound,
+    GatewayProxyNetworkConnectionBusy,
+    IamnotSupported,
+    InitiatorInvalid,
+    InitiatorNotFound,
+    InternalError,
+    InvalidEndpoint,
+    InvalidGateway,
+    InvalidParameters,
+    InvalidSchedule,
+    LocalStorageLimitExceeded,
+    LunAlreadyAllocated,
+    LunInvalid,
+    MaximumContentLengthExceeded,
+    MaximumTapeCartridgeCountExceeded,
+    MaximumVolumeCountExceeded,
+    NetworkConfigurationChanged,
+    NoDisksAvailable,
+    NotImplemented,
+    NotSupported,
+    OperationAborted,
+    OutdatedGateway,
+    ParametersNotImplemented,
+    RegionInvalid,
+    RequestTimeout,
+    ServiceUnavailable,
+    SnapshotDeleted,
+    SnapshotIdInvalid,
+    SnapshotInProgress,
+    SnapshotNotFound,
+    SnapshotScheduleNotFound,
+    StagingAreaFull,
+    StorageFailure,
+    TapeCartridgeNotFound,
+    TargetAlreadyExists,
+    TargetInvalid,
+    TargetNotFound,
+    UnauthorizedOperation,
+    VolumeAlreadyExists,
+    VolumeIdInvalid,
+    VolumeInUse,
+    VolumeNotFound,
+    VolumeNotReady,
+}
+
+impl Into<String> for ErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            ErrorCode::ActivationKeyExpired => "ActivationKeyExpired",
+            ErrorCode::ActivationKeyInvalid => "ActivationKeyInvalid",
+            ErrorCode::ActivationKeyNotFound => "ActivationKeyNotFound",
+            ErrorCode::AuthenticationFailure => "AuthenticationFailure",
+            ErrorCode::BandwidthThrottleScheduleNotFound => "BandwidthThrottleScheduleNotFound",
+            ErrorCode::Blocked => "Blocked",
+            ErrorCode::CannotExportSnapshot => "CannotExportSnapshot",
+            ErrorCode::ChapCredentialNotFound => "ChapCredentialNotFound",
+            ErrorCode::DiskAlreadyAllocated => "DiskAlreadyAllocated",
+            ErrorCode::DiskDoesNotExist => "DiskDoesNotExist",
+            ErrorCode::DiskSizeGreaterThanVolumeMaxSize => "DiskSizeGreaterThanVolumeMaxSize",
+            ErrorCode::DiskSizeLessThanVolumeSize => "DiskSizeLessThanVolumeSize",
+            ErrorCode::DiskSizeNotGigAligned => "DiskSizeNotGigAligned",
+            ErrorCode::DuplicateCertificateInfo => "DuplicateCertificateInfo",
+            ErrorCode::DuplicateSchedule => "DuplicateSchedule",
+            ErrorCode::EndpointNotFound => "EndpointNotFound",
+            ErrorCode::GatewayInternalError => "GatewayInternalError",
+            ErrorCode::GatewayNotConnected => "GatewayNotConnected",
+            ErrorCode::GatewayNotFound => "GatewayNotFound",
+            ErrorCode::GatewayProxyNetworkConnectionBusy => "GatewayProxyNetworkConnectionBusy",
+            ErrorCode::IamnotSupported => "IAMNotSupported",
+            ErrorCode::InitiatorInvalid => "InitiatorInvalid",
+            ErrorCode::InitiatorNotFound => "InitiatorNotFound",
+            ErrorCode::InternalError => "InternalError",
+            ErrorCode::InvalidEndpoint => "InvalidEndpoint",
+            ErrorCode::InvalidGateway => "InvalidGateway",
+            ErrorCode::InvalidParameters => "InvalidParameters",
+            ErrorCode::InvalidSchedule => "InvalidSchedule",
+            ErrorCode::LocalStorageLimitExceeded => "LocalStorageLimitExceeded",
+            ErrorCode::LunAlreadyAllocated => "LunAlreadyAllocated ",
+            ErrorCode::LunInvalid => "LunInvalid",
+            ErrorCode::MaximumContentLengthExceeded => "MaximumContentLengthExceeded",
+            ErrorCode::MaximumTapeCartridgeCountExceeded => "MaximumTapeCartridgeCountExceeded",
+            ErrorCode::MaximumVolumeCountExceeded => "MaximumVolumeCountExceeded",
+            ErrorCode::NetworkConfigurationChanged => "NetworkConfigurationChanged",
+            ErrorCode::NoDisksAvailable => "NoDisksAvailable",
+            ErrorCode::NotImplemented => "NotImplemented",
+            ErrorCode::NotSupported => "NotSupported",
+            ErrorCode::OperationAborted => "OperationAborted",
+            ErrorCode::OutdatedGateway => "OutdatedGateway",
+            ErrorCode::ParametersNotImplemented => "ParametersNotImplemented",
+            ErrorCode::RegionInvalid => "RegionInvalid",
+            ErrorCode::RequestTimeout => "RequestTimeout",
+            ErrorCode::ServiceUnavailable => "ServiceUnavailable",
+            ErrorCode::SnapshotDeleted => "SnapshotDeleted",
+            ErrorCode::SnapshotIdInvalid => "SnapshotIdInvalid",
+            ErrorCode::SnapshotInProgress => "SnapshotInProgress",
+            ErrorCode::SnapshotNotFound => "SnapshotNotFound",
+            ErrorCode::SnapshotScheduleNotFound => "SnapshotScheduleNotFound",
+            ErrorCode::StagingAreaFull => "StagingAreaFull",
+            ErrorCode::StorageFailure => "StorageFailure",
+            ErrorCode::TapeCartridgeNotFound => "TapeCartridgeNotFound",
+            ErrorCode::TargetAlreadyExists => "TargetAlreadyExists",
+            ErrorCode::TargetInvalid => "TargetInvalid",
+            ErrorCode::TargetNotFound => "TargetNotFound",
+            ErrorCode::UnauthorizedOperation => "UnauthorizedOperation",
+            ErrorCode::VolumeAlreadyExists => "VolumeAlreadyExists",
+            ErrorCode::VolumeIdInvalid => "VolumeIdInvalid",
+            ErrorCode::VolumeInUse => "VolumeInUse",
+            ErrorCode::VolumeNotFound => "VolumeNotFound",
+            ErrorCode::VolumeNotReady => "VolumeNotReady",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivationKeyExpired" => Ok(ErrorCode::ActivationKeyExpired),
+            "ActivationKeyInvalid" => Ok(ErrorCode::ActivationKeyInvalid),
+            "ActivationKeyNotFound" => Ok(ErrorCode::ActivationKeyNotFound),
+            "AuthenticationFailure" => Ok(ErrorCode::AuthenticationFailure),
+            "BandwidthThrottleScheduleNotFound" => Ok(ErrorCode::BandwidthThrottleScheduleNotFound),
+            "Blocked" => Ok(ErrorCode::Blocked),
+            "CannotExportSnapshot" => Ok(ErrorCode::CannotExportSnapshot),
+            "ChapCredentialNotFound" => Ok(ErrorCode::ChapCredentialNotFound),
+            "DiskAlreadyAllocated" => Ok(ErrorCode::DiskAlreadyAllocated),
+            "DiskDoesNotExist" => Ok(ErrorCode::DiskDoesNotExist),
+            "DiskSizeGreaterThanVolumeMaxSize" => Ok(ErrorCode::DiskSizeGreaterThanVolumeMaxSize),
+            "DiskSizeLessThanVolumeSize" => Ok(ErrorCode::DiskSizeLessThanVolumeSize),
+            "DiskSizeNotGigAligned" => Ok(ErrorCode::DiskSizeNotGigAligned),
+            "DuplicateCertificateInfo" => Ok(ErrorCode::DuplicateCertificateInfo),
+            "DuplicateSchedule" => Ok(ErrorCode::DuplicateSchedule),
+            "EndpointNotFound" => Ok(ErrorCode::EndpointNotFound),
+            "GatewayInternalError" => Ok(ErrorCode::GatewayInternalError),
+            "GatewayNotConnected" => Ok(ErrorCode::GatewayNotConnected),
+            "GatewayNotFound" => Ok(ErrorCode::GatewayNotFound),
+            "GatewayProxyNetworkConnectionBusy" => Ok(ErrorCode::GatewayProxyNetworkConnectionBusy),
+            "IAMNotSupported" => Ok(ErrorCode::IamnotSupported),
+            "InitiatorInvalid" => Ok(ErrorCode::InitiatorInvalid),
+            "InitiatorNotFound" => Ok(ErrorCode::InitiatorNotFound),
+            "InternalError" => Ok(ErrorCode::InternalError),
+            "InvalidEndpoint" => Ok(ErrorCode::InvalidEndpoint),
+            "InvalidGateway" => Ok(ErrorCode::InvalidGateway),
+            "InvalidParameters" => Ok(ErrorCode::InvalidParameters),
+            "InvalidSchedule" => Ok(ErrorCode::InvalidSchedule),
+            "LocalStorageLimitExceeded" => Ok(ErrorCode::LocalStorageLimitExceeded),
+            "LunAlreadyAllocated " => Ok(ErrorCode::LunAlreadyAllocated),
+            "LunInvalid" => Ok(ErrorCode::LunInvalid),
+            "MaximumContentLengthExceeded" => Ok(ErrorCode::MaximumContentLengthExceeded),
+            "MaximumTapeCartridgeCountExceeded" => Ok(ErrorCode::MaximumTapeCartridgeCountExceeded),
+            "MaximumVolumeCountExceeded" => Ok(ErrorCode::MaximumVolumeCountExceeded),
+            "NetworkConfigurationChanged" => Ok(ErrorCode::NetworkConfigurationChanged),
+            "NoDisksAvailable" => Ok(ErrorCode::NoDisksAvailable),
+            "NotImplemented" => Ok(ErrorCode::NotImplemented),
+            "NotSupported" => Ok(ErrorCode::NotSupported),
+            "OperationAborted" => Ok(ErrorCode::OperationAborted),
+            "OutdatedGateway" => Ok(ErrorCode::OutdatedGateway),
+            "ParametersNotImplemented" => Ok(ErrorCode::ParametersNotImplemented),
+            "RegionInvalid" => Ok(ErrorCode::RegionInvalid),
+            "RequestTimeout" => Ok(ErrorCode::RequestTimeout),
+            "ServiceUnavailable" => Ok(ErrorCode::ServiceUnavailable),
+            "SnapshotDeleted" => Ok(ErrorCode::SnapshotDeleted),
+            "SnapshotIdInvalid" => Ok(ErrorCode::SnapshotIdInvalid),
+            "SnapshotInProgress" => Ok(ErrorCode::SnapshotInProgress),
+            "SnapshotNotFound" => Ok(ErrorCode::SnapshotNotFound),
+            "SnapshotScheduleNotFound" => Ok(ErrorCode::SnapshotScheduleNotFound),
+            "StagingAreaFull" => Ok(ErrorCode::StagingAreaFull),
+            "StorageFailure" => Ok(ErrorCode::StorageFailure),
+            "TapeCartridgeNotFound" => Ok(ErrorCode::TapeCartridgeNotFound),
+            "TargetAlreadyExists" => Ok(ErrorCode::TargetAlreadyExists),
+            "TargetInvalid" => Ok(ErrorCode::TargetInvalid),
+            "TargetNotFound" => Ok(ErrorCode::TargetNotFound),
+            "UnauthorizedOperation" => Ok(ErrorCode::UnauthorizedOperation),
+            "VolumeAlreadyExists" => Ok(ErrorCode::VolumeAlreadyExists),
+            "VolumeIdInvalid" => Ok(ErrorCode::VolumeIdInvalid),
+            "VolumeInUse" => Ok(ErrorCode::VolumeInUse),
+            "VolumeNotFound" => Ok(ErrorCode::VolumeNotFound),
+            "VolumeNotReady" => Ok(ErrorCode::VolumeNotReady),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a file share.</p>"]
@@ -7361,7 +7569,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ActivateGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7386,7 +7594,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<AddCacheOutput>(String::from_utf8_lossy(&response.body)
                                                               .as_ref())
                            .unwrap())
@@ -7412,7 +7620,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddTagsToResourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7439,7 +7647,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddUploadBufferOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7466,7 +7674,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddWorkingStorageOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7493,7 +7701,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CancelArchivalOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7520,7 +7728,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CancelRetrievalOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7549,7 +7757,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateCachediSCSIVolumeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateCachediSCSIVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7573,7 +7781,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateNFSFileShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7600,7 +7808,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateSnapshotOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7626,7 +7834,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateSnapshotFromVolumeRecoveryPointOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateSnapshotFromVolumeRecoveryPointError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7652,7 +7860,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateStorediSCSIVolumeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateStorediSCSIVolumeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7678,7 +7886,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateTapeWithBarcodeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7705,7 +7913,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateTapesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateTapesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7731,7 +7939,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteBandwidthRateLimitOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteBandwidthRateLimitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7757,7 +7965,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteChapCredentialsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7784,7 +7992,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteFileShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7811,7 +8019,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7839,7 +8047,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteSnapshotScheduleOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7864,7 +8072,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteTapeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteTapeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7888,7 +8096,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteTapeArchiveOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7915,7 +8123,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteVolumeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7943,7 +8151,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeBandwidthRateLimitOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeBandwidthRateLimitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7967,7 +8175,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCacheOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7995,7 +8203,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCachediSCSIVolumesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeCachediSCSIVolumesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8021,7 +8229,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeChapCredentialsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeChapCredentialsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8047,7 +8255,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeGatewayInformationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeGatewayInformationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8073,7 +8281,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeMaintenanceStartTimeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeMaintenanceStartTimeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8099,7 +8307,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeNFSFileSharesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8128,7 +8336,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeSnapshotScheduleOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeSnapshotScheduleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8154,7 +8362,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeStorediSCSIVolumesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeStorediSCSIVolumesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8179,7 +8387,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTapeArchivesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8208,7 +8416,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTapeRecoveryPointsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeTapeRecoveryPointsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8232,7 +8440,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTapesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8259,7 +8467,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeUploadBufferOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8286,7 +8494,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeVTLDevicesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8315,7 +8523,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeWorkingStorageOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8342,7 +8550,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisableGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8369,7 +8577,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListFileSharesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8396,7 +8604,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListGatewaysOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8422,7 +8630,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListLocalDisksOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8450,7 +8658,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListTagsForResourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8475,7 +8683,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ListTapesOutput>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -8502,7 +8710,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListVolumeInitiatorsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8531,7 +8739,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListVolumeRecoveryPointsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListVolumeRecoveryPointsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8555,7 +8763,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListVolumesOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListVolumesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8579,7 +8787,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RefreshCacheOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8607,7 +8815,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RemoveTagsFromResourceOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8632,7 +8840,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ResetCacheOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ResetCacheError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8657,7 +8865,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RetrieveTapeArchiveOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8686,7 +8894,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RetrieveTapeRecoveryPointOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RetrieveTapeRecoveryPointError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8712,7 +8920,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<SetLocalConsolePasswordOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(SetLocalConsolePasswordError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8736,7 +8944,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ShutdownGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8763,7 +8971,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartGatewayOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8791,7 +8999,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateBandwidthRateLimitOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateBandwidthRateLimitError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8817,7 +9025,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateChapCredentialsOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8846,7 +9054,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateGatewayInformationOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateGatewayInformationError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8872,7 +9080,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateGatewaySoftwareNowOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateGatewaySoftwareNowError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8898,7 +9106,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateMaintenanceStartTimeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateMaintenanceStartTimeError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -8922,7 +9130,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateNFSFileShareOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8951,7 +9159,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateSnapshotScheduleOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -8979,7 +9187,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateVTLDeviceTypeOutput>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -11,18 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
-use std::str::FromStr;
 use xml::EventReader;
 use xml::reader::ParserConfig;
 use rusoto_core::param::{Params, ServiceParams};
@@ -1087,7 +1082,7 @@ impl NonNegativeIntegerTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<i64, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = i64::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<i64>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1793,7 +1788,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -1834,7 +1829,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -1879,7 +1874,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -1922,7 +1917,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -1964,7 +1959,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2008,7 +2003,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 
@@ -2052,7 +2047,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign(&try!(self.credentials_provider.credentials()));
         let response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
 

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -1937,7 +1933,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddAttachmentsToSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1965,7 +1961,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AddCommunicationToCaseResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1992,7 +1988,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateCaseResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateCaseError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2016,7 +2012,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeAttachmentResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2043,7 +2039,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCasesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2070,7 +2066,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeCommunicationsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2097,7 +2093,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeServicesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2125,7 +2121,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeSeverityLevelsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2151,7 +2147,7 @@ fn describe_trusted_advisor_check_refresh_statuses(&self, input: &DescribeTruste
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckRefreshStatusesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeTrustedAdvisorCheckRefreshStatusesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2178,7 +2174,7 @@ fn describe_trusted_advisor_check_refresh_statuses(&self, input: &DescribeTruste
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckResultResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeTrustedAdvisorCheckResultError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2201,7 +2197,7 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckSummariesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeTrustedAdvisorCheckSummariesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2227,7 +2223,7 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTrustedAdvisorChecksResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeTrustedAdvisorChecksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2253,7 +2249,7 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RefreshTrustedAdvisorCheckResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RefreshTrustedAdvisorCheckError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2277,7 +2273,7 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ResolveCaseResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ResolveCaseError::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -197,6 +193,47 @@ pub struct ActivityTaskTimedOutEventAttributes {
     pub timeout_type: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActivityTaskTimeoutType {
+    Heartbeat,
+    ScheduleToClose,
+    ScheduleToStart,
+    StartToClose,
+}
+
+impl Into<String> for ActivityTaskTimeoutType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActivityTaskTimeoutType {
+    fn into(self) -> &'static str {
+        match self {
+            ActivityTaskTimeoutType::Heartbeat => "HEARTBEAT",
+            ActivityTaskTimeoutType::ScheduleToClose => "SCHEDULE_TO_CLOSE",
+            ActivityTaskTimeoutType::ScheduleToStart => "SCHEDULE_TO_START",
+            ActivityTaskTimeoutType::StartToClose => "START_TO_CLOSE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActivityTaskTimeoutType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HEARTBEAT" => Ok(ActivityTaskTimeoutType::Heartbeat),
+            "SCHEDULE_TO_CLOSE" => Ok(ActivityTaskTimeoutType::ScheduleToClose),
+            "SCHEDULE_TO_START" => Ok(ActivityTaskTimeoutType::ScheduleToStart),
+            "START_TO_CLOSE" => Ok(ActivityTaskTimeoutType::StartToClose),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents an activity type.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityType {
@@ -290,6 +327,41 @@ pub struct CancelTimerDecisionAttributes {
     pub timer_id: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelTimerFailedCause {
+    OperationNotPermitted,
+    TimerIdUnknown,
+}
+
+impl Into<String> for CancelTimerFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelTimerFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            CancelTimerFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+            CancelTimerFailedCause::TimerIdUnknown => "TIMER_ID_UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelTimerFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => Ok(CancelTimerFailedCause::OperationNotPermitted),
+            "TIMER_ID_UNKNOWN" => Ok(CancelTimerFailedCause::TimerIdUnknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides details of the <code>CancelTimerFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CancelTimerFailedEventAttributes {
@@ -313,6 +385,43 @@ pub struct CancelWorkflowExecutionDecisionAttributes {
     pub details: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    UnhandledDecision,
+}
+
+impl Into<String> for CancelWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            CancelWorkflowExecutionFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+            CancelWorkflowExecutionFailedCause::UnhandledDecision => "UNHANDLED_DECISION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(CancelWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "UNHANDLED_DECISION" => Ok(CancelWorkflowExecutionFailedCause::UnhandledDecision),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides details of the <code>CancelWorkflowExecutionFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CancelWorkflowExecutionFailedEventAttributes {
@@ -322,6 +431,44 @@ pub struct CancelWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelWorkflowExecution</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="decisionTaskCompletedEventId")]
     pub decision_task_completed_event_id: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChildPolicy {
+    Abandon,
+    RequestCancel,
+    Terminate,
+}
+
+impl Into<String> for ChildPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChildPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ChildPolicy::Abandon => "ABANDON",
+            ChildPolicy::RequestCancel => "REQUEST_CANCEL",
+            ChildPolicy::Terminate => "TERMINATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChildPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ABANDON" => Ok(ChildPolicy::Abandon),
+            "REQUEST_CANCEL" => Ok(ChildPolicy::RequestCancel),
+            "TERMINATE" => Ok(ChildPolicy::Terminate),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provide details of the <code>ChildWorkflowExecutionCanceled</code> event.</p>"]
@@ -442,6 +589,53 @@ pub struct ChildWorkflowExecutionTimedOutEventAttributes {
     pub workflow_type: WorkflowType,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloseStatus {
+    Canceled,
+    Completed,
+    ContinuedAsNew,
+    Failed,
+    Terminated,
+    TimedOut,
+}
+
+impl Into<String> for CloseStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloseStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CloseStatus::Canceled => "CANCELED",
+            CloseStatus::Completed => "COMPLETED",
+            CloseStatus::ContinuedAsNew => "CONTINUED_AS_NEW",
+            CloseStatus::Failed => "FAILED",
+            CloseStatus::Terminated => "TERMINATED",
+            CloseStatus::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloseStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELED" => Ok(CloseStatus::Canceled),
+            "COMPLETED" => Ok(CloseStatus::Completed),
+            "CONTINUED_AS_NEW" => Ok(CloseStatus::ContinuedAsNew),
+            "FAILED" => Ok(CloseStatus::Failed),
+            "TERMINATED" => Ok(CloseStatus::Terminated),
+            "TIMED_OUT" => Ok(CloseStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Used to filter the closed workflow executions in visibility APIs by their close status.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct CloseStatusFilter {
@@ -457,6 +651,45 @@ pub struct CompleteWorkflowExecutionDecisionAttributes {
     #[serde(rename="result")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub result: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CompleteWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    UnhandledDecision,
+}
+
+impl Into<String> for CompleteWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CompleteWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            CompleteWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            CompleteWorkflowExecutionFailedCause::UnhandledDecision => "UNHANDLED_DECISION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CompleteWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(CompleteWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "UNHANDLED_DECISION" => Ok(CompleteWorkflowExecutionFailedCause::UnhandledDecision),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details of the <code>CompleteWorkflowExecutionFailed</code> event.</p>"]
@@ -507,6 +740,86 @@ pub struct ContinueAsNewWorkflowExecutionDecisionAttributes {
     #[serde(rename="workflowTypeVersion")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub workflow_type_version: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContinueAsNewWorkflowExecutionFailedCause {
+    ContinueAsNewWorkflowExecutionRateExceeded,
+    DefaultChildPolicyUndefined,
+    DefaultExecutionStartToCloseTimeoutUndefined,
+    DefaultTaskListUndefined,
+    DefaultTaskStartToCloseTimeoutUndefined,
+    OperationNotPermitted,
+    UnhandledDecision,
+    WorkflowTypeDeprecated,
+    WorkflowTypeDoesNotExist,
+}
+
+impl Into<String> for ContinueAsNewWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContinueAsNewWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            ContinueAsNewWorkflowExecutionFailedCause::ContinueAsNewWorkflowExecutionRateExceeded => "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+            ContinueAsNewWorkflowExecutionFailedCause::DefaultChildPolicyUndefined => {
+                "DEFAULT_CHILD_POLICY_UNDEFINED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::DefaultExecutionStartToCloseTimeoutUndefined => "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+            ContinueAsNewWorkflowExecutionFailedCause::DefaultTaskListUndefined => {
+                "DEFAULT_TASK_LIST_UNDEFINED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::DefaultTaskStartToCloseTimeoutUndefined => {
+                "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::UnhandledDecision => "UNHANDLED_DECISION",
+            ContinueAsNewWorkflowExecutionFailedCause::WorkflowTypeDeprecated => {
+                "WORKFLOW_TYPE_DEPRECATED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::WorkflowTypeDoesNotExist => {
+                "WORKFLOW_TYPE_DOES_NOT_EXIST"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContinueAsNewWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED" => Ok(ContinueAsNewWorkflowExecutionFailedCause::ContinueAsNewWorkflowExecutionRateExceeded),
+            "DEFAULT_CHILD_POLICY_UNDEFINED" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::DefaultChildPolicyUndefined)
+            }
+            "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED" => Ok(ContinueAsNewWorkflowExecutionFailedCause::DefaultExecutionStartToCloseTimeoutUndefined),
+            "DEFAULT_TASK_LIST_UNDEFINED" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::DefaultTaskListUndefined)
+            }
+            "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED" => Ok(ContinueAsNewWorkflowExecutionFailedCause::DefaultTaskStartToCloseTimeoutUndefined),
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "UNHANDLED_DECISION" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::UnhandledDecision)
+            }
+            "WORKFLOW_TYPE_DEPRECATED" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::WorkflowTypeDeprecated)
+            }
+            "WORKFLOW_TYPE_DOES_NOT_EXIST" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::WorkflowTypeDoesNotExist)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details of the <code>ContinueAsNewWorkflowExecutionFailed</code> event.</p>"]
@@ -747,6 +1060,110 @@ pub struct DecisionTaskTimedOutEventAttributes {
     pub timeout_type: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DecisionTaskTimeoutType {
+    StartToClose,
+}
+
+impl Into<String> for DecisionTaskTimeoutType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DecisionTaskTimeoutType {
+    fn into(self) -> &'static str {
+        match self {
+            DecisionTaskTimeoutType::StartToClose => "START_TO_CLOSE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DecisionTaskTimeoutType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "START_TO_CLOSE" => Ok(DecisionTaskTimeoutType::StartToClose),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DecisionType {
+    CancelTimer,
+    CancelWorkflowExecution,
+    CompleteWorkflowExecution,
+    ContinueAsNewWorkflowExecution,
+    FailWorkflowExecution,
+    RecordMarker,
+    RequestCancelActivityTask,
+    RequestCancelExternalWorkflowExecution,
+    ScheduleActivityTask,
+    ScheduleLambdaFunction,
+    SignalExternalWorkflowExecution,
+    StartChildWorkflowExecution,
+    StartTimer,
+}
+
+impl Into<String> for DecisionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DecisionType {
+    fn into(self) -> &'static str {
+        match self {
+            DecisionType::CancelTimer => "CancelTimer",
+            DecisionType::CancelWorkflowExecution => "CancelWorkflowExecution",
+            DecisionType::CompleteWorkflowExecution => "CompleteWorkflowExecution",
+            DecisionType::ContinueAsNewWorkflowExecution => "ContinueAsNewWorkflowExecution",
+            DecisionType::FailWorkflowExecution => "FailWorkflowExecution",
+            DecisionType::RecordMarker => "RecordMarker",
+            DecisionType::RequestCancelActivityTask => "RequestCancelActivityTask",
+            DecisionType::RequestCancelExternalWorkflowExecution => {
+                "RequestCancelExternalWorkflowExecution"
+            }
+            DecisionType::ScheduleActivityTask => "ScheduleActivityTask",
+            DecisionType::ScheduleLambdaFunction => "ScheduleLambdaFunction",
+            DecisionType::SignalExternalWorkflowExecution => "SignalExternalWorkflowExecution",
+            DecisionType::StartChildWorkflowExecution => "StartChildWorkflowExecution",
+            DecisionType::StartTimer => "StartTimer",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DecisionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CancelTimer" => Ok(DecisionType::CancelTimer),
+            "CancelWorkflowExecution" => Ok(DecisionType::CancelWorkflowExecution),
+            "CompleteWorkflowExecution" => Ok(DecisionType::CompleteWorkflowExecution),
+            "ContinueAsNewWorkflowExecution" => Ok(DecisionType::ContinueAsNewWorkflowExecution),
+            "FailWorkflowExecution" => Ok(DecisionType::FailWorkflowExecution),
+            "RecordMarker" => Ok(DecisionType::RecordMarker),
+            "RequestCancelActivityTask" => Ok(DecisionType::RequestCancelActivityTask),
+            "RequestCancelExternalWorkflowExecution" => {
+                Ok(DecisionType::RequestCancelExternalWorkflowExecution)
+            }
+            "ScheduleActivityTask" => Ok(DecisionType::ScheduleActivityTask),
+            "ScheduleLambdaFunction" => Ok(DecisionType::ScheduleLambdaFunction),
+            "SignalExternalWorkflowExecution" => Ok(DecisionType::SignalExternalWorkflowExecution),
+            "StartChildWorkflowExecution" => Ok(DecisionType::StartChildWorkflowExecution),
+            "StartTimer" => Ok(DecisionType::StartTimer),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeprecateActivityTypeInput {
     #[doc="<p>The activity type to deprecate.</p>"]
@@ -855,6 +1272,260 @@ pub struct DomainInfos {
     pub next_page_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    ActivityTaskCancelRequested,
+    ActivityTaskCanceled,
+    ActivityTaskCompleted,
+    ActivityTaskFailed,
+    ActivityTaskScheduled,
+    ActivityTaskStarted,
+    ActivityTaskTimedOut,
+    CancelTimerFailed,
+    CancelWorkflowExecutionFailed,
+    ChildWorkflowExecutionCanceled,
+    ChildWorkflowExecutionCompleted,
+    ChildWorkflowExecutionFailed,
+    ChildWorkflowExecutionStarted,
+    ChildWorkflowExecutionTerminated,
+    ChildWorkflowExecutionTimedOut,
+    CompleteWorkflowExecutionFailed,
+    ContinueAsNewWorkflowExecutionFailed,
+    DecisionTaskCompleted,
+    DecisionTaskScheduled,
+    DecisionTaskStarted,
+    DecisionTaskTimedOut,
+    ExternalWorkflowExecutionCancelRequested,
+    ExternalWorkflowExecutionSignaled,
+    FailWorkflowExecutionFailed,
+    LambdaFunctionCompleted,
+    LambdaFunctionFailed,
+    LambdaFunctionScheduled,
+    LambdaFunctionStarted,
+    LambdaFunctionTimedOut,
+    MarkerRecorded,
+    RecordMarkerFailed,
+    RequestCancelActivityTaskFailed,
+    RequestCancelExternalWorkflowExecutionFailed,
+    RequestCancelExternalWorkflowExecutionInitiated,
+    ScheduleActivityTaskFailed,
+    ScheduleLambdaFunctionFailed,
+    SignalExternalWorkflowExecutionFailed,
+    SignalExternalWorkflowExecutionInitiated,
+    StartChildWorkflowExecutionFailed,
+    StartChildWorkflowExecutionInitiated,
+    StartLambdaFunctionFailed,
+    StartTimerFailed,
+    TimerCanceled,
+    TimerFired,
+    TimerStarted,
+    WorkflowExecutionCancelRequested,
+    WorkflowExecutionCanceled,
+    WorkflowExecutionCompleted,
+    WorkflowExecutionContinuedAsNew,
+    WorkflowExecutionFailed,
+    WorkflowExecutionSignaled,
+    WorkflowExecutionStarted,
+    WorkflowExecutionTerminated,
+    WorkflowExecutionTimedOut,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::ActivityTaskCancelRequested => "ActivityTaskCancelRequested",
+            EventType::ActivityTaskCanceled => "ActivityTaskCanceled",
+            EventType::ActivityTaskCompleted => "ActivityTaskCompleted",
+            EventType::ActivityTaskFailed => "ActivityTaskFailed",
+            EventType::ActivityTaskScheduled => "ActivityTaskScheduled",
+            EventType::ActivityTaskStarted => "ActivityTaskStarted",
+            EventType::ActivityTaskTimedOut => "ActivityTaskTimedOut",
+            EventType::CancelTimerFailed => "CancelTimerFailed",
+            EventType::CancelWorkflowExecutionFailed => "CancelWorkflowExecutionFailed",
+            EventType::ChildWorkflowExecutionCanceled => "ChildWorkflowExecutionCanceled",
+            EventType::ChildWorkflowExecutionCompleted => "ChildWorkflowExecutionCompleted",
+            EventType::ChildWorkflowExecutionFailed => "ChildWorkflowExecutionFailed",
+            EventType::ChildWorkflowExecutionStarted => "ChildWorkflowExecutionStarted",
+            EventType::ChildWorkflowExecutionTerminated => "ChildWorkflowExecutionTerminated",
+            EventType::ChildWorkflowExecutionTimedOut => "ChildWorkflowExecutionTimedOut",
+            EventType::CompleteWorkflowExecutionFailed => "CompleteWorkflowExecutionFailed",
+            EventType::ContinueAsNewWorkflowExecutionFailed => {
+                "ContinueAsNewWorkflowExecutionFailed"
+            }
+            EventType::DecisionTaskCompleted => "DecisionTaskCompleted",
+            EventType::DecisionTaskScheduled => "DecisionTaskScheduled",
+            EventType::DecisionTaskStarted => "DecisionTaskStarted",
+            EventType::DecisionTaskTimedOut => "DecisionTaskTimedOut",
+            EventType::ExternalWorkflowExecutionCancelRequested => {
+                "ExternalWorkflowExecutionCancelRequested"
+            }
+            EventType::ExternalWorkflowExecutionSignaled => "ExternalWorkflowExecutionSignaled",
+            EventType::FailWorkflowExecutionFailed => "FailWorkflowExecutionFailed",
+            EventType::LambdaFunctionCompleted => "LambdaFunctionCompleted",
+            EventType::LambdaFunctionFailed => "LambdaFunctionFailed",
+            EventType::LambdaFunctionScheduled => "LambdaFunctionScheduled",
+            EventType::LambdaFunctionStarted => "LambdaFunctionStarted",
+            EventType::LambdaFunctionTimedOut => "LambdaFunctionTimedOut",
+            EventType::MarkerRecorded => "MarkerRecorded",
+            EventType::RecordMarkerFailed => "RecordMarkerFailed",
+            EventType::RequestCancelActivityTaskFailed => "RequestCancelActivityTaskFailed",
+            EventType::RequestCancelExternalWorkflowExecutionFailed => {
+                "RequestCancelExternalWorkflowExecutionFailed"
+            }
+            EventType::RequestCancelExternalWorkflowExecutionInitiated => {
+                "RequestCancelExternalWorkflowExecutionInitiated"
+            }
+            EventType::ScheduleActivityTaskFailed => "ScheduleActivityTaskFailed",
+            EventType::ScheduleLambdaFunctionFailed => "ScheduleLambdaFunctionFailed",
+            EventType::SignalExternalWorkflowExecutionFailed => {
+                "SignalExternalWorkflowExecutionFailed"
+            }
+            EventType::SignalExternalWorkflowExecutionInitiated => {
+                "SignalExternalWorkflowExecutionInitiated"
+            }
+            EventType::StartChildWorkflowExecutionFailed => "StartChildWorkflowExecutionFailed",
+            EventType::StartChildWorkflowExecutionInitiated => {
+                "StartChildWorkflowExecutionInitiated"
+            }
+            EventType::StartLambdaFunctionFailed => "StartLambdaFunctionFailed",
+            EventType::StartTimerFailed => "StartTimerFailed",
+            EventType::TimerCanceled => "TimerCanceled",
+            EventType::TimerFired => "TimerFired",
+            EventType::TimerStarted => "TimerStarted",
+            EventType::WorkflowExecutionCancelRequested => "WorkflowExecutionCancelRequested",
+            EventType::WorkflowExecutionCanceled => "WorkflowExecutionCanceled",
+            EventType::WorkflowExecutionCompleted => "WorkflowExecutionCompleted",
+            EventType::WorkflowExecutionContinuedAsNew => "WorkflowExecutionContinuedAsNew",
+            EventType::WorkflowExecutionFailed => "WorkflowExecutionFailed",
+            EventType::WorkflowExecutionSignaled => "WorkflowExecutionSignaled",
+            EventType::WorkflowExecutionStarted => "WorkflowExecutionStarted",
+            EventType::WorkflowExecutionTerminated => "WorkflowExecutionTerminated",
+            EventType::WorkflowExecutionTimedOut => "WorkflowExecutionTimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivityTaskCancelRequested" => Ok(EventType::ActivityTaskCancelRequested),
+            "ActivityTaskCanceled" => Ok(EventType::ActivityTaskCanceled),
+            "ActivityTaskCompleted" => Ok(EventType::ActivityTaskCompleted),
+            "ActivityTaskFailed" => Ok(EventType::ActivityTaskFailed),
+            "ActivityTaskScheduled" => Ok(EventType::ActivityTaskScheduled),
+            "ActivityTaskStarted" => Ok(EventType::ActivityTaskStarted),
+            "ActivityTaskTimedOut" => Ok(EventType::ActivityTaskTimedOut),
+            "CancelTimerFailed" => Ok(EventType::CancelTimerFailed),
+            "CancelWorkflowExecutionFailed" => Ok(EventType::CancelWorkflowExecutionFailed),
+            "ChildWorkflowExecutionCanceled" => Ok(EventType::ChildWorkflowExecutionCanceled),
+            "ChildWorkflowExecutionCompleted" => Ok(EventType::ChildWorkflowExecutionCompleted),
+            "ChildWorkflowExecutionFailed" => Ok(EventType::ChildWorkflowExecutionFailed),
+            "ChildWorkflowExecutionStarted" => Ok(EventType::ChildWorkflowExecutionStarted),
+            "ChildWorkflowExecutionTerminated" => Ok(EventType::ChildWorkflowExecutionTerminated),
+            "ChildWorkflowExecutionTimedOut" => Ok(EventType::ChildWorkflowExecutionTimedOut),
+            "CompleteWorkflowExecutionFailed" => Ok(EventType::CompleteWorkflowExecutionFailed),
+            "ContinueAsNewWorkflowExecutionFailed" => {
+                Ok(EventType::ContinueAsNewWorkflowExecutionFailed)
+            }
+            "DecisionTaskCompleted" => Ok(EventType::DecisionTaskCompleted),
+            "DecisionTaskScheduled" => Ok(EventType::DecisionTaskScheduled),
+            "DecisionTaskStarted" => Ok(EventType::DecisionTaskStarted),
+            "DecisionTaskTimedOut" => Ok(EventType::DecisionTaskTimedOut),
+            "ExternalWorkflowExecutionCancelRequested" => {
+                Ok(EventType::ExternalWorkflowExecutionCancelRequested)
+            }
+            "ExternalWorkflowExecutionSignaled" => Ok(EventType::ExternalWorkflowExecutionSignaled),
+            "FailWorkflowExecutionFailed" => Ok(EventType::FailWorkflowExecutionFailed),
+            "LambdaFunctionCompleted" => Ok(EventType::LambdaFunctionCompleted),
+            "LambdaFunctionFailed" => Ok(EventType::LambdaFunctionFailed),
+            "LambdaFunctionScheduled" => Ok(EventType::LambdaFunctionScheduled),
+            "LambdaFunctionStarted" => Ok(EventType::LambdaFunctionStarted),
+            "LambdaFunctionTimedOut" => Ok(EventType::LambdaFunctionTimedOut),
+            "MarkerRecorded" => Ok(EventType::MarkerRecorded),
+            "RecordMarkerFailed" => Ok(EventType::RecordMarkerFailed),
+            "RequestCancelActivityTaskFailed" => Ok(EventType::RequestCancelActivityTaskFailed),
+            "RequestCancelExternalWorkflowExecutionFailed" => {
+                Ok(EventType::RequestCancelExternalWorkflowExecutionFailed)
+            }
+            "RequestCancelExternalWorkflowExecutionInitiated" => {
+                Ok(EventType::RequestCancelExternalWorkflowExecutionInitiated)
+            }
+            "ScheduleActivityTaskFailed" => Ok(EventType::ScheduleActivityTaskFailed),
+            "ScheduleLambdaFunctionFailed" => Ok(EventType::ScheduleLambdaFunctionFailed),
+            "SignalExternalWorkflowExecutionFailed" => {
+                Ok(EventType::SignalExternalWorkflowExecutionFailed)
+            }
+            "SignalExternalWorkflowExecutionInitiated" => {
+                Ok(EventType::SignalExternalWorkflowExecutionInitiated)
+            }
+            "StartChildWorkflowExecutionFailed" => Ok(EventType::StartChildWorkflowExecutionFailed),
+            "StartChildWorkflowExecutionInitiated" => {
+                Ok(EventType::StartChildWorkflowExecutionInitiated)
+            }
+            "StartLambdaFunctionFailed" => Ok(EventType::StartLambdaFunctionFailed),
+            "StartTimerFailed" => Ok(EventType::StartTimerFailed),
+            "TimerCanceled" => Ok(EventType::TimerCanceled),
+            "TimerFired" => Ok(EventType::TimerFired),
+            "TimerStarted" => Ok(EventType::TimerStarted),
+            "WorkflowExecutionCancelRequested" => Ok(EventType::WorkflowExecutionCancelRequested),
+            "WorkflowExecutionCanceled" => Ok(EventType::WorkflowExecutionCanceled),
+            "WorkflowExecutionCompleted" => Ok(EventType::WorkflowExecutionCompleted),
+            "WorkflowExecutionContinuedAsNew" => Ok(EventType::WorkflowExecutionContinuedAsNew),
+            "WorkflowExecutionFailed" => Ok(EventType::WorkflowExecutionFailed),
+            "WorkflowExecutionSignaled" => Ok(EventType::WorkflowExecutionSignaled),
+            "WorkflowExecutionStarted" => Ok(EventType::WorkflowExecutionStarted),
+            "WorkflowExecutionTerminated" => Ok(EventType::WorkflowExecutionTerminated),
+            "WorkflowExecutionTimedOut" => Ok(EventType::WorkflowExecutionTimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionStatus {
+    Closed,
+    Open,
+}
+
+impl Into<String> for ExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionStatus::Closed => "CLOSED",
+            ExecutionStatus::Open => "OPEN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLOSED" => Ok(ExecutionStatus::Closed),
+            "OPEN" => Ok(ExecutionStatus::Open),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Used to filter the workflow executions in visibility APIs by various time-based rules. Each parameter, if specified, defines a rule that must be satisfied by each returned query result. The parameter values are in the <a href=\"https://en.wikipedia.org/wiki/Unix_time\">Unix Time format</a>. For example: <code>\"oldestDate\": 1325376070.</code></p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ExecutionTimeFilter {
@@ -900,6 +1571,43 @@ pub struct FailWorkflowExecutionDecisionAttributes {
     #[serde(rename="reason")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub reason: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    UnhandledDecision,
+}
+
+impl Into<String> for FailWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            FailWorkflowExecutionFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+            FailWorkflowExecutionFailedCause::UnhandledDecision => "UNHANDLED_DECISION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(FailWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "UNHANDLED_DECISION" => Ok(FailWorkflowExecutionFailedCause::UnhandledDecision),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details of the <code>FailWorkflowExecutionFailed</code> event.</p>"]
@@ -1284,6 +1992,38 @@ pub struct LambdaFunctionTimedOutEventAttributes {
     pub timeout_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LambdaFunctionTimeoutType {
+    StartToClose,
+}
+
+impl Into<String> for LambdaFunctionTimeoutType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LambdaFunctionTimeoutType {
+    fn into(self) -> &'static str {
+        match self {
+            LambdaFunctionTimeoutType::StartToClose => "START_TO_CLOSE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LambdaFunctionTimeoutType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "START_TO_CLOSE" => Ok(LambdaFunctionTimeoutType::StartToClose),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListActivityTypesInput {
     #[doc="<p>The name of the domain in which the activity types have been registered.</p>"]
@@ -1522,6 +2262,38 @@ pub struct RecordMarkerDecisionAttributes {
     pub marker_name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecordMarkerFailedCause {
+    OperationNotPermitted,
+}
+
+impl Into<String> for RecordMarkerFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecordMarkerFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            RecordMarkerFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecordMarkerFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => Ok(RecordMarkerFailedCause::OperationNotPermitted),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides details of the <code>RecordMarkerFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RecordMarkerFailedEventAttributes {
@@ -1632,12 +2404,86 @@ pub struct RegisterWorkflowTypeInput {
     pub version: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RegistrationStatus {
+    Deprecated,
+    Registered,
+}
+
+impl Into<String> for RegistrationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RegistrationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RegistrationStatus::Deprecated => "DEPRECATED",
+            RegistrationStatus::Registered => "REGISTERED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RegistrationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEPRECATED" => Ok(RegistrationStatus::Deprecated),
+            "REGISTERED" => Ok(RegistrationStatus::Registered),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides details of the <code>RequestCancelActivityTask</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RequestCancelActivityTaskDecisionAttributes {
     #[doc="<p>The <code>activityId</code> of the activity task to be canceled.</p>"]
     #[serde(rename="activityId")]
     pub activity_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequestCancelActivityTaskFailedCause {
+    ActivityIdUnknown,
+    OperationNotPermitted,
+}
+
+impl Into<String> for RequestCancelActivityTaskFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequestCancelActivityTaskFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            RequestCancelActivityTaskFailedCause::ActivityIdUnknown => "ACTIVITY_ID_UNKNOWN",
+            RequestCancelActivityTaskFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequestCancelActivityTaskFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVITY_ID_UNKNOWN" => Ok(RequestCancelActivityTaskFailedCause::ActivityIdUnknown),
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(RequestCancelActivityTaskFailedCause::OperationNotPermitted)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details of the <code>RequestCancelActivityTaskFailed</code> event.</p>"]
@@ -1668,6 +2514,50 @@ pub struct RequestCancelExternalWorkflowExecutionDecisionAttributes {
     #[doc="<p><b>Required.</b> The <code>workflowId</code> of the external workflow execution to cancel.</p>"]
     #[serde(rename="workflowId")]
     pub workflow_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequestCancelExternalWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    RequestCancelExternalWorkflowExecutionRateExceeded,
+    UnknownExternalWorkflowExecution,
+}
+
+impl Into<String> for RequestCancelExternalWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequestCancelExternalWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            RequestCancelExternalWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            RequestCancelExternalWorkflowExecutionFailedCause::RequestCancelExternalWorkflowExecutionRateExceeded => "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+            RequestCancelExternalWorkflowExecutionFailedCause::UnknownExternalWorkflowExecution => {
+                "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequestCancelExternalWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(RequestCancelExternalWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED" => Ok(RequestCancelExternalWorkflowExecutionFailedCause::RequestCancelExternalWorkflowExecutionRateExceeded),
+            "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION" => Ok(RequestCancelExternalWorkflowExecutionFailedCause::UnknownExternalWorkflowExecution),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details of the <code>RequestCancelExternalWorkflowExecutionFailed</code> event.</p>"]
@@ -1831,6 +2721,104 @@ pub struct ScheduleActivityTaskDecisionAttributes {
     pub task_priority: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScheduleActivityTaskFailedCause {
+    ActivityCreationRateExceeded,
+    ActivityIdAlreadyInUse,
+    ActivityTypeDeprecated,
+    ActivityTypeDoesNotExist,
+    DefaultHeartbeatTimeoutUndefined,
+    DefaultScheduleToCloseTimeoutUndefined,
+    DefaultScheduleToStartTimeoutUndefined,
+    DefaultStartToCloseTimeoutUndefined,
+    DefaultTaskListUndefined,
+    OpenActivitiesLimitExceeded,
+    OperationNotPermitted,
+}
+
+impl Into<String> for ScheduleActivityTaskFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScheduleActivityTaskFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            ScheduleActivityTaskFailedCause::ActivityCreationRateExceeded => {
+                "ACTIVITY_CREATION_RATE_EXCEEDED"
+            }
+            ScheduleActivityTaskFailedCause::ActivityIdAlreadyInUse => "ACTIVITY_ID_ALREADY_IN_USE",
+            ScheduleActivityTaskFailedCause::ActivityTypeDeprecated => "ACTIVITY_TYPE_DEPRECATED",
+            ScheduleActivityTaskFailedCause::ActivityTypeDoesNotExist => {
+                "ACTIVITY_TYPE_DOES_NOT_EXIST"
+            }
+            ScheduleActivityTaskFailedCause::DefaultHeartbeatTimeoutUndefined => {
+                "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::DefaultScheduleToCloseTimeoutUndefined => {
+                "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::DefaultScheduleToStartTimeoutUndefined => {
+                "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::DefaultStartToCloseTimeoutUndefined => {
+                "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::DefaultTaskListUndefined => {
+                "DEFAULT_TASK_LIST_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::OpenActivitiesLimitExceeded => {
+                "OPEN_ACTIVITIES_LIMIT_EXCEEDED"
+            }
+            ScheduleActivityTaskFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScheduleActivityTaskFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVITY_CREATION_RATE_EXCEEDED" => {
+                Ok(ScheduleActivityTaskFailedCause::ActivityCreationRateExceeded)
+            }
+            "ACTIVITY_ID_ALREADY_IN_USE" => {
+                Ok(ScheduleActivityTaskFailedCause::ActivityIdAlreadyInUse)
+            }
+            "ACTIVITY_TYPE_DEPRECATED" => {
+                Ok(ScheduleActivityTaskFailedCause::ActivityTypeDeprecated)
+            }
+            "ACTIVITY_TYPE_DOES_NOT_EXIST" => {
+                Ok(ScheduleActivityTaskFailedCause::ActivityTypeDoesNotExist)
+            }
+            "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultHeartbeatTimeoutUndefined)
+            }
+            "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultScheduleToCloseTimeoutUndefined)
+            }
+            "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultScheduleToStartTimeoutUndefined)
+            }
+            "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultStartToCloseTimeoutUndefined)
+            }
+            "DEFAULT_TASK_LIST_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultTaskListUndefined)
+            }
+            "OPEN_ACTIVITIES_LIMIT_EXCEEDED" => {
+                Ok(ScheduleActivityTaskFailedCause::OpenActivitiesLimitExceeded)
+            }
+            "OPERATION_NOT_PERMITTED" => Ok(ScheduleActivityTaskFailedCause::OperationNotPermitted),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides details of the <code>ScheduleActivityTaskFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ScheduleActivityTaskFailedEventAttributes {
@@ -1865,6 +2853,59 @@ pub struct ScheduleLambdaFunctionDecisionAttributes {
     #[serde(rename="startToCloseTimeout")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub start_to_close_timeout: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScheduleLambdaFunctionFailedCause {
+    IdAlreadyInUse,
+    LambdaFunctionCreationRateExceeded,
+    LambdaServiceNotAvailableInRegion,
+    OpenLambdaFunctionsLimitExceeded,
+}
+
+impl Into<String> for ScheduleLambdaFunctionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScheduleLambdaFunctionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            ScheduleLambdaFunctionFailedCause::IdAlreadyInUse => "ID_ALREADY_IN_USE",
+            ScheduleLambdaFunctionFailedCause::LambdaFunctionCreationRateExceeded => {
+                "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED"
+            }
+            ScheduleLambdaFunctionFailedCause::LambdaServiceNotAvailableInRegion => {
+                "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION"
+            }
+            ScheduleLambdaFunctionFailedCause::OpenLambdaFunctionsLimitExceeded => {
+                "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScheduleLambdaFunctionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ID_ALREADY_IN_USE" => Ok(ScheduleLambdaFunctionFailedCause::IdAlreadyInUse),
+            "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED" => {
+                Ok(ScheduleLambdaFunctionFailedCause::LambdaFunctionCreationRateExceeded)
+            }
+            "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION" => {
+                Ok(ScheduleLambdaFunctionFailedCause::LambdaServiceNotAvailableInRegion)
+            }
+            "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED" => {
+                Ok(ScheduleLambdaFunctionFailedCause::OpenLambdaFunctionsLimitExceeded)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details for the <code>ScheduleLambdaFunctionFailed</code> event.</p>"]
@@ -1905,6 +2946,52 @@ pub struct SignalExternalWorkflowExecutionDecisionAttributes {
     #[doc="<p><b>Required.</b> The <code>workflowId</code> of the workflow execution to be signaled.</p>"]
     #[serde(rename="workflowId")]
     pub workflow_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SignalExternalWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    SignalExternalWorkflowExecutionRateExceeded,
+    UnknownExternalWorkflowExecution,
+}
+
+impl Into<String> for SignalExternalWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SignalExternalWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            SignalExternalWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            SignalExternalWorkflowExecutionFailedCause::SignalExternalWorkflowExecutionRateExceeded => "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+            SignalExternalWorkflowExecutionFailedCause::UnknownExternalWorkflowExecution => {
+                "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for SignalExternalWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(SignalExternalWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED" => Ok(SignalExternalWorkflowExecutionFailedCause::SignalExternalWorkflowExecutionRateExceeded),
+            "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION" => {
+                Ok(SignalExternalWorkflowExecutionFailedCause::UnknownExternalWorkflowExecution)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details of the <code>SignalExternalWorkflowExecutionFailed</code> event.</p>"]
@@ -2025,6 +3112,108 @@ pub struct StartChildWorkflowExecutionDecisionAttributes {
     pub workflow_type: WorkflowType,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StartChildWorkflowExecutionFailedCause {
+    ChildCreationRateExceeded,
+    DefaultChildPolicyUndefined,
+    DefaultExecutionStartToCloseTimeoutUndefined,
+    DefaultTaskListUndefined,
+    DefaultTaskStartToCloseTimeoutUndefined,
+    OpenChildrenLimitExceeded,
+    OpenWorkflowsLimitExceeded,
+    OperationNotPermitted,
+    WorkflowAlreadyRunning,
+    WorkflowTypeDeprecated,
+    WorkflowTypeDoesNotExist,
+}
+
+impl Into<String> for StartChildWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StartChildWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            StartChildWorkflowExecutionFailedCause::ChildCreationRateExceeded => {
+                "CHILD_CREATION_RATE_EXCEEDED"
+            }
+            StartChildWorkflowExecutionFailedCause::DefaultChildPolicyUndefined => {
+                "DEFAULT_CHILD_POLICY_UNDEFINED"
+            }
+            StartChildWorkflowExecutionFailedCause::DefaultExecutionStartToCloseTimeoutUndefined => "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+            StartChildWorkflowExecutionFailedCause::DefaultTaskListUndefined => {
+                "DEFAULT_TASK_LIST_UNDEFINED"
+            }
+            StartChildWorkflowExecutionFailedCause::DefaultTaskStartToCloseTimeoutUndefined => {
+                "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+            }
+            StartChildWorkflowExecutionFailedCause::OpenChildrenLimitExceeded => {
+                "OPEN_CHILDREN_LIMIT_EXCEEDED"
+            }
+            StartChildWorkflowExecutionFailedCause::OpenWorkflowsLimitExceeded => {
+                "OPEN_WORKFLOWS_LIMIT_EXCEEDED"
+            }
+            StartChildWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            StartChildWorkflowExecutionFailedCause::WorkflowAlreadyRunning => {
+                "WORKFLOW_ALREADY_RUNNING"
+            }
+            StartChildWorkflowExecutionFailedCause::WorkflowTypeDeprecated => {
+                "WORKFLOW_TYPE_DEPRECATED"
+            }
+            StartChildWorkflowExecutionFailedCause::WorkflowTypeDoesNotExist => {
+                "WORKFLOW_TYPE_DOES_NOT_EXIST"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for StartChildWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHILD_CREATION_RATE_EXCEEDED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::ChildCreationRateExceeded)
+            }
+            "DEFAULT_CHILD_POLICY_UNDEFINED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::DefaultChildPolicyUndefined)
+            }
+            "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED" => Ok(StartChildWorkflowExecutionFailedCause::DefaultExecutionStartToCloseTimeoutUndefined),
+            "DEFAULT_TASK_LIST_UNDEFINED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::DefaultTaskListUndefined)
+            }
+            "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::DefaultTaskStartToCloseTimeoutUndefined)
+            }
+            "OPEN_CHILDREN_LIMIT_EXCEEDED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::OpenChildrenLimitExceeded)
+            }
+            "OPEN_WORKFLOWS_LIMIT_EXCEEDED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::OpenWorkflowsLimitExceeded)
+            }
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "WORKFLOW_ALREADY_RUNNING" => {
+                Ok(StartChildWorkflowExecutionFailedCause::WorkflowAlreadyRunning)
+            }
+            "WORKFLOW_TYPE_DEPRECATED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::WorkflowTypeDeprecated)
+            }
+            "WORKFLOW_TYPE_DOES_NOT_EXIST" => {
+                Ok(StartChildWorkflowExecutionFailedCause::WorkflowTypeDoesNotExist)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides details of the <code>StartChildWorkflowExecutionFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StartChildWorkflowExecutionFailedEventAttributes {
@@ -2096,6 +3285,38 @@ pub struct StartChildWorkflowExecutionInitiatedEventAttributes {
     pub workflow_type: WorkflowType,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StartLambdaFunctionFailedCause {
+    AssumeRoleFailed,
+}
+
+impl Into<String> for StartLambdaFunctionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StartLambdaFunctionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            StartLambdaFunctionFailedCause::AssumeRoleFailed => "ASSUME_ROLE_FAILED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StartLambdaFunctionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSUME_ROLE_FAILED" => Ok(StartLambdaFunctionFailedCause::AssumeRoleFailed),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides details for the <code>StartLambdaFunctionFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StartLambdaFunctionFailedEventAttributes {
@@ -2126,6 +3347,47 @@ pub struct StartTimerDecisionAttributes {
     #[doc="<p><b>Required.</b> The unique ID of the timer.</p> <p>The specified string must not start or end with whitespace. It must not contain a <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any control characters (\\u0000-\\u001f | \\u007f - \\u009f). Also, it must not contain the literal string quotarnquot.</p>"]
     #[serde(rename="timerId")]
     pub timer_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StartTimerFailedCause {
+    OpenTimersLimitExceeded,
+    OperationNotPermitted,
+    TimerCreationRateExceeded,
+    TimerIdAlreadyInUse,
+}
+
+impl Into<String> for StartTimerFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StartTimerFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            StartTimerFailedCause::OpenTimersLimitExceeded => "OPEN_TIMERS_LIMIT_EXCEEDED",
+            StartTimerFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+            StartTimerFailedCause::TimerCreationRateExceeded => "TIMER_CREATION_RATE_EXCEEDED",
+            StartTimerFailedCause::TimerIdAlreadyInUse => "TIMER_ID_ALREADY_IN_USE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StartTimerFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPEN_TIMERS_LIMIT_EXCEEDED" => Ok(StartTimerFailedCause::OpenTimersLimitExceeded),
+            "OPERATION_NOT_PERMITTED" => Ok(StartTimerFailedCause::OperationNotPermitted),
+            "TIMER_CREATION_RATE_EXCEEDED" => Ok(StartTimerFailedCause::TimerCreationRateExceeded),
+            "TIMER_ID_ALREADY_IN_USE" => Ok(StartTimerFailedCause::TimerIdAlreadyInUse),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details of the <code>StartTimerFailed</code> event.</p>"]
@@ -2281,6 +3543,38 @@ pub struct WorkflowExecution {
     #[doc="<p>The user defined identifier associated with the workflow execution.</p>"]
     #[serde(rename="workflowId")]
     pub workflow_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkflowExecutionCancelRequestedCause {
+    ChildPolicyApplied,
+}
+
+impl Into<String> for WorkflowExecutionCancelRequestedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkflowExecutionCancelRequestedCause {
+    fn into(self) -> &'static str {
+        match self {
+            WorkflowExecutionCancelRequestedCause::ChildPolicyApplied => "CHILD_POLICY_APPLIED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkflowExecutionCancelRequestedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHILD_POLICY_APPLIED" => Ok(WorkflowExecutionCancelRequestedCause::ChildPolicyApplied),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides details of the <code>WorkflowExecutionCancelRequested</code> event.</p>"]
@@ -2587,6 +3881,44 @@ pub struct WorkflowExecutionStartedEventAttributes {
     pub workflow_type: WorkflowType,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkflowExecutionTerminatedCause {
+    ChildPolicyApplied,
+    EventLimitExceeded,
+    OperatorInitiated,
+}
+
+impl Into<String> for WorkflowExecutionTerminatedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkflowExecutionTerminatedCause {
+    fn into(self) -> &'static str {
+        match self {
+            WorkflowExecutionTerminatedCause::ChildPolicyApplied => "CHILD_POLICY_APPLIED",
+            WorkflowExecutionTerminatedCause::EventLimitExceeded => "EVENT_LIMIT_EXCEEDED",
+            WorkflowExecutionTerminatedCause::OperatorInitiated => "OPERATOR_INITIATED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkflowExecutionTerminatedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHILD_POLICY_APPLIED" => Ok(WorkflowExecutionTerminatedCause::ChildPolicyApplied),
+            "EVENT_LIMIT_EXCEEDED" => Ok(WorkflowExecutionTerminatedCause::EventLimitExceeded),
+            "OPERATOR_INITIATED" => Ok(WorkflowExecutionTerminatedCause::OperatorInitiated),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides details of the <code>WorkflowExecutionTerminated</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct WorkflowExecutionTerminatedEventAttributes {
@@ -2616,6 +3948,38 @@ pub struct WorkflowExecutionTimedOutEventAttributes {
     #[doc="<p>The type of timeout that caused this event.</p>"]
     #[serde(rename="timeoutType")]
     pub timeout_type: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkflowExecutionTimeoutType {
+    StartToClose,
+}
+
+impl Into<String> for WorkflowExecutionTimeoutType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkflowExecutionTimeoutType {
+    fn into(self) -> &'static str {
+        match self {
+            WorkflowExecutionTimeoutType::StartToClose => "START_TO_CLOSE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkflowExecutionTimeoutType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "START_TO_CLOSE" => Ok(WorkflowExecutionTimeoutType::StartToClose),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a workflow type.</p>"]
@@ -5455,7 +6819,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<WorkflowExecutionCount>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CountClosedWorkflowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5481,7 +6845,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<WorkflowExecutionCount>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CountOpenWorkflowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5506,7 +6870,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PendingTaskCount>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CountPendingActivityTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5531,7 +6895,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<PendingTaskCount>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CountPendingDecisionTasksError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5556,7 +6920,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeprecateActivityTypeError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))
@@ -5579,7 +6943,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeprecateDomainError::from_body(String::from_utf8_lossy(&response.body)
                                                         .as_ref()))
@@ -5605,7 +6969,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(DeprecateWorkflowTypeError::from_body(String::from_utf8_lossy(&response.body)
                                                               .as_ref()))
@@ -5630,7 +6994,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ActivityTypeDetail>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5657,7 +7021,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<DomainDetail>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())
@@ -5688,7 +7052,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<WorkflowExecutionDetail>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5712,7 +7076,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<WorkflowTypeDetail>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5740,7 +7104,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<History>(String::from_utf8_lossy(&response.body)
                                                        .as_ref())
                            .unwrap())
@@ -5766,7 +7130,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ActivityTypeInfos>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5795,7 +7159,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<WorkflowExecutionInfos>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListClosedWorkflowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5817,7 +7181,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<DomainInfos>(String::from_utf8_lossy(&response.body)
                                                            .as_ref())
                            .unwrap())
@@ -5845,7 +7209,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<WorkflowExecutionInfos>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListOpenWorkflowExecutionsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5869,7 +7233,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<WorkflowTypeInfos>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -5896,7 +7260,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<ActivityTask>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())
@@ -5925,7 +7289,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<DecisionTask>(String::from_utf8_lossy(&response.body)
                                                             .as_ref())
                            .unwrap())
@@ -5956,7 +7320,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ActivityTaskStatus>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(RecordActivityTaskHeartbeatError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -5980,7 +7344,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(RegisterActivityTypeError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -6003,7 +7367,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(RegisterDomainError::from_body(String::from_utf8_lossy(&response.body)
                                                        .as_ref()))
@@ -6028,7 +7392,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 Err(RegisterWorkflowTypeError::from_body(String::from_utf8_lossy(&response.body)
                                                              .as_ref()))
@@ -6054,7 +7418,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RequestCancelWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6077,7 +7441,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RespondActivityTaskCanceledError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6100,7 +7464,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RespondActivityTaskCompletedError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6123,7 +7487,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RespondActivityTaskFailedError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6146,7 +7510,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(RespondDecisionTaskCompletedError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6169,7 +7533,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(SignalWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }
@@ -6192,7 +7556,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<Run>(String::from_utf8_lossy(&response.body).as_ref())
                        .unwrap())
             }
@@ -6221,7 +7585,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => Err(TerminateWorkflowExecutionError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
         }
     }

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -114,6 +110,126 @@ pub struct ByteMatchTuple {
     #[doc="<p>Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass AWS WAF. If you specify a transformation, AWS WAF performs the transformation on <code>TargetString</code> before inspecting a request for a match.</p> <p> <b>CMD_LINE</b> </p> <p>When you're concerned that attackers are injecting an operating system commandline command and using unusual formatting to disguise some or all of the command, use this option to perform the following transformations:</p> <ul> <li> <p>Delete the following characters: \\ \" ' ^</p> </li> <li> <p>Delete spaces before the following characters: / (</p> </li> <li> <p>Replace the following characters with a space: , ;</p> </li> <li> <p>Replace multiple spaces with one space</p> </li> <li> <p>Convert uppercase letters (A-Z) to lowercase (a-z)</p> </li> </ul> <p> <b>COMPRESS_WHITE_SPACE</b> </p> <p>Use this option to replace the following characters with a space character (decimal 32):</p> <ul> <li> <p>\\f, formfeed, decimal 12</p> </li> <li> <p>\\t, tab, decimal 9</p> </li> <li> <p>\\n, newline, decimal 10</p> </li> <li> <p>\\r, carriage return, decimal 13</p> </li> <li> <p>\\v, vertical tab, decimal 11</p> </li> <li> <p>non-breaking space, decimal 160</p> </li> </ul> <p> <code>COMPRESS_WHITE_SPACE</code> also replaces multiple spaces with one space.</p> <p> <b>HTML_ENTITY_DECODE</b> </p> <p>Use this option to replace HTML-encoded characters with unencoded characters. <code>HTML_ENTITY_DECODE</code> performs the following operations:</p> <ul> <li> <p>Replaces <code>(ampersand)quot;</code> with <code>\"</code> </p> </li> <li> <p>Replaces <code>(ampersand)nbsp;</code> with a non-breaking space, decimal 160</p> </li> <li> <p>Replaces <code>(ampersand)lt;</code> with a \"less than\" symbol</p> </li> <li> <p>Replaces <code>(ampersand)gt;</code> with <code>&gt;</code> </p> </li> <li> <p>Replaces characters that are represented in hexadecimal format, <code>(ampersand)#xhhhh;</code>, with the corresponding characters</p> </li> <li> <p>Replaces characters that are represented in decimal format, <code>(ampersand)#nnnn;</code>, with the corresponding characters</p> </li> </ul> <p> <b>LOWERCASE</b> </p> <p>Use this option to convert uppercase letters (A-Z) to lowercase (a-z).</p> <p> <b>URL_DECODE</b> </p> <p>Use this option to decode a URL-encoded value.</p> <p> <b>NONE</b> </p> <p>Specify <code>NONE</code> if you don't want to perform any text transformations.</p>"]
     #[serde(rename="TextTransformation")]
     pub text_transformation: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeAction {
+    Delete,
+    Insert,
+}
+
+impl Into<String> for ChangeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeAction {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeAction::Delete => "DELETE",
+            ChangeAction::Insert => "INSERT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE" => Ok(ChangeAction::Delete),
+            "INSERT" => Ok(ChangeAction::Insert),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeTokenStatus {
+    Insync,
+    Pending,
+    Provisioned,
+}
+
+impl Into<String> for ChangeTokenStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeTokenStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeTokenStatus::Insync => "INSYNC",
+            ChangeTokenStatus::Pending => "PENDING",
+            ChangeTokenStatus::Provisioned => "PROVISIONED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeTokenStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSYNC" => Ok(ChangeTokenStatus::Insync),
+            "PENDING" => Ok(ChangeTokenStatus::Pending),
+            "PROVISIONED" => Ok(ChangeTokenStatus::Provisioned),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    Eq,
+    Ge,
+    Gt,
+    Le,
+    Lt,
+    Ne,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::Eq => "EQ",
+            ComparisonOperator::Ge => "GE",
+            ComparisonOperator::Gt => "GT",
+            ComparisonOperator::Le => "LE",
+            ComparisonOperator::Lt => "LT",
+            ComparisonOperator::Ne => "NE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EQ" => Ok(ComparisonOperator::Eq),
+            "GE" => Ok(ComparisonOperator::Ge),
+            "GT" => Ok(ComparisonOperator::Gt),
+            "LE" => Ok(ComparisonOperator::Le),
+            "LT" => Ok(ComparisonOperator::Lt),
+            "NE" => Ok(ComparisonOperator::Ne),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -772,6 +888,41 @@ pub struct IPSetDescriptor {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IPSetDescriptorType {
+    Ipv4,
+    Ipv6,
+}
+
+impl Into<String> for IPSetDescriptorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IPSetDescriptorType {
+    fn into(self) -> &'static str {
+        match self {
+            IPSetDescriptorType::Ipv4 => "IPV4",
+            IPSetDescriptorType::Ipv6 => "IPV6",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IPSetDescriptorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IPV4" => Ok(IPSetDescriptorType::Ipv4),
+            "IPV6" => Ok(IPSetDescriptorType::Ipv6),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the identifier and the name of the <code>IPSet</code>.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct IPSetSummary {
@@ -1005,6 +1156,208 @@ pub struct ListXssMatchSetsResponse {
     pub xss_match_sets: Option<Vec<XssMatchSetSummary>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MatchFieldType {
+    Body,
+    Header,
+    Method,
+    QueryString,
+    Uri,
+}
+
+impl Into<String> for MatchFieldType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MatchFieldType {
+    fn into(self) -> &'static str {
+        match self {
+            MatchFieldType::Body => "BODY",
+            MatchFieldType::Header => "HEADER",
+            MatchFieldType::Method => "METHOD",
+            MatchFieldType::QueryString => "QUERY_STRING",
+            MatchFieldType::Uri => "URI",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MatchFieldType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BODY" => Ok(MatchFieldType::Body),
+            "HEADER" => Ok(MatchFieldType::Header),
+            "METHOD" => Ok(MatchFieldType::Method),
+            "QUERY_STRING" => Ok(MatchFieldType::QueryString),
+            "URI" => Ok(MatchFieldType::Uri),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterExceptionField {
+    ByteMatchFieldType,
+    ByteMatchPositionalConstraint,
+    ByteMatchTextTransformation,
+    ChangeAction,
+    IpsetType,
+    NextMarker,
+    PredicateType,
+    RateKey,
+    RuleType,
+    SizeConstraintComparisonOperator,
+    SqlInjectionMatchFieldType,
+    WafAction,
+}
+
+impl Into<String> for ParameterExceptionField {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterExceptionField {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterExceptionField::ByteMatchFieldType => "BYTE_MATCH_FIELD_TYPE",
+            ParameterExceptionField::ByteMatchPositionalConstraint => {
+                "BYTE_MATCH_POSITIONAL_CONSTRAINT"
+            }
+            ParameterExceptionField::ByteMatchTextTransformation => {
+                "BYTE_MATCH_TEXT_TRANSFORMATION"
+            }
+            ParameterExceptionField::ChangeAction => "CHANGE_ACTION",
+            ParameterExceptionField::IpsetType => "IPSET_TYPE",
+            ParameterExceptionField::NextMarker => "NEXT_MARKER",
+            ParameterExceptionField::PredicateType => "PREDICATE_TYPE",
+            ParameterExceptionField::RateKey => "RATE_KEY",
+            ParameterExceptionField::RuleType => "RULE_TYPE",
+            ParameterExceptionField::SizeConstraintComparisonOperator => {
+                "SIZE_CONSTRAINT_COMPARISON_OPERATOR"
+            }
+            ParameterExceptionField::SqlInjectionMatchFieldType => "SQL_INJECTION_MATCH_FIELD_TYPE",
+            ParameterExceptionField::WafAction => "WAF_ACTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterExceptionField {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BYTE_MATCH_FIELD_TYPE" => Ok(ParameterExceptionField::ByteMatchFieldType),
+            "BYTE_MATCH_POSITIONAL_CONSTRAINT" => {
+                Ok(ParameterExceptionField::ByteMatchPositionalConstraint)
+            }
+            "BYTE_MATCH_TEXT_TRANSFORMATION" => {
+                Ok(ParameterExceptionField::ByteMatchTextTransformation)
+            }
+            "CHANGE_ACTION" => Ok(ParameterExceptionField::ChangeAction),
+            "IPSET_TYPE" => Ok(ParameterExceptionField::IpsetType),
+            "NEXT_MARKER" => Ok(ParameterExceptionField::NextMarker),
+            "PREDICATE_TYPE" => Ok(ParameterExceptionField::PredicateType),
+            "RATE_KEY" => Ok(ParameterExceptionField::RateKey),
+            "RULE_TYPE" => Ok(ParameterExceptionField::RuleType),
+            "SIZE_CONSTRAINT_COMPARISON_OPERATOR" => {
+                Ok(ParameterExceptionField::SizeConstraintComparisonOperator)
+            }
+            "SQL_INJECTION_MATCH_FIELD_TYPE" => {
+                Ok(ParameterExceptionField::SqlInjectionMatchFieldType)
+            }
+            "WAF_ACTION" => Ok(ParameterExceptionField::WafAction),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterExceptionReason {
+    IllegalCombination,
+    InvalidOption,
+}
+
+impl Into<String> for ParameterExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterExceptionReason::IllegalCombination => "ILLEGAL_COMBINATION",
+            ParameterExceptionReason::InvalidOption => "INVALID_OPTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ILLEGAL_COMBINATION" => Ok(ParameterExceptionReason::IllegalCombination),
+            "INVALID_OPTION" => Ok(ParameterExceptionReason::InvalidOption),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PositionalConstraint {
+    Contains,
+    ContainsWord,
+    EndsWith,
+    Exactly,
+    StartsWith,
+}
+
+impl Into<String> for PositionalConstraint {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PositionalConstraint {
+    fn into(self) -> &'static str {
+        match self {
+            PositionalConstraint::Contains => "CONTAINS",
+            PositionalConstraint::ContainsWord => "CONTAINS_WORD",
+            PositionalConstraint::EndsWith => "ENDS_WITH",
+            PositionalConstraint::Exactly => "EXACTLY",
+            PositionalConstraint::StartsWith => "STARTS_WITH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PositionalConstraint {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTAINS" => Ok(PositionalConstraint::Contains),
+            "CONTAINS_WORD" => Ok(PositionalConstraint::ContainsWord),
+            "ENDS_WITH" => Ok(PositionalConstraint::EndsWith),
+            "EXACTLY" => Ok(PositionalConstraint::Exactly),
+            "STARTS_WITH" => Ok(PositionalConstraint::StartsWith),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the <a>ByteMatchSet</a>, <a>IPSet</a>, <a>SqlInjectionMatchSet</a>, <a>XssMatchSet</a>, and <a>SizeConstraintSet</a> objects that you want to add to a <code>Rule</code> and, for each object, indicates whether you want to negate the settings, for example, requests that do NOT originate from the IP address 192.0.2.44. </p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Predicate {
@@ -1017,6 +1370,50 @@ pub struct Predicate {
     #[doc="<p>The type of predicate in a <code>Rule</code>, such as <code>ByteMatchSet</code> or <code>IPSet</code>.</p>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PredicateType {
+    ByteMatch,
+    Ipmatch,
+    SizeConstraint,
+    SqlInjectionMatch,
+    XssMatch,
+}
+
+impl Into<String> for PredicateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PredicateType {
+    fn into(self) -> &'static str {
+        match self {
+            PredicateType::ByteMatch => "ByteMatch",
+            PredicateType::Ipmatch => "IPMatch",
+            PredicateType::SizeConstraint => "SizeConstraint",
+            PredicateType::SqlInjectionMatch => "SqlInjectionMatch",
+            PredicateType::XssMatch => "XssMatch",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PredicateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ByteMatch" => Ok(PredicateType::ByteMatch),
+            "IPMatch" => Ok(PredicateType::Ipmatch),
+            "SizeConstraint" => Ok(PredicateType::SizeConstraint),
+            "SqlInjectionMatch" => Ok(PredicateType::SqlInjectionMatch),
+            "XssMatch" => Ok(PredicateType::XssMatch),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>"]
@@ -1042,6 +1439,38 @@ pub struct RateBasedRule {
     #[doc="<p>A unique identifier for a <code>RateBasedRule</code>. You use <code>RuleId</code> to get more information about a <code>RateBasedRule</code> (see <a>GetRateBasedRule</a>), update a <code>RateBasedRule</code> (see <a>UpdateRateBasedRule</a>), insert a <code>RateBasedRule</code> into a <code>WebACL</code> or delete one from a <code>WebACL</code> (see <a>UpdateWebACL</a>), or delete a <code>RateBasedRule</code> from AWS WAF (see <a>DeleteRateBasedRule</a>).</p>"]
     #[serde(rename="RuleId")]
     pub rule_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RateKey {
+    Ip,
+}
+
+impl Into<String> for RateKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RateKey {
+    fn into(self) -> &'static str {
+        match self {
+            RateKey::Ip => "IP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RateKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IP" => Ok(RateKey::Ip),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>"]
@@ -1204,6 +1633,53 @@ pub struct SqlInjectionMatchTuple {
     #[doc="<p>Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass AWS WAF. If you specify a transformation, AWS WAF performs the transformation on <code>FieldToMatch</code> before inspecting a request for a match.</p> <p> <b>CMD_LINE</b> </p> <p>When you're concerned that attackers are injecting an operating system commandline command and using unusual formatting to disguise some or all of the command, use this option to perform the following transformations:</p> <ul> <li> <p>Delete the following characters: \\ \" ' ^</p> </li> <li> <p>Delete spaces before the following characters: / (</p> </li> <li> <p>Replace the following characters with a space: , ;</p> </li> <li> <p>Replace multiple spaces with one space</p> </li> <li> <p>Convert uppercase letters (A-Z) to lowercase (a-z)</p> </li> </ul> <p> <b>COMPRESS_WHITE_SPACE</b> </p> <p>Use this option to replace the following characters with a space character (decimal 32):</p> <ul> <li> <p>\\f, formfeed, decimal 12</p> </li> <li> <p>\\t, tab, decimal 9</p> </li> <li> <p>\\n, newline, decimal 10</p> </li> <li> <p>\\r, carriage return, decimal 13</p> </li> <li> <p>\\v, vertical tab, decimal 11</p> </li> <li> <p>non-breaking space, decimal 160</p> </li> </ul> <p> <code>COMPRESS_WHITE_SPACE</code> also replaces multiple spaces with one space.</p> <p> <b>HTML_ENTITY_DECODE</b> </p> <p>Use this option to replace HTML-encoded characters with unencoded characters. <code>HTML_ENTITY_DECODE</code> performs the following operations:</p> <ul> <li> <p>Replaces <code>(ampersand)quot;</code> with <code>\"</code> </p> </li> <li> <p>Replaces <code>(ampersand)nbsp;</code> with a non-breaking space, decimal 160</p> </li> <li> <p>Replaces <code>(ampersand)lt;</code> with a \"less than\" symbol</p> </li> <li> <p>Replaces <code>(ampersand)gt;</code> with <code>&gt;</code> </p> </li> <li> <p>Replaces characters that are represented in hexadecimal format, <code>(ampersand)#xhhhh;</code>, with the corresponding characters</p> </li> <li> <p>Replaces characters that are represented in decimal format, <code>(ampersand)#nnnn;</code>, with the corresponding characters</p> </li> </ul> <p> <b>LOWERCASE</b> </p> <p>Use this option to convert uppercase letters (A-Z) to lowercase (a-z).</p> <p> <b>URL_DECODE</b> </p> <p>Use this option to decode a URL-encoded value.</p> <p> <b>NONE</b> </p> <p>Specify <code>NONE</code> if you don't want to perform any text transformations.</p>"]
     #[serde(rename="TextTransformation")]
     pub text_transformation: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TextTransformation {
+    CmdLine,
+    CompressWhiteSpace,
+    HtmlEntityDecode,
+    Lowercase,
+    None,
+    UrlDecode,
+}
+
+impl Into<String> for TextTransformation {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TextTransformation {
+    fn into(self) -> &'static str {
+        match self {
+            TextTransformation::CmdLine => "CMD_LINE",
+            TextTransformation::CompressWhiteSpace => "COMPRESS_WHITE_SPACE",
+            TextTransformation::HtmlEntityDecode => "HTML_ENTITY_DECODE",
+            TextTransformation::Lowercase => "LOWERCASE",
+            TextTransformation::None => "NONE",
+            TextTransformation::UrlDecode => "URL_DECODE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TextTransformation {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CMD_LINE" => Ok(TextTransformation::CmdLine),
+            "COMPRESS_WHITE_SPACE" => Ok(TextTransformation::CompressWhiteSpace),
+            "HTML_ENTITY_DECODE" => Ok(TextTransformation::HtmlEntityDecode),
+            "LOWERCASE" => Ok(TextTransformation::Lowercase),
+            "NONE" => Ok(TextTransformation::None),
+            "URL_DECODE" => Ok(TextTransformation::UrlDecode),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>In a <a>GetSampledRequests</a> request, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which you want AWS WAF to return a sample of web requests.</p> <p>In a <a>GetSampledRequests</a> response, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which AWS WAF actually returned a sample of web requests. AWS WAF gets the specified number of requests from among the first 5,000 requests that your AWS resource receives during the specified time period. If your resource receives more than 5,000 requests during that period, AWS WAF stops sampling after the 5,000th request. In that case, <code>EndTime</code> is the time that AWS WAF received the 5,000th request. </p>"]
@@ -1403,6 +1879,79 @@ pub struct WafAction {
     #[doc="<p>Specifies how you want AWS WAF to respond to requests that match the settings in a <code>Rule</code>. Valid settings include the following:</p> <ul> <li> <p> <code>ALLOW</code>: AWS WAF allows requests</p> </li> <li> <p> <code>BLOCK</code>: AWS WAF blocks requests</p> </li> <li> <p> <code>COUNT</code>: AWS WAF increments a counter of the requests that match all of the conditions in the rule. AWS WAF then continues to inspect the web request based on the remaining rules in the web ACL. You can't specify <code>COUNT</code> for the default action for a <code>WebACL</code>.</p> </li> </ul>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WafActionType {
+    Allow,
+    Block,
+    Count,
+}
+
+impl Into<String> for WafActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WafActionType {
+    fn into(self) -> &'static str {
+        match self {
+            WafActionType::Allow => "ALLOW",
+            WafActionType::Block => "BLOCK",
+            WafActionType::Count => "COUNT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WafActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALLOW" => Ok(WafActionType::Allow),
+            "BLOCK" => Ok(WafActionType::Block),
+            "COUNT" => Ok(WafActionType::Count),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WafRuleType {
+    RateBased,
+    Regular,
+}
+
+impl Into<String> for WafRuleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WafRuleType {
+    fn into(self) -> &'static str {
+        match self {
+            WafRuleType::RateBased => "RATE_BASED",
+            WafRuleType::Regular => "REGULAR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WafRuleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RATE_BASED" => Ok(WafRuleType::RateBased),
+            "REGULAR" => Ok(WafRuleType::Regular),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>"]
@@ -6445,7 +6994,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<AssociateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6473,7 +7022,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6500,7 +7049,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6525,7 +7074,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6552,7 +7101,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6578,7 +7127,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6604,7 +7153,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6628,7 +7177,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6654,7 +7203,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6682,7 +7231,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6709,7 +7258,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6734,7 +7283,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6761,7 +7310,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6787,7 +7336,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6813,7 +7362,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6837,7 +7386,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6863,7 +7412,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6891,7 +7440,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DisassociateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6918,7 +7467,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6942,7 +7491,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetChangeTokenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6971,7 +7520,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetChangeTokenStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6996,7 +7545,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7020,7 +7569,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7049,7 +7598,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRateBasedRuleManagedKeysResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetRateBasedRuleManagedKeysError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7071,7 +7620,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetRuleResponse>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -7098,7 +7647,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetSampledRequestsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7127,7 +7676,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7156,7 +7705,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7178,7 +7727,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7204,7 +7753,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetWebACLForResourceResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7231,7 +7780,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7258,7 +7807,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListByteMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7285,7 +7834,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListIPSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListIPSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7310,7 +7859,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRateBasedRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7339,7 +7888,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListResourcesForWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7364,7 +7913,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListRulesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7390,7 +7939,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListSizeConstraintSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7419,7 +7968,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListSqlInjectionMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListSqlInjectionMatchSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7443,7 +7992,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListWebACLsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListWebACLsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7467,7 +8016,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListXssMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7495,7 +8044,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7522,7 +8071,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7547,7 +8096,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7574,7 +8123,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7600,7 +8149,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7626,7 +8175,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7650,7 +8199,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7676,7 +8225,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -11,15 +11,11 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -101,6 +97,126 @@ pub struct ByteMatchTuple {
     #[doc="<p>Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass AWS WAF. If you specify a transformation, AWS WAF performs the transformation on <code>TargetString</code> before inspecting a request for a match.</p> <p> <b>CMD_LINE</b> </p> <p>When you're concerned that attackers are injecting an operating system commandline command and using unusual formatting to disguise some or all of the command, use this option to perform the following transformations:</p> <ul> <li> <p>Delete the following characters: \\ \" ' ^</p> </li> <li> <p>Delete spaces before the following characters: / (</p> </li> <li> <p>Replace the following characters with a space: , ;</p> </li> <li> <p>Replace multiple spaces with one space</p> </li> <li> <p>Convert uppercase letters (A-Z) to lowercase (a-z)</p> </li> </ul> <p> <b>COMPRESS_WHITE_SPACE</b> </p> <p>Use this option to replace the following characters with a space character (decimal 32):</p> <ul> <li> <p>\\f, formfeed, decimal 12</p> </li> <li> <p>\\t, tab, decimal 9</p> </li> <li> <p>\\n, newline, decimal 10</p> </li> <li> <p>\\r, carriage return, decimal 13</p> </li> <li> <p>\\v, vertical tab, decimal 11</p> </li> <li> <p>non-breaking space, decimal 160</p> </li> </ul> <p> <code>COMPRESS_WHITE_SPACE</code> also replaces multiple spaces with one space.</p> <p> <b>HTML_ENTITY_DECODE</b> </p> <p>Use this option to replace HTML-encoded characters with unencoded characters. <code>HTML_ENTITY_DECODE</code> performs the following operations:</p> <ul> <li> <p>Replaces <code>(ampersand)quot;</code> with <code>\"</code> </p> </li> <li> <p>Replaces <code>(ampersand)nbsp;</code> with a non-breaking space, decimal 160</p> </li> <li> <p>Replaces <code>(ampersand)lt;</code> with a \"less than\" symbol</p> </li> <li> <p>Replaces <code>(ampersand)gt;</code> with <code>&gt;</code> </p> </li> <li> <p>Replaces characters that are represented in hexadecimal format, <code>(ampersand)#xhhhh;</code>, with the corresponding characters</p> </li> <li> <p>Replaces characters that are represented in decimal format, <code>(ampersand)#nnnn;</code>, with the corresponding characters</p> </li> </ul> <p> <b>LOWERCASE</b> </p> <p>Use this option to convert uppercase letters (A-Z) to lowercase (a-z).</p> <p> <b>URL_DECODE</b> </p> <p>Use this option to decode a URL-encoded value.</p> <p> <b>NONE</b> </p> <p>Specify <code>NONE</code> if you don't want to perform any text transformations.</p>"]
     #[serde(rename="TextTransformation")]
     pub text_transformation: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeAction {
+    Delete,
+    Insert,
+}
+
+impl Into<String> for ChangeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeAction {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeAction::Delete => "DELETE",
+            ChangeAction::Insert => "INSERT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE" => Ok(ChangeAction::Delete),
+            "INSERT" => Ok(ChangeAction::Insert),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeTokenStatus {
+    Insync,
+    Pending,
+    Provisioned,
+}
+
+impl Into<String> for ChangeTokenStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeTokenStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeTokenStatus::Insync => "INSYNC",
+            ChangeTokenStatus::Pending => "PENDING",
+            ChangeTokenStatus::Provisioned => "PROVISIONED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeTokenStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSYNC" => Ok(ChangeTokenStatus::Insync),
+            "PENDING" => Ok(ChangeTokenStatus::Pending),
+            "PROVISIONED" => Ok(ChangeTokenStatus::Provisioned),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    Eq,
+    Ge,
+    Gt,
+    Le,
+    Lt,
+    Ne,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::Eq => "EQ",
+            ComparisonOperator::Ge => "GE",
+            ComparisonOperator::Gt => "GT",
+            ComparisonOperator::Le => "LE",
+            ComparisonOperator::Lt => "LT",
+            ComparisonOperator::Ne => "NE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EQ" => Ok(ComparisonOperator::Eq),
+            "GE" => Ok(ComparisonOperator::Ge),
+            "GT" => Ok(ComparisonOperator::Gt),
+            "LE" => Ok(ComparisonOperator::Le),
+            "LT" => Ok(ComparisonOperator::Lt),
+            "NE" => Ok(ComparisonOperator::Ne),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -734,6 +850,41 @@ pub struct IPSetDescriptor {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IPSetDescriptorType {
+    Ipv4,
+    Ipv6,
+}
+
+impl Into<String> for IPSetDescriptorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IPSetDescriptorType {
+    fn into(self) -> &'static str {
+        match self {
+            IPSetDescriptorType::Ipv4 => "IPV4",
+            IPSetDescriptorType::Ipv6 => "IPV6",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IPSetDescriptorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IPV4" => Ok(IPSetDescriptorType::Ipv4),
+            "IPV6" => Ok(IPSetDescriptorType::Ipv6),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the identifier and the name of the <code>IPSet</code>.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct IPSetSummary {
@@ -952,6 +1103,208 @@ pub struct ListXssMatchSetsResponse {
     pub xss_match_sets: Option<Vec<XssMatchSetSummary>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MatchFieldType {
+    Body,
+    Header,
+    Method,
+    QueryString,
+    Uri,
+}
+
+impl Into<String> for MatchFieldType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MatchFieldType {
+    fn into(self) -> &'static str {
+        match self {
+            MatchFieldType::Body => "BODY",
+            MatchFieldType::Header => "HEADER",
+            MatchFieldType::Method => "METHOD",
+            MatchFieldType::QueryString => "QUERY_STRING",
+            MatchFieldType::Uri => "URI",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MatchFieldType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BODY" => Ok(MatchFieldType::Body),
+            "HEADER" => Ok(MatchFieldType::Header),
+            "METHOD" => Ok(MatchFieldType::Method),
+            "QUERY_STRING" => Ok(MatchFieldType::QueryString),
+            "URI" => Ok(MatchFieldType::Uri),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterExceptionField {
+    ByteMatchFieldType,
+    ByteMatchPositionalConstraint,
+    ByteMatchTextTransformation,
+    ChangeAction,
+    IpsetType,
+    NextMarker,
+    PredicateType,
+    RateKey,
+    RuleType,
+    SizeConstraintComparisonOperator,
+    SqlInjectionMatchFieldType,
+    WafAction,
+}
+
+impl Into<String> for ParameterExceptionField {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterExceptionField {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterExceptionField::ByteMatchFieldType => "BYTE_MATCH_FIELD_TYPE",
+            ParameterExceptionField::ByteMatchPositionalConstraint => {
+                "BYTE_MATCH_POSITIONAL_CONSTRAINT"
+            }
+            ParameterExceptionField::ByteMatchTextTransformation => {
+                "BYTE_MATCH_TEXT_TRANSFORMATION"
+            }
+            ParameterExceptionField::ChangeAction => "CHANGE_ACTION",
+            ParameterExceptionField::IpsetType => "IPSET_TYPE",
+            ParameterExceptionField::NextMarker => "NEXT_MARKER",
+            ParameterExceptionField::PredicateType => "PREDICATE_TYPE",
+            ParameterExceptionField::RateKey => "RATE_KEY",
+            ParameterExceptionField::RuleType => "RULE_TYPE",
+            ParameterExceptionField::SizeConstraintComparisonOperator => {
+                "SIZE_CONSTRAINT_COMPARISON_OPERATOR"
+            }
+            ParameterExceptionField::SqlInjectionMatchFieldType => "SQL_INJECTION_MATCH_FIELD_TYPE",
+            ParameterExceptionField::WafAction => "WAF_ACTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterExceptionField {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BYTE_MATCH_FIELD_TYPE" => Ok(ParameterExceptionField::ByteMatchFieldType),
+            "BYTE_MATCH_POSITIONAL_CONSTRAINT" => {
+                Ok(ParameterExceptionField::ByteMatchPositionalConstraint)
+            }
+            "BYTE_MATCH_TEXT_TRANSFORMATION" => {
+                Ok(ParameterExceptionField::ByteMatchTextTransformation)
+            }
+            "CHANGE_ACTION" => Ok(ParameterExceptionField::ChangeAction),
+            "IPSET_TYPE" => Ok(ParameterExceptionField::IpsetType),
+            "NEXT_MARKER" => Ok(ParameterExceptionField::NextMarker),
+            "PREDICATE_TYPE" => Ok(ParameterExceptionField::PredicateType),
+            "RATE_KEY" => Ok(ParameterExceptionField::RateKey),
+            "RULE_TYPE" => Ok(ParameterExceptionField::RuleType),
+            "SIZE_CONSTRAINT_COMPARISON_OPERATOR" => {
+                Ok(ParameterExceptionField::SizeConstraintComparisonOperator)
+            }
+            "SQL_INJECTION_MATCH_FIELD_TYPE" => {
+                Ok(ParameterExceptionField::SqlInjectionMatchFieldType)
+            }
+            "WAF_ACTION" => Ok(ParameterExceptionField::WafAction),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterExceptionReason {
+    IllegalCombination,
+    InvalidOption,
+}
+
+impl Into<String> for ParameterExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterExceptionReason::IllegalCombination => "ILLEGAL_COMBINATION",
+            ParameterExceptionReason::InvalidOption => "INVALID_OPTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ILLEGAL_COMBINATION" => Ok(ParameterExceptionReason::IllegalCombination),
+            "INVALID_OPTION" => Ok(ParameterExceptionReason::InvalidOption),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PositionalConstraint {
+    Contains,
+    ContainsWord,
+    EndsWith,
+    Exactly,
+    StartsWith,
+}
+
+impl Into<String> for PositionalConstraint {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PositionalConstraint {
+    fn into(self) -> &'static str {
+        match self {
+            PositionalConstraint::Contains => "CONTAINS",
+            PositionalConstraint::ContainsWord => "CONTAINS_WORD",
+            PositionalConstraint::EndsWith => "ENDS_WITH",
+            PositionalConstraint::Exactly => "EXACTLY",
+            PositionalConstraint::StartsWith => "STARTS_WITH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PositionalConstraint {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTAINS" => Ok(PositionalConstraint::Contains),
+            "CONTAINS_WORD" => Ok(PositionalConstraint::ContainsWord),
+            "ENDS_WITH" => Ok(PositionalConstraint::EndsWith),
+            "EXACTLY" => Ok(PositionalConstraint::Exactly),
+            "STARTS_WITH" => Ok(PositionalConstraint::StartsWith),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the <a>ByteMatchSet</a>, <a>IPSet</a>, <a>SqlInjectionMatchSet</a>, <a>XssMatchSet</a>, and <a>SizeConstraintSet</a> objects that you want to add to a <code>Rule</code> and, for each object, indicates whether you want to negate the settings, for example, requests that do NOT originate from the IP address 192.0.2.44. </p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Predicate {
@@ -964,6 +1317,50 @@ pub struct Predicate {
     #[doc="<p>The type of predicate in a <code>Rule</code>, such as <code>ByteMatchSet</code> or <code>IPSet</code>.</p>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PredicateType {
+    ByteMatch,
+    Ipmatch,
+    SizeConstraint,
+    SqlInjectionMatch,
+    XssMatch,
+}
+
+impl Into<String> for PredicateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PredicateType {
+    fn into(self) -> &'static str {
+        match self {
+            PredicateType::ByteMatch => "ByteMatch",
+            PredicateType::Ipmatch => "IPMatch",
+            PredicateType::SizeConstraint => "SizeConstraint",
+            PredicateType::SqlInjectionMatch => "SqlInjectionMatch",
+            PredicateType::XssMatch => "XssMatch",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PredicateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ByteMatch" => Ok(PredicateType::ByteMatch),
+            "IPMatch" => Ok(PredicateType::Ipmatch),
+            "SizeConstraint" => Ok(PredicateType::SizeConstraint),
+            "SqlInjectionMatch" => Ok(PredicateType::SqlInjectionMatch),
+            "XssMatch" => Ok(PredicateType::XssMatch),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>"]
@@ -989,6 +1386,38 @@ pub struct RateBasedRule {
     #[doc="<p>A unique identifier for a <code>RateBasedRule</code>. You use <code>RuleId</code> to get more information about a <code>RateBasedRule</code> (see <a>GetRateBasedRule</a>), update a <code>RateBasedRule</code> (see <a>UpdateRateBasedRule</a>), insert a <code>RateBasedRule</code> into a <code>WebACL</code> or delete one from a <code>WebACL</code> (see <a>UpdateWebACL</a>), or delete a <code>RateBasedRule</code> from AWS WAF (see <a>DeleteRateBasedRule</a>).</p>"]
     #[serde(rename="RuleId")]
     pub rule_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RateKey {
+    Ip,
+}
+
+impl Into<String> for RateKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RateKey {
+    fn into(self) -> &'static str {
+        match self {
+            RateKey::Ip => "IP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RateKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IP" => Ok(RateKey::Ip),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>"]
@@ -1151,6 +1580,53 @@ pub struct SqlInjectionMatchTuple {
     #[doc="<p>Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass AWS WAF. If you specify a transformation, AWS WAF performs the transformation on <code>FieldToMatch</code> before inspecting a request for a match.</p> <p> <b>CMD_LINE</b> </p> <p>When you're concerned that attackers are injecting an operating system commandline command and using unusual formatting to disguise some or all of the command, use this option to perform the following transformations:</p> <ul> <li> <p>Delete the following characters: \\ \" ' ^</p> </li> <li> <p>Delete spaces before the following characters: / (</p> </li> <li> <p>Replace the following characters with a space: , ;</p> </li> <li> <p>Replace multiple spaces with one space</p> </li> <li> <p>Convert uppercase letters (A-Z) to lowercase (a-z)</p> </li> </ul> <p> <b>COMPRESS_WHITE_SPACE</b> </p> <p>Use this option to replace the following characters with a space character (decimal 32):</p> <ul> <li> <p>\\f, formfeed, decimal 12</p> </li> <li> <p>\\t, tab, decimal 9</p> </li> <li> <p>\\n, newline, decimal 10</p> </li> <li> <p>\\r, carriage return, decimal 13</p> </li> <li> <p>\\v, vertical tab, decimal 11</p> </li> <li> <p>non-breaking space, decimal 160</p> </li> </ul> <p> <code>COMPRESS_WHITE_SPACE</code> also replaces multiple spaces with one space.</p> <p> <b>HTML_ENTITY_DECODE</b> </p> <p>Use this option to replace HTML-encoded characters with unencoded characters. <code>HTML_ENTITY_DECODE</code> performs the following operations:</p> <ul> <li> <p>Replaces <code>(ampersand)quot;</code> with <code>\"</code> </p> </li> <li> <p>Replaces <code>(ampersand)nbsp;</code> with a non-breaking space, decimal 160</p> </li> <li> <p>Replaces <code>(ampersand)lt;</code> with a \"less than\" symbol</p> </li> <li> <p>Replaces <code>(ampersand)gt;</code> with <code>&gt;</code> </p> </li> <li> <p>Replaces characters that are represented in hexadecimal format, <code>(ampersand)#xhhhh;</code>, with the corresponding characters</p> </li> <li> <p>Replaces characters that are represented in decimal format, <code>(ampersand)#nnnn;</code>, with the corresponding characters</p> </li> </ul> <p> <b>LOWERCASE</b> </p> <p>Use this option to convert uppercase letters (A-Z) to lowercase (a-z).</p> <p> <b>URL_DECODE</b> </p> <p>Use this option to decode a URL-encoded value.</p> <p> <b>NONE</b> </p> <p>Specify <code>NONE</code> if you don't want to perform any text transformations.</p>"]
     #[serde(rename="TextTransformation")]
     pub text_transformation: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TextTransformation {
+    CmdLine,
+    CompressWhiteSpace,
+    HtmlEntityDecode,
+    Lowercase,
+    None,
+    UrlDecode,
+}
+
+impl Into<String> for TextTransformation {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TextTransformation {
+    fn into(self) -> &'static str {
+        match self {
+            TextTransformation::CmdLine => "CMD_LINE",
+            TextTransformation::CompressWhiteSpace => "COMPRESS_WHITE_SPACE",
+            TextTransformation::HtmlEntityDecode => "HTML_ENTITY_DECODE",
+            TextTransformation::Lowercase => "LOWERCASE",
+            TextTransformation::None => "NONE",
+            TextTransformation::UrlDecode => "URL_DECODE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TextTransformation {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CMD_LINE" => Ok(TextTransformation::CmdLine),
+            "COMPRESS_WHITE_SPACE" => Ok(TextTransformation::CompressWhiteSpace),
+            "HTML_ENTITY_DECODE" => Ok(TextTransformation::HtmlEntityDecode),
+            "LOWERCASE" => Ok(TextTransformation::Lowercase),
+            "NONE" => Ok(TextTransformation::None),
+            "URL_DECODE" => Ok(TextTransformation::UrlDecode),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>In a <a>GetSampledRequests</a> request, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which you want AWS WAF to return a sample of web requests.</p> <p>In a <a>GetSampledRequests</a> response, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which AWS WAF actually returned a sample of web requests. AWS WAF gets the specified number of requests from among the first 5,000 requests that your AWS resource receives during the specified time period. If your resource receives more than 5,000 requests during that period, AWS WAF stops sampling after the 5,000th request. In that case, <code>EndTime</code> is the time that AWS WAF received the 5,000th request. </p>"]
@@ -1350,6 +1826,79 @@ pub struct WafAction {
     #[doc="<p>Specifies how you want AWS WAF to respond to requests that match the settings in a <code>Rule</code>. Valid settings include the following:</p> <ul> <li> <p> <code>ALLOW</code>: AWS WAF allows requests</p> </li> <li> <p> <code>BLOCK</code>: AWS WAF blocks requests</p> </li> <li> <p> <code>COUNT</code>: AWS WAF increments a counter of the requests that match all of the conditions in the rule. AWS WAF then continues to inspect the web request based on the remaining rules in the web ACL. You can't specify <code>COUNT</code> for the default action for a <code>WebACL</code>.</p> </li> </ul>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WafActionType {
+    Allow,
+    Block,
+    Count,
+}
+
+impl Into<String> for WafActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WafActionType {
+    fn into(self) -> &'static str {
+        match self {
+            WafActionType::Allow => "ALLOW",
+            WafActionType::Block => "BLOCK",
+            WafActionType::Count => "COUNT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WafActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALLOW" => Ok(WafActionType::Allow),
+            "BLOCK" => Ok(WafActionType::Block),
+            "COUNT" => Ok(WafActionType::Count),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WafRuleType {
+    RateBased,
+    Regular,
+}
+
+impl Into<String> for WafRuleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WafRuleType {
+    fn into(self) -> &'static str {
+        match self {
+            WafRuleType::RateBased => "RATE_BASED",
+            WafRuleType::Regular => "REGULAR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WafRuleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RATE_BASED" => Ok(WafRuleType::RateBased),
+            "REGULAR" => Ok(WafRuleType::Regular),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>"]
@@ -5986,7 +6535,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6013,7 +6562,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6037,7 +6586,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6064,7 +6613,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6089,7 +6638,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6114,7 +6663,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6138,7 +6687,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6164,7 +6713,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6191,7 +6740,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6218,7 +6767,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6242,7 +6791,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6269,7 +6818,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6294,7 +6843,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6319,7 +6868,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6343,7 +6892,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6369,7 +6918,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6396,7 +6945,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6420,7 +6969,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetChangeTokenResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6448,7 +6997,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetChangeTokenStatusResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6473,7 +7022,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6497,7 +7046,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6526,7 +7075,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetRateBasedRuleManagedKeysResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetRateBasedRuleManagedKeysError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6548,7 +7097,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 Ok(serde_json::from_str::<GetRuleResponse>(String::from_utf8_lossy(&response.body)
                                                                .as_ref())
                            .unwrap())
@@ -6574,7 +7123,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetSampledRequestsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6602,7 +7151,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6630,7 +7179,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6652,7 +7201,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(GetWebACLError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6676,7 +7225,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<GetXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6703,7 +7252,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListByteMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6730,7 +7279,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListIPSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListIPSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6754,7 +7303,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRateBasedRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6779,7 +7328,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListRulesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6804,7 +7353,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListSizeConstraintSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6832,7 +7381,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListSqlInjectionMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListSqlInjectionMatchSetsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6856,7 +7405,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListWebACLsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ListWebACLsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6880,7 +7429,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ListXssMatchSetsResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6907,7 +7456,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateByteMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6934,7 +7483,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateIPSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateIPSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -6958,7 +7507,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateRateBasedRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -6985,7 +7534,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateRuleResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateRuleError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7010,7 +7559,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateSizeConstraintSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateSizeConstraintSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7035,7 +7584,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(UpdateSqlInjectionMatchSetError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -7059,7 +7608,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateWebACLResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -7085,7 +7634,7 @@ impl<P, D> Waf for WafClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<UpdateXssMatchSetResponse>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -11,21 +11,55 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Compute {
+    Performance,
+    Standard,
+    Value,
+}
+
+impl Into<String> for Compute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Compute {
+    fn into(self) -> &'static str {
+        match self {
+            Compute::Performance => "PERFORMANCE",
+            Compute::Standard => "STANDARD",
+            Compute::Value => "VALUE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Compute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PERFORMANCE" => Ok(Compute::Performance),
+            "STANDARD" => Ok(Compute::Standard),
+            "VALUE" => Ok(Compute::Value),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about the compute type of a WorkSpace bundle.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ComputeType {
@@ -33,6 +67,44 @@ pub struct ComputeType {
     #[serde(rename="Name")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectionState {
+    Connected,
+    Disconnected,
+    Unknown,
+}
+
+impl Into<String> for ConnectionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectionState {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectionState::Connected => "CONNECTED",
+            ConnectionState::Disconnected => "DISCONNECTED",
+            ConnectionState::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONNECTED" => Ok(ConnectionState::Connected),
+            "DISCONNECTED" => Ok(ConnectionState::Disconnected),
+            "UNKNOWN" => Ok(ConnectionState::Unknown),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The request of the <a>CreateTags</a> operation.</p>"]
@@ -347,6 +419,41 @@ pub struct RebuildWorkspacesResult {
     pub failed_requests: Option<Vec<FailedWorkspaceChangeRequest>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RunningMode {
+    AlwaysOn,
+    AutoStop,
+}
+
+impl Into<String> for RunningMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RunningMode {
+    fn into(self) -> &'static str {
+        match self {
+            RunningMode::AlwaysOn => "ALWAYS_ON",
+            RunningMode::AutoStop => "AUTO_STOP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RunningMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALWAYS_ON" => Ok(RunningMode::AlwaysOn),
+            "AUTO_STOP" => Ok(RunningMode::AutoStop),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the start request.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartRequest {
@@ -604,6 +711,85 @@ pub struct WorkspaceDirectory {
     pub workspace_security_group_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkspaceDirectoryState {
+    Deregistered,
+    Deregistering,
+    Error,
+    Registered,
+    Registering,
+}
+
+impl Into<String> for WorkspaceDirectoryState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkspaceDirectoryState {
+    fn into(self) -> &'static str {
+        match self {
+            WorkspaceDirectoryState::Deregistered => "DEREGISTERED",
+            WorkspaceDirectoryState::Deregistering => "DEREGISTERING",
+            WorkspaceDirectoryState::Error => "ERROR",
+            WorkspaceDirectoryState::Registered => "REGISTERED",
+            WorkspaceDirectoryState::Registering => "REGISTERING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkspaceDirectoryState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEREGISTERED" => Ok(WorkspaceDirectoryState::Deregistered),
+            "DEREGISTERING" => Ok(WorkspaceDirectoryState::Deregistering),
+            "ERROR" => Ok(WorkspaceDirectoryState::Error),
+            "REGISTERED" => Ok(WorkspaceDirectoryState::Registered),
+            "REGISTERING" => Ok(WorkspaceDirectoryState::Registering),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkspaceDirectoryType {
+    AdConnector,
+    SimpleAd,
+}
+
+impl Into<String> for WorkspaceDirectoryType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkspaceDirectoryType {
+    fn into(self) -> &'static str {
+        match self {
+            WorkspaceDirectoryType::AdConnector => "AD_CONNECTOR",
+            WorkspaceDirectoryType::SimpleAd => "SIMPLE_AD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkspaceDirectoryType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AD_CONNECTOR" => Ok(WorkspaceDirectoryType::AdConnector),
+            "SIMPLE_AD" => Ok(WorkspaceDirectoryType::SimpleAd),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the properties of a WorkSpace.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkspaceProperties {
@@ -648,6 +834,77 @@ pub struct WorkspaceRequest {
     #[serde(rename="WorkspaceProperties")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub workspace_properties: Option<WorkspaceProperties>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkspaceState {
+    Available,
+    Error,
+    Impaired,
+    Maintenance,
+    Pending,
+    Rebooting,
+    Rebuilding,
+    Starting,
+    Stopped,
+    Stopping,
+    Suspended,
+    Terminated,
+    Terminating,
+    Unhealthy,
+}
+
+impl Into<String> for WorkspaceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkspaceState {
+    fn into(self) -> &'static str {
+        match self {
+            WorkspaceState::Available => "AVAILABLE",
+            WorkspaceState::Error => "ERROR",
+            WorkspaceState::Impaired => "IMPAIRED",
+            WorkspaceState::Maintenance => "MAINTENANCE",
+            WorkspaceState::Pending => "PENDING",
+            WorkspaceState::Rebooting => "REBOOTING",
+            WorkspaceState::Rebuilding => "REBUILDING",
+            WorkspaceState::Starting => "STARTING",
+            WorkspaceState::Stopped => "STOPPED",
+            WorkspaceState::Stopping => "STOPPING",
+            WorkspaceState::Suspended => "SUSPENDED",
+            WorkspaceState::Terminated => "TERMINATED",
+            WorkspaceState::Terminating => "TERMINATING",
+            WorkspaceState::Unhealthy => "UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkspaceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(WorkspaceState::Available),
+            "ERROR" => Ok(WorkspaceState::Error),
+            "IMPAIRED" => Ok(WorkspaceState::Impaired),
+            "MAINTENANCE" => Ok(WorkspaceState::Maintenance),
+            "PENDING" => Ok(WorkspaceState::Pending),
+            "REBOOTING" => Ok(WorkspaceState::Rebooting),
+            "REBUILDING" => Ok(WorkspaceState::Rebuilding),
+            "STARTING" => Ok(WorkspaceState::Starting),
+            "STOPPED" => Ok(WorkspaceState::Stopped),
+            "STOPPING" => Ok(WorkspaceState::Stopping),
+            "SUSPENDED" => Ok(WorkspaceState::Suspended),
+            "TERMINATED" => Ok(WorkspaceState::Terminated),
+            "TERMINATING" => Ok(WorkspaceState::Terminating),
+            "UNHEALTHY" => Ok(WorkspaceState::Unhealthy),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by CreateTags
@@ -1842,7 +2099,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateTagsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(CreateTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1866,7 +2123,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<CreateWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1891,7 +2148,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DeleteTagsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DeleteTagsError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1915,7 +2172,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeTagsResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -1942,7 +2199,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeWorkspaceBundlesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeWorkspaceBundlesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1968,7 +2225,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeWorkspaceDirectoriesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeWorkspaceDirectoriesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -1992,7 +2249,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2022,7 +2279,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<DescribeWorkspacesConnectionStatusResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(DescribeWorkspacesConnectionStatusError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2048,7 +2305,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<ModifyWorkspacePropertiesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => Err(ModifyWorkspacePropertiesError::from_body(String::from_utf8_lossy(&response.body).as_ref())),
@@ -2072,7 +2329,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RebootWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2099,7 +2356,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<RebuildWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2126,7 +2383,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StartWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2153,7 +2410,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<StopWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {
@@ -2180,7 +2437,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                             Ok(serde_json::from_str::<TerminateWorkspacesResult>(String::from_utf8_lossy(&response.body).as_ref()).unwrap())
                         }
             _ => {

--- a/service_crategen/src/commands/generate/codegen/json.rs
+++ b/service_crategen/src/commands/generate/codegen/json.rs
@@ -44,7 +44,7 @@ impl GenerateProtocol for JsonGenerator {
                     let response = try!(self.dispatcher.dispatch(&request));
 
                     match response.status {{
-                        StatusCode::Ok => {{
+                        ::hyper::status::StatusCode::Ok => {{
                             {ok_response}
                         }}
                         _ => Err({error_type}::from_body(String::from_utf8_lossy(&response.body).as_ref())),

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -41,7 +41,7 @@ impl GenerateProtocol for QueryGenerator {
                     request.sign(&try!(self.credentials_provider.credentials()));
                     let response = try!(self.dispatcher.dispatch(&request));
                     match response.status {{
-                        StatusCode::Ok => {{
+                        ::hyper::status::StatusCode::Ok => {{
                             {parse_payload}
                             Ok(result)
                         }}
@@ -68,8 +68,7 @@ impl GenerateProtocol for QueryGenerator {
 
     fn generate_prelude(&self, writer: &mut FileWriter, _service: &Service) -> IoResult {
         writeln!(writer,
-                 "use std::str::FromStr;
-            use xml::EventReader;
+                 "use xml::EventReader;
             use xml::reader::ParserConfig;
             use rusoto_core::param::{{Params, ServiceParams}};
             use rusoto_core::signature::SignedRequest;

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -157,7 +157,7 @@ trait CodegenString {
 }
 impl CodegenString for StatusCode {
     fn enum_as_string(&self) -> String {
-        format!("StatusCode::{:?}", self)
+        format!("::hyper::status::StatusCode::{:?}", self)
     }
 }
 
@@ -166,7 +166,7 @@ fn http_code_to_status_code(code: Option<i32>) -> String {
         Some(actual_code) => StatusCode::from_u16(actual_code as u16).enum_as_string(),
         // Some service definitions such as elastictranscoder don't specify
         // the response code, we'll assume this:
-        None => "StatusCode::Ok".to_string(),
+        None => "::hyper::status::StatusCode::Ok".to_string(),
     }
 }
 
@@ -390,9 +390,9 @@ fn generate_status_code_parser(operation: &Operation, service: &Service) -> Stri
         if let Some(ref location) = member.location {
             if location == "statusCode" {
                 if output_shape.required(member_name) {
-                    status_code_parser += &format!("result.{} = StatusCode::to_u16(&response.status);", member_name.to_snake_case());
+                    status_code_parser += &format!("result.{} = ::hyper::status::StatusCode::to_u16(&response.status);", member_name.to_snake_case());
                 } else {
-                    status_code_parser += &format!("result.{} = Some(StatusCode::to_u16(&response.status) as i64);", member_name.to_snake_case());
+                    status_code_parser += &format!("result.{} = Some(::hyper::status::StatusCode::to_u16(&response.status) as i64);", member_name.to_snake_case());
                 }
             }
         }

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -66,7 +66,7 @@ impl GenerateProtocol for RestXmlGenerator {
                     let response = try!(self.dispatcher.dispatch(&request));
 
                     match response.status {{
-                        StatusCode::Ok|StatusCode::NoContent|StatusCode::PartialContent => {{
+                        ::hyper::status::StatusCode::Ok|::hyper::status::StatusCode::NoContent|::hyper::status::StatusCode::PartialContent => {{
                             {parse_response_body}
                             {parse_non_payload}
                             Ok(result)
@@ -101,7 +101,6 @@ impl GenerateProtocol for RestXmlGenerator {
 
     fn generate_prelude(&self, writer: &mut FileWriter, service: &Service) -> IoResult {
         let mut imports = "
-            use std::str::{FromStr};
             use xml::reader::ParserConfig;
             use rusoto_core::param::{Params, ServiceParams};
             use rusoto_core::signature::SignedRequest;

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -268,12 +268,12 @@ fn generate_map_deserializer(shape: &Shape) -> String {
 fn generate_primitive_deserializer(shape: &Shape) -> String {
     let statement = match shape.shape_type {
         ShapeType::String | ShapeType::Timestamp => "try!(characters(stack))",
-        ShapeType::Integer => "i64::from_str(try!(characters(stack)).as_ref()).unwrap()",
-        ShapeType::Long => "i64::from_str(try!(characters(stack)).as_ref()).unwrap()",
-        ShapeType::Double => "f64::from_str(try!(characters(stack)).as_ref()).unwrap()",
-        ShapeType::Float => "f32::from_str(try!(characters(stack)).as_ref()).unwrap()",
+        ShapeType::Integer => "try!(characters(stack)).parse::<i64>().unwrap()",
+        ShapeType::Long => "try!(characters(stack)).parse::<i64>().unwrap()",
+        ShapeType::Double => "try!(characters(stack)).parse::<f64>().unwrap()",
+        ShapeType::Float => "try!(characters(stack)).parse::<f32>().unwrap()",
         ShapeType::Blob => "try!(characters(stack)).into_bytes()",
-        ShapeType::Boolean => "bool::from_str(try!(characters(stack)).as_ref()).unwrap()",
+        ShapeType::Boolean => "try!(characters(stack)).parse::<bool>().unwrap()",
         _ => panic!("Unknown primitive shape type"),
     };
 


### PR DESCRIPTION
Closes #340 (probably).

Per comments in #340, I believe this is the best approach to supporting botocore enum definitions.

For now, they can be used like:
```rust
KeySchemaElement {
    attribute_name: "test".into(),
    key_type: KeyType::Hash.into()
}
```

but if/when we support builders in the future, this becomes even nicer:

```rust
KeySchemaElementBuilder::new()
    .attribute_name("test")
    .key_type(KeyType::Hash)
    .build();
```

### Remaining Concerns
How can we improve discoverability of these enums? Currently they're just hidden in the big list of types that are generated with each service and mixed in with error enums. They're not mentioned from the documentation, nor are they linked from the types they're intended to be used for.