### PR TITLE
make rusoto core use http pools in default client

### DIFF
--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -18,6 +18,7 @@ use hyper::status::StatusCode;
 use hyper::method::Method;
 use hyper::client::RedirectPolicy;
 use hyper::net::HttpsConnector;
+use hyper::client::pool::Pool;
 use hyper_native_tls::NativeTlsClient;
 
 use log::LogLevel::Debug;
@@ -174,7 +175,7 @@ pub fn default_tls_client() -> Result<Client, TlsError> {
         }
     };
     let connector = HttpsConnector::new(ssl);
-    let mut client = Client::with_connector(connector);
+    let mut client = Client::with_connector(Pool::with_connector(Default::default(), connector));
     client.set_redirect_policy(RedirectPolicy::FollowNone);
     Ok(client)
 }


### PR DESCRIPTION
fixes #801

first off huge thanks to @nieksand for not only noticing this, but
also being the one who implemented this fix (I'm just here merging it,
and verifying it does fix the problem he found).

as @nieksand points out the method of constructing an http client
that we were using did not setup a connection pool, and so each
call would create a brand new connection instead of potentially
re-using the same connection if it's already open.

I used test code, that I've uploaded to a gist here:
https://gist.github.com/SecurityInsanity/c7f2dabbb348b4342314b99f98b0e810

Next I captured a pcap with the command:
```
$ tcpdump -i <interface> "tcp[tcpflags] & (tcp-syn) != 0" -w <location_to_pcap>
```
this shows roughly all new connections.

I found a place to upload pcaps online (I'd be happy to upload them
somewhere else if someone wants). The Old PCAP is located here:
https://packettotal.com/cgi-bin/view-analysis.cgi?id=58c3785d80dae11fc1b9e3d2c5dbe9a4
as you can see there's a total of 74 open connections after running the code
above for a few seconds.

The new pcap is located here:
https://packettotal.com/cgi-bin/view-analysis.cgi?id=6e6b2874a8781fb6799991be647a49fe

As you can see the first one opened 74 connections (a new one each time)
meanwhile the second one who ran for a similar time frame only opened
the connection once to httpbin, and simply re-used it. thus confirming
that when using a connection pool the connection can be re-used.