### PR TITLE
Suppprt for route53 endpoint

### DIFF
--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -407,6 +407,9 @@ fn build_hostname(service: &str, region: Region) -> String {
                 _ => format!("s3-{}.amazonaws.com", region),
             }
         }
+        "route53" => {
+            String::from("route53.amazonaws.com")
+        }
         _ => {
             match region {
                 Region::CnNorth1 => format!("{}.{}.amazonaws.com.cn", service, region),

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -408,7 +408,7 @@ fn build_hostname(service: &str, region: Region) -> String {
             }
         }
         "route53" => {
-            String::from("route53.amazonaws.com")
+            "route53.amazonaws.com".to_owned()
         }
         _ => {
             match region {


### PR DESCRIPTION
Route 53 uses a single region independent endpoint. This PR includes a fix for that.