### PR TITLE
provide async credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 testfile.zip
 *.pyc
 venv
+*.rs.bk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 (Please put an entry here in each PR)
 - Added CHANGELOG
 - Updated CONTRIBUTING to explain PR process
+- Updated Credentials crate to use hyper 0.11 (aka the Async IO Update).
 
 ## [0.28.0] - 2017-08-25
 

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -14,9 +14,12 @@ version = "0.8.0"
 
 [dependencies]
 chrono = "0.4.0"
-reqwest = "0.6.2"
+futures = "0.1"
+hyper = "0.11"
+hyper-tls = "0.1"
 regex = "0.2.1"
 serde_json = "1.0.2"
+tokio-core = "0.1"
 
 [dependencies.clippy]
 optional = true

--- a/rusoto/credential/src/claims.rs
+++ b/rusoto/credential/src/claims.rs
@@ -14,16 +14,16 @@ pub const SUBJECT: &'static str = "sub";
 /// Key used in the claims map for the `Audience` claim.
 ///
 /// The intended audience (also known as client ID) of the web identity token.
-/// This is traditionally the client identifier issued to the application that requested the web identity token. 
+/// This is traditionally the client identifier issued to the application that requested the web identity token.
 /// For OpenID Connect this field contains the value of the `aud` claim.
 /// For SAML this is the value of the `Recipient` attribute of the `SubjectConfirmationData`
-/// element of the SAML assertion. 
+/// element of the SAML assertion.
 pub const AUDIENCE: &'static str = "aud";
 
 /// Key used in the claims map for the `Issuer` claim.
 ///
-/// For OpenID Connect ID Tokens this contains the value of the `iss` field. 
-/// For OAuth 2.0 access tokens, this contains the value of the `ProviderId` parameter 
-/// that was passed in the `AssumeRoleWithWebIdentity` request. 
-/// For SAML this is the value of the Issuer element of the SAML assertion. 
+/// For OpenID Connect ID Tokens this contains the value of the `iss` field.
+/// For OAuth 2.0 access tokens, this contains the value of the `ProviderId` parameter
+/// that was passed in the `AssumeRoleWithWebIdentity` request.
+/// For SAML this is the value of the Issuer element of the SAML assertion.
 pub const ISSUER: &'static str = "iss";

--- a/rusoto/credential/src/environment.rs
+++ b/rusoto/credential/src/environment.rs
@@ -18,28 +18,33 @@ impl ProvideAwsCredentials for EnvironmentProvider {
 fn credentials_from_environment() -> Result<AwsCredentials, CredentialsError> {
     let env_key = match env_var("AWS_ACCESS_KEY_ID") {
         Ok(val) => val,
-        Err(_) => return Err(CredentialsError::new("No AWS_ACCESS_KEY_ID in environment"))
+        Err(_) => return Err(CredentialsError::new("No AWS_ACCESS_KEY_ID in environment")),
     };
     let env_secret = match env_var("AWS_SECRET_ACCESS_KEY") {
         Ok(val) => val,
-        Err(_) => return Err(CredentialsError::new("No AWS_SECRET_ACCESS_KEY in environment"))
+        Err(_) => {
+            return Err(CredentialsError::new(
+                "No AWS_SECRET_ACCESS_KEY in environment",
+            ))
+        }
     };
 
     if env_key.is_empty() || env_secret.is_empty() {
-        return Err(CredentialsError::new("Couldn't find either AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY or both in environment."));
+        return Err(CredentialsError::new(
+            "Couldn't find either AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY or both in environment.",
+        ));
     }
 
     // Present when using temporary credentials, e.g. on Lambda with IAM roles
     let token = match env_var("AWS_SESSION_TOKEN") {
-        Ok(val) => {
-            if val.is_empty() {
-                None
-            } else {
-                Some(val)
-            }
-        }
+        Ok(val) => if val.is_empty() { None } else { Some(val) },
         Err(_) => None,
     };
 
-    Ok(AwsCredentials::new(env_key, env_secret, token, in_ten_minutes()))
+    Ok(AwsCredentials::new(
+        env_key,
+        env_secret,
+        token,
+        in_ten_minutes(),
+    ))
 }

--- a/rusoto/credential/src/instance_metadata.rs
+++ b/rusoto/credential/src/instance_metadata.rs
@@ -1,9 +1,11 @@
 //! The Credentials Provider for an AWS Resource's IAM Role.
 
-use reqwest;
-use std::io::Read;
+use hyper::Uri;
+use std::time::Duration as StdDuration;
+use tokio_core::reactor::Core;
 
-use {AwsCredentials, CredentialsError, ProvideAwsCredentials, parse_credentials_from_aws_service};
+use {AwsCredentials, CredentialsError, ProvideAwsCredentials, ProvideTimeoutableAwsCredentials,
+     make_request, parse_credentials_from_aws_service};
 
 const AWS_CREDENTIALS_PROVIDER_IP: &'static str = "169.254.169.254";
 const AWS_CREDENTIALS_PROVIDER_PATH: &'static str = "latest/meta-data/iam/security-credentials";
@@ -14,36 +16,30 @@ pub struct InstanceMetadataProvider;
 
 impl ProvideAwsCredentials for InstanceMetadataProvider {
     fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        get_credentials_from_role()
+        get_credentials_from_role(None)
+    }
+}
+
+impl ProvideTimeoutableAwsCredentials for InstanceMetadataProvider {
+    fn credentials_with_timeout(
+        &self,
+        timeout: StdDuration,
+    ) -> Result<AwsCredentials, CredentialsError> {
+        get_credentials_from_role(Some(timeout))
     }
 }
 
 /// Gets the role name to get credentials for using the IAM Metadata Service (169.254.169.254).
-fn get_role_name() -> Result<String, CredentialsError> {
+fn get_role_name(timeout: Option<StdDuration>) -> Result<String, CredentialsError> {
     let role_name_address = format!(
-        "http://{}/{}",
+        "http://{}/{}/",
         AWS_CREDENTIALS_PROVIDER_IP,
         AWS_CREDENTIALS_PROVIDER_PATH
     );
-    let response = reqwest::get(&role_name_address);
-
-    match response {
-        Ok(mut resp) => {
-            if resp.status().is_success() {
-                let mut role_name = String::new();
-                if resp.read_to_string(&mut role_name).is_err() {
-                    return Err(CredentialsError::new(
-                        "Didn't get a parsable role name from metadata service",
-                    ));
-                }
-                Ok(role_name)
-            } else {
-                return Err(CredentialsError::new(format!(
-                    "Couldn't connect to credentials provider: {}",
-                    resp.status()
-                )));
-            }
-        }
+    let core = try!(Core::new());
+    let uri = try!(role_name_address.parse::<Uri>());
+    match make_request(core, uri, timeout) {
+        Ok(resp) => Ok(resp),
         Err(err) => {
             return Err(CredentialsError::new(
                 format!("Couldn't connect to credentials provider: {}", err),
@@ -53,8 +49,10 @@ fn get_role_name() -> Result<String, CredentialsError> {
 }
 
 /// Gets the credentials for an EC2 Instances IAM Role.
-fn get_credentials_from_role() -> Result<AwsCredentials, CredentialsError> {
-    let role_name = try!(get_role_name());
+fn get_credentials_from_role(
+    timeout: Option<StdDuration>,
+) -> Result<AwsCredentials, CredentialsError> {
+    let role_name = try!(get_role_name(timeout.clone()));
     let credentials_provider_url = format!(
         "http://{}/{}/{}",
         AWS_CREDENTIALS_PROVIDER_IP,
@@ -62,26 +60,10 @@ fn get_credentials_from_role() -> Result<AwsCredentials, CredentialsError> {
         role_name
     );
 
-    let response = reqwest::get(&credentials_provider_url);
-
-    match response {
-        Ok(mut resp) => {
-            if resp.status().is_success() {
-                let mut credentials_response = String::new();
-                if resp.read_to_string(&mut credentials_response).is_err() {
-                    return Err(CredentialsError::new(
-                        "Had issues with reading iam role response: {}",
-                    ));
-                }
-
-                parse_credentials_from_aws_service(&credentials_response)
-            } else {
-                return Err(CredentialsError::new(format!(
-                    "Couldn't connect to credentials provider: {}",
-                    resp.status()
-                )));
-            }
-        }
+    let core = try!(Core::new());
+    let uri = try!(credentials_provider_url.parse::<Uri>());
+    match make_request(core, uri, timeout) {
+        Ok(resp) => parse_credentials_from_aws_service(&resp),
         Err(err) => {
             return Err(CredentialsError::new(
                 format!("Couldn't connect to credentials provider: {}", err),

--- a/rusoto/credential/src/static_provider.rs
+++ b/rusoto/credential/src/static_provider.rs
@@ -20,7 +20,12 @@ pub struct StaticProvider {
 impl StaticProvider {
     /// Creates a new Static Provider. This should be used when you want to statically, or programmatically
     /// provide access to AWS.
-    pub fn new(access_key: String, secret_access_key: String, token: Option<String>, valid_for: Option<i64>) -> StaticProvider {
+    pub fn new(
+        access_key: String,
+        secret_access_key: String,
+        token: Option<String>,
+        valid_for: Option<i64>,
+    ) -> StaticProvider {
         StaticProvider {
             aws_access_key_id: access_key,
             aws_secret_access_key: secret_access_key,
@@ -68,32 +73,48 @@ impl StaticProvider {
 
 impl ProvideAwsCredentials for StaticProvider {
     fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        Ok(AwsCredentials::new(self.aws_access_key_id.clone(), self.aws_secret_access_key.clone(),
-            self.token.clone(), Utc::now() + Duration::seconds(self.valid_for)))
+        Ok(AwsCredentials::new(
+            self.aws_access_key_id.clone(),
+            self.aws_secret_access_key.clone(),
+            self.token.clone(),
+            Utc::now() + Duration::seconds(self.valid_for),
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {ProvideAwsCredentials};
+    use ProvideAwsCredentials;
     use super::*;
 
     #[test]
     fn test_static_provider_creation() {
-        let result = StaticProvider::new("fake-key".to_owned(), "fake-secret".to_owned(), Some("token".to_owned()), Some(300)).credentials();
+        let result = StaticProvider::new(
+            "fake-key".to_owned(),
+            "fake-secret".to_owned(),
+            Some("token".to_owned()),
+            Some(300),
+        ).credentials();
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_static_provider_minimal_creation() {
-        let result = StaticProvider::new_minimal("fake-key-2".to_owned(), "fake-secret-2".to_owned()).credentials();
+        let result =
+            StaticProvider::new_minimal("fake-key-2".to_owned(), "fake-secret-2".to_owned())
+                .credentials();
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_static_provider_custom_time_expiration() {
         let start_time = Utc::now();
-        let result = StaticProvider::new("fake-key".to_owned(), "fake-secret".to_owned(), None, Some(10000)).credentials();
+        let result = StaticProvider::new(
+            "fake-key".to_owned(),
+            "fake-secret".to_owned(),
+            None,
+            Some(10000),
+        ).credentials();
         assert!(result.is_ok());
         let finalized = result.unwrap();
         let expires_at = finalized.expires_at().clone();


### PR DESCRIPTION
fixes #604
fixes #755

here it is (after literally months (sorry about that :( )). the first
commit in rusoto adding in async futures. (soon to probably be copied
to the main service generated crates). for now though, lets keep talk
cenetered around the credentials crate.

I'll split this PR Message up into multiple parts:

  1. Why this took so long. Cause I feel bad.
  2. Why I chose hyper over reqwest.
  3. What in the interface has changed.

---------------------------------------------------------------------

Why this took so long:
---

This took a long time (months) for a couple reasons:

  1. I kept flip-flopping between using pure hyper, or reqwest. Ideally
    I should've just pushed up both, but I didn't know which one I liked
    more, and it bugged me. A lame excuse, but it's true. It wasn't until
    I talked too @matthewkmayer at RustConf I pulled the trigger on Hyper.
  2. #LifeProblems.
  3. After I got back from RustConf, I realized I still wasn't happy with
     bits of my hyper implementation, and so I reworked them into this final
     PR.

All in all, there isn't really a good reason, and I'm sorry for taking
so long to do this task. It really shouldn't of taken longer, and I know
it only hurts us the rusoto community to not be using async io. :heart:

-----------------------------------------------------------------------

Why I chose hyper over reqwest:
---

There are two "main" crates battling for your http client implementation
right now. you can either use the slimmed down hyper, or the batteries
included reqwest. infact ***we even used reqwest*** inside the credentials
crate prior to this PR. So why'd I break this? Reqwest has many things
we don't need. We're just providing credentials here.

For Example:
Reqwest has more dependencies than hyper. Now this isn't really
a "problem" per say since they're fairly small crates anyway.
Specifically with a quick search I noticed (libflate, mime_guess,
serde_urlencoded, and uuid. plus any unique dependent crates of them).
These aren't really "that big of a deal", but the credentials crate
has always been the "if you don't want to buy into all of rusoto, but
need to authenticate, here you go" kind of crate. I think we should
value this philosophy when choosing dependencies. if there's no downsides
we shouldn't ***make*** people buy into deps they wouldn't have.

Imagine an HTTP Server, that signed URLs, from AWS Credentials grabbed
from an Instance Profile. Why should they have to download uuid? If
they're not doing anything with UUIDs, they shouldn't have too. Since
we don't explicitly need reqwest, or there's no downsides of hyper for
our use case, let's not needlessly buy into dependencies. (Even if they
are small).

There's minor things (that mainly fall down to personal preference
as well), but this is the one main reason I see to use hyper, and it's
a good one imo. We don't need a battery included mindset for the credentials
crate. For something like S3 you can probably say you do, but ***not for***
credentials. We only need timeouts (which reqwest makes *interesting*).

----------------------------------------------------------------------------

What has changed in the interface?
---

For existing consumers? Nothing! Infact they even get the benifit of timeouts
now. So if anything they're only gaining, but the exact same behavior is exhibited.
They can upgrade seamlessly.

However, I have added in a new trait: ProvideTimeoutableAwsCredentials.
ProvideTimeoutableAwsCredentials allows users to specify a custom timeout
value for their code. (If they don't like our default of 30 seconds).