### PR TITLE
extend object body by len not capacity

### DIFF
--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -229,7 +229,7 @@ fn test_get_object(client: &TestClient, bucket: &str, filename: &str) {
         }
 
         println!("read {} bytes", len);
-        body.extend_from_slice(&buf);
+        body.extend_from_slice(&buf[0..len]);
     }
 
     assert!(body.len() > 0);


### PR DESCRIPTION
It does not break the test, but if someone copy/pastes the test code
the object gotten from S3 will have holes in it because the object
is extended by the buffer size, not the number of bytes read from
the stream.