### PR TITLE
Fix up custom region changes that interfered with endpoint overrides.

### DIFF
--- a/integration_tests/tests/appstream.rs
+++ b/integration_tests/tests/appstream.rs
@@ -2,12 +2,14 @@
 
 extern crate rusoto_core;
 extern crate rusoto_appstream;
+extern crate env_logger;
 
 use rusoto_appstream::{AppStream, AppStreamClient, DescribeFleetsRequest};
 use rusoto_core::{DefaultCredentialsProvider, Region, default_tls_client};
 
 #[test]
 fn should_describe_fleets() {
+    let _ = env_logger::init();
     let credentials = DefaultCredentialsProvider::new().unwrap();
     let client = AppStreamClient::new(default_tls_client().unwrap(), credentials, Region::UsEast1);
     let request = DescribeFleetsRequest::default();

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -114,7 +114,11 @@ impl SignedRequest {
     }
 
     pub fn hostname(&self) -> String {
-        build_hostname(&self.service, &self.region)
+        // hostname may be already set by an endpoint prefix
+        match self.hostname {
+            Some(ref h) => h.to_string(),
+            None => build_hostname(&self.service, &self.region),
+        }
     }
 
     // If the key exists in headers, set it to blank/unoccupied:


### PR DESCRIPTION
Fixes a bug that slipped through in https://github.com/rusoto/rusoto/pull/759 .  Still works with local dynamodb etc...