### PR TITLE
Fix Route 53 POST APIs

### DIFF
--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -148,7 +148,7 @@ impl AliasListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize(name, element));
+            parts.push(StringSerializer::serialize("String", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -350,7 +350,7 @@ impl AwsAccountNumberListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize(name, element));
+            parts.push(StringSerializer::serialize("String", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -589,7 +589,7 @@ impl CacheBehaviorListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(CacheBehaviorSerializer::serialize(name, element));
+            parts.push(CacheBehaviorSerializer::serialize("CacheBehavior", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -1091,7 +1091,7 @@ impl CookieNameListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize(name, element));
+            parts.push(StringSerializer::serialize("String", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -1747,7 +1747,7 @@ impl CustomErrorResponseListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(CustomErrorResponseSerializer::serialize(name, element));
+            parts.push(CustomErrorResponseSerializer::serialize("CustomErrorResponse", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -3430,7 +3430,7 @@ impl HeaderListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize(name, element));
+            parts.push(StringSerializer::serialize("String", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -4113,7 +4113,8 @@ impl LambdaFunctionAssociationListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(LambdaFunctionAssociationSerializer::serialize(name, element));
+            parts.push(LambdaFunctionAssociationSerializer::serialize("LambdaFunctionAssociation",
+                                                                      element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -4591,7 +4592,7 @@ impl LocationListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize(name, element));
+            parts.push(StringSerializer::serialize("String", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -4777,7 +4778,7 @@ impl MethodsListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(MethodSerializer::serialize(name, element));
+            parts.push(MethodSerializer::serialize("Method", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5033,7 +5034,7 @@ impl OriginCustomHeadersListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(OriginCustomHeaderSerializer::serialize(name, element));
+            parts.push(OriginCustomHeaderSerializer::serialize("OriginCustomHeader", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5089,7 +5090,7 @@ impl OriginListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(OriginSerializer::serialize(name, element));
+            parts.push(OriginSerializer::serialize("Origin", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5308,7 +5309,7 @@ impl PathListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize(name, element));
+            parts.push(StringSerializer::serialize("String", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5527,7 +5528,7 @@ impl QueryStringCacheKeysListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize(name, element));
+            parts.push(StringSerializer::serialize("String", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5936,7 +5937,7 @@ impl SslProtocolsListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(SslProtocolSerializer::serialize(name, element));
+            parts.push(SslProtocolSerializer::serialize("SslProtocol", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -6590,7 +6591,7 @@ impl TagKeyListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagKeySerializer::serialize(name, element));
+            parts.push(TagKeySerializer::serialize("TagKey", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -6667,7 +6668,7 @@ impl TagListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagSerializer::serialize(name, element));
+            parts.push(TagSerializer::serialize("Tag", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -255,6 +255,20 @@ pub struct AssociateVPCWithHostedZoneRequest {
     pub vpc: VPC,
 }
 
+pub struct AssociateVPCWithHostedZoneRequestSerializer;
+impl AssociateVPCWithHostedZoneRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &AssociateVPCWithHostedZoneRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+
+        if let Some(ref value) = obj.comment {
+            serialized += &AssociateVPCCommentSerializer::serialize("Comment", value);
+        }
+        serialized += &VPCSerializer::serialize("VPC", &obj.vpc);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains the response information for the <code>AssociateVPCWithHostedZone</code> request.</p>"]
 #[derive(Default,Debug)]
 pub struct AssociateVPCWithHostedZoneResponse {
@@ -439,6 +453,16 @@ pub struct ChangeResourceRecordSetsRequest {
     pub hosted_zone_id: String,
 }
 
+pub struct ChangeResourceRecordSetsRequestSerializer;
+impl ChangeResourceRecordSetsRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &ChangeResourceRecordSetsRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &ChangeBatchSerializer::serialize("ChangeBatch", &obj.change_batch);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type containing the response for the request.</p>"]
 #[derive(Default,Debug)]
 pub struct ChangeResourceRecordSetsResponse {
@@ -516,6 +540,23 @@ pub struct ChangeTagsForResourceRequest {
     pub resource_type: String,
 }
 
+pub struct ChangeTagsForResourceRequestSerializer;
+impl ChangeTagsForResourceRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &ChangeTagsForResourceRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+
+        if let Some(ref value) = obj.add_tags {
+            serialized += &TagListSerializer::serialize("AddTags", value);
+        }
+
+        if let Some(ref value) = obj.remove_tag_keys {
+            serialized += &TagKeyListSerializer::serialize("RemoveTagKeys", value);
+        }
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>Empty response for the request.</p>"]
 #[derive(Default,Debug)]
 pub struct ChangeTagsForResourceResponse;
@@ -544,7 +585,7 @@ impl ChangesSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(ChangeSerializer::serialize(name, element));
+            parts.push(ChangeSerializer::serialize("Change", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -642,7 +683,7 @@ impl ChildHealthCheckListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(HealthCheckIdSerializer::serialize(name, element));
+            parts.push(HealthCheckIdSerializer::serialize("HealthCheckId", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -790,6 +831,19 @@ pub struct CreateHealthCheckRequest {
     pub health_check_config: HealthCheckConfig,
 }
 
+pub struct CreateHealthCheckRequestSerializer;
+impl CreateHealthCheckRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &CreateHealthCheckRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &HealthCheckNonceSerializer::serialize("CallerReference",
+                                                             &obj.caller_reference);
+        serialized += &HealthCheckConfigSerializer::serialize("HealthCheckConfig",
+                                                              &obj.health_check_config);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type containing the response information for the new health check.</p>"]
 #[derive(Default,Debug)]
 pub struct CreateHealthCheckResponse {
@@ -856,6 +910,29 @@ pub struct CreateHostedZoneRequest {
     pub vpc: Option<VPC>,
 }
 
+pub struct CreateHostedZoneRequestSerializer;
+impl CreateHostedZoneRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &CreateHostedZoneRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &NonceSerializer::serialize("CallerReference", &obj.caller_reference);
+
+        if let Some(ref value) = obj.delegation_set_id {
+            serialized += &ResourceIdSerializer::serialize("DelegationSetId", value);
+        }
+
+        if let Some(ref value) = obj.hosted_zone_config {
+            serialized += &HostedZoneConfigSerializer::serialize("HostedZoneConfig", value);
+        }
+        serialized += &DNSNameSerializer::serialize("Name", &obj.name);
+
+        if let Some(ref value) = obj.vpc {
+            serialized += &VPCSerializer::serialize("VPC", value);
+        }
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type containing the response information for the hosted zone.</p>"]
 #[derive(Default,Debug)]
 pub struct CreateHostedZoneResponse {
@@ -933,6 +1010,20 @@ pub struct CreateReusableDelegationSetRequest {
     pub hosted_zone_id: Option<String>,
 }
 
+pub struct CreateReusableDelegationSetRequestSerializer;
+impl CreateReusableDelegationSetRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &CreateReusableDelegationSetRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &NonceSerializer::serialize("CallerReference", &obj.caller_reference);
+
+        if let Some(ref value) = obj.hosted_zone_id {
+            serialized += &ResourceIdSerializer::serialize("HostedZoneId", value);
+        }
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[derive(Default,Debug)]
 pub struct CreateReusableDelegationSetResponse {
     #[doc="<p>A complex type that contains name server information.</p>"]
@@ -1000,6 +1091,22 @@ pub struct CreateTrafficPolicyInstanceRequest {
     pub traffic_policy_version: i64,
 }
 
+pub struct CreateTrafficPolicyInstanceRequestSerializer;
+impl CreateTrafficPolicyInstanceRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &CreateTrafficPolicyInstanceRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &ResourceIdSerializer::serialize("HostedZoneId", &obj.hosted_zone_id);
+        serialized += &DNSNameSerializer::serialize("Name", &obj.name);
+        serialized += &TTLSerializer::serialize("TTL", &obj.ttl);
+        serialized += &TrafficPolicyIdSerializer::serialize("TrafficPolicyId",
+                                                            &obj.traffic_policy_id);
+        serialized += &TrafficPolicyVersionSerializer::serialize("TrafficPolicyVersion",
+                                                                 &obj.traffic_policy_version);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicyInstance</code> request.</p>"]
 #[derive(Default,Debug)]
 pub struct CreateTrafficPolicyInstanceResponse {
@@ -1064,6 +1171,21 @@ pub struct CreateTrafficPolicyRequest {
     pub name: String,
 }
 
+pub struct CreateTrafficPolicyRequestSerializer;
+impl CreateTrafficPolicyRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &CreateTrafficPolicyRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+
+        if let Some(ref value) = obj.comment {
+            serialized += &TrafficPolicyCommentSerializer::serialize("Comment", value);
+        }
+        serialized += &TrafficPolicyDocumentSerializer::serialize("Document", &obj.document);
+        serialized += &TrafficPolicyNameSerializer::serialize("Name", &obj.name);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicy</code> request.</p>"]
 #[derive(Default,Debug)]
 pub struct CreateTrafficPolicyResponse {
@@ -1127,6 +1249,20 @@ pub struct CreateTrafficPolicyVersionRequest {
     pub id: String,
 }
 
+pub struct CreateTrafficPolicyVersionRequestSerializer;
+impl CreateTrafficPolicyVersionRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &CreateTrafficPolicyVersionRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+
+        if let Some(ref value) = obj.comment {
+            serialized += &TrafficPolicyCommentSerializer::serialize("Comment", value);
+        }
+        serialized += &TrafficPolicyDocumentSerializer::serialize("Document", &obj.document);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicyVersion</code> request.</p>"]
 #[derive(Default,Debug)]
 pub struct CreateTrafficPolicyVersionResponse {
@@ -1189,6 +1325,19 @@ pub struct CreateVPCAssociationAuthorizationRequest {
     pub vpc: VPC,
 }
 
+pub struct CreateVPCAssociationAuthorizationRequestSerializer;
+impl CreateVPCAssociationAuthorizationRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str,
+                     obj: &CreateVPCAssociationAuthorizationRequest,
+                     xmlns: &str)
+                     -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &VPCSerializer::serialize("VPC", &obj.vpc);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains the response information from a <code>CreateVPCAssociationAuthorization</code> request.</p>"]
 #[derive(Default,Debug)]
 pub struct CreateVPCAssociationAuthorizationResponse {
@@ -1605,6 +1754,19 @@ pub struct DeleteVPCAssociationAuthorizationRequest {
     pub vpc: VPC,
 }
 
+pub struct DeleteVPCAssociationAuthorizationRequestSerializer;
+impl DeleteVPCAssociationAuthorizationRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str,
+                     obj: &DeleteVPCAssociationAuthorizationRequest,
+                     xmlns: &str)
+                     -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &VPCSerializer::serialize("VPC", &obj.vpc);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>Empty response for the request.</p>"]
 #[derive(Default,Debug)]
 pub struct DeleteVPCAssociationAuthorizationResponse;
@@ -1757,6 +1919,23 @@ pub struct DisassociateVPCFromHostedZoneRequest {
     pub vpc: VPC,
 }
 
+pub struct DisassociateVPCFromHostedZoneRequestSerializer;
+impl DisassociateVPCFromHostedZoneRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str,
+                     obj: &DisassociateVPCFromHostedZoneRequest,
+                     xmlns: &str)
+                     -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+
+        if let Some(ref value) = obj.comment {
+            serialized += &DisassociateVPCCommentSerializer::serialize("Comment", value);
+        }
+        serialized += &VPCSerializer::serialize("VPC", &obj.vpc);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains the response information for the disassociate request.</p>"]
 #[derive(Default,Debug)]
 pub struct DisassociateVPCFromHostedZoneResponse {
@@ -3477,7 +3656,7 @@ impl HealthCheckRegionListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(HealthCheckRegionSerializer::serialize(name, element));
+            parts.push(HealthCheckRegionSerializer::serialize("HealthCheckRegion", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -4533,6 +4712,16 @@ pub struct ListTagsForResourcesRequest {
     pub resource_type: String,
 }
 
+pub struct ListTagsForResourcesRequestSerializer;
+impl ListTagsForResourcesRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &ListTagsForResourcesRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &TagResourceIdListSerializer::serialize("ResourceIds", &obj.resource_ids);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type containing tags for the specified resources.</p>"]
 #[derive(Default,Debug)]
 pub struct ListTagsForResourcesResponse {
@@ -6000,7 +6189,7 @@ impl ResourceRecordsSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(ResourceRecordSerializer::serialize(name, element));
+            parts.push(ResourceRecordSerializer::serialize("ResourceRecord", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -6360,7 +6549,7 @@ impl TagKeyListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagKeySerializer::serialize(name, element));
+            parts.push(TagKeySerializer::serialize("TagKey", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -6416,7 +6605,7 @@ impl TagListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagSerializer::serialize(name, element));
+            parts.push(TagSerializer::serialize("Tag", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -6456,7 +6645,7 @@ impl TagResourceIdListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagResourceIdSerializer::serialize(name, element));
+            parts.push(TagResourceIdSerializer::serialize("TagResourceId", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -7262,6 +7451,73 @@ pub struct UpdateHealthCheckRequest {
     pub search_string: Option<String>,
 }
 
+pub struct UpdateHealthCheckRequestSerializer;
+impl UpdateHealthCheckRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &UpdateHealthCheckRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+
+        if let Some(ref value) = obj.alarm_identifier {
+            serialized += &AlarmIdentifierSerializer::serialize("AlarmIdentifier", value);
+        }
+
+        if let Some(ref value) = obj.child_health_checks {
+            serialized += &ChildHealthCheckListSerializer::serialize("ChildHealthChecks", value);
+        }
+
+        if let Some(ref value) = obj.enable_sni {
+            serialized += &EnableSNISerializer::serialize("EnableSNI", value);
+        }
+
+        if let Some(ref value) = obj.failure_threshold {
+            serialized += &FailureThresholdSerializer::serialize("FailureThreshold", value);
+        }
+
+        if let Some(ref value) = obj.fully_qualified_domain_name {
+            serialized += &FullyQualifiedDomainNameSerializer::serialize("FullyQualifiedDomainName",
+                                                                         value);
+        }
+
+        if let Some(ref value) = obj.health_check_version {
+            serialized += &HealthCheckVersionSerializer::serialize("HealthCheckVersion", value);
+        }
+
+        if let Some(ref value) = obj.health_threshold {
+            serialized += &HealthThresholdSerializer::serialize("HealthThreshold", value);
+        }
+
+        if let Some(ref value) = obj.ip_address {
+            serialized += &IPAddressSerializer::serialize("IPAddress", value);
+        }
+
+        if let Some(ref value) = obj.insufficient_data_health_status {
+            serialized += &InsufficientDataHealthStatusSerializer::serialize("InsufficientDataHealthStatus",
+                                                                             value);
+        }
+
+        if let Some(ref value) = obj.inverted {
+            serialized += &InvertedSerializer::serialize("Inverted", value);
+        }
+
+        if let Some(ref value) = obj.port {
+            serialized += &PortSerializer::serialize("Port", value);
+        }
+
+        if let Some(ref value) = obj.regions {
+            serialized += &HealthCheckRegionListSerializer::serialize("Regions", value);
+        }
+
+        if let Some(ref value) = obj.resource_path {
+            serialized += &ResourcePathSerializer::serialize("ResourcePath", value);
+        }
+
+        if let Some(ref value) = obj.search_string {
+            serialized += &SearchStringSerializer::serialize("SearchString", value);
+        }
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[derive(Default,Debug)]
 pub struct UpdateHealthCheckResponse {
     pub health_check: HealthCheck,
@@ -7318,6 +7574,19 @@ pub struct UpdateHostedZoneCommentRequest {
     pub id: String,
 }
 
+pub struct UpdateHostedZoneCommentRequestSerializer;
+impl UpdateHostedZoneCommentRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &UpdateHostedZoneCommentRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+
+        if let Some(ref value) = obj.comment {
+            serialized += &ResourceDescriptionSerializer::serialize("Comment", value);
+        }
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains the response to the <code>UpdateHostedZoneComment</code> request.</p>"]
 #[derive(Default,Debug)]
 pub struct UpdateHostedZoneCommentResponse {
@@ -7378,6 +7647,16 @@ pub struct UpdateTrafficPolicyCommentRequest {
     pub version: i64,
 }
 
+pub struct UpdateTrafficPolicyCommentRequestSerializer;
+impl UpdateTrafficPolicyCommentRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &UpdateTrafficPolicyCommentRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &TrafficPolicyCommentSerializer::serialize("Comment", &obj.comment);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains the response information for the traffic policy.</p>"]
 #[derive(Default,Debug)]
 pub struct UpdateTrafficPolicyCommentResponse {
@@ -7442,6 +7721,20 @@ pub struct UpdateTrafficPolicyInstanceRequest {
     pub traffic_policy_version: i64,
 }
 
+pub struct UpdateTrafficPolicyInstanceRequestSerializer;
+impl UpdateTrafficPolicyInstanceRequestSerializer {
+    #[allow(unused_variables, warnings)]
+    pub fn serialize(name: &str, obj: &UpdateTrafficPolicyInstanceRequest, xmlns: &str) -> String {
+        let mut serialized = format!("<{name} xmlns=\"{xmlns}\">", name = name, xmlns = xmlns);
+        serialized += &TTLSerializer::serialize("TTL", &obj.ttl);
+        serialized += &TrafficPolicyIdSerializer::serialize("TrafficPolicyId",
+                                                            &obj.traffic_policy_id);
+        serialized += &TrafficPolicyVersionSerializer::serialize("TrafficPolicyVersion",
+                                                                 &obj.traffic_policy_version);
+        serialized += &format!("</{name}>", name = name);
+        serialized
+    }
+}
 #[doc="<p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>"]
 #[derive(Default,Debug)]
 pub struct UpdateTrafficPolicyInstanceResponse {
@@ -12070,7 +12363,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = AssociateVPCWithHostedZoneRequestSerializer::serialize("AssociateVPCWithHostedZoneRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12121,7 +12416,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = ChangeResourceRecordSetsRequestSerializer::serialize("ChangeResourceRecordSetsRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12173,7 +12470,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = ChangeTagsForResourceRequestSerializer::serialize("ChangeTagsForResourceRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12221,7 +12520,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = CreateHealthCheckRequestSerializer::serialize("CreateHealthCheckRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12272,7 +12573,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = CreateHostedZoneRequestSerializer::serialize("CreateHostedZoneRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12324,7 +12627,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = CreateReusableDelegationSetRequestSerializer::serialize("CreateReusableDelegationSetRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12374,7 +12679,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = CreateTrafficPolicyRequestSerializer::serialize("CreateTrafficPolicyRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12424,7 +12731,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = CreateTrafficPolicyInstanceRequestSerializer::serialize("CreateTrafficPolicyInstanceRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12475,7 +12784,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = CreateTrafficPolicyVersionRequestSerializer::serialize("CreateTrafficPolicyVersionRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12528,7 +12839,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = CreateVPCAssociationAuthorizationRequestSerializer::serialize("CreateVPCAssociationAuthorizationRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12830,7 +13143,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = DeleteVPCAssociationAuthorizationRequestSerializer::serialize("DeleteVPCAssociationAuthorizationRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -12880,7 +13195,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = DisassociateVPCFromHostedZoneRequestSerializer::serialize("DisassociateVPCFromHostedZoneRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -13998,7 +14315,9 @@ impl<P, D> Route53 for Route53Client<P, D>
 
 
 
+        let payload = ListTagsForResourcesRequestSerializer::serialize("ListTagsForResourcesRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -14463,7 +14782,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
 
 
+        let payload = UpdateHealthCheckRequestSerializer::serialize("UpdateHealthCheckRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -14514,7 +14835,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
 
 
+        let payload = UpdateHostedZoneCommentRequestSerializer::serialize("UpdateHostedZoneCommentRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -14566,7 +14889,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
 
 
+        let payload = UpdateTrafficPolicyCommentRequestSerializer::serialize("UpdateTrafficPolicyCommentRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 
@@ -14616,7 +14941,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
 
 
 
+        let payload = UpdateTrafficPolicyInstanceRequestSerializer::serialize("UpdateTrafficPolicyInstanceRequest", &input, "https://route53.amazonaws.com/doc/2013-04-01/").into_bytes();
 
+        request.set_payload(Some(payload));
 
         request.sign(&try!(self.credentials_provider.credentials()));
 

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -264,7 +264,7 @@ impl AllowedHeadersSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(AllowedHeaderSerializer::serialize(name, element));
+            parts.push(AllowedHeaderSerializer::serialize("AllowedHeader", element));
         }
         parts.join("")
     }
@@ -330,7 +330,7 @@ impl AllowedMethodsSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(AllowedMethodSerializer::serialize(name, element));
+            parts.push(AllowedMethodSerializer::serialize("AllowedMethod", element));
         }
         parts.join("")
     }
@@ -396,7 +396,7 @@ impl AllowedOriginsSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(AllowedOriginSerializer::serialize(name, element));
+            parts.push(AllowedOriginSerializer::serialize("AllowedOrigin", element));
         }
         parts.join("")
     }
@@ -1297,7 +1297,7 @@ impl CORSRulesSerializer {
     pub fn serialize(name: &str, obj: &Vec<CORSRule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(CORSRuleSerializer::serialize(name, element));
+            parts.push(CORSRuleSerializer::serialize("CORSRule", element));
         }
         parts.join("")
     }
@@ -1657,7 +1657,7 @@ impl CompletedPartListSerializer {
     pub fn serialize(name: &str, obj: &Vec<CompletedPart>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(CompletedPartSerializer::serialize(name, element));
+            parts.push(CompletedPartSerializer::serialize("CompletedPart", element));
         }
         parts.join("")
     }
@@ -3070,7 +3070,7 @@ impl EventListSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(EventSerializer::serialize(name, element));
+            parts.push(EventSerializer::serialize("Event", element));
         }
         parts.join("")
     }
@@ -3186,7 +3186,7 @@ impl ExposeHeadersSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(ExposeHeaderSerializer::serialize(name, element));
+            parts.push(ExposeHeaderSerializer::serialize("ExposeHeader", element));
         }
         parts.join("")
     }
@@ -3309,7 +3309,7 @@ impl FilterRuleListSerializer {
     pub fn serialize(name: &str, obj: &Vec<FilterRule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(FilterRuleSerializer::serialize(name, element));
+            parts.push(FilterRuleSerializer::serialize("FilterRule", element));
         }
         parts.join("")
     }
@@ -4643,7 +4643,7 @@ impl GrantsSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(GrantSerializer::serialize(name, element));
+            parts.push(GrantSerializer::serialize("Grant", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5408,7 +5408,8 @@ impl InventoryOptionalFieldsSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(InventoryOptionalFieldSerializer::serialize(name, element));
+            parts.push(InventoryOptionalFieldSerializer::serialize("InventoryOptionalField",
+                                                                   element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5822,7 +5823,7 @@ impl LambdaFunctionConfigurationListSerializer {
     pub fn serialize(name: &str, obj: &Vec<LambdaFunctionConfiguration>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(LambdaFunctionConfigurationSerializer::serialize(name, element));
+            parts.push(LambdaFunctionConfigurationSerializer::serialize("LambdaFunctionConfiguration", element));
         }
         parts.join("")
     }
@@ -6239,7 +6240,7 @@ impl LifecycleRulesSerializer {
     pub fn serialize(name: &str, obj: &Vec<LifecycleRule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(LifecycleRuleSerializer::serialize(name, element));
+            parts.push(LifecycleRuleSerializer::serialize("LifecycleRule", element));
         }
         parts.join("")
     }
@@ -8099,7 +8100,7 @@ impl NoncurrentVersionTransitionListSerializer {
     pub fn serialize(name: &str, obj: &Vec<NoncurrentVersionTransition>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(NoncurrentVersionTransitionSerializer::serialize(name, element));
+            parts.push(NoncurrentVersionTransitionSerializer::serialize("NoncurrentVersionTransition", element));
         }
         parts.join("")
     }
@@ -8452,7 +8453,7 @@ impl ObjectIdentifierListSerializer {
     pub fn serialize(name: &str, obj: &Vec<ObjectIdentifier>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(ObjectIdentifierSerializer::serialize(name, element));
+            parts.push(ObjectIdentifierSerializer::serialize("ObjectIdentifier", element));
         }
         parts.join("")
     }
@@ -9524,7 +9525,7 @@ impl QueueConfigurationListSerializer {
     pub fn serialize(name: &str, obj: &Vec<QueueConfiguration>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(QueueConfigurationSerializer::serialize(name, element));
+            parts.push(QueueConfigurationSerializer::serialize("QueueConfiguration", element));
         }
         parts.join("")
     }
@@ -9971,7 +9972,7 @@ impl ReplicationRulesSerializer {
     pub fn serialize(name: &str, obj: &Vec<ReplicationRule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(ReplicationRuleSerializer::serialize(name, element));
+            parts.push(ReplicationRuleSerializer::serialize("ReplicationRule", element));
         }
         parts.join("")
     }
@@ -10257,7 +10258,7 @@ impl RoutingRulesSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(RoutingRuleSerializer::serialize(name, element));
+            parts.push(RoutingRuleSerializer::serialize("RoutingRule", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -10414,7 +10415,7 @@ impl RulesSerializer {
     pub fn serialize(name: &str, obj: &Vec<Rule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(RuleSerializer::serialize(name, element));
+            parts.push(RuleSerializer::serialize("Rule", element));
         }
         parts.join("")
     }
@@ -10841,7 +10842,7 @@ impl TagSetSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagSerializer::serialize(name, element));
+            parts.push(TagSerializer::serialize("Tag", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -11010,7 +11011,7 @@ impl TargetGrantsSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TargetGrantSerializer::serialize(name, element));
+            parts.push(TargetGrantSerializer::serialize("TargetGrant", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -11296,7 +11297,7 @@ impl TopicConfigurationListSerializer {
     pub fn serialize(name: &str, obj: &Vec<TopicConfiguration>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(TopicConfigurationSerializer::serialize(name, element));
+            parts.push(TopicConfigurationSerializer::serialize("TopicConfiguration", element));
         }
         parts.join("")
     }
@@ -11416,7 +11417,7 @@ impl TransitionListSerializer {
     pub fn serialize(name: &str, obj: &Vec<Transition>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(TransitionSerializer::serialize(name, element));
+            parts.push(TransitionSerializer::serialize("Transition", element));
         }
         parts.join("")
     }

--- a/service_crategen/src/botocore.rs
+++ b/service_crategen/src/botocore.rs
@@ -87,6 +87,8 @@ pub struct Input {
     pub documentation: Option<String>,
     #[serde(deserialize_with="ShapeName::deserialize_shape_name")]
     pub shape: String,
+    #[serde(rename="xmlNamespace")]
+    pub xml_namespace: Option<XmlNamespace>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -315,7 +315,7 @@ fn generate_list_serializer(shape: &Shape) -> String {
 
     serializer += &format!("
         for element in obj {{
-            parts.push({element_type}Serializer::serialize(name, element));
+            parts.push({element_type}Serializer::serialize(\"{element_type}\", element));
         }}",
                            element_type = element_type);
 

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -124,7 +124,11 @@ impl GenerateProtocol for RestXmlGenerator {
 
     fn generate_serializer(&self, name: &str, shape: &Shape, service: &Service) -> Option<String> {
         if name != "RestoreRequest" && name.ends_with("Request") {
-            return None;
+            if used_as_request_payload(shape) {
+                return Some(generate_request_payload_serializer(name, shape));
+            } else {
+                return None;
+            }
         }
 
         let ty = get_rust_type(service, name, shape, false, self.timestamp_type());
@@ -172,7 +176,8 @@ fn generate_payload_serialization(service: &Service, operation: &Operation) -> O
         return None;
     }
 
-    let input_shape = service.get_shape(&operation.input.as_ref().unwrap().shape).unwrap();
+    let input = operation.input.as_ref().unwrap();
+    let input_shape = service.get_shape(&input.shape).unwrap();
 
     let mut parts: Vec<String> = Vec::new();
 
@@ -182,6 +187,14 @@ fn generate_payload_serialization(service: &Service, operation: &Operation) -> O
         parts.push(generate_payload_member_serialization(input_shape));
         parts.push(generate_service_specific_code(service, operation)
             .unwrap_or_else(|| "".to_owned()));
+        parts.push("request.set_payload(Some(payload));".to_owned());
+    } else if used_as_request_payload(input_shape) {
+        // In Route 53, no operation has "payload" parameter but some API actually requires
+        // payload. In that case, the payload should include members whose "location" parameter is
+        // missing.
+        let xmlns = input.xml_namespace.as_ref().unwrap();
+        parts.push(format!("let payload = {name}Serializer::serialize(\"{name}\", &input, \"{xmlns}\").into_bytes();", name = input.shape, xmlns = xmlns.uri));
+        parts.push(generate_service_specific_code(service, operation).unwrap_or_else(|| "".to_owned()));
         parts.push("request.set_payload(Some(payload));".to_owned());
     }
 
@@ -390,4 +403,37 @@ fn generate_complex_struct_field_serializer(shape: &Shape,
                 location_name = location_name,
                 field_name = generate_field_name(member_name))
     }
+}
+
+fn used_as_request_payload(shape: &Shape) -> bool {
+    if shape.payload.is_some() {
+        return false;
+    }
+    if let Some(ref members) = shape.members {
+        for member in members.values() {
+            if member.location.is_none() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn generate_request_payload_serializer(name: &str, shape: &Shape) -> String {
+    let mut parts = Vec::new();
+    parts.push(format!("pub struct {name}Serializer;", name = name));
+    parts.push(format!("impl {name}Serializer {{", name = name));
+    parts.push("#[allow(unused_variables, warnings)]".to_owned());
+    parts.push(format!("pub fn serialize(name: &str, obj: &{name}, xmlns: &str) -> String {{", name = name));
+    parts.push("let mut serialized = format!(\"<{name} xmlns=\\\"{xmlns}\\\">\", name=name, xmlns=xmlns);".to_owned());
+    for (member_name, member) in shape.members.as_ref().unwrap() {
+        if member.location.is_none() {
+            let location_name = member.location_name.as_ref().unwrap_or(member_name);
+            parts.push(generate_complex_struct_field_serializer(shape, member, location_name, member_name));
+        }
+    }
+    parts.push("serialized += &format!(\"</{name}>\", name=name);".to_owned());
+    parts.push("serialized".to_owned());
+    parts.push("}}".to_owned());
+    parts.join("\n")
 }


### PR DESCRIPTION
This should fix #765 .

The root cause is split into two parts;

- In Route 53, no operation has "payload" parameter but some API actually
requires payload. In that case, the payload should include members whose
"location" parameter is missing.
- XML element name of each list element was wrong

I confirmed that ChangeResourceRecordSets works in simple cases at least.