### PR TITLE
[wip] enable SCCache for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: required
 dist: trusty
+
 language: rust
-# cache dependencies: https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
-cache: cargo
 # run builds for all the trains (and more)
 rust:
   - stable
@@ -11,9 +10,38 @@ rust:
 os:
   - linux
   - osx
+
+# cache dependencies: https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
+cache: cargo
 cache:
   directories:
     - $HOME/.cargo
+
+env:
+  global:
+    - RUST_BACKTRACE=1
+# TODO: Enable SCCache
+#    - SCCACHE_ERROR_LOG=/tmp/sccache.log
+#    - RUSTC_WRAPPER=/usr/local/bin/sccache
+#    - SCCACHE_BUCKET=rusoto-ci-sccache
+#    - AWS_ACCESS_KEY_ID=""
+    # AWS_SECRET_ACCESS_KEY=...
+#    - secure: ""
+
+    # GH_TOKEN...
+    - secure: zcYaxF4IGX+8XnSnG9Sh3q05rp+XX8Fc7gRLM3VcSpaNNd6tvNNxvjZNAn6gySuaoKBApCIMFAKHgfpO46DHqBjxU7ONnFW3xRGfi4f4VCx7+bagRmrMfxZPcDgZ0tZRs4S+0mALkYmvjhJmymQIAOUmz0LEezKsiVhh5qlkC/GLKaQzaU6Hy6u2+pymU9jfFt14O1s3e+UyyYeY22Bo6PZoRxdSDhLjvDZQQNxMx5CmCZHU7j3sH6aYRCltOdiYNTR3TB7GKrVJt6kn/q2SKwUxPDFvBpmE1v4NZr26262mZtBtUvxIUwTgPritntSPLm/qcNAKP93P9Bleq0QJXSDDOxl4Jf+Vpi1MUdf6MvacRVLsXInKJvNHDztBgmrLnkXWF70EmAwV9MjuGRhzjXCWhxVq/I0nebIdJHgJH195OpBa2jdeh6E0Xf6NOQ6N1S5vCyhotFIswwFAaff0znZw3je/iM7jxSPlRCMpxXkSjRVTbvoqDGIpNvxqs8WYDCpOTmDHz0rdOqvumIQFVt/i9Vk5gwNrZBOeOppjYg8jP0E0PHglfeU05SojgWBNbpn9j6JzTdPWbNhOE/HXNzTbHf5S9khqcI324c9bllOYAi0qrpBt1hawnuYi8cURpm64sYGODVhIt1fkqcqD6Nlv4uARF/+U4jWHGgPzBRQ=
+
+# TODO: Enable SCCache
+#install:
+#  - |
+#      case "$TRAVIS_OS_NAME" in
+#        linux)
+#          curl -fo /usr/local/bin/sccache https://path/to/linux/sccache && chmod +x /usr/local/bin/sccache
+#          ;;
+#        osx)
+#          curl -fo /usr/local/bin/sccache https://path/to/osx/sccache && chmod +x /usr/local/bin/sccache
+#          ;;
+#      esac
 script:
   - |
       echo "Generating service crates..." &&
@@ -23,9 +51,9 @@ script:
   - echo "Running Rusoto tests" && cargo update && cargo test --lib --all -v
   - |
       echo "Building integration tests" &&
-      ( cd integration_tests && \
-        cargo test --features "all" --no-run && \
-        cd .. )
+        ( cd integration_tests && \
+          cargo test --features "all" --no-run && \
+          cd .. )
   - |
       echo "Running cargo docs on stable Rust on Linux" &&
       if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -41,18 +69,19 @@ after_success:
         && git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages \
         && cd ..
       fi
-env:
-  global:
-    - RUST_BACKTRACE=1
-    # encrypted Github token for doc upload
-    - secure: zcYaxF4IGX+8XnSnG9Sh3q05rp+XX8Fc7gRLM3VcSpaNNd6tvNNxvjZNAn6gySuaoKBApCIMFAKHgfpO46DHqBjxU7ONnFW3xRGfi4f4VCx7+bagRmrMfxZPcDgZ0tZRs4S+0mALkYmvjhJmymQIAOUmz0LEezKsiVhh5qlkC/GLKaQzaU6Hy6u2+pymU9jfFt14O1s3e+UyyYeY22Bo6PZoRxdSDhLjvDZQQNxMx5CmCZHU7j3sH6aYRCltOdiYNTR3TB7GKrVJt6kn/q2SKwUxPDFvBpmE1v4NZr26262mZtBtUvxIUwTgPritntSPLm/qcNAKP93P9Bleq0QJXSDDOxl4Jf+Vpi1MUdf6MvacRVLsXInKJvNHDztBgmrLnkXWF70EmAwV9MjuGRhzjXCWhxVq/I0nebIdJHgJH195OpBa2jdeh6E0Xf6NOQ6N1S5vCyhotFIswwFAaff0znZw3je/iM7jxSPlRCMpxXkSjRVTbvoqDGIpNvxqs8WYDCpOTmDHz0rdOqvumIQFVt/i9Vk5gwNrZBOeOppjYg8jP0E0PHglfeU05SojgWBNbpn9j6JzTdPWbNhOE/HXNzTbHf5S9khqcI324c9bllOYAi0qrpBt1hawnuYi8cURpm64sYGODVhIt1fkqcqD6Nlv4uARF/+U4jWHGgPzBRQ=
+# TODO: Enable SCCache
+#after_failure:
+#  - echo "### Build Failed, Echoing SCCache Log\n"
+#  - cat /tmp/sccache.log
 
 branches:
   only:
     - master
     - auto
+
 notifications:
   email: false
+
 matrix:
   fast_finish: true
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,13 +6,21 @@ environment:
   global:
     # This will be used as part of the zipfile name
     PROJECT_NAME: rusoto
+# TODO: Enable SCCache
+#    SCCACHE_BUCKET: rusoto-ci-sccache
+#    AWS_ACCESS_KEY_ID: ""
+#    AWS_SECRET_ACCESS_KEY:
+#      secure: ""
+
   matrix:
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: beta
+
 cache:
   - 'C:\Users\appveyor\.cargo'
+
 # Install Rust and Cargo
 # (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)
 install:
@@ -22,6 +30,11 @@ install:
   - rustc -Vv
   - cargo -V
   - git submodule update --init --recursive
+# TODO: Enable SCCache
+#  - appveyor DownloadFile https://path/to/windows/sccache
+#  - mv sccache sccache.exe
+#  - set PATH=%PATH%;%CD%
+#  - set SCCACHE_ERROR_LOG=%CD%/sccache.log
 
 build: off
 test_script:
@@ -30,6 +43,10 @@ test_script:
   - cd integration_tests
   - cargo test --features "all" --no-run
   - cd ..
+
+#TODO: Enable SCCache
+#on_failure:
+#  - cat %CD%\sccache.log || exit 0
 
 branches:
   only:


### PR DESCRIPTION
refs #774

what this pr does:

this pr adds in sccache which is a caching utility for rust builds.
this should really help take down our build times because almost all
of our time is spent building crates. by caching builds that haven't
changed with sccache we'll be able to greatly increase the speed of
travis/appveyor.

this is just one proposed solution to solving build time outs on PRs.
we'll need lots of discussion as to whether this is the right move,
and other alternatives :smile: 

---

short explnantion of why this is wip:

this commit adds in [SCCache][sccache_link] for all CI Builds
(AppVeyor, and Travis alike). or I should say it would. I need
some help from maintainers to truly test, and see if this will
end up fixing our build woes for real, instead of just me
testing locally. a more winded explanation is below.

i know it seems like a lot of setup, but really if we don't like
sccache after testing we can undo all of this really easy, and
just attack the problem elsewhere.

---

long explnantion of why this is wip:

testing locally on my machine is great and all (infact I'm seeing
multiple minutes shaved off my build for just the service crates)
however lets be honest there's always a difference between local vs
travis vs appveyor.

however, in order to truly test this I need some help from the rusoto
maintainers :smile: those who can access encrypt variables in travis, and
those who have access to the AWS Account where rusoto will do it's
integration tests.

Specifically SCCache will need access to an S3 Bucket, and a pair
of encrypted AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY to access them.
Then we'll need someone to build SCCache for all platforms, and upload
them to some place public we trust (perhaps another S3 bucket in the same
account?). so that way we can download them in CI (building sccache is slow).

I've listed steps below for what would be the easiest way to perform this, and
how we can get it in this PR to test :smile: .

---

Things that I need help on getting ready:

- Building SCCache for All Platforms.

  The first thing we'll need to do is build sccache for all platforms
  so they can be downloaded later in CI. luckily sccache provides the
  ability to do this through a `build_release.sh` script in the main
  repo. I've included a link to it: [HERE][sccache_build_script].
  that being said I happen to have a mac/windows/linux box so if you
  need someone to help build I'd be happy to :smile:  .

  Once SCCache has been built for all platforms we'll need to upload the
  resulting binaries somewhere that appveyor/travis can access them without
  auth. I personally recommend a public S3 bucket inside the AWS Testing account
  (this is how the core rust repo does it as well).

- Creating an S3 Bucket for SCCache + AWS Credentials

  We need to create an S3 Bucket for Rusoto to use SCCache, that it can use to store
  artifacts. We'll also need a user who can access this bucket (and pass in the values
  to sccache). the steps for this will look like:

    - Create an S3 Bucket in the rusoto AWS Account.
    - Create a user with `s3:*` on resources: `bucket-arn` && `bucket-arn/*`
    - Create an Access Key Pair/Secret Access Key for user that you just created.
    - Follow [travis guides][travis_encrypt] to encrypt Secret Access Key, and share
      the access key id + encrypted secret access key either in the PR comment, or
      by emailing me.
    - Follow [appveyor guides][appveyor_encrypt] to encrypt Secret Access Key, and share
      access key id + encrypted secret acacess key either in the PR comment, or by emailing
      me.

[sccache_link]: https://github.com/mozilla/sccache
[sccache_build_script]: https://github.com/mozilla/sccache/blob/master/scripts/build-release.sh
[travis_encrypt]: https://docs.travis-ci.com/user/encryption-keys#Usage
[appveyor_encrypt]: https://www.appveyor.com/docs/build-configuration/#secure-variables