### PR TITLE
Adds a changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Rusoto changes
+
+## [Unreleased]
+
+(Please put an entry here in each PR)
+
+## [0.28.0] - 2017-08-25
+
+### Added
+- Credentials: accept `aws_security_token` for backwards compatibility
+- Codegen: add `check` command for missing or outdated services
+- API Gateway support
+- Mechanical Turk support
+- Polly support
+- Glacier support
+- Header on files that are generated to guide changes the code generation
+- AWS Batch support
+- Use botocore provided documentation in our crate documentation
+- Credentials crate allows unrecognized fields in credentials profile
+- Route53 now sends request to the right endpoint
+- Route53 integration test
+- Streaming download support for S3
+- Custom region now supported: used for local DynamoDB and API compatible services such as Minio and Ceph
+- Code of Condcut
+
+### Changed
+- Moved root Cargo.toml to root of git project to allow git dependency references
+- Updated botocore to 1.5.75
+- Integration tests now build, but don't run, as part of the CI process
+- Credentials crate got dependency upgrades
+- REST protocols now sends requests with headers and bodies
+
+### Removed
+- Credentials crate no longer retries credential acquiring
+- Type aliases removed.  Example: we no longer use `BucketName` which was an alias for `String`.
+- travis-cargo from TravisCI builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 (Please put an entry here in each PR)
+- Added CHANGELOG
+- Updated CONTRIBUTING to explain PR process
 
 ## [0.28.0] - 2017-08-25
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,17 @@
 # Contributing to Rusoto
 
-### Setting up build environment (only needed once)
+### General information
+
+Any contribution intentionally submitted for inclusion in the work by you shall be licensed under the MIT license, without any additional terms or conditions.
+
+Pull requests (PRs) should follow these guidelines:
+* Include an entry in the [CHANGELOG](CHANGELOG.md).
+* Generated code should be included in the PR.  Putting the codegen changes in a separate commit is preferred.
+* Tests are highly encouraged.
+
+The project follows the code of conduct as specified in [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
+
+### Setting up the build environment (only needed once)
 
 See minimum version of Rust required in [README](README.md).
 
@@ -34,12 +45,9 @@ To run only the in-crate unit tests, which don't call out to AWS, include the `-
 
 For more verbose test output, you can run `cargo test --verbose --features FEATURE -- --nocapture`.
 
-**Warning**: When building or testing with `--features all` the build/test can require upwards of 5 GB of memory. You can limit the number of features to build at once to prevent running out of memory. That can be achieved using the `--features` flag, e.g. `cargo build --features packagea && cargo build --features packageb`. See [rusoto.org](https://www.rusoto.org/supported-aws-services.html) for a table of available services and their Cargo feature names. 
-
 ### Rust code generation from boto core service definitions:
 
-See [Cargo.toml](codegen/Cargo.toml) and [build.rs](codegen/build.rs) in the
-rusoto_codegen subcrate.
+See the [README](service_crategen/README.md) in the service_crategen subcrate.
 
 ## Clippy
 


### PR DESCRIPTION
Having a changelog has been [requested before](https://github.com/rusoto/rusoto/issues/670#issuecomment-306942679) and there's also some discussion in the Rust subreddit about how nice they are to have.

I've put the release notes for 0.28.0 in it.  Not every PR is mentioned as some are not exactly user facing, such as "we fixed a bug where our docs weren't correctly publishing."

Inspiration from http://keepachangelog.com/en/1.0.0/ .