### PR TITLE
Serialize/deserialize region with AWS standard style

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -32,7 +32,6 @@ ring = "0.11"
 base64 = "0.6"
 hex = "0.2"
 serde = "1.0.2"
-serde_derive = "1.0.2"
 time = "0.1.35"
 url = "1.2.0"
 xml-rs = "0.6"
@@ -49,6 +48,7 @@ version = "0.0"
 env_logger = "0.4.0"
 rand = "^0.3.14"
 serde_json = "1.0.1"
+serde_test = "1.0.1"
 
 [features]
 nightly-testing = ["clippy", "rusoto_credential/nightly-testing"]

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -50,8 +50,6 @@ extern crate hex;
 extern crate base64;
 pub extern crate rusoto_credential as credential;
 extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 extern crate time;
 extern crate url;
 extern crate xml;

--- a/rusoto/core/src/region.rs
+++ b/rusoto/core/src/region.rs
@@ -8,12 +8,13 @@ use std;
 use std::error::Error;
 use std::str::FromStr;
 use std::fmt::{Display, Error as FmtError, Formatter};
+use serde::{de, Serialize, Serializer, Deserialize, Deserializer};
 
 /// An AWS region.
 /// `Custom` can be used to use a local or otherwise non-AWS endpoint.  This may be used for API-compatible services, such as DynamoDB Local or Ceph.
 /// Example: `Region::Custom("http://localhost:8000".to_owned())` instead of `Region::UsEast1`.
 /// `CnNorth1` is currently untested due to Rusoto maintainers not having access to AWS China.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Region {
     ApNortheast1,
     ApNortheast2,
@@ -37,6 +38,26 @@ pub enum Region {
 #[derive(Debug,PartialEq)]
 pub struct ParseRegionError {
     message: String,
+}
+
+// Manually derived for lack of way to flatten Custom variant
+// Related: https://github.com/serde-rs/serde/issues/119
+impl Serialize for Region {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where S: Serializer
+    {
+        serializer.collect_str(&self.to_string())
+    }
+}
+
+// Manually derived to deserialize both the standard 'us-east-1' kebab-case style
+// as well as 'UsEast1' PascalCase style to faciliate migrating from older versions
+impl<'de> Deserialize<'de> for Region {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        String::deserialize(deserializer)?.parse().map_err(de::Error::custom)
+    }
 }
 
 impl Display for Region {
@@ -70,21 +91,21 @@ impl FromStr for Region {
     fn from_str(s: &str) -> Result<Region, ParseRegionError> {
         let v : &str = &s.to_lowercase();
         match v {
-            "ap-northeast-1" => Ok(Region::ApNortheast1),
-            "ap-northeast-2" => Ok(Region::ApNortheast2),
-            "ap-south-1" => Ok(Region::ApSouth1),
-            "ap-southeast-1" => Ok(Region::ApSoutheast1),
-            "ap-southeast-2" => Ok(Region::ApSoutheast2),
-            "ca-central-1" => Ok(Region::CaCentral1),
-            "eu-central-1" => Ok(Region::EuCentral1),
-            "eu-west-1" => Ok(Region::EuWest1),
-            "eu-west-2" => Ok(Region::EuWest2),
-            "sa-east-1" => Ok(Region::SaEast1),
-            "us-east-1" => Ok(Region::UsEast1),
-            "us-east-2" => Ok(Region::UsEast2),
-            "us-west-1" => Ok(Region::UsWest1),
-            "us-west-2" => Ok(Region::UsWest2),
-            "cn-north-1" => Ok(Region::CnNorth1),
+            "ap-northeast-1" | "apnortheast1" => Ok(Region::ApNortheast1),
+            "ap-northeast-2" | "apnortheast2" => Ok(Region::ApNortheast2),
+            "ap-south-1" | "apsouth1" => Ok(Region::ApSouth1),
+            "ap-southeast-1" | "apsoutheast1" => Ok(Region::ApSoutheast1),
+            "ap-southeast-2" | "apsoutheast2" => Ok(Region::ApSoutheast2),
+            "ca-central-1" | "cacentral1" => Ok(Region::CaCentral1),
+            "eu-central-1" | "eucentral1" => Ok(Region::EuCentral1),
+            "eu-west-1" | "euwest1" => Ok(Region::EuWest1),
+            "eu-west-2" | "euwest2" => Ok(Region::EuWest2),
+            "sa-east-1" | "saeast1" => Ok(Region::SaEast1),
+            "us-east-1" | "useast1" => Ok(Region::UsEast1),
+            "us-east-2" | "useast2" => Ok(Region::UsEast2),
+            "us-west-1" | "uswest1" => Ok(Region::UsWest1),
+            "us-west-2" | "uswest2" => Ok(Region::UsWest2),
+            "cn-north-1" | "cnnorth1" => Ok(Region::CnNorth1),
             s => Err(ParseRegionError::new(s)),
         }
     }
@@ -125,6 +146,8 @@ pub fn default_region() -> Region {
 
 #[cfg(test)]
 mod tests {
+    extern crate serde_test;
+    use self::serde_test::{Token, assert_tokens, assert_ser_tokens, assert_de_tokens};
     use super::*;
 
     #[test]
@@ -173,5 +196,50 @@ mod tests {
         assert_eq!(Region::UsWest1.to_string(), "us-west-1".to_owned());
         assert_eq!(Region::UsWest2.to_string(), "us-west-2".to_owned());
         assert_eq!(Region::CnNorth1.to_string(), "cn-north-1".to_owned());
+    }
+
+    #[test]
+    fn region_serialize_deserialize() {
+        assert_tokens(&Region::ApNortheast1, &[Token::String("ap-northeast-1")]);
+        assert_tokens(&Region::ApNortheast2, &[Token::String("ap-northeast-2")]);
+        assert_tokens(&Region::ApSouth1, &[Token::String("ap-south-1")]);
+        assert_tokens(&Region::ApSoutheast1, &[Token::String("ap-southeast-1")]);
+        assert_tokens(&Region::ApSoutheast2, &[Token::String("ap-southeast-2")]);
+        assert_tokens(&Region::CaCentral1, &[Token::String("ca-central-1")]);
+        assert_tokens(&Region::EuCentral1, &[Token::String("eu-central-1")]);
+        assert_tokens(&Region::EuWest1, &[Token::String("eu-west-1")]);
+        assert_tokens(&Region::EuWest2, &[Token::String("eu-west-2")]);
+        assert_tokens(&Region::SaEast1, &[Token::String("sa-east-1")]);
+        assert_tokens(&Region::UsEast1, &[Token::String("us-east-1")]);
+        assert_tokens(&Region::UsEast2, &[Token::String("us-east-2")]);
+        assert_tokens(&Region::UsWest1, &[Token::String("us-west-1")]);
+        assert_tokens(&Region::UsWest2, &[Token::String("us-west-2")]);
+        assert_tokens(&Region::CnNorth1, &[Token::String("cn-north-1")]);
+    }
+
+    #[test]
+    fn region_serialize_custom() {
+        let custom_region = Region::Custom("http://localhost:8000".to_owned());
+        assert_ser_tokens(&custom_region, &[Token::String("http://localhost:8000")]);
+    }
+
+    // Test we can still deserialize from the old style to ease migration
+    #[test]
+    fn region_deserialize_migration() {
+        assert_de_tokens(&Region::ApNortheast1, &[Token::String("ApNortheast1")]);
+        assert_de_tokens(&Region::ApNortheast2, &[Token::String("ApNortheast2")]);
+        assert_de_tokens(&Region::ApSouth1, &[Token::String("ApSouth1")]);
+        assert_de_tokens(&Region::ApSoutheast1, &[Token::String("ApSoutheast1")]);
+        assert_de_tokens(&Region::ApSoutheast2, &[Token::String("ApSoutheast2")]);
+        assert_de_tokens(&Region::CaCentral1, &[Token::String("CaCentral1")]);
+        assert_de_tokens(&Region::EuCentral1, &[Token::String("EuCentral1")]);
+        assert_de_tokens(&Region::EuWest1, &[Token::String("EuWest1")]);
+        assert_de_tokens(&Region::EuWest2, &[Token::String("EuWest2")]);
+        assert_de_tokens(&Region::SaEast1, &[Token::String("SaEast1")]);
+        assert_de_tokens(&Region::UsEast1, &[Token::String("UsEast1")]);
+        assert_de_tokens(&Region::UsEast2, &[Token::String("UsEast2")]);
+        assert_de_tokens(&Region::UsWest1, &[Token::String("UsWest1")]);
+        assert_de_tokens(&Region::UsWest2, &[Token::String("UsWest2")]);
+        assert_de_tokens(&Region::CnNorth1, &[Token::String("CnNorth1")]);
     }
 }


### PR DESCRIPTION
Switch serde to use 'us-east-1' style instead of 'UsEast1',
  using the `ToString` and `FromStr` traits.

In order to reduce breakage for existing code using
  region with 'UsEast1' style, `FromStr` used by deserialization
  now also supports the previous style.

Caveats:

1. Deserializing and then serializing 'UsEast1' will result in 'us-east-1'.
2. While you can serialize `Region::Custom(...)`, you can't currently deserialize to it.

Resolves #788