### PR TITLE
[WIP] Implement helper for S3 presigned urls

### DIFF
--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -12,6 +12,7 @@ use std::io::Read;
 use time::get_time;
 
 use rusoto_core::{DefaultCredentialsProvider, Region};
+use rusoto_core::credential::{AwsCredentials, ProvideAwsCredentials};
 use rusoto_s3::{S3, S3Client, HeadObjectRequest, CopyObjectRequest, GetObjectRequest,
                  PutObjectRequest, DeleteObjectRequest, PutBucketCorsRequest, CORSConfiguration,
                  CORSRule, CreateBucketRequest, DeleteBucketRequest, CreateMultipartUploadRequest,
@@ -37,6 +38,9 @@ fn test_all_the_things() {
     let utf8_filename = format!("test[über]file@{}", get_time().sec);
     let binary_filename = format!("test_file_b{}", get_time().sec);
     let multipart_filename = format!("test_multipart_file_{}", get_time().sec);
+
+    // generate a presigned url
+    test_generate_presigned_url(&Region::UsEast1, &DefaultCredentialsProvider::new().unwrap().credentials().unwrap(), &test_bucket, &multipart_filename);
 
     // get a list of list_buckets
     test_list_buckets(&client);
@@ -343,4 +347,16 @@ fn test_put_bucket_cors(client: &TestClient, bucket: &str) {
 
     let result = client.put_bucket_cors(&req).expect("Couldn't apply bucket CORS");
     println!("{:#?}", result);
+}
+
+fn test_generate_presigned_url(region: &Region, credentials: &AwsCredentials, _bucket: &str, _filename: &str) {
+    let get_req = GetObjectRequest {
+        bucket: "example_bucket".to_string(),
+        key: "example_file".to_string(),
+        ..Default::default()
+    };
+
+    let result = rusoto_s3::util::generate_presigned_url(region, credentials, &get_req).unwrap();
+    println!("get object result: {:#?}", result);
+    assert_eq!(result, "tomato");
 }

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -17,7 +17,7 @@ use time::now_utc;
 use url::percent_encoding::{utf8_percent_encode, EncodeSet};
 use hex::ToHex;
 
-use param::Params;
+use param::{Params, ServiceParams};
 use region::Region;
 use credential::AwsCredentials;
 
@@ -152,6 +152,94 @@ impl SignedRequest {
 
     pub fn set_params(&mut self, params: Params) {
         self.params = params;
+    }
+
+    // The request has to be signed *before* calling presigned_url
+    // http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+    pub fn generate_presigned_url(&mut self, creds: &AwsCredentials) -> String {
+        debug!("Presigning request URL");
+
+        self.sign(creds);
+        let hostname = match self.hostname {
+            Some(ref h) => h.to_string(),
+            None => build_hostname(&self.service, &self.region),
+        };
+
+        let current_time = now_utc();
+        let current_time_fmted = current_time.strftime("%Y%m%dT%H%M%SZ").unwrap();
+        let current_date = current_time.strftime("%Y%m%d").unwrap();
+
+        let signed_headers = signed_headers(&self.headers);
+        self.canonical_uri = canonical_uri(&self.path);
+
+        self.remove_header("x-amz-content-sha256");
+        self.add_header("X-Amz-Content-Sha256", "");
+        self.remove_header("X-Amz-Date");
+        self.add_header("X-Amz-Date", &format!("{}", &current_time_fmted));
+        self.params.put("X-Amz-Date", format!("{}", &current_time_fmted));
+        self.params.put("x-amz-date", format!("{}", &current_time_fmted));
+
+        self.params.put("x-amz-content-sha256", "");
+        self.remove_header("content-type");
+        self.add_header("content-type", "");
+
+        self.params.put("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+        self.params.put("X-Amz-Credential", format!("{}/{}/{}/{}/aws4_request", &creds.aws_access_key_id(), format!("{}", &current_date), self.region, self.service));
+        let expiration_time = {
+            let default_expiration_time = "3600".to_string();
+            let default_expiration_time_2 = "3600".to_string();
+            self.params.get("response-expires")
+                .clone()
+                .unwrap_or(&Some(default_expiration_time))
+                .clone()
+                .unwrap_or(default_expiration_time_2)
+        };
+        self.params.put("X-Amz-Expires", format!("{}", expiration_time));
+        self.params.put("X-Amz-SignedHeaders", &signed_headers);
+
+        self.canonical_query_string = build_canonical_query_string(&self.params);
+
+        self.canonical_uri = canonical_uri(&self.path);
+        let canonical_headers = canonical_headers(&self.headers);
+
+        debug!("canonical_query_string: {:?}", self.canonical_query_string);
+
+
+        let canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
+                                        &self.method,
+                                        self.canonical_uri,
+                                        self.canonical_query_string,
+                                        canonical_headers,
+                                        &signed_headers,
+                                        "UNSIGNED-PAYLOAD");
+
+        debug!("canonical_request: {:?}", canonical_request);
+
+        // use the hashed canonical request to build the string to sign
+        let hashed_canonical_request = to_hexdigest(&canonical_request);
+
+        debug!("hashed_canonical_request: {:?}", hashed_canonical_request);
+
+        let scope = format!("{}/{}/{}/aws4_request",
+                            current_date,
+                            self.region,
+                            &self.service);
+
+        debug!("scope: {}", scope);
+
+        let string_to_sign = string_to_sign(current_time, &hashed_canonical_request, &scope);
+
+        debug!("string_to_sign: {}", string_to_sign);
+
+        // construct the signing key and sign the string with it
+        let signing_key = signing_key(creds.aws_secret_access_key(),
+                                      current_time,
+                                      &self.region.to_string(),
+                                      &self.service);
+        let signature = signature(&string_to_sign, &signing_key);
+        self.params.put("X-Amz-Signature", signature);
+
+        format!("https://{}{}?{}", hostname, self.canonical_uri, build_canonical_query_string(&self.params))
     }
 
     pub fn sign(&mut self, creds: &AwsCredentials) {

--- a/rusoto/services/s3/src/custom/util.rs
+++ b/rusoto/services/s3/src/custom/util.rs
@@ -1,4 +1,9 @@
 use rusoto_core::signature;
+use rusoto_core::signature::SignedRequest;
+use rusoto_core::param::{Params, ServiceParams};
+use rusoto_core::region::Region;
+use rusoto_core::credential::AwsCredentials;
+use generated::{GetObjectRequest, GetObjectError};
 
 /// URL encodes an S3 object key. This is necessary for `copy_object` and `upload_part_copy`,
 /// which require the `copy_source` field to be URL encoded.
@@ -7,7 +12,7 @@ use rusoto_core::signature;
 ///
 /// ```
 /// use rusoto_s3::CopyObjectRequest;
-/// 
+///
 /// let request = CopyObjectRequest {
 ///     bucket: "my-bucket".to_owned(),
 ///     key: "my-key".to_owned(),
@@ -17,4 +22,79 @@ use rusoto_core::signature;
 /// ```
 pub fn encode_key<T: AsRef<str>>(key: T) -> String {
     signature::encode_uri_path(key.as_ref())
+}
+
+
+/// TODO: document this
+pub fn generate_presigned_url(region: &Region, credentials: &AwsCredentials, input: &GetObjectRequest) -> Result<String, GetObjectError> {
+    let request_uri = format!("/{bucket}/{key}", bucket = input.bucket, key = input.key);
+
+    let mut request = SignedRequest::new("GET", "s3", &region, &request_uri);
+
+    if let Some(ref if_match) = input.if_match {
+        request.add_header("If-Match", &if_match.to_string());
+    }
+
+    if let Some(ref if_modified_since) = input.if_modified_since {
+        request.add_header("If-Modified-Since", &if_modified_since.to_string());
+    }
+
+    if let Some(ref if_none_match) = input.if_none_match {
+        request.add_header("If-None-Match", &if_none_match.to_string());
+    }
+
+    if let Some(ref if_unmodified_since) = input.if_unmodified_since {
+        request.add_header("If-Unmodified-Since", &if_unmodified_since.to_string());
+    }
+
+    if let Some(ref range) = input.range {
+        request.add_header("Range", &range.to_string());
+    }
+
+    if let Some(ref request_payer) = input.request_payer {
+        request.add_header("x-amz-request-payer", &request_payer.to_string());
+    }
+
+    if let Some(ref sse_customer_algorithm) = input.sse_customer_algorithm {
+        request.add_header("x-amz-server-side-encryption-customer-algorithm",
+                           &sse_customer_algorithm.to_string());
+    }
+
+    if let Some(ref sse_customer_key) = input.sse_customer_key {
+        request.add_header("x-amz-server-side-encryption-customer-key",
+                           &sse_customer_key.to_string());
+    }
+
+    if let Some(ref sse_customer_key_md5) = input.sse_customer_key_md5 {
+        request.add_header("x-amz-server-side-encryption-customer-key-MD5",
+                           &sse_customer_key_md5.to_string());
+    }
+    let mut params = Params::new();
+    if let Some(ref x) = input.part_number {
+        params.put("partNumber", x);
+    }
+    if let Some(ref x) = input.response_cache_control {
+        params.put("response-cache-control", x);
+    }
+    if let Some(ref x) = input.response_content_disposition {
+        params.put("response-content-disposition", x);
+    }
+    if let Some(ref x) = input.response_content_encoding {
+        params.put("response-content-encoding", x);
+    }
+    if let Some(ref x) = input.response_content_language {
+        params.put("response-content-language", x);
+    }
+    if let Some(ref x) = input.response_content_type {
+        params.put("response-content-type", x);
+    }
+    if let Some(ref x) = input.response_expires {
+        params.put("response-expires", x);
+    }
+    if let Some(ref x) = input.version_id {
+        params.put("versionId", x);
+    }
+    request.set_params(params);
+
+    Ok(request.generate_presigned_url(&credentials))
 }


### PR DESCRIPTION
I open this PR to request feedback on a better way to implement this feature.
The provided code works but there are very ugly bits in `signature.rs`, and it
would be much nicer to have `generate_presigned_url` as a method on S3Client
but it's generated code and I couldn't figure out a clean way to extend it so
far. The copy-pasted code from `get_object` in `generate_presigned_url` is also
a big smell in my opinion, and it of course needs more testing.

I'll spend more time trying to find an acceptable way to extend rusoto with
that feature but any feedback would be very welcome :)