### PR TITLE
Fix doc upload?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ after_success:
   # upload the documentation from the build if it's from Rust stable, Linux and not a pull request:
   - |
       if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" && "$TRAVIS_PULL_REQUEST" == false ]]; then
-        cd rusoto && echo '<meta http-equiv=refresh content=0;url=rusoto_core/index.html>' > target/doc/index.html \
+        echo '<meta http-equiv=refresh content=0;url=rusoto_core/index.html>' > target/doc/index.html \
         && mkdir target/doc/rusoto/ && echo '<meta http-equiv=refresh content=0;url=../rusoto_core/index.html>' > target/doc/rusoto/index.html \
         && sudo pip install ghp-import && ghp-import -n target/doc \
         && git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages \


### PR DESCRIPTION
I noticed docs weren't being updated in in the Github Pages after merges to master, as of about 10 days ago. Notably, none of the new services are uploaded, type aliases still exist and services don't have the botocore documentation.

I believe this has to do with moving the workspace into the repository root, so the docs aren't being generated in the same place anymore, causing the command to fail and not upload. We're not seeing that failure in Travis because in bash, `if` always returns 0 (success) to my knowledge, so even if the inner command fails, we still succeed. I'm not sure how to actually get that inner exit code out, though I don't think it's a huge deal either.