### PR TITLE
Update libraries for rusoto_credential

### DIFF
--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.25.0"
 homepage = "https://www.rusoto.org/"
 
 [dependencies]
-chrono = "0.2.21"
+chrono = "0.4.0"
 hyper = "0.10.0"
 
 [dependencies.clippy]

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use rusoto_core::{DispatchSignedRequest, HttpResponse, HttpDispatchError, SignedRequest};
 use rusoto_core::credential::{ProvideAwsCredentials, CredentialsError, AwsCredentials};
-use chrono::{Duration, UTC};
+use chrono::{Duration, Utc};
 use hyper::status::StatusCode;
 
 const ONE_DAY: i64 = 86400;
@@ -22,7 +22,7 @@ impl ProvideAwsCredentials for MockCredentialsProvider {
         Ok(AwsCredentials::new("mock_key",
                                "mock_secret",
                                None,
-                               UTC::now() + Duration::seconds(ONE_DAY)))
+                               Utc::now() + Duration::seconds(ONE_DAY)))
     }
 }
 

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.7.0"
 
 [dependencies]
-chrono = "0.2.25"
+chrono = "0.4.0"
 reqwest = "0.4.0"
 regex = "0.2.1"
 serde_json = "1.0.2"

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.7.0"
 
 [dependencies]
 chrono = "0.4.0"
-reqwest = "0.4.0"
+reqwest = "0.6.2"
 regex = "0.2.1"
 serde_json = "1.0.2"
 

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.7.0"
 chrono = "0.2.25"
 reqwest = "0.4.0"
 regex = "0.2.1"
-serde_json = "0.9.4"
+serde_json = "1.0.2"
 
 [dependencies.clippy]
 optional = true

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -29,7 +29,7 @@ use std::sync::Mutex;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
-use chrono::{Duration, UTC, DateTime, ParseError};
+use chrono::{Duration, Utc, DateTime, ParseError};
 use serde_json::{from_str as json_from_str, Value};
 
 /// AWS API access credentials, including access key, secret key, token (for IAM profiles),
@@ -39,14 +39,14 @@ pub struct AwsCredentials {
     key: String,
     secret: String,
     token: Option<String>,
-    expires_at: DateTime<UTC>,
+    expires_at: DateTime<Utc>,
     claims: BTreeMap<String, String>,
 }
 
 impl AwsCredentials {
     /// Create a new `AwsCredentials` from a key ID, secret key, optional access token, and expiry
     /// time.
-    pub fn new<K, S>(key:K, secret:S, token:Option<String>, expires_at:DateTime<UTC>)
+    pub fn new<K, S>(key:K, secret:S, token:Option<String>, expires_at:DateTime<Utc>)
     -> AwsCredentials where K:Into<String>, S:Into<String> {
         AwsCredentials {
             key: key.into(),
@@ -68,7 +68,7 @@ impl AwsCredentials {
     }
 
     /// Get a reference to the expiry time.
-    pub fn expires_at(&self) -> &DateTime<UTC> {
+    pub fn expires_at(&self) -> &DateTime<Utc> {
         &self.expires_at
     }
 
@@ -81,7 +81,7 @@ impl AwsCredentials {
     fn credentials_are_expired(&self) -> bool {
         // This is a rough hack to hopefully avoid someone requesting creds then sitting on them
         // before issuing the request:
-        self.expires_at < UTC::now() + Duration::seconds(20)
+        self.expires_at < Utc::now() + Duration::seconds(20)
     }
 
     /// Get the token claims
@@ -277,8 +277,8 @@ impl ChainProvider {
 }
 
 /// Gets the DateTime that is 10 minutes from the current Time.
-fn in_ten_minutes() -> DateTime<UTC> {
-    UTC::now() + Duration::seconds(600)
+fn in_ten_minutes() -> DateTime<Utc> {
+    Utc::now() + Duration::seconds(600)
 }
 
 /// Reduces Boilerplate on getting json values. Wraps `serde_json::Value.get(key)`.

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.rusoto.org/"
 [build-dependencies]
 
 [dependencies]
-chrono = "0.2.25"
+chrono = "0.4.0"
 hyper = "0.10.0"
 xml-rs = "0.6"
 

--- a/rusoto/services/sts/src/custom/credential.rs
+++ b/rusoto/services/sts/src/custom/credential.rs
@@ -1,4 +1,5 @@
-use chrono::*;
+use chrono::prelude::*;
+use chrono::Duration;
 
 use rusoto_core;
 
@@ -25,7 +26,7 @@ pub trait NewAwsCredsForStsCreds {
 
 impl NewAwsCredsForStsCreds for AwsCredentials {
     fn new_for_credentials(sts_creds: ::Credentials) -> Result<AwsCredentials, CredentialsError> {
-        let expires_at = try!(sts_creds.expiration.parse::<DateTime<UTC>>().map_err(CredentialsError::from));
+        let expires_at = try!(sts_creds.expiration.parse::<DateTime<Utc>>().map_err(CredentialsError::from));
 
         Ok(AwsCredentials::new(
             sts_creds.access_key_id, 

--- a/service_crategen/services.json
+++ b/service_crategen/services.json
@@ -452,7 +452,7 @@
     "coreVersion": "0.27.0",
     "protocolVersion": "2011-06-15",
     "customDependencies": {
-      "chrono": "0.2.25"
+      "chrono": "0.4.0"
     },
     "baseTypeName": "Sts"
   },


### PR DESCRIPTION
It's intentional to use reqwest 0.6.2 instead 0.7, currently the latest version. Reqwest 0.6.2 is the last version that depends on Hyper 0.10, which is used by other rusoto_* packages. I think it's better to make them share the same version of Hyper to minimize compilation cost as possible.