### PR TITLE
fully documents the credentials crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added Athena service
 - Added X-Ray service
 - Updated Credentials crate to use hyper 0.11 (aka the Async IO Update).
+- Added Documentation to Credentials Crate.
+- Make Rusoto Core use HTTP Pools to re-use connections.
+- Fixed Edge Cases in URI Encoding of Rusoto (double query encoding, +'s in query strings).
 
 ## [0.28.0] - 2017-08-25
 


### PR DESCRIPTION
fixes #810

this commit enforces documentation on the credentials crate (and
actually documents it so things don't just start failing).

I also realized I had forgotten to add changelog entries for other
PRs (:gasp:) so I've gone ahead, and added those entries for my
PRs here.