### PR TITLE
fix uri encoding for services that use qs params

### DIFF
--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -540,7 +540,7 @@ impl AttachInstancesQuerySerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_ids {
             InstanceIdsSerializer::serialize(params,
                                              &format!("{}{}", prefix, "InstanceIds"),
@@ -590,7 +590,7 @@ impl AttachLoadBalancerTargetGroupsTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         TargetGroupARNsSerializer::serialize(params,
                                              &format!("{}{}", prefix, "TargetGroupARNs"),
                                              &obj.target_group_ar_ns);
@@ -638,7 +638,7 @@ impl AttachLoadBalancersTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         LoadBalancerNamesSerializer::serialize(params,
                                                &format!("{}{}", prefix, "LoadBalancerNames"),
                                                &obj.load_balancer_names);
@@ -922,10 +922,11 @@ impl AutoScalingGroupNamesTypeSerializer {
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1475,16 +1476,18 @@ impl BlockDeviceMappingSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DeviceName"), &obj.device_name);
+        params.put(&format!("{}{}", prefix, "DeviceName"),
+                   &obj.device_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ebs {
             EbsSerializer::serialize(params, &format!("{}{}", prefix, "Ebs"), field_value);
         }
         if let Some(ref field_value) = obj.no_device {
             params.put(&format!("{}{}", prefix, "NoDevice"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.virtual_name {
-            params.put(&format!("{}{}", prefix, "VirtualName"), &field_value);
+            params.put(&format!("{}{}", prefix, "VirtualName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1644,18 +1647,19 @@ impl CompleteLifecycleActionTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "LifecycleActionResult"),
-                   &obj.lifecycle_action_result);
+                   &obj.lifecycle_action_result.replace("+", "%2B"));
         if let Some(ref field_value) = obj.lifecycle_action_token {
             params.put(&format!("{}{}", prefix, "LifecycleActionToken"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "LifecycleHookName"),
-                   &obj.lifecycle_hook_name);
+                   &obj.lifecycle_hook_name.replace("+", "%2B"));
 
     }
 }
@@ -1724,7 +1728,7 @@ impl CreateAutoScalingGroupTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.availability_zones {
             AvailabilityZonesSerializer::serialize(params,
                                                    &format!("{}{}", prefix, "AvailabilityZones"),
@@ -1732,25 +1736,27 @@ impl CreateAutoScalingGroupTypeSerializer {
         }
         if let Some(ref field_value) = obj.default_cooldown {
             params.put(&format!("{}{}", prefix, "DefaultCooldown"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.desired_capacity {
             params.put(&format!("{}{}", prefix, "DesiredCapacity"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_grace_period {
             params.put(&format!("{}{}", prefix, "HealthCheckGracePeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_type {
-            params.put(&format!("{}{}", prefix, "HealthCheckType"), &field_value);
+            params.put(&format!("{}{}", prefix, "HealthCheckType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.launch_configuration_name {
             params.put(&format!("{}{}", prefix, "LaunchConfigurationName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.load_balancer_names {
             LoadBalancerNamesSerializer::serialize(params,
@@ -1758,15 +1764,16 @@ impl CreateAutoScalingGroupTypeSerializer {
                                                    field_value);
         }
         params.put(&format!("{}{}", prefix, "MaxSize"),
-                   &obj.max_size.to_string());
+                   &obj.max_size.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "MinSize"),
-                   &obj.min_size.to_string());
+                   &obj.min_size.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.new_instances_protected_from_scale_in {
             params.put(&format!("{}{}", prefix, "NewInstancesProtectedFromScaleIn"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.placement_group {
-            params.put(&format!("{}{}", prefix, "PlacementGroup"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlacementGroup"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagsSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
@@ -1784,7 +1791,8 @@ impl CreateAutoScalingGroupTypeSerializer {
                                                      field_value);
         }
         if let Some(ref field_value) = obj.vpc_zone_identifier {
-            params.put(&format!("{}{}", prefix, "VPCZoneIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "VPCZoneIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1843,7 +1851,7 @@ impl CreateLaunchConfigurationTypeSerializer {
 
         if let Some(ref field_value) = obj.associate_public_ip_address {
             params.put(&format!("{}{}", prefix, "AssociatePublicIpAddress"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.block_device_mappings {
             BlockDeviceMappingsSerializer::serialize(params,
@@ -1853,7 +1861,8 @@ impl CreateLaunchConfigurationTypeSerializer {
                                                      field_value);
         }
         if let Some(ref field_value) = obj.classic_link_vpc_id {
-            params.put(&format!("{}{}", prefix, "ClassicLinkVPCId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClassicLinkVPCId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.classic_link_vpc_security_groups {
             ClassicLinkVPCSecurityGroupsSerializer::serialize(params,
@@ -1864,16 +1873,19 @@ impl CreateLaunchConfigurationTypeSerializer {
         }
         if let Some(ref field_value) = obj.ebs_optimized {
             params.put(&format!("{}{}", prefix, "EbsOptimized"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iam_instance_profile {
-            params.put(&format!("{}{}", prefix, "IamInstanceProfile"), &field_value);
+            params.put(&format!("{}{}", prefix, "IamInstanceProfile"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.image_id {
-            params.put(&format!("{}{}", prefix, "ImageId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ImageId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_monitoring {
             InstanceMonitoringSerializer::serialize(params,
@@ -1881,21 +1893,26 @@ impl CreateLaunchConfigurationTypeSerializer {
                                                     field_value);
         }
         if let Some(ref field_value) = obj.instance_type {
-            params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kernel_id {
-            params.put(&format!("{}{}", prefix, "KernelId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KernelId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.key_name {
-            params.put(&format!("{}{}", prefix, "KeyName"), &field_value);
+            params.put(&format!("{}{}", prefix, "KeyName"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "LaunchConfigurationName"),
-                   &obj.launch_configuration_name);
+                   &obj.launch_configuration_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.placement_tenancy {
-            params.put(&format!("{}{}", prefix, "PlacementTenancy"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlacementTenancy"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ramdisk_id {
-            params.put(&format!("{}{}", prefix, "RamdiskId"), &field_value);
+            params.put(&format!("{}{}", prefix, "RamdiskId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_groups {
             SecurityGroupsSerializer::serialize(params,
@@ -1903,10 +1920,12 @@ impl CreateLaunchConfigurationTypeSerializer {
                                                 field_value);
         }
         if let Some(ref field_value) = obj.spot_price {
-            params.put(&format!("{}{}", prefix, "SpotPrice"), &field_value);
+            params.put(&format!("{}{}", prefix, "SpotPrice"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_data {
-            params.put(&format!("{}{}", prefix, "UserData"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserData"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2023,11 +2042,15 @@ impl CustomizedMetricSpecificationSerializer {
                                                   &format!("{}{}", prefix, "Dimensions"),
                                                   field_value);
         }
-        params.put(&format!("{}{}", prefix, "MetricName"), &obj.metric_name);
-        params.put(&format!("{}{}", prefix, "Namespace"), &obj.namespace);
-        params.put(&format!("{}{}", prefix, "Statistic"), &obj.statistic);
+        params.put(&format!("{}{}", prefix, "MetricName"),
+                   &obj.metric_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Namespace"),
+                   &obj.namespace.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Statistic"),
+                   &obj.statistic.replace("+", "%2B"));
         if let Some(ref field_value) = obj.unit {
-            params.put(&format!("{}{}", prefix, "Unit"), &field_value);
+            params.put(&format!("{}{}", prefix, "Unit"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2053,10 +2076,10 @@ impl DeleteAutoScalingGroupTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.force_delete {
             params.put(&format!("{}{}", prefix, "ForceDelete"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -2102,9 +2125,9 @@ impl DeleteLifecycleHookTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "LifecycleHookName"),
-                   &obj.lifecycle_hook_name);
+                   &obj.lifecycle_hook_name.replace("+", "%2B"));
 
     }
 }
@@ -2129,8 +2152,9 @@ impl DeleteNotificationConfigurationTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
-        params.put(&format!("{}{}", prefix, "TopicARN"), &obj.topic_arn);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "TopicARN"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -2156,9 +2180,10 @@ impl DeletePolicyTypeSerializer {
 
         if let Some(ref field_value) = obj.auto_scaling_group_name {
             params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -2183,9 +2208,9 @@ impl DeleteScheduledActionTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ScheduledActionName"),
-                   &obj.scheduled_action_name);
+                   &obj.scheduled_action_name.replace("+", "%2B"));
 
     }
 }
@@ -2353,10 +2378,11 @@ impl DescribeAutoScalingInstancesTypeSerializer {
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2530,7 +2556,7 @@ impl DescribeLifecycleHooksTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.lifecycle_hook_names {
             LifecycleHookNamesSerializer::serialize(params,
                                                     &format!("{}{}", prefix, "LifecycleHookNames"),
@@ -2562,13 +2588,14 @@ impl DescribeLoadBalancerTargetGroupsRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2651,13 +2678,14 @@ impl DescribeLoadBalancersRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2864,10 +2892,11 @@ impl DescribeNotificationConfigurationsTypeSerializer {
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2900,14 +2929,15 @@ impl DescribePoliciesTypeSerializer {
 
         if let Some(ref field_value) = obj.auto_scaling_group_name {
             params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.policy_names {
             PolicyNamesSerializer::serialize(params,
@@ -2953,14 +2983,15 @@ impl DescribeScalingActivitiesTypeSerializer {
         }
         if let Some(ref field_value) = obj.auto_scaling_group_name {
             params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2995,17 +3026,19 @@ impl DescribeScheduledActionsTypeSerializer {
 
         if let Some(ref field_value) = obj.auto_scaling_group_name {
             params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.scheduled_action_names {
             ScheduledActionNamesSerializer::serialize(params,
@@ -3015,7 +3048,8 @@ impl DescribeScheduledActionsTypeSerializer {
                                                       field_value);
         }
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3047,10 +3081,11 @@ impl DescribeTagsTypeSerializer {
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3178,14 +3213,16 @@ impl DetachInstancesQuerySerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_ids {
             InstanceIdsSerializer::serialize(params,
                                              &format!("{}{}", prefix, "InstanceIds"),
                                              field_value);
         }
         params.put(&format!("{}{}", prefix, "ShouldDecrementDesiredCapacity"),
-                   &obj.should_decrement_desired_capacity.to_string());
+                   &obj.should_decrement_desired_capacity
+                        .to_string()
+                        .replace("+", "%2B"));
 
     }
 }
@@ -3229,7 +3266,7 @@ impl DetachLoadBalancerTargetGroupsTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         TargetGroupARNsSerializer::serialize(params,
                                              &format!("{}{}", prefix, "TargetGroupARNs"),
                                              &obj.target_group_ar_ns);
@@ -3277,7 +3314,7 @@ impl DetachLoadBalancersTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         LoadBalancerNamesSerializer::serialize(params,
                                                &format!("{}{}", prefix, "LoadBalancerNames"),
                                                &obj.load_balancer_names);
@@ -3305,7 +3342,7 @@ impl DisableMetricsCollectionQuerySerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.metrics {
             MetricsSerializer::serialize(params, &format!("{}{}", prefix, "Metrics"), field_value);
         }
@@ -3418,24 +3455,27 @@ impl EbsSerializer {
 
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(&format!("{}{}", prefix, "DeleteOnTermination"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.encrypted {
             params.put(&format!("{}{}", prefix, "Encrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_id {
-            params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_size {
             params.put(&format!("{}{}", prefix, "VolumeSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_type {
-            params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "VolumeType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3477,8 +3517,9 @@ impl EnableMetricsCollectionQuerySerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
-        params.put(&format!("{}{}", prefix, "Granularity"), &obj.granularity);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Granularity"),
+                   &obj.granularity.replace("+", "%2B"));
         if let Some(ref field_value) = obj.metrics {
             MetricsSerializer::serialize(params, &format!("{}{}", prefix, "Metrics"), field_value);
         }
@@ -3655,14 +3696,16 @@ impl EnterStandbyQuerySerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_ids {
             InstanceIdsSerializer::serialize(params,
                                              &format!("{}{}", prefix, "InstanceIds"),
                                              field_value);
         }
         params.put(&format!("{}{}", prefix, "ShouldDecrementDesiredCapacity"),
-                   &obj.should_decrement_desired_capacity.to_string());
+                   &obj.should_decrement_desired_capacity
+                        .to_string()
+                        .replace("+", "%2B"));
 
     }
 }
@@ -3708,21 +3751,22 @@ impl ExecutePolicyTypeSerializer {
 
         if let Some(ref field_value) = obj.auto_scaling_group_name {
             params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.breach_threshold {
             params.put(&format!("{}{}", prefix, "BreachThreshold"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.honor_cooldown {
             params.put(&format!("{}{}", prefix, "HonorCooldown"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.metric_value {
             params.put(&format!("{}{}", prefix, "MetricValue"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -3796,7 +3840,7 @@ impl ExitStandbyQuerySerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_ids {
             InstanceIdsSerializer::serialize(params,
                                              &format!("{}{}", prefix, "InstanceIds"),
@@ -3826,7 +3870,8 @@ impl FilterSerializer {
         }
 
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "Name"), &field_value);
+            params.put(&format!("{}{}", prefix, "Name"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.values {
             ValuesSerializer::serialize(params, &format!("{}{}", prefix, "Values"), field_value);
@@ -4048,7 +4093,7 @@ impl InstanceMonitoringSerializer {
 
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -4296,7 +4341,7 @@ impl LaunchConfigurationNameTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LaunchConfigurationName"),
-                   &obj.launch_configuration_name);
+                   &obj.launch_configuration_name.replace("+", "%2B"));
 
     }
 }
@@ -4343,10 +4388,11 @@ impl LaunchConfigurationNamesTypeSerializer {
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5086,8 +5132,10 @@ impl MetricDimensionSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
-        params.put(&format!("{}{}", prefix, "Value"), &obj.value);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Value"),
+                   &obj.value.replace("+", "%2B"));
 
     }
 }
@@ -5769,9 +5817,10 @@ impl PredefinedMetricSpecificationSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "PredefinedMetricType"),
-                   &obj.predefined_metric_type);
+                   &obj.predefined_metric_type.replace("+", "%2B"));
         if let Some(ref field_value) = obj.resource_label {
-            params.put(&format!("{}{}", prefix, "ResourceLabel"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceLabel"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6009,30 +6058,32 @@ impl PutLifecycleHookTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.default_result {
-            params.put(&format!("{}{}", prefix, "DefaultResult"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultResult"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.heartbeat_timeout {
             params.put(&format!("{}{}", prefix, "HeartbeatTimeout"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "LifecycleHookName"),
-                   &obj.lifecycle_hook_name);
+                   &obj.lifecycle_hook_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.lifecycle_transition {
             params.put(&format!("{}{}", prefix, "LifecycleTransition"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_metadata {
             params.put(&format!("{}{}", prefix, "NotificationMetadata"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_target_arn {
             params.put(&format!("{}{}", prefix, "NotificationTargetARN"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.role_arn {
-            params.put(&format!("{}{}", prefix, "RoleARN"), &field_value);
+            params.put(&format!("{}{}", prefix, "RoleARN"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6060,13 +6111,14 @@ impl PutNotificationConfigurationTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         AutoScalingNotificationTypesSerializer::serialize(params,
                                                           &format!("{}{}",
                                                                   prefix,
                                                                   "NotificationTypes"),
                                                           &obj.notification_types);
-        params.put(&format!("{}{}", prefix, "TopicARN"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "TopicARN"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -6111,37 +6163,40 @@ impl PutScalingPolicyTypeSerializer {
         }
 
         if let Some(ref field_value) = obj.adjustment_type {
-            params.put(&format!("{}{}", prefix, "AdjustmentType"), &field_value);
+            params.put(&format!("{}{}", prefix, "AdjustmentType"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.cooldown {
             params.put(&format!("{}{}", prefix, "Cooldown"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.estimated_instance_warmup {
             params.put(&format!("{}{}", prefix, "EstimatedInstanceWarmup"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.metric_aggregation_type {
             params.put(&format!("{}{}", prefix, "MetricAggregationType"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.min_adjustment_magnitude {
             params.put(&format!("{}{}", prefix, "MinAdjustmentMagnitude"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.min_adjustment_step {
             params.put(&format!("{}{}", prefix, "MinAdjustmentStep"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.policy_type {
-            params.put(&format!("{}{}", prefix, "PolicyType"), &field_value);
+            params.put(&format!("{}{}", prefix, "PolicyType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.scaling_adjustment {
             params.put(&format!("{}{}", prefix, "ScalingAdjustment"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.step_adjustments {
             StepAdjustmentsSerializer::serialize(params,
@@ -6193,32 +6248,36 @@ impl PutScheduledUpdateGroupActionTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.desired_capacity {
             params.put(&format!("{}{}", prefix, "DesiredCapacity"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_size {
             params.put(&format!("{}{}", prefix, "MaxSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.min_size {
             params.put(&format!("{}{}", prefix, "MinSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.recurrence {
-            params.put(&format!("{}{}", prefix, "Recurrence"), &field_value);
+            params.put(&format!("{}{}", prefix, "Recurrence"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ScheduledActionName"),
-                   &obj.scheduled_action_name);
+                   &obj.scheduled_action_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.time {
-            params.put(&format!("{}{}", prefix, "Time"), &field_value);
+            params.put(&format!("{}{}", prefix, "Time"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6269,16 +6328,17 @@ impl RecordLifecycleActionHeartbeatTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.lifecycle_action_token {
             params.put(&format!("{}{}", prefix, "LifecycleActionToken"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "LifecycleHookName"),
-                   &obj.lifecycle_hook_name);
+                   &obj.lifecycle_hook_name.replace("+", "%2B"));
 
     }
 }
@@ -6509,7 +6569,7 @@ impl ScalingProcessQuerySerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.scaling_processes {
             ProcessNamesSerializer::serialize(params,
                                               &format!("{}{}", prefix, "ScalingProcesses"),
@@ -6813,12 +6873,12 @@ impl SetDesiredCapacityTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DesiredCapacity"),
-                   &obj.desired_capacity.to_string());
+                   &obj.desired_capacity.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.honor_cooldown {
             params.put(&format!("{}{}", prefix, "HonorCooldown"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6845,11 +6905,13 @@ impl SetInstanceHealthQuerySerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "HealthStatus"), &obj.health_status);
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "HealthStatus"),
+                   &obj.health_status.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.should_respect_grace_period {
             params.put(&format!("{}{}", prefix, "ShouldRespectGracePeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6897,12 +6959,12 @@ impl SetInstanceProtectionQuerySerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         InstanceIdsSerializer::serialize(params,
                                          &format!("{}{}", prefix, "InstanceIds"),
                                          &obj.instance_ids);
         params.put(&format!("{}{}", prefix, "ProtectedFromScaleIn"),
-                   &obj.protected_from_scale_in.to_string());
+                   &obj.protected_from_scale_in.to_string().replace("+", "%2B"));
 
     }
 }
@@ -6997,14 +7059,14 @@ impl StepAdjustmentSerializer {
 
         if let Some(ref field_value) = obj.metric_interval_lower_bound {
             params.put(&format!("{}{}", prefix, "MetricIntervalLowerBound"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.metric_interval_upper_bound {
             params.put(&format!("{}{}", prefix, "MetricIntervalUpperBound"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ScalingAdjustment"),
-                   &obj.scaling_adjustment.to_string());
+                   &obj.scaling_adjustment.to_string().replace("+", "%2B"));
 
     }
 }
@@ -7185,19 +7247,23 @@ impl TagSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Key"), &obj.key);
+        params.put(&format!("{}{}", prefix, "Key"),
+                   &obj.key.replace("+", "%2B"));
         if let Some(ref field_value) = obj.propagate_at_launch {
             params.put(&format!("{}{}", prefix, "PropagateAtLaunch"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_id {
-            params.put(&format!("{}{}", prefix, "ResourceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_type {
-            params.put(&format!("{}{}", prefix, "ResourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7553,7 +7619,7 @@ impl TargetTrackingConfigurationSerializer {
         }
         if let Some(ref field_value) = obj.disable_scale_in {
             params.put(&format!("{}{}", prefix, "DisableScaleIn"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.predefined_metric_specification {
             PredefinedMetricSpecificationSerializer::serialize(params,
@@ -7563,7 +7629,7 @@ impl TargetTrackingConfigurationSerializer {
                                                                field_value);
         }
         params.put(&format!("{}{}", prefix, "TargetValue"),
-                   &obj.target_value.to_string());
+                   &obj.target_value.to_string().replace("+", "%2B"));
 
     }
 }
@@ -7587,9 +7653,12 @@ impl TerminateInstanceInAutoScalingGroupTypeSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ShouldDecrementDesiredCapacity"),
-                   &obj.should_decrement_desired_capacity.to_string());
+                   &obj.should_decrement_desired_capacity
+                        .to_string()
+                        .replace("+", "%2B"));
 
     }
 }
@@ -7704,7 +7773,7 @@ impl UpdateAutoScalingGroupTypeSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoScalingGroupName"),
-                   &obj.auto_scaling_group_name);
+                   &obj.auto_scaling_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.availability_zones {
             AvailabilityZonesSerializer::serialize(params,
                                                    &format!("{}{}", prefix, "AvailabilityZones"),
@@ -7712,37 +7781,39 @@ impl UpdateAutoScalingGroupTypeSerializer {
         }
         if let Some(ref field_value) = obj.default_cooldown {
             params.put(&format!("{}{}", prefix, "DefaultCooldown"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.desired_capacity {
             params.put(&format!("{}{}", prefix, "DesiredCapacity"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_grace_period {
             params.put(&format!("{}{}", prefix, "HealthCheckGracePeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_type {
-            params.put(&format!("{}{}", prefix, "HealthCheckType"), &field_value);
+            params.put(&format!("{}{}", prefix, "HealthCheckType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.launch_configuration_name {
             params.put(&format!("{}{}", prefix, "LaunchConfigurationName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_size {
             params.put(&format!("{}{}", prefix, "MaxSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.min_size {
             params.put(&format!("{}{}", prefix, "MinSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.new_instances_protected_from_scale_in {
             params.put(&format!("{}{}", prefix, "NewInstancesProtectedFromScaleIn"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.placement_group {
-            params.put(&format!("{}{}", prefix, "PlacementGroup"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlacementGroup"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.termination_policies {
             TerminationPoliciesSerializer::serialize(params,
@@ -7752,7 +7823,8 @@ impl UpdateAutoScalingGroupTypeSerializer {
                                                      field_value);
         }
         if let Some(ref field_value) = obj.vpc_zone_identifier {
-            params.put(&format!("{}{}", prefix, "VPCZoneIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "VPCZoneIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -335,9 +335,11 @@ impl CancelUpdateStackInputSerializer {
         }
 
         if let Some(ref field_value) = obj.client_request_token {
-            params.put(&format!("{}{}", prefix, "ClientRequestToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientRequestToken"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
 
     }
 }
@@ -815,7 +817,8 @@ impl ContinueUpdateRollbackInputSerializer {
         }
 
         if let Some(ref field_value) = obj.client_request_token {
-            params.put(&format!("{}{}", prefix, "ClientRequestToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientRequestToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resources_to_skip {
             ResourcesToSkipSerializer::serialize(params,
@@ -823,9 +826,11 @@ impl ContinueUpdateRollbackInputSerializer {
                                                  field_value);
         }
         if let Some(ref field_value) = obj.role_arn {
-            params.put(&format!("{}{}", prefix, "RoleARN"), &field_value);
+            params.put(&format!("{}{}", prefix, "RoleARN"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
 
     }
 }
@@ -901,15 +906,18 @@ impl CreateChangeSetInputSerializer {
                                               field_value);
         }
         params.put(&format!("{}{}", prefix, "ChangeSetName"),
-                   &obj.change_set_name);
+                   &obj.change_set_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.change_set_type {
-            params.put(&format!("{}{}", prefix, "ChangeSetType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ChangeSetType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_ar_ns {
             NotificationARNsSerializer::serialize(params,
@@ -927,7 +935,8 @@ impl CreateChangeSetInputSerializer {
                                                field_value);
         }
         if let Some(ref field_value) = obj.role_arn {
-            params.put(&format!("{}{}", prefix, "RoleARN"), &field_value);
+            params.put(&format!("{}{}", prefix, "RoleARN"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.rollback_configuration {
             RollbackConfigurationSerializer::serialize(params,
@@ -936,19 +945,22 @@ impl CreateChangeSetInputSerializer {
                                                                "RollbackConfiguration"),
                                                        field_value);
         }
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagsSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.template_body {
-            params.put(&format!("{}{}", prefix, "TemplateBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_url {
-            params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateURL"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.use_previous_template {
             params.put(&format!("{}{}", prefix, "UsePreviousTemplate"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1061,11 +1073,12 @@ impl CreateStackInputSerializer {
                                               field_value);
         }
         if let Some(ref field_value) = obj.client_request_token {
-            params.put(&format!("{}{}", prefix, "ClientRequestToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientRequestToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.disable_rollback {
             params.put(&format!("{}{}", prefix, "DisableRollback"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_ar_ns {
             NotificationARNsSerializer::serialize(params,
@@ -1073,7 +1086,8 @@ impl CreateStackInputSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.on_failure {
-            params.put(&format!("{}{}", prefix, "OnFailure"), &field_value);
+            params.put(&format!("{}{}", prefix, "OnFailure"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameters {
             ParametersSerializer::serialize(params,
@@ -1086,7 +1100,8 @@ impl CreateStackInputSerializer {
                                                field_value);
         }
         if let Some(ref field_value) = obj.role_arn {
-            params.put(&format!("{}{}", prefix, "RoleARN"), &field_value);
+            params.put(&format!("{}{}", prefix, "RoleARN"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.rollback_configuration {
             RollbackConfigurationSerializer::serialize(params,
@@ -1095,25 +1110,30 @@ impl CreateStackInputSerializer {
                                                                "RollbackConfiguration"),
                                                        field_value);
         }
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.stack_policy_body {
-            params.put(&format!("{}{}", prefix, "StackPolicyBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackPolicyBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_policy_url {
-            params.put(&format!("{}{}", prefix, "StackPolicyURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackPolicyURL"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagsSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.template_body {
-            params.put(&format!("{}{}", prefix, "TemplateBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_url {
-            params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateURL"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.timeout_in_minutes {
             params.put(&format!("{}{}", prefix, "TimeoutInMinutes"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1147,7 +1167,8 @@ impl CreateStackInstancesInputSerializer {
                                          &format!("{}{}", prefix, "Accounts"),
                                          &obj.accounts);
         if let Some(ref field_value) = obj.operation_id {
-            params.put(&format!("{}{}", prefix, "OperationId"), &field_value);
+            params.put(&format!("{}{}", prefix, "OperationId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.operation_preferences {
             StackSetOperationPreferencesSerializer::serialize(params,
@@ -1158,7 +1179,7 @@ impl CreateStackInstancesInputSerializer {
         }
         RegionListSerializer::serialize(params, &format!("{}{}", prefix, "Regions"), &obj.regions);
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1297,10 +1318,12 @@ impl CreateStackSetInputSerializer {
                                               field_value);
         }
         if let Some(ref field_value) = obj.client_request_token {
-            params.put(&format!("{}{}", prefix, "ClientRequestToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientRequestToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameters {
             ParametersSerializer::serialize(params,
@@ -1308,15 +1331,17 @@ impl CreateStackSetInputSerializer {
                                             field_value);
         }
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagsSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.template_body {
-            params.put(&format!("{}{}", prefix, "TemplateBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_url {
-            params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateURL"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1405,9 +1430,10 @@ impl DeleteChangeSetInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ChangeSetName"),
-                   &obj.change_set_name);
+                   &obj.change_set_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.stack_name {
-            params.put(&format!("{}{}", prefix, "StackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1457,7 +1483,8 @@ impl DeleteStackInputSerializer {
         }
 
         if let Some(ref field_value) = obj.client_request_token {
-            params.put(&format!("{}{}", prefix, "ClientRequestToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientRequestToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.retain_resources {
             RetainResourcesSerializer::serialize(params,
@@ -1465,9 +1492,11 @@ impl DeleteStackInputSerializer {
                                                  field_value);
         }
         if let Some(ref field_value) = obj.role_arn {
-            params.put(&format!("{}{}", prefix, "RoleARN"), &field_value);
+            params.put(&format!("{}{}", prefix, "RoleARN"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
 
     }
 }
@@ -1502,7 +1531,8 @@ impl DeleteStackInstancesInputSerializer {
                                          &format!("{}{}", prefix, "Accounts"),
                                          &obj.accounts);
         if let Some(ref field_value) = obj.operation_id {
-            params.put(&format!("{}{}", prefix, "OperationId"), &field_value);
+            params.put(&format!("{}{}", prefix, "OperationId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.operation_preferences {
             StackSetOperationPreferencesSerializer::serialize(params,
@@ -1513,9 +1543,9 @@ impl DeleteStackInstancesInputSerializer {
         }
         RegionListSerializer::serialize(params, &format!("{}{}", prefix, "Regions"), &obj.regions);
         params.put(&format!("{}{}", prefix, "RetainStacks"),
-                   &obj.retain_stacks.to_string());
+                   &obj.retain_stacks.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1586,7 +1616,7 @@ impl DeleteStackSetInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1642,7 +1672,8 @@ impl DescribeAccountLimitsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1726,12 +1757,14 @@ impl DescribeChangeSetInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ChangeSetName"),
-                   &obj.change_set_name);
+                   &obj.change_set_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_name {
-            params.put(&format!("{}{}", prefix, "StackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1905,10 +1938,12 @@ impl DescribeStackEventsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_name {
-            params.put(&format!("{}{}", prefix, "StackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1991,11 +2026,11 @@ impl DescribeStackInstanceInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "StackInstanceAccount"),
-                   &obj.stack_instance_account);
+                   &obj.stack_instance_account.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "StackInstanceRegion"),
-                   &obj.stack_instance_region);
+                   &obj.stack_instance_region.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -2069,8 +2104,9 @@ impl DescribeStackResourceInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LogicalResourceId"),
-                   &obj.logical_resource_id);
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+                   &obj.logical_resource_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
 
     }
 }
@@ -2147,13 +2183,16 @@ impl DescribeStackResourcesInputSerializer {
         }
 
         if let Some(ref field_value) = obj.logical_resource_id {
-            params.put(&format!("{}{}", prefix, "LogicalResourceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "LogicalResourceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.physical_resource_id {
-            params.put(&format!("{}{}", prefix, "PhysicalResourceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "PhysicalResourceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_name {
-            params.put(&format!("{}{}", prefix, "StackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2226,7 +2265,7 @@ impl DescribeStackSetInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -2249,9 +2288,10 @@ impl DescribeStackSetOperationInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "OperationId"), &obj.operation_id);
+        params.put(&format!("{}{}", prefix, "OperationId"),
+                   &obj.operation_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -2374,10 +2414,12 @@ impl DescribeStacksInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_name {
-            params.put(&format!("{}{}", prefix, "StackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2493,10 +2535,12 @@ impl EstimateTemplateCostInputSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.template_body {
-            params.put(&format!("{}{}", prefix, "TemplateBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_url {
-            params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateURL"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2600,12 +2644,14 @@ impl ExecuteChangeSetInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ChangeSetName"),
-                   &obj.change_set_name);
+                   &obj.change_set_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.client_request_token {
-            params.put(&format!("{}{}", prefix, "ClientRequestToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientRequestToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_name {
-            params.put(&format!("{}{}", prefix, "StackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2821,7 +2867,8 @@ impl GetStackPolicyInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
 
     }
 }
@@ -2898,13 +2945,16 @@ impl GetTemplateInputSerializer {
         }
 
         if let Some(ref field_value) = obj.change_set_name {
-            params.put(&format!("{}{}", prefix, "ChangeSetName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ChangeSetName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_name {
-            params.put(&format!("{}{}", prefix, "StackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_stage {
-            params.put(&format!("{}{}", prefix, "TemplateStage"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateStage"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2991,16 +3041,20 @@ impl GetTemplateSummaryInputSerializer {
         }
 
         if let Some(ref field_value) = obj.stack_name {
-            params.put(&format!("{}{}", prefix, "StackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_set_name {
-            params.put(&format!("{}{}", prefix, "StackSetName"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackSetName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_body {
-            params.put(&format!("{}{}", prefix, "TemplateBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_url {
-            params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateURL"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3206,9 +3260,11 @@ impl ListChangeSetsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
 
     }
 }
@@ -3286,7 +3342,8 @@ impl ListExportsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3364,9 +3421,11 @@ impl ListImportsInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ExportName"), &obj.export_name);
+        params.put(&format!("{}{}", prefix, "ExportName"),
+                   &obj.export_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3452,21 +3511,22 @@ impl ListStackInstancesInputSerializer {
 
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_instance_account {
             params.put(&format!("{}{}", prefix, "StackInstanceAccount"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_instance_region {
             params.put(&format!("{}{}", prefix, "StackInstanceRegion"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -3546,9 +3606,11 @@ impl ListStackResourcesInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
 
     }
 }
@@ -3633,14 +3695,16 @@ impl ListStackSetOperationResultsInputSerializer {
 
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "OperationId"), &obj.operation_id);
+        params.put(&format!("{}{}", prefix, "OperationId"),
+                   &obj.operation_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -3721,13 +3785,14 @@ impl ListStackSetOperationsInputSerializer {
 
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -3807,13 +3872,15 @@ impl ListStackSetsInputSerializer {
 
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.status {
-            params.put(&format!("{}{}", prefix, "Status"), &field_value);
+            params.put(&format!("{}{}", prefix, "Status"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3894,7 +3961,8 @@ impl ListStacksInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_status_filter {
             StackStatusFilterSerializer::serialize(params,
@@ -4340,14 +4408,16 @@ impl ParameterSerializer {
         }
 
         if let Some(ref field_value) = obj.parameter_key {
-            params.put(&format!("{}{}", prefix, "ParameterKey"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterKey"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameter_value {
-            params.put(&format!("{}{}", prefix, "ParameterValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.use_previous_value {
             params.put(&format!("{}{}", prefix, "UsePreviousValue"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -5268,7 +5338,7 @@ impl RollbackConfigurationSerializer {
 
         if let Some(ref field_value) = obj.monitoring_time_in_minutes {
             params.put(&format!("{}{}", prefix, "MonitoringTimeInMinutes"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.rollback_triggers {
             RollbackTriggersSerializer::serialize(params,
@@ -5342,8 +5412,10 @@ impl RollbackTriggerSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Arn"), &obj.arn);
-        params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
+        params.put(&format!("{}{}", prefix, "Arn"),
+                   &obj.arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Type"),
+                   &obj.type_.replace("+", "%2B"));
 
     }
 }
@@ -5463,12 +5535,15 @@ impl SetStackPolicyInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.stack_policy_body {
-            params.put(&format!("{}{}", prefix, "StackPolicyBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackPolicyBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_policy_url {
-            params.put(&format!("{}{}", prefix, "StackPolicyURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackPolicyURL"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5498,10 +5573,13 @@ impl SignalResourceInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LogicalResourceId"),
-                   &obj.logical_resource_id);
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
-        params.put(&format!("{}{}", prefix, "Status"), &obj.status);
-        params.put(&format!("{}{}", prefix, "UniqueId"), &obj.unique_id);
+                   &obj.logical_resource_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Status"),
+                   &obj.status.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UniqueId"),
+                   &obj.unique_id.replace("+", "%2B"));
 
     }
 }
@@ -6774,19 +6852,19 @@ impl StackSetOperationPreferencesSerializer {
 
         if let Some(ref field_value) = obj.failure_tolerance_count {
             params.put(&format!("{}{}", prefix, "FailureToleranceCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.failure_tolerance_percentage {
             params.put(&format!("{}{}", prefix, "FailureTolerancePercentage"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_concurrent_count {
             params.put(&format!("{}{}", prefix, "MaxConcurrentCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_concurrent_percentage {
             params.put(&format!("{}{}", prefix, "MaxConcurrentPercentage"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.region_order {
             RegionListSerializer::serialize(params,
@@ -7461,9 +7539,10 @@ impl StopStackSetOperationInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "OperationId"), &obj.operation_id);
+        params.put(&format!("{}{}", prefix, "OperationId"),
+                   &obj.operation_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
 
     }
 }
@@ -7550,8 +7629,10 @@ impl TagSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Key"), &obj.key);
-        params.put(&format!("{}{}", prefix, "Value"), &obj.value);
+        params.put(&format!("{}{}", prefix, "Key"),
+                   &obj.key.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Value"),
+                   &obj.value.replace("+", "%2B"));
 
     }
 }
@@ -7940,7 +8021,8 @@ impl UpdateStackInputSerializer {
                                               field_value);
         }
         if let Some(ref field_value) = obj.client_request_token {
-            params.put(&format!("{}{}", prefix, "ClientRequestToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientRequestToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_ar_ns {
             NotificationARNsSerializer::serialize(params,
@@ -7958,7 +8040,8 @@ impl UpdateStackInputSerializer {
                                                field_value);
         }
         if let Some(ref field_value) = obj.role_arn {
-            params.put(&format!("{}{}", prefix, "RoleARN"), &field_value);
+            params.put(&format!("{}{}", prefix, "RoleARN"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.rollback_configuration {
             RollbackConfigurationSerializer::serialize(params,
@@ -7967,33 +8050,38 @@ impl UpdateStackInputSerializer {
                                                                "RollbackConfiguration"),
                                                        field_value);
         }
-        params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
+        params.put(&format!("{}{}", prefix, "StackName"),
+                   &obj.stack_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.stack_policy_body {
-            params.put(&format!("{}{}", prefix, "StackPolicyBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackPolicyBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_policy_during_update_body {
             params.put(&format!("{}{}", prefix, "StackPolicyDuringUpdateBody"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_policy_during_update_url {
             params.put(&format!("{}{}", prefix, "StackPolicyDuringUpdateURL"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stack_policy_url {
-            params.put(&format!("{}{}", prefix, "StackPolicyURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "StackPolicyURL"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagsSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.template_body {
-            params.put(&format!("{}{}", prefix, "TemplateBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_url {
-            params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateURL"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.use_previous_template {
             params.put(&format!("{}{}", prefix, "UsePreviousTemplate"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8088,10 +8176,12 @@ impl UpdateStackSetInputSerializer {
                                               field_value);
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.operation_id {
-            params.put(&format!("{}{}", prefix, "OperationId"), &field_value);
+            params.put(&format!("{}{}", prefix, "OperationId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.operation_preferences {
             StackSetOperationPreferencesSerializer::serialize(params,
@@ -8106,19 +8196,21 @@ impl UpdateStackSetInputSerializer {
                                             field_value);
         }
         params.put(&format!("{}{}", prefix, "StackSetName"),
-                   &obj.stack_set_name);
+                   &obj.stack_set_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagsSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.template_body {
-            params.put(&format!("{}{}", prefix, "TemplateBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_url {
-            params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateURL"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.use_previous_template {
             params.put(&format!("{}{}", prefix, "UsePreviousTemplate"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8221,10 +8313,12 @@ impl ValidateTemplateInputSerializer {
         }
 
         if let Some(ref field_value) = obj.template_body {
-            params.put(&format!("{}{}", prefix, "TemplateBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_url {
-            params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateURL"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -222,20 +222,23 @@ impl AnalysisOptionsSerializer {
 
         if let Some(ref field_value) = obj.algorithmic_stemming {
             params.put(&format!("{}{}", prefix, "AlgorithmicStemming"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.japanese_tokenization_dictionary {
             params.put(&format!("{}{}", prefix, "JapaneseTokenizationDictionary"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stemming_dictionary {
-            params.put(&format!("{}{}", prefix, "StemmingDictionary"), &field_value);
+            params.put(&format!("{}{}", prefix, "StemmingDictionary"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.stopwords {
-            params.put(&format!("{}{}", prefix, "Stopwords"), &field_value);
+            params.put(&format!("{}{}", prefix, "Stopwords"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.synonyms {
-            params.put(&format!("{}{}", prefix, "Synonyms"), &field_value);
+            params.put(&format!("{}{}", prefix, "Synonyms"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -318,9 +321,9 @@ impl AnalysisSchemeSerializer {
                                                  field_value);
         }
         params.put(&format!("{}{}", prefix, "AnalysisSchemeLanguage"),
-                   &obj.analysis_scheme_language);
+                   &obj.analysis_scheme_language.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "AnalysisSchemeName"),
-                   &obj.analysis_scheme_name);
+                   &obj.analysis_scheme_name.replace("+", "%2B"));
 
     }
 }
@@ -517,7 +520,8 @@ impl BuildSuggestersRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -588,7 +592,8 @@ impl CreateDomainRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -730,22 +735,24 @@ impl DateArrayOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_fields {
-            params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceFields"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -844,26 +851,28 @@ impl DateOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sort_enabled {
             params.put(&format!("{}{}", prefix, "SortEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_field {
-            params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceField"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -889,7 +898,8 @@ impl DefineAnalysisSchemeRequestSerializer {
         AnalysisSchemeSerializer::serialize(params,
                                             &format!("{}{}", prefix, "AnalysisScheme"),
                                             &obj.analysis_scheme);
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -960,7 +970,8 @@ impl DefineExpressionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         ExpressionSerializer::serialize(params,
                                         &format!("{}{}", prefix, "Expression"),
                                         &obj.expression);
@@ -1034,7 +1045,8 @@ impl DefineIndexFieldRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         IndexFieldSerializer::serialize(params,
                                         &format!("{}{}", prefix, "IndexField"),
                                         &obj.index_field);
@@ -1108,7 +1120,8 @@ impl DefineSuggesterRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         SuggesterSerializer::serialize(params,
                                        &format!("{}{}", prefix, "Suggester"),
                                        &obj.suggester);
@@ -1183,8 +1196,9 @@ impl DeleteAnalysisSchemeRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AnalysisSchemeName"),
-                   &obj.analysis_scheme_name);
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+                   &obj.analysis_scheme_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -1256,7 +1270,8 @@ impl DeleteDomainRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -1328,9 +1343,10 @@ impl DeleteExpressionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ExpressionName"),
-                   &obj.expression_name);
+                   &obj.expression_name.replace("+", "%2B"));
 
     }
 }
@@ -1402,9 +1418,10 @@ impl DeleteIndexFieldRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "IndexFieldName"),
-                   &obj.index_field_name);
+                   &obj.index_field_name.replace("+", "%2B"));
 
     }
 }
@@ -1477,9 +1494,10 @@ impl DeleteSuggesterRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SuggesterName"),
-                   &obj.suggester_name);
+                   &obj.suggester_name.replace("+", "%2B"));
 
     }
 }
@@ -1561,9 +1579,10 @@ impl DescribeAnalysisSchemesRequestSerializer {
         }
         if let Some(ref field_value) = obj.deployed {
             params.put(&format!("{}{}", prefix, "Deployed"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -1640,9 +1659,10 @@ impl DescribeAvailabilityOptionsRequestSerializer {
 
         if let Some(ref field_value) = obj.deployed {
             params.put(&format!("{}{}", prefix, "Deployed"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -1794,9 +1814,10 @@ impl DescribeExpressionsRequestSerializer {
 
         if let Some(ref field_value) = obj.deployed {
             params.put(&format!("{}{}", prefix, "Deployed"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.expression_names {
             StandardNameListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "ExpressionNames"),
@@ -1879,9 +1900,10 @@ impl DescribeIndexFieldsRequestSerializer {
 
         if let Some(ref field_value) = obj.deployed {
             params.put(&format!("{}{}", prefix, "Deployed"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.field_names {
             DynamicFieldNameListSerializer::serialize(params,
                                                       &format!("{}{}", prefix, "FieldNames"),
@@ -1957,7 +1979,8 @@ impl DescribeScalingParametersRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -2033,9 +2056,10 @@ impl DescribeServiceAccessPoliciesRequestSerializer {
 
         if let Some(ref field_value) = obj.deployed {
             params.put(&format!("{}{}", prefix, "Deployed"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -2114,9 +2138,10 @@ impl DescribeSuggestersRequestSerializer {
 
         if let Some(ref field_value) = obj.deployed {
             params.put(&format!("{}{}", prefix, "Deployed"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.suggester_names {
             StandardNameListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "SuggesterNames"),
@@ -2250,12 +2275,15 @@ impl DocumentSuggesterOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.fuzzy_matching {
-            params.put(&format!("{}{}", prefix, "FuzzyMatching"), &field_value);
+            params.put(&format!("{}{}", prefix, "FuzzyMatching"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sort_expression {
-            params.put(&format!("{}{}", prefix, "SortExpression"), &field_value);
+            params.put(&format!("{}{}", prefix, "SortExpression"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SourceField"), &obj.source_field);
+        params.put(&format!("{}{}", prefix, "SourceField"),
+                   &obj.source_field.replace("+", "%2B"));
 
     }
 }
@@ -2589,22 +2617,23 @@ impl DoubleArrayOptionsSerializer {
 
         if let Some(ref field_value) = obj.default_value {
             params.put(&format!("{}{}", prefix, "DefaultValue"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_fields {
-            params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceFields"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2704,26 +2733,27 @@ impl DoubleOptionsSerializer {
 
         if let Some(ref field_value) = obj.default_value {
             params.put(&format!("{}{}", prefix, "DefaultValue"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sort_enabled {
             params.put(&format!("{}{}", prefix, "SortEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_field {
-            params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceField"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2821,9 +2851,9 @@ impl ExpressionSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ExpressionName"),
-                   &obj.expression_name);
+                   &obj.expression_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ExpressionValue"),
-                   &obj.expression_value);
+                   &obj.expression_value.replace("+", "%2B"));
 
     }
 }
@@ -3036,7 +3066,8 @@ impl IndexDocumentsRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -3244,9 +3275,9 @@ impl IndexFieldSerializer {
                                                field_value);
         }
         params.put(&format!("{}{}", prefix, "IndexFieldName"),
-                   &obj.index_field_name);
+                   &obj.index_field_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "IndexFieldType"),
-                   &obj.index_field_type);
+                   &obj.index_field_type.replace("+", "%2B"));
         if let Some(ref field_value) = obj.int_array_options {
             IntArrayOptionsSerializer::serialize(params,
                                                  &format!("{}{}", prefix, "IntArrayOptions"),
@@ -3498,22 +3529,23 @@ impl IntArrayOptionsSerializer {
 
         if let Some(ref field_value) = obj.default_value {
             params.put(&format!("{}{}", prefix, "DefaultValue"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_fields {
-            params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceFields"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3613,26 +3645,27 @@ impl IntOptionsSerializer {
 
         if let Some(ref field_value) = obj.default_value {
             params.put(&format!("{}{}", prefix, "DefaultValue"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sort_enabled {
             params.put(&format!("{}{}", prefix, "SortEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_field {
-            params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceField"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3731,26 +3764,28 @@ impl LatLonOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sort_enabled {
             params.put(&format!("{}{}", prefix, "SortEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_field {
-            params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceField"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3948,22 +3983,24 @@ impl LiteralArrayOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_fields {
-            params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceFields"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4062,26 +4099,28 @@ impl LiteralOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.facet_enabled {
             params.put(&format!("{}{}", prefix, "FacetEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.search_enabled {
             params.put(&format!("{}{}", prefix, "SearchEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sort_enabled {
             params.put(&format!("{}{}", prefix, "SortEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_field {
-            params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceField"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4350,15 +4389,15 @@ impl ScalingParametersSerializer {
 
         if let Some(ref field_value) = obj.desired_instance_type {
             params.put(&format!("{}{}", prefix, "DesiredInstanceType"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.desired_partition_count {
             params.put(&format!("{}{}", prefix, "DesiredPartitionCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.desired_replication_count {
             params.put(&format!("{}{}", prefix, "DesiredReplicationCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -4603,7 +4642,7 @@ impl SuggesterSerializer {
                                                               "DocumentSuggesterOptions"),
                                                       &obj.document_suggester_options);
         params.put(&format!("{}{}", prefix, "SuggesterName"),
-                   &obj.suggester_name);
+                   &obj.suggester_name.replace("+", "%2B"));
 
     }
 }
@@ -4804,21 +4843,24 @@ impl TextArrayOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.analysis_scheme {
-            params.put(&format!("{}{}", prefix, "AnalysisScheme"), &field_value);
+            params.put(&format!("{}{}", prefix, "AnalysisScheme"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.default_value {
-            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.highlight_enabled {
             params.put(&format!("{}{}", prefix, "HighlightEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_fields {
-            params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceFields"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4917,25 +4959,28 @@ impl TextOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.analysis_scheme {
-            params.put(&format!("{}{}", prefix, "AnalysisScheme"), &field_value);
+            params.put(&format!("{}{}", prefix, "AnalysisScheme"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.default_value {
-            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.highlight_enabled {
             params.put(&format!("{}{}", prefix, "HighlightEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_enabled {
             params.put(&format!("{}{}", prefix, "ReturnEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sort_enabled {
             params.put(&format!("{}{}", prefix, "SortEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_field {
-            params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceField"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4973,9 +5018,10 @@ impl UpdateAvailabilityOptionsRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "MultiAZ"),
-                   &obj.multi_az.to_string());
+                   &obj.multi_az.to_string().replace("+", "%2B"));
 
     }
 }
@@ -5046,7 +5092,8 @@ impl UpdateScalingParametersRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         ScalingParametersSerializer::serialize(params,
                                                &format!("{}{}", prefix, "ScalingParameters"),
                                                &obj.scaling_parameters);
@@ -5123,8 +5170,9 @@ impl UpdateServiceAccessPoliciesRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AccessPolicies"),
-                   &obj.access_policies);
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+                   &obj.access_policies.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -783,23 +783,28 @@ impl DescribeAlarmHistoryInputSerializer {
         }
 
         if let Some(ref field_value) = obj.alarm_name {
-            params.put(&format!("{}{}", prefix, "AlarmName"), &field_value);
+            params.put(&format!("{}{}", prefix, "AlarmName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_date {
-            params.put(&format!("{}{}", prefix, "EndDate"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndDate"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.history_item_type {
-            params.put(&format!("{}{}", prefix, "HistoryItemType"), &field_value);
+            params.put(&format!("{}{}", prefix, "HistoryItemType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.start_date {
-            params.put(&format!("{}{}", prefix, "StartDate"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartDate"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -894,18 +899,24 @@ impl DescribeAlarmsForMetricInputSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.extended_statistic {
-            params.put(&format!("{}{}", prefix, "ExtendedStatistic"), &field_value);
+            params.put(&format!("{}{}", prefix, "ExtendedStatistic"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "MetricName"), &obj.metric_name);
-        params.put(&format!("{}{}", prefix, "Namespace"), &obj.namespace);
+        params.put(&format!("{}{}", prefix, "MetricName"),
+                   &obj.metric_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Namespace"),
+                   &obj.namespace.replace("+", "%2B"));
         if let Some(ref field_value) = obj.period {
-            params.put(&format!("{}{}", prefix, "Period"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Period"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.statistic {
-            params.put(&format!("{}{}", prefix, "Statistic"), &field_value);
+            params.put(&format!("{}{}", prefix, "Statistic"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.unit {
-            params.put(&format!("{}{}", prefix, "Unit"), &field_value);
+            params.put(&format!("{}{}", prefix, "Unit"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -987,10 +998,12 @@ impl DescribeAlarmsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.action_prefix {
-            params.put(&format!("{}{}", prefix, "ActionPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "ActionPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.alarm_name_prefix {
-            params.put(&format!("{}{}", prefix, "AlarmNamePrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "AlarmNamePrefix"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.alarm_names {
             AlarmNamesSerializer::serialize(params,
@@ -999,13 +1012,15 @@ impl DescribeAlarmsInputSerializer {
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.state_value {
-            params.put(&format!("{}{}", prefix, "StateValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "StateValue"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1130,8 +1145,10 @@ impl DimensionSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
-        params.put(&format!("{}{}", prefix, "Value"), &obj.value);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Value"),
+                   &obj.value.replace("+", "%2B"));
 
     }
 }
@@ -1155,9 +1172,11 @@ impl DimensionFilterSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1373,7 +1392,8 @@ impl GetDashboardInputSerializer {
         }
 
         if let Some(ref field_value) = obj.dashboard_name {
-            params.put(&format!("{}{}", prefix, "DashboardName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DashboardName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1479,23 +1499,29 @@ impl GetMetricStatisticsInputSerializer {
                                             &format!("{}{}", prefix, "Dimensions"),
                                             field_value);
         }
-        params.put(&format!("{}{}", prefix, "EndTime"), &obj.end_time);
+        params.put(&format!("{}{}", prefix, "EndTime"),
+                   &obj.end_time.replace("+", "%2B"));
         if let Some(ref field_value) = obj.extended_statistics {
             ExtendedStatisticsSerializer::serialize(params,
                                                     &format!("{}{}", prefix, "ExtendedStatistics"),
                                                     field_value);
         }
-        params.put(&format!("{}{}", prefix, "MetricName"), &obj.metric_name);
-        params.put(&format!("{}{}", prefix, "Namespace"), &obj.namespace);
-        params.put(&format!("{}{}", prefix, "Period"), &obj.period.to_string());
-        params.put(&format!("{}{}", prefix, "StartTime"), &obj.start_time);
+        params.put(&format!("{}{}", prefix, "MetricName"),
+                   &obj.metric_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Namespace"),
+                   &obj.namespace.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Period"),
+                   &obj.period.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "StartTime"),
+                   &obj.start_time.replace("+", "%2B"));
         if let Some(ref field_value) = obj.statistics {
             StatisticsSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Statistics"),
                                             field_value);
         }
         if let Some(ref field_value) = obj.unit {
-            params.put(&format!("{}{}", prefix, "Unit"), &field_value);
+            params.put(&format!("{}{}", prefix, "Unit"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1631,10 +1657,11 @@ impl ListDashboardsInputSerializer {
 
         if let Some(ref field_value) = obj.dashboard_name_prefix {
             params.put(&format!("{}{}", prefix, "DashboardNamePrefix"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1723,13 +1750,16 @@ impl ListMetricsInputSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.metric_name {
-            params.put(&format!("{}{}", prefix, "MetricName"), &field_value);
+            params.put(&format!("{}{}", prefix, "MetricName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.namespace {
-            params.put(&format!("{}{}", prefix, "Namespace"), &field_value);
+            params.put(&format!("{}{}", prefix, "Namespace"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2153,7 +2183,8 @@ impl MetricDatumSerializer {
                                             &format!("{}{}", prefix, "Dimensions"),
                                             field_value);
         }
-        params.put(&format!("{}{}", prefix, "MetricName"), &obj.metric_name);
+        params.put(&format!("{}{}", prefix, "MetricName"),
+                   &obj.metric_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.statistic_values {
             StatisticSetSerializer::serialize(params,
                                               &format!("{}{}", prefix, "StatisticValues"),
@@ -2161,16 +2192,19 @@ impl MetricDatumSerializer {
         }
         if let Some(ref field_value) = obj.storage_resolution {
             params.put(&format!("{}{}", prefix, "StorageResolution"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.timestamp {
-            params.put(&format!("{}{}", prefix, "Timestamp"), &field_value);
+            params.put(&format!("{}{}", prefix, "Timestamp"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.unit {
-            params.put(&format!("{}{}", prefix, "Unit"), &field_value);
+            params.put(&format!("{}{}", prefix, "Unit"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -2306,10 +2340,12 @@ impl PutDashboardInputSerializer {
         }
 
         if let Some(ref field_value) = obj.dashboard_body {
-            params.put(&format!("{}{}", prefix, "DashboardBody"), &field_value);
+            params.put(&format!("{}{}", prefix, "DashboardBody"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dashboard_name {
-            params.put(&format!("{}{}", prefix, "DashboardName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DashboardName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2414,7 +2450,7 @@ impl PutMetricAlarmInputSerializer {
 
         if let Some(ref field_value) = obj.actions_enabled {
             params.put(&format!("{}{}", prefix, "ActionsEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.alarm_actions {
             ResourceListSerializer::serialize(params,
@@ -2422,11 +2458,13 @@ impl PutMetricAlarmInputSerializer {
                                               field_value);
         }
         if let Some(ref field_value) = obj.alarm_description {
-            params.put(&format!("{}{}", prefix, "AlarmDescription"), &field_value);
+            params.put(&format!("{}{}", prefix, "AlarmDescription"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "AlarmName"), &obj.alarm_name);
+        params.put(&format!("{}{}", prefix, "AlarmName"),
+                   &obj.alarm_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ComparisonOperator"),
-                   &obj.comparison_operator);
+                   &obj.comparison_operator.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dimensions {
             DimensionsSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Dimensions"),
@@ -2434,36 +2472,43 @@ impl PutMetricAlarmInputSerializer {
         }
         if let Some(ref field_value) = obj.evaluate_low_sample_count_percentile {
             params.put(&format!("{}{}", prefix, "EvaluateLowSampleCountPercentile"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "EvaluationPeriods"),
-                   &obj.evaluation_periods.to_string());
+                   &obj.evaluation_periods.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.extended_statistic {
-            params.put(&format!("{}{}", prefix, "ExtendedStatistic"), &field_value);
+            params.put(&format!("{}{}", prefix, "ExtendedStatistic"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.insufficient_data_actions {
             ResourceListSerializer::serialize(params,
                                               &format!("{}{}", prefix, "InsufficientDataActions"),
                                               field_value);
         }
-        params.put(&format!("{}{}", prefix, "MetricName"), &obj.metric_name);
-        params.put(&format!("{}{}", prefix, "Namespace"), &obj.namespace);
+        params.put(&format!("{}{}", prefix, "MetricName"),
+                   &obj.metric_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Namespace"),
+                   &obj.namespace.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ok_actions {
             ResourceListSerializer::serialize(params,
                                               &format!("{}{}", prefix, "OKActions"),
                                               field_value);
         }
-        params.put(&format!("{}{}", prefix, "Period"), &obj.period.to_string());
+        params.put(&format!("{}{}", prefix, "Period"),
+                   &obj.period.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.statistic {
-            params.put(&format!("{}{}", prefix, "Statistic"), &field_value);
+            params.put(&format!("{}{}", prefix, "Statistic"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "Threshold"),
-                   &obj.threshold.to_string());
+                   &obj.threshold.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.treat_missing_data {
-            params.put(&format!("{}{}", prefix, "TreatMissingData"), &field_value);
+            params.put(&format!("{}{}", prefix, "TreatMissingData"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.unit {
-            params.put(&format!("{}{}", prefix, "Unit"), &field_value);
+            params.put(&format!("{}{}", prefix, "Unit"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2490,7 +2535,8 @@ impl PutMetricDataInputSerializer {
         MetricDataSerializer::serialize(params,
                                         &format!("{}{}", prefix, "MetricData"),
                                         &obj.metric_data);
-        params.put(&format!("{}{}", prefix, "Namespace"), &obj.namespace);
+        params.put(&format!("{}{}", prefix, "Namespace"),
+                   &obj.namespace.replace("+", "%2B"));
 
     }
 }
@@ -2584,12 +2630,16 @@ impl SetAlarmStateInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "AlarmName"), &obj.alarm_name);
-        params.put(&format!("{}{}", prefix, "StateReason"), &obj.state_reason);
+        params.put(&format!("{}{}", prefix, "AlarmName"),
+                   &obj.alarm_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "StateReason"),
+                   &obj.state_reason.replace("+", "%2B"));
         if let Some(ref field_value) = obj.state_reason_data {
-            params.put(&format!("{}{}", prefix, "StateReasonData"), &field_value);
+            params.put(&format!("{}{}", prefix, "StateReasonData"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "StateValue"), &obj.state_value);
+        params.put(&format!("{}{}", prefix, "StateValue"),
+                   &obj.state_value.replace("+", "%2B"));
 
     }
 }
@@ -2702,12 +2752,13 @@ impl StatisticSetSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "Maximum"),
-                   &obj.maximum.to_string());
+                   &obj.maximum.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "Minimum"),
-                   &obj.minimum.to_string());
+                   &obj.minimum.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SampleCount"),
-                   &obj.sample_count.to_string());
-        params.put(&format!("{}{}", prefix, "Sum"), &obj.sum.to_string());
+                   &obj.sample_count.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Sum"),
+                   &obj.sum.to_string().replace("+", "%2B"));
 
     }
 }

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -63,7 +63,8 @@ impl AcceptReservedInstancesExchangeQuoteRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         ReservedInstanceIdSetSerializer::serialize(params,
                                                    &format!("{}{}", prefix, "ReservedInstanceId"),
@@ -149,11 +150,12 @@ impl AcceptVpcPeeringConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_peering_connection_id {
             params.put(&format!("{}{}", prefix, "VpcPeeringConnectionId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -690,13 +692,16 @@ impl AllocateAddressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.address {
-            params.put(&format!("{}{}", prefix, "Address"), &field_value);
+            params.put(&format!("{}{}", prefix, "Address"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain {
-            params.put(&format!("{}{}", prefix, "Domain"), &field_value);
+            params.put(&format!("{}{}", prefix, "Domain"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -789,16 +794,19 @@ impl AllocateHostsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.auto_placement {
-            params.put(&format!("{}{}", prefix, "AutoPlacement"), &field_value);
+            params.put(&format!("{}{}", prefix, "AutoPlacement"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "AvailabilityZone"),
-                   &obj.availability_zone);
+                   &obj.availability_zone.replace("+", "%2B"));
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceType"), &obj.instance_type);
+        params.put(&format!("{}{}", prefix, "InstanceType"),
+                   &obj.instance_type.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "Quantity"),
-                   &obj.quantity.to_string());
+                   &obj.quantity.to_string().replace("+", "%2B"));
 
     }
 }
@@ -929,7 +937,7 @@ impl AssignIpv6AddressesRequestSerializer {
 
         if let Some(ref field_value) = obj.ipv_6_address_count {
             params.put(&format!("{}{}", prefix, "Ipv6AddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             Ipv6AddressListSerializer::serialize(params,
@@ -937,7 +945,7 @@ impl AssignIpv6AddressesRequestSerializer {
                                                  field_value);
         }
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
 
     }
 }
@@ -1023,10 +1031,10 @@ impl AssignPrivateIpAddressesRequestSerializer {
 
         if let Some(ref field_value) = obj.allow_reassignment {
             params.put(&format!("{}{}", prefix, "AllowReassignment"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.private_ip_addresses {
             PrivateIpAddressStringListSerializer::serialize(params,
                                                             &format!("{}{}",
@@ -1036,7 +1044,7 @@ impl AssignPrivateIpAddressesRequestSerializer {
         }
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(&format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1072,26 +1080,32 @@ impl AssociateAddressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.allocation_id {
-            params.put(&format!("{}{}", prefix, "AllocationId"), &field_value);
+            params.put(&format!("{}{}", prefix, "AllocationId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.allow_reassociation {
             params.put(&format!("{}{}", prefix, "AllowReassociation"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.network_interface_id {
-            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.private_ip_address {
-            params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrivateIpAddress"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.public_ip {
-            params.put(&format!("{}{}", prefix, "PublicIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "PublicIp"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1168,11 +1182,13 @@ impl AssociateDhcpOptionsRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DhcpOptionsId"),
-                   &obj.dhcp_options_id);
+                   &obj.dhcp_options_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -1200,7 +1216,8 @@ impl AssociateIamInstanceProfileRequestSerializer {
                                                                      prefix,
                                                                      "IamInstanceProfile"),
                                                              &obj.iam_instance_profile);
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
 
     }
 }
@@ -1275,11 +1292,13 @@ impl AssociateRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "RouteTableId"),
-                   &obj.route_table_id);
-        params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
+                   &obj.route_table_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "SubnetId"),
+                   &obj.subnet_id.replace("+", "%2B"));
 
     }
 }
@@ -1352,8 +1371,9 @@ impl AssociateSubnetCidrBlockRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "Ipv6CidrBlock"),
-                   &obj.ipv_6_cidr_block);
-        params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
+                   &obj.ipv_6_cidr_block.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "SubnetId"),
+                   &obj.subnet_id.replace("+", "%2B"));
 
     }
 }
@@ -1431,9 +1451,10 @@ impl AssociateVpcCidrBlockRequestSerializer {
 
         if let Some(ref field_value) = obj.amazon_provided_ipv_6_cidr_block {
             params.put(&format!("{}{}", prefix, "AmazonProvidedIpv6CidrBlock"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -1527,13 +1548,16 @@ impl AttachClassicLinkVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         GroupIdStringListSerializer::serialize(params,
                                                &format!("{}{}", prefix, "SecurityGroupId"),
                                                &obj.groups);
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -1609,11 +1633,13 @@ impl AttachInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "InternetGatewayId"),
-                   &obj.internet_gateway_id);
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+                   &obj.internet_gateway_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -1642,13 +1668,15 @@ impl AttachNetworkInterfaceRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DeviceIndex"),
-                   &obj.device_index.to_string());
+                   &obj.device_index.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
 
     }
 }
@@ -1725,12 +1753,16 @@ impl AttachVolumeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Device"), &obj.device);
+        params.put(&format!("{}{}", prefix, "Device"),
+                   &obj.device.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
-        params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VolumeId"),
+                   &obj.volume_id.replace("+", "%2B"));
 
     }
 }
@@ -1757,11 +1789,13 @@ impl AttachVpnGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "VpnGatewayId"),
-                   &obj.vpn_gateway_id);
+                   &obj.vpn_gateway_id.replace("+", "%2B"));
 
     }
 }
@@ -1890,7 +1924,8 @@ impl AttributeBooleanValueSerializer {
         }
 
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1955,7 +1990,8 @@ impl AttributeValueSerializer {
         }
 
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1995,34 +2031,39 @@ impl AuthorizeSecurityGroupEgressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.cidr_ip {
-            params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "CidrIp"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.from_port {
             params.put(&format!("{}{}", prefix, "FromPort"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "GroupId"), &obj.group_id);
+        params.put(&format!("{}{}", prefix, "GroupId"),
+                   &obj.group_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ip_permissions {
             IpPermissionListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "IpPermissions"),
                                                   field_value);
         }
         if let Some(ref field_value) = obj.ip_protocol {
-            params.put(&format!("{}{}", prefix, "IpProtocol"), &field_value);
+            params.put(&format!("{}{}", prefix, "IpProtocol"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_security_group_name {
             params.put(&format!("{}{}", prefix, "SourceSecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_security_group_owner_id {
             params.put(&format!("{}{}", prefix, "SourceSecurityGroupOwnerId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -2064,20 +2105,24 @@ impl AuthorizeSecurityGroupIngressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.cidr_ip {
-            params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "CidrIp"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.from_port {
             params.put(&format!("{}{}", prefix, "FromPort"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_id {
-            params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ip_permissions {
             IpPermissionListSerializer::serialize(params,
@@ -2085,18 +2130,20 @@ impl AuthorizeSecurityGroupIngressRequestSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.ip_protocol {
-            params.put(&format!("{}{}", prefix, "IpProtocol"), &field_value);
+            params.put(&format!("{}{}", prefix, "IpProtocol"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_security_group_name {
             params.put(&format!("{}{}", prefix, "SourceSecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_security_group_owner_id {
             params.put(&format!("{}{}", prefix, "SourceSecurityGroupOwnerId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -2482,7 +2529,9 @@ impl BlobAttributeValueSerializer {
 
         if let Some(ref field_value) = obj.value {
             params.put(&format!("{}{}", prefix, "Value"),
-                       ::std::str::from_utf8(&field_value).unwrap());
+                       ::std::str::from_utf8(&field_value)
+                           .unwrap()
+                           .replace("+", "%2B"));
         }
 
     }
@@ -2566,7 +2615,8 @@ impl BlockDeviceMappingSerializer {
         }
 
         if let Some(ref field_value) = obj.device_name {
-            params.put(&format!("{}{}", prefix, "DeviceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DeviceName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ebs {
             EbsBlockDeviceSerializer::serialize(params,
@@ -2574,10 +2624,12 @@ impl BlockDeviceMappingSerializer {
                                                 field_value);
         }
         if let Some(ref field_value) = obj.no_device {
-            params.put(&format!("{}{}", prefix, "NoDevice"), &field_value);
+            params.put(&format!("{}{}", prefix, "NoDevice"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.virtual_name {
-            params.put(&format!("{}{}", prefix, "VirtualName"), &field_value);
+            params.put(&format!("{}{}", prefix, "VirtualName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2696,9 +2748,11 @@ impl BundleInstanceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
         StorageSerializer::serialize(params, &format!("{}{}", prefix, "Storage"), &obj.storage);
 
     }
@@ -2988,9 +3042,11 @@ impl CancelBundleTaskRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "BundleId"), &obj.bundle_id);
+        params.put(&format!("{}{}", prefix, "BundleId"),
+                   &obj.bundle_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3068,12 +3124,14 @@ impl CancelConversionRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ConversionTaskId"),
-                   &obj.conversion_task_id);
+                   &obj.conversion_task_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reason_message {
-            params.put(&format!("{}{}", prefix, "ReasonMessage"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReasonMessage"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3097,7 +3155,7 @@ impl CancelExportTaskRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ExportTaskId"),
-                   &obj.export_task_id);
+                   &obj.export_task_id.replace("+", "%2B"));
 
     }
 }
@@ -3124,13 +3182,16 @@ impl CancelImportTaskRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.cancel_reason {
-            params.put(&format!("{}{}", prefix, "CancelReason"), &field_value);
+            params.put(&format!("{}{}", prefix, "CancelReason"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.import_task_id {
-            params.put(&format!("{}{}", prefix, "ImportTaskId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ImportTaskId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3214,7 +3275,7 @@ impl CancelReservedInstancesListingRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ReservedInstancesListingId"),
-                   &obj.reserved_instances_listing_id);
+                   &obj.reserved_instances_listing_id.replace("+", "%2B"));
 
     }
 }
@@ -3443,13 +3504,14 @@ impl CancelSpotFleetRequestsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         ValueStringListSerializer::serialize(params,
                                              &format!("{}{}", prefix, "SpotFleetRequestId"),
                                              &obj.spot_fleet_request_ids);
         params.put(&format!("{}{}", prefix, "TerminateInstances"),
-                   &obj.terminate_instances.to_string());
+                   &obj.terminate_instances.to_string().replace("+", "%2B"));
 
     }
 }
@@ -3648,7 +3710,8 @@ impl CancelSpotInstanceRequestsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         SpotInstanceRequestIdListSerializer::serialize(params,
                                                        &format!("{}{}",
@@ -4036,17 +4099,20 @@ impl ClientDataSerializer {
         }
 
         if let Some(ref field_value) = obj.comment {
-            params.put(&format!("{}{}", prefix, "Comment"), &field_value);
+            params.put(&format!("{}{}", prefix, "Comment"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.upload_end {
-            params.put(&format!("{}{}", prefix, "UploadEnd"), &field_value);
+            params.put(&format!("{}{}", prefix, "UploadEnd"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.upload_size {
             params.put(&format!("{}{}", prefix, "UploadSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.upload_start {
-            params.put(&format!("{}{}", prefix, "UploadStart"), &field_value);
+            params.put(&format!("{}{}", prefix, "UploadStart"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4074,10 +4140,13 @@ impl ConfirmProductInstanceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
-        params.put(&format!("{}{}", prefix, "ProductCode"), &obj.product_code);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "ProductCode"),
+                   &obj.product_code.replace("+", "%2B"));
 
     }
 }
@@ -4295,25 +4364,31 @@ impl CopyImageRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.encrypted {
             params.put(&format!("{}{}", prefix, "Encrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SourceImageId"),
-                   &obj.source_image_id);
-        params.put(&format!("{}{}", prefix, "SourceRegion"), &obj.source_region);
+                   &obj.source_image_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "SourceRegion"),
+                   &obj.source_region.replace("+", "%2B"));
 
     }
 }
@@ -4399,27 +4474,33 @@ impl CopySnapshotRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.destination_region {
-            params.put(&format!("{}{}", prefix, "DestinationRegion"), &field_value);
+            params.put(&format!("{}{}", prefix, "DestinationRegion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.encrypted {
             params.put(&format!("{}{}", prefix, "Encrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.presigned_url {
-            params.put(&format!("{}{}", prefix, "PresignedUrl"), &field_value);
+            params.put(&format!("{}{}", prefix, "PresignedUrl"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SourceRegion"), &obj.source_region);
+        params.put(&format!("{}{}", prefix, "SourceRegion"),
+                   &obj.source_region.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SourceSnapshotId"),
-                   &obj.source_snapshot_id);
+                   &obj.source_snapshot_id.replace("+", "%2B"));
 
     }
 }
@@ -4496,12 +4577,16 @@ impl CreateCustomerGatewayRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "BgpAsn"), &obj.bgp_asn.to_string());
+        params.put(&format!("{}{}", prefix, "BgpAsn"),
+                   &obj.bgp_asn.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "IpAddress"), &obj.public_ip);
-        params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
+        params.put(&format!("{}{}", prefix, "IpAddress"),
+                   &obj.public_ip.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Type"),
+                   &obj.type_.replace("+", "%2B"));
 
     }
 }
@@ -4574,7 +4659,8 @@ impl CreateDefaultVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -4653,7 +4739,8 @@ impl CreateDhcpOptionsRequestSerializer {
                                                               "DhcpConfiguration"),
                                                       &obj.dhcp_configurations);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -4730,12 +4817,15 @@ impl CreateEgressOnlyInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -4822,17 +4912,20 @@ impl CreateFlowLogsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DeliverLogsPermissionArn"),
-                   &obj.deliver_logs_permission_arn);
+                   &obj.deliver_logs_permission_arn.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "LogGroupName"),
-                   &obj.log_group_name);
+                   &obj.log_group_name.replace("+", "%2B"));
         ValueStringListSerializer::serialize(params,
                                              &format!("{}{}", prefix, "ResourceId"),
                                              &obj.resource_ids);
-        params.put(&format!("{}{}", prefix, "ResourceType"), &obj.resource_type);
-        params.put(&format!("{}{}", prefix, "TrafficType"), &obj.traffic_type);
+        params.put(&format!("{}{}", prefix, "ResourceType"),
+                   &obj.resource_type.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "TrafficType"),
+                   &obj.traffic_type.replace("+", "%2B"));
 
     }
 }
@@ -4927,13 +5020,16 @@ impl CreateFpgaImageRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         StorageLocationSerializer::serialize(params,
                                              &format!("{}{}", prefix, "InputStorageLocation"),
@@ -4944,7 +5040,8 @@ impl CreateFpgaImageRequestSerializer {
                                                  field_value);
         }
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "Name"), &field_value);
+            params.put(&format!("{}{}", prefix, "Name"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5040,16 +5137,20 @@ impl CreateImageRequestSerializer {
                                                                field_value);
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.no_reboot {
             params.put(&format!("{}{}", prefix, "NoReboot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -5128,7 +5229,8 @@ impl CreateInstanceExportTaskRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.export_to_s3_task {
             ExportToS3TaskSpecificationSerializer::serialize(params,
@@ -5137,9 +5239,11 @@ impl CreateInstanceExportTaskRequestSerializer {
                                                                      "ExportToS3"),
                                                              field_value);
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.target_environment {
-            params.put(&format!("{}{}", prefix, "TargetEnvironment"), &field_value);
+            params.put(&format!("{}{}", prefix, "TargetEnvironment"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5213,7 +5317,8 @@ impl CreateInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -5289,9 +5394,11 @@ impl CreateKeyPairRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "KeyName"), &obj.key_name);
+        params.put(&format!("{}{}", prefix, "KeyName"),
+                   &obj.key_name.replace("+", "%2B"));
 
     }
 }
@@ -5317,11 +5424,14 @@ impl CreateNatGatewayRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "AllocationId"), &obj.allocation_id);
+        params.put(&format!("{}{}", prefix, "AllocationId"),
+                   &obj.allocation_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
+        params.put(&format!("{}{}", prefix, "SubnetId"),
+                   &obj.subnet_id.replace("+", "%2B"));
 
     }
 }
@@ -5418,31 +5528,37 @@ impl CreateNetworkAclEntryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.cidr_block {
-            params.put(&format!("{}{}", prefix, "CidrBlock"), &field_value);
+            params.put(&format!("{}{}", prefix, "CidrBlock"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress.to_string());
+        params.put(&format!("{}{}", prefix, "Egress"),
+                   &obj.egress.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.icmp_type_code {
             IcmpTypeCodeSerializer::serialize(params,
                                               &format!("{}{}", prefix, "Icmp"),
                                               field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_cidr_block {
-            params.put(&format!("{}{}", prefix, "Ipv6CidrBlock"), &field_value);
+            params.put(&format!("{}{}", prefix, "Ipv6CidrBlock"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkAclId"),
-                   &obj.network_acl_id);
+                   &obj.network_acl_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.port_range {
             PortRangeSerializer::serialize(params,
                                            &format!("{}{}", prefix, "PortRange"),
                                            field_value);
         }
-        params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
-        params.put(&format!("{}{}", prefix, "RuleAction"), &obj.rule_action);
+        params.put(&format!("{}{}", prefix, "Protocol"),
+                   &obj.protocol.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RuleAction"),
+                   &obj.rule_action.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "RuleNumber"),
-                   &obj.rule_number.to_string());
+                   &obj.rule_number.to_string().replace("+", "%2B"));
 
     }
 }
@@ -5467,9 +5583,11 @@ impl CreateNetworkAclRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -5550,17 +5668,21 @@ impl CreateNetworkInterfacePermissionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.aws_account_id {
-            params.put(&format!("{}{}", prefix, "AwsAccountId"), &field_value);
+            params.put(&format!("{}{}", prefix, "AwsAccountId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.aws_service {
-            params.put(&format!("{}{}", prefix, "AwsService"), &field_value);
+            params.put(&format!("{}{}", prefix, "AwsService"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
-        params.put(&format!("{}{}", prefix, "Permission"), &obj.permission);
+                   &obj.network_interface_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Permission"),
+                   &obj.permission.replace("+", "%2B"));
 
     }
 }
@@ -5648,10 +5770,12 @@ impl CreateNetworkInterfaceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.groups {
             SecurityGroupIdStringListSerializer::serialize(params,
@@ -5662,7 +5786,7 @@ impl CreateNetworkInterfaceRequestSerializer {
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
             params.put(&format!("{}{}", prefix, "Ipv6AddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             InstanceIpv6AddressListSerializer::serialize(params,
@@ -5670,7 +5794,8 @@ impl CreateNetworkInterfaceRequestSerializer {
                                                          field_value);
         }
         if let Some(ref field_value) = obj.private_ip_address {
-            params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrivateIpAddress"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.private_ip_addresses {
             PrivateIpAddressSpecificationListSerializer::serialize(params,
@@ -5681,9 +5806,10 @@ impl CreateNetworkInterfaceRequestSerializer {
         }
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(&format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
+        params.put(&format!("{}{}", prefix, "SubnetId"),
+                   &obj.subnet_id.replace("+", "%2B"));
 
     }
 }
@@ -5760,10 +5886,13 @@ impl CreatePlacementGroupRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
-        params.put(&format!("{}{}", prefix, "Strategy"), &obj.strategy);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Strategy"),
+                   &obj.strategy.replace("+", "%2B"));
 
     }
 }
@@ -5791,16 +5920,17 @@ impl CreateReservedInstancesListingRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ClientToken"), &obj.client_token);
+        params.put(&format!("{}{}", prefix, "ClientToken"),
+                   &obj.client_token.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "InstanceCount"),
-                   &obj.instance_count.to_string());
+                   &obj.instance_count.to_string().replace("+", "%2B"));
         PriceScheduleSpecificationListSerializer::serialize(params,
                                                             &format!("{}{}",
                                                                     prefix,
                                                                     "PriceSchedules"),
                                                             &obj.price_schedules);
         params.put(&format!("{}{}", prefix, "ReservedInstancesId"),
-                   &obj.reserved_instances_id);
+                   &obj.reserved_instances_id.replace("+", "%2B"));
 
     }
 }
@@ -5891,36 +6021,41 @@ impl CreateRouteRequestSerializer {
 
         if let Some(ref field_value) = obj.destination_cidr_block {
             params.put(&format!("{}{}", prefix, "DestinationCidrBlock"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.destination_ipv_6_cidr_block {
             params.put(&format!("{}{}", prefix, "DestinationIpv6CidrBlock"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.egress_only_internet_gateway_id {
             params.put(&format!("{}{}", prefix, "EgressOnlyInternetGatewayId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.gateway_id {
-            params.put(&format!("{}{}", prefix, "GatewayId"), &field_value);
+            params.put(&format!("{}{}", prefix, "GatewayId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.nat_gateway_id {
-            params.put(&format!("{}{}", prefix, "NatGatewayId"), &field_value);
+            params.put(&format!("{}{}", prefix, "NatGatewayId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.network_interface_id {
-            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "RouteTableId"),
-                   &obj.route_table_id);
+                   &obj.route_table_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.vpc_peering_connection_id {
             params.put(&format!("{}{}", prefix, "VpcPeeringConnectionId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5995,9 +6130,11 @@ impl CreateRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -6076,13 +6213,16 @@ impl CreateSecurityGroupRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "GroupDescription"),
-                   &obj.description);
+                   &obj.description.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.vpc_id {
-            params.put(&format!("{}{}", prefix, "VpcId"), &field_value);
+            params.put(&format!("{}{}", prefix, "VpcId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6159,12 +6299,15 @@ impl CreateSnapshotRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
+        params.put(&format!("{}{}", prefix, "VolumeId"),
+                   &obj.volume_id.replace("+", "%2B"));
 
     }
 }
@@ -6190,12 +6333,15 @@ impl CreateSpotDatafeedSubscriptionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Bucket"), &obj.bucket);
+        params.put(&format!("{}{}", prefix, "Bucket"),
+                   &obj.bucket.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.prefix {
-            params.put(&format!("{}{}", prefix, "Prefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "Prefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6276,16 +6422,21 @@ impl CreateSubnetRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "CidrBlock"), &obj.cidr_block);
+        params.put(&format!("{}{}", prefix, "CidrBlock"),
+                   &obj.cidr_block.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ipv_6_cidr_block {
-            params.put(&format!("{}{}", prefix, "Ipv6CidrBlock"), &field_value);
+            params.put(&format!("{}{}", prefix, "Ipv6CidrBlock"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -6361,7 +6512,8 @@ impl CreateTagsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         ResourceIdListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "ResourceId"),
@@ -6437,10 +6589,12 @@ impl CreateVolumePermissionSerializer {
         }
 
         if let Some(ref field_value) = obj.group {
-            params.put(&format!("{}{}", prefix, "Group"), &field_value);
+            params.put(&format!("{}{}", prefix, "Group"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_id {
-            params.put(&format!("{}{}", prefix, "UserId"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6567,25 +6721,30 @@ impl CreateVolumeRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AvailabilityZone"),
-                   &obj.availability_zone);
+                   &obj.availability_zone.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.encrypted {
             params.put(&format!("{}{}", prefix, "Encrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.size {
-            params.put(&format!("{}{}", prefix, "Size"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Size"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_id {
-            params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_specifications {
             TagSpecificationListSerializer::serialize(params,
@@ -6593,7 +6752,8 @@ impl CreateVolumeRequestSerializer {
                                                       field_value);
         }
         if let Some(ref field_value) = obj.volume_type {
-            params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "VolumeType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6627,21 +6787,26 @@ impl CreateVpcEndpointRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.policy_document {
-            params.put(&format!("{}{}", prefix, "PolicyDocument"), &field_value);
+            params.put(&format!("{}{}", prefix, "PolicyDocument"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.route_table_ids {
             ValueStringListSerializer::serialize(params,
                                                  &format!("{}{}", prefix, "RouteTableId"),
                                                  field_value);
         }
-        params.put(&format!("{}{}", prefix, "ServiceName"), &obj.service_name);
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "ServiceName"),
+                   &obj.service_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -6726,16 +6891,20 @@ impl CreateVpcPeeringConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.peer_owner_id {
-            params.put(&format!("{}{}", prefix, "PeerOwnerId"), &field_value);
+            params.put(&format!("{}{}", prefix, "PeerOwnerId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.peer_vpc_id {
-            params.put(&format!("{}{}", prefix, "PeerVpcId"), &field_value);
+            params.put(&format!("{}{}", prefix, "PeerVpcId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_id {
-            params.put(&format!("{}{}", prefix, "VpcId"), &field_value);
+            params.put(&format!("{}{}", prefix, "VpcId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6817,14 +6986,17 @@ impl CreateVpcRequestSerializer {
 
         if let Some(ref field_value) = obj.amazon_provided_ipv_6_cidr_block {
             params.put(&format!("{}{}", prefix, "AmazonProvidedIpv6CidrBlock"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "CidrBlock"), &obj.cidr_block);
+        params.put(&format!("{}{}", prefix, "CidrBlock"),
+                   &obj.cidr_block.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_tenancy {
-            params.put(&format!("{}{}", prefix, "InstanceTenancy"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceTenancy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6904,9 +7076,10 @@ impl CreateVpnConnectionRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CustomerGatewayId"),
-                   &obj.customer_gateway_id);
+                   &obj.customer_gateway_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.options {
             VpnConnectionOptionsSpecificationSerializer::serialize(params,
@@ -6915,9 +7088,10 @@ impl CreateVpnConnectionRequestSerializer {
                                                                            "Options"),
                                                                    field_value);
         }
-        params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
+        params.put(&format!("{}{}", prefix, "Type"),
+                   &obj.type_.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "VpnGatewayId"),
-                   &obj.vpn_gateway_id);
+                   &obj.vpn_gateway_id.replace("+", "%2B"));
 
     }
 }
@@ -6992,9 +7166,9 @@ impl CreateVpnConnectionRouteRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DestinationCidrBlock"),
-                   &obj.destination_cidr_block);
+                   &obj.destination_cidr_block.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "VpnConnectionId"),
-                   &obj.vpn_connection_id);
+                   &obj.vpn_connection_id.replace("+", "%2B"));
 
     }
 }
@@ -7021,12 +7195,15 @@ impl CreateVpnGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
+        params.put(&format!("{}{}", prefix, "Type"),
+                   &obj.type_.replace("+", "%2B"));
 
     }
 }
@@ -7274,9 +7451,10 @@ impl DeleteCustomerGatewayRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CustomerGatewayId"),
-                   &obj.customer_gateway_id);
+                   &obj.customer_gateway_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7302,9 +7480,10 @@ impl DeleteDhcpOptionsRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DhcpOptionsId"),
-                   &obj.dhcp_options_id);
+                   &obj.dhcp_options_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7329,10 +7508,11 @@ impl DeleteEgressOnlyInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "EgressOnlyInternetGatewayId"),
-                   &obj.egress_only_internet_gateway_id);
+                   &obj.egress_only_internet_gateway_id.replace("+", "%2B"));
 
     }
 }
@@ -7480,10 +7660,11 @@ impl DeleteInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "InternetGatewayId"),
-                   &obj.internet_gateway_id);
+                   &obj.internet_gateway_id.replace("+", "%2B"));
 
     }
 }
@@ -7508,9 +7689,11 @@ impl DeleteKeyPairRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "KeyName"), &obj.key_name);
+        params.put(&format!("{}{}", prefix, "KeyName"),
+                   &obj.key_name.replace("+", "%2B"));
 
     }
 }
@@ -7533,7 +7716,7 @@ impl DeleteNatGatewayRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "NatGatewayId"),
-                   &obj.nat_gateway_id);
+                   &obj.nat_gateway_id.replace("+", "%2B"));
 
     }
 }
@@ -7611,13 +7794,15 @@ impl DeleteNetworkAclEntryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress.to_string());
+        params.put(&format!("{}{}", prefix, "Egress"),
+                   &obj.egress.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "NetworkAclId"),
-                   &obj.network_acl_id);
+                   &obj.network_acl_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "RuleNumber"),
-                   &obj.rule_number.to_string());
+                   &obj.rule_number.to_string().replace("+", "%2B"));
 
     }
 }
@@ -7642,10 +7827,11 @@ impl DeleteNetworkAclRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkAclId"),
-                   &obj.network_acl_id);
+                   &obj.network_acl_id.replace("+", "%2B"));
 
     }
 }
@@ -7672,13 +7858,15 @@ impl DeleteNetworkInterfacePermissionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkInterfacePermissionId"),
-                   &obj.network_interface_permission_id);
+                   &obj.network_interface_permission_id.replace("+", "%2B"));
 
     }
 }
@@ -7753,10 +7941,11 @@ impl DeleteNetworkInterfaceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
 
     }
 }
@@ -7781,9 +7970,11 @@ impl DeletePlacementGroupRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
 
     }
 }
@@ -7813,17 +8004,18 @@ impl DeleteRouteRequestSerializer {
 
         if let Some(ref field_value) = obj.destination_cidr_block {
             params.put(&format!("{}{}", prefix, "DestinationCidrBlock"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.destination_ipv_6_cidr_block {
             params.put(&format!("{}{}", prefix, "DestinationIpv6CidrBlock"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "RouteTableId"),
-                   &obj.route_table_id);
+                   &obj.route_table_id.replace("+", "%2B"));
 
     }
 }
@@ -7848,10 +8040,11 @@ impl DeleteRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "RouteTableId"),
-                   &obj.route_table_id);
+                   &obj.route_table_id.replace("+", "%2B"));
 
     }
 }
@@ -7878,13 +8071,16 @@ impl DeleteSecurityGroupRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_id {
-            params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7910,9 +8106,11 @@ impl DeleteSnapshotRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SnapshotId"), &obj.snapshot_id);
+        params.put(&format!("{}{}", prefix, "SnapshotId"),
+                   &obj.snapshot_id.replace("+", "%2B"));
 
     }
 }
@@ -7935,7 +8133,8 @@ impl DeleteSpotDatafeedSubscriptionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7961,9 +8160,11 @@ impl DeleteSubnetRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
+        params.put(&format!("{}{}", prefix, "SubnetId"),
+                   &obj.subnet_id.replace("+", "%2B"));
 
     }
 }
@@ -7990,7 +8191,8 @@ impl DeleteTagsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         ResourceIdListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "ResourceId"),
@@ -8022,9 +8224,11 @@ impl DeleteVolumeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
+        params.put(&format!("{}{}", prefix, "VolumeId"),
+                   &obj.volume_id.replace("+", "%2B"));
 
     }
 }
@@ -8049,7 +8253,8 @@ impl DeleteVpcEndpointsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         ValueStringListSerializer::serialize(params,
                                              &format!("{}{}", prefix, "VpcEndpointId"),
@@ -8128,10 +8333,11 @@ impl DeleteVpcPeeringConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "VpcPeeringConnectionId"),
-                   &obj.vpc_peering_connection_id);
+                   &obj.vpc_peering_connection_id.replace("+", "%2B"));
 
     }
 }
@@ -8206,9 +8412,11 @@ impl DeleteVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -8233,10 +8441,11 @@ impl DeleteVpnConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "VpnConnectionId"),
-                   &obj.vpn_connection_id);
+                   &obj.vpn_connection_id.replace("+", "%2B"));
 
     }
 }
@@ -8261,9 +8470,9 @@ impl DeleteVpnConnectionRouteRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DestinationCidrBlock"),
-                   &obj.destination_cidr_block);
+                   &obj.destination_cidr_block.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "VpnConnectionId"),
-                   &obj.vpn_connection_id);
+                   &obj.vpn_connection_id.replace("+", "%2B"));
 
     }
 }
@@ -8288,10 +8497,11 @@ impl DeleteVpnGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "VpnGatewayId"),
-                   &obj.vpn_gateway_id);
+                   &obj.vpn_gateway_id.replace("+", "%2B"));
 
     }
 }
@@ -8316,9 +8526,11 @@ impl DeregisterImageRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
+        params.put(&format!("{}{}", prefix, "ImageId"),
+                   &obj.image_id.replace("+", "%2B"));
 
     }
 }
@@ -8350,7 +8562,8 @@ impl DescribeAccountAttributesRequestSerializer {
                                                                 field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8436,7 +8649,8 @@ impl DescribeAddressesRequestSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -8523,7 +8737,8 @@ impl DescribeAvailabilityZonesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -8617,7 +8832,8 @@ impl DescribeBundleTasksRequestSerializer {
                                                     field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -8704,7 +8920,8 @@ impl DescribeClassicLinkInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -8718,10 +8935,11 @@ impl DescribeClassicLinkInstancesRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8852,7 +9070,8 @@ impl DescribeConversionTasksRequestSerializer {
                                                         field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8935,7 +9154,8 @@ impl DescribeCustomerGatewaysRequestSerializer {
                                                              field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -9023,7 +9243,8 @@ impl DescribeDhcpOptionsRequestSerializer {
                                                          field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -9109,7 +9330,8 @@ impl DescribeEgressOnlyInternetGatewaysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.egress_only_internet_gateway_ids {
             EgressOnlyInternetGatewayIdListSerializer::serialize(params,
@@ -9120,10 +9342,11 @@ impl DescribeEgressOnlyInternetGatewaysRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9208,7 +9431,8 @@ impl DescribeElasticGpusRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.elastic_gpu_ids {
             ElasticGpuIdSetSerializer::serialize(params,
@@ -9222,10 +9446,11 @@ impl DescribeElasticGpusRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9403,10 +9628,11 @@ impl DescribeFlowLogsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9494,7 +9720,8 @@ impl DescribeFpgaImagesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -9508,10 +9735,11 @@ impl DescribeFpgaImagesRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.owners {
             OwnerStringListSerializer::serialize(params,
@@ -9610,21 +9838,23 @@ impl DescribeHostReservationOfferingsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_duration {
             params.put(&format!("{}{}", prefix, "MaxDuration"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.min_duration {
             params.put(&format!("{}{}", prefix, "MinDuration"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.offering_id {
-            params.put(&format!("{}{}", prefix, "OfferingId"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9722,10 +9952,11 @@ impl DescribeHostReservationsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9821,10 +10052,11 @@ impl DescribeHostsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9921,10 +10153,11 @@ impl DescribeIamInstanceProfileAssociationsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10002,7 +10235,8 @@ impl DescribeIdFormatRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.resource {
-            params.put(&format!("{}{}", prefix, "Resource"), &field_value);
+            params.put(&format!("{}{}", prefix, "Resource"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10076,9 +10310,11 @@ impl DescribeIdentityIdFormatRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PrincipalArn"), &obj.principal_arn);
+        params.put(&format!("{}{}", prefix, "PrincipalArn"),
+                   &obj.principal_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.resource {
-            params.put(&format!("{}{}", prefix, "Resource"), &field_value);
+            params.put(&format!("{}{}", prefix, "Resource"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10154,11 +10390,14 @@ impl DescribeImageAttributeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
+        params.put(&format!("{}{}", prefix, "Attribute"),
+                   &obj.attribute.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
+        params.put(&format!("{}{}", prefix, "ImageId"),
+                   &obj.image_id.replace("+", "%2B"));
 
     }
 }
@@ -10189,7 +10428,8 @@ impl DescribeImagesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.executable_users {
             ExecutableByStringListSerializer::serialize(params,
@@ -10290,7 +10530,8 @@ impl DescribeImportImageTasksRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -10304,10 +10545,11 @@ impl DescribeImportImageTasksRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10395,7 +10637,8 @@ impl DescribeImportSnapshotTasksRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -10409,10 +10652,11 @@ impl DescribeImportSnapshotTasksRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10496,11 +10740,14 @@ impl DescribeInstanceAttributeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
+        params.put(&format!("{}{}", prefix, "Attribute"),
+                   &obj.attribute.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
 
     }
 }
@@ -10533,7 +10780,8 @@ impl DescribeInstanceStatusRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -10542,7 +10790,7 @@ impl DescribeInstanceStatusRequestSerializer {
         }
         if let Some(ref field_value) = obj.include_all_instances {
             params.put(&format!("{}{}", prefix, "IncludeAllInstances"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_ids {
             InstanceIdStringListSerializer::serialize(params,
@@ -10551,10 +10799,11 @@ impl DescribeInstanceStatusRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10642,7 +10891,8 @@ impl DescribeInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -10656,10 +10906,11 @@ impl DescribeInstancesRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10743,7 +10994,8 @@ impl DescribeInternetGatewaysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -10831,7 +11083,8 @@ impl DescribeKeyPairsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -10922,7 +11175,8 @@ impl DescribeMovingAddressesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -10931,10 +11185,11 @@ impl DescribeMovingAddressesRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.public_ips {
             ValueStringListSerializer::serialize(params,
@@ -11031,7 +11286,7 @@ impl DescribeNatGatewaysRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.nat_gateway_ids {
             ValueStringListSerializer::serialize(params,
@@ -11039,7 +11294,8 @@ impl DescribeNatGatewaysRequestSerializer {
                                                  field_value);
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -11123,7 +11379,8 @@ impl DescribeNetworkAclsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -11211,13 +11468,15 @@ impl DescribeNetworkInterfaceAttributeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.attribute {
-            params.put(&format!("{}{}", prefix, "Attribute"), &field_value);
+            params.put(&format!("{}{}", prefix, "Attribute"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
 
     }
 }
@@ -11331,7 +11590,7 @@ impl DescribeNetworkInterfacePermissionsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.network_interface_permission_ids {
             NetworkInterfacePermissionIdListSerializer::serialize(params,
@@ -11341,7 +11600,8 @@ impl DescribeNetworkInterfacePermissionsRequestSerializer {
                                                                   field_value);
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -11424,7 +11684,8 @@ impl DescribeNetworkInterfacesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -11515,7 +11776,8 @@ impl DescribePlacementGroupsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -11607,7 +11869,8 @@ impl DescribePrefixListsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -11616,10 +11879,11 @@ impl DescribePrefixListsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.prefix_list_ids {
             ValueStringListSerializer::serialize(params,
@@ -11708,7 +11972,8 @@ impl DescribeRegionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -11801,11 +12066,11 @@ impl DescribeReservedInstancesListingsRequestSerializer {
         }
         if let Some(ref field_value) = obj.reserved_instances_id {
             params.put(&format!("{}{}", prefix, "ReservedInstancesId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_instances_listing_id {
             params.put(&format!("{}{}", prefix, "ReservedInstancesListingId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -11889,7 +12154,8 @@ impl DescribeReservedInstancesModificationsRequestSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_instances_modification_ids {
             ReservedInstancesModificationIdStringListSerializer::serialize(params,
@@ -12005,10 +12271,12 @@ impl DescribeReservedInstancesOfferingsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -12017,41 +12285,47 @@ impl DescribeReservedInstancesOfferingsRequestSerializer {
         }
         if let Some(ref field_value) = obj.include_marketplace {
             params.put(&format!("{}{}", prefix, "IncludeMarketplace"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_tenancy {
-            params.put(&format!("{}{}", prefix, "InstanceTenancy"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceTenancy"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_type {
-            params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_duration {
             params.put(&format!("{}{}", prefix, "MaxDuration"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_instance_count {
             params.put(&format!("{}{}", prefix, "MaxInstanceCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.min_duration {
             params.put(&format!("{}{}", prefix, "MinDuration"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.offering_class {
-            params.put(&format!("{}{}", prefix, "OfferingClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingClass"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.offering_type {
-            params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.product_description {
-            params.put(&format!("{}{}", prefix, "ProductDescription"), &field_value);
+            params.put(&format!("{}{}", prefix, "ProductDescription"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_instances_offering_ids {
             ReservedInstancesOfferingIdStringListSerializer::serialize(params,
@@ -12145,7 +12419,8 @@ impl DescribeReservedInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -12153,10 +12428,12 @@ impl DescribeReservedInstancesRequestSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.offering_class {
-            params.put(&format!("{}{}", prefix, "OfferingClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingClass"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.offering_type {
-            params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_instances_ids {
             ReservedInstancesIdStringListSerializer::serialize(params,
@@ -12242,7 +12519,8 @@ impl DescribeRouteTablesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -12342,7 +12620,8 @@ impl DescribeScheduledInstanceAvailabilityRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -12356,18 +12635,19 @@ impl DescribeScheduledInstanceAvailabilityRequestSerializer {
                                                       &obj.first_slot_start_time_range);
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_slot_duration_in_hours {
             params.put(&format!("{}{}", prefix, "MaxSlotDurationInHours"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.min_slot_duration_in_hours {
             params.put(&format!("{}{}", prefix, "MinSlotDurationInHours"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         ScheduledInstanceRecurrenceRequestSerializer::serialize(params,
                                                                 &format!("{}{}",
@@ -12461,7 +12741,8 @@ impl DescribeScheduledInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -12470,10 +12751,11 @@ impl DescribeScheduledInstancesRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.scheduled_instance_ids {
             ScheduledInstanceIdRequestSetSerializer::serialize(params,
@@ -12569,7 +12851,8 @@ impl DescribeSecurityGroupReferencesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         GroupIdsSerializer::serialize(params, &format!("{}{}", prefix, "GroupId"), &obj.group_id);
 
@@ -12650,7 +12933,8 @@ impl DescribeSecurityGroupsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -12742,11 +13026,14 @@ impl DescribeSnapshotAttributeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
+        params.put(&format!("{}{}", prefix, "Attribute"),
+                   &obj.attribute.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SnapshotId"), &obj.snapshot_id);
+        params.put(&format!("{}{}", prefix, "SnapshotId"),
+                   &obj.snapshot_id.replace("+", "%2B"));
 
     }
 }
@@ -12843,7 +13130,8 @@ impl DescribeSnapshotsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -12852,10 +13140,11 @@ impl DescribeSnapshotsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.owner_ids {
             OwnerStringListSerializer::serialize(params,
@@ -12950,7 +13239,8 @@ impl DescribeSpotDatafeedSubscriptionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -13029,17 +13319,19 @@ impl DescribeSpotFleetInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SpotFleetRequestId"),
-                   &obj.spot_fleet_request_id);
+                   &obj.spot_fleet_request_id.replace("+", "%2B"));
 
     }
 }
@@ -13135,21 +13427,25 @@ impl DescribeSpotFleetRequestHistoryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.event_type {
-            params.put(&format!("{}{}", prefix, "EventType"), &field_value);
+            params.put(&format!("{}{}", prefix, "EventType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SpotFleetRequestId"),
-                   &obj.spot_fleet_request_id);
-        params.put(&format!("{}{}", prefix, "StartTime"), &obj.start_time);
+                   &obj.spot_fleet_request_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "StartTime"),
+                   &obj.start_time.replace("+", "%2B"));
 
     }
 }
@@ -13253,14 +13549,16 @@ impl DescribeSpotFleetRequestsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.spot_fleet_request_ids {
             ValueStringListSerializer::serialize(params,
@@ -13350,7 +13648,8 @@ impl DescribeSpotInstanceRequestsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -13453,13 +13752,16 @@ impl DescribeSpotPriceHistoryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -13473,10 +13775,11 @@ impl DescribeSpotPriceHistoryRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.product_descriptions {
             ProductDescriptionListSerializer::serialize(params,
@@ -13486,7 +13789,8 @@ impl DescribeSpotPriceHistoryRequestSerializer {
                                                         field_value);
         }
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -13571,16 +13875,19 @@ impl DescribeStaleSecurityGroupsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -13663,7 +13970,8 @@ impl DescribeSubnetsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -13752,7 +14060,8 @@ impl DescribeTagsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -13761,10 +14070,11 @@ impl DescribeTagsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -13848,12 +14158,15 @@ impl DescribeVolumeAttributeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.attribute {
-            params.put(&format!("{}{}", prefix, "Attribute"), &field_value);
+            params.put(&format!("{}{}", prefix, "Attribute"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
+        params.put(&format!("{}{}", prefix, "VolumeId"),
+                   &obj.volume_id.replace("+", "%2B"));
 
     }
 }
@@ -13947,7 +14260,8 @@ impl DescribeVolumeStatusRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -13956,10 +14270,11 @@ impl DescribeVolumeStatusRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_ids {
             VolumeIdStringListSerializer::serialize(params,
@@ -14051,7 +14366,8 @@ impl DescribeVolumesModificationsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -14060,10 +14376,11 @@ impl DescribeVolumesModificationsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_ids {
             VolumeIdStringListSerializer::serialize(params,
@@ -14156,7 +14473,8 @@ impl DescribeVolumesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -14165,10 +14483,11 @@ impl DescribeVolumesRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_ids {
             VolumeIdStringListSerializer::serialize(params,
@@ -14255,11 +14574,14 @@ impl DescribeVpcAttributeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
+        params.put(&format!("{}{}", prefix, "Attribute"),
+                   &obj.attribute.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -14350,10 +14672,11 @@ impl DescribeVpcClassicLinkDnsSupportRequestSerializer {
 
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_ids {
             VpcClassicLinkIdListSerializer::serialize(params,
@@ -14441,7 +14764,8 @@ impl DescribeVpcClassicLinkRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -14529,14 +14853,16 @@ impl DescribeVpcEndpointServicesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -14625,7 +14951,8 @@ impl DescribeVpcEndpointsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -14634,10 +14961,11 @@ impl DescribeVpcEndpointsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_results {
             params.put(&format!("{}{}", prefix, "MaxResults"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_endpoint_ids {
             ValueStringListSerializer::serialize(params,
@@ -14726,7 +15054,8 @@ impl DescribeVpcPeeringConnectionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -14815,7 +15144,8 @@ impl DescribeVpcsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -14902,7 +15232,8 @@ impl DescribeVpnConnectionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -14992,7 +15323,8 @@ impl DescribeVpnGatewaysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -15080,10 +15412,13 @@ impl DetachClassicLinkVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -15159,11 +15494,13 @@ impl DetachInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "InternetGatewayId"),
-                   &obj.internet_gateway_id);
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+                   &obj.internet_gateway_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -15189,12 +15526,15 @@ impl DetachNetworkInterfaceRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "AttachmentId"), &obj.attachment_id);
+        params.put(&format!("{}{}", prefix, "AttachmentId"),
+                   &obj.attachment_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -15226,18 +15566,23 @@ impl DetachVolumeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.device {
-            params.put(&format!("{}{}", prefix, "Device"), &field_value);
+            params.put(&format!("{}{}", prefix, "Device"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
+        params.put(&format!("{}{}", prefix, "VolumeId"),
+                   &obj.volume_id.replace("+", "%2B"));
 
     }
 }
@@ -15264,11 +15609,13 @@ impl DetachVpnGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "VpnGatewayId"),
-                   &obj.vpn_gateway_id);
+                   &obj.vpn_gateway_id.replace("+", "%2B"));
 
     }
 }
@@ -15556,9 +15903,10 @@ impl DisableVgwRoutePropagationRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GatewayId"), &obj.gateway_id);
+        params.put(&format!("{}{}", prefix, "GatewayId"),
+                   &obj.gateway_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "RouteTableId"),
-                   &obj.route_table_id);
+                   &obj.route_table_id.replace("+", "%2B"));
 
     }
 }
@@ -15581,7 +15929,8 @@ impl DisableVpcClassicLinkDnsSupportRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.vpc_id {
-            params.put(&format!("{}{}", prefix, "VpcId"), &field_value);
+            params.put(&format!("{}{}", prefix, "VpcId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -15657,9 +16006,11 @@ impl DisableVpcClassicLinkRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -15735,13 +16086,16 @@ impl DisassociateAddressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.association_id {
-            params.put(&format!("{}{}", prefix, "AssociationId"), &field_value);
+            params.put(&format!("{}{}", prefix, "AssociationId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.public_ip {
-            params.put(&format!("{}{}", prefix, "PublicIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "PublicIp"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -15764,7 +16118,7 @@ impl DisassociateIamInstanceProfileRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AssociationId"),
-                   &obj.association_id);
+                   &obj.association_id.replace("+", "%2B"));
 
     }
 }
@@ -15837,9 +16191,10 @@ impl DisassociateRouteTableRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AssociationId"),
-                   &obj.association_id);
+                   &obj.association_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -15862,7 +16217,7 @@ impl DisassociateSubnetCidrBlockRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AssociationId"),
-                   &obj.association_id);
+                   &obj.association_id.replace("+", "%2B"));
 
     }
 }
@@ -15938,7 +16293,7 @@ impl DisassociateVpcCidrBlockRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AssociationId"),
-                   &obj.association_id);
+                   &obj.association_id.replace("+", "%2B"));
 
     }
 }
@@ -16018,7 +16373,8 @@ impl DiskImageSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.image {
             DiskImageDetailSerializer::serialize(params,
@@ -16121,10 +16477,12 @@ impl DiskImageDetailSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Bytes"), &obj.bytes.to_string());
-        params.put(&format!("{}{}", prefix, "Format"), &obj.format);
+        params.put(&format!("{}{}", prefix, "Bytes"),
+                   &obj.bytes.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Format"),
+                   &obj.format.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ImportManifestUrl"),
-                   &obj.import_manifest_url);
+                   &obj.import_manifest_url.replace("+", "%2B"));
 
     }
 }
@@ -16328,24 +16686,27 @@ impl EbsBlockDeviceSerializer {
 
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(&format!("{}{}", prefix, "DeleteOnTermination"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.encrypted {
             params.put(&format!("{}{}", prefix, "Encrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_id {
-            params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_size {
             params.put(&format!("{}{}", prefix, "VolumeSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_type {
-            params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "VolumeType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -16441,10 +16802,11 @@ impl EbsInstanceBlockDeviceSpecificationSerializer {
 
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(&format!("{}{}", prefix, "DeleteOnTermination"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_id {
-            params.put(&format!("{}{}", prefix, "VolumeId"), &field_value);
+            params.put(&format!("{}{}", prefix, "VolumeId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -16803,7 +17165,8 @@ impl ElasticGpuSpecificationSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
+        params.put(&format!("{}{}", prefix, "Type"),
+                   &obj.type_.replace("+", "%2B"));
 
     }
 }
@@ -16950,9 +17313,10 @@ impl EnableVgwRoutePropagationRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GatewayId"), &obj.gateway_id);
+        params.put(&format!("{}{}", prefix, "GatewayId"),
+                   &obj.gateway_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "RouteTableId"),
-                   &obj.route_table_id);
+                   &obj.route_table_id.replace("+", "%2B"));
 
     }
 }
@@ -16977,9 +17341,11 @@ impl EnableVolumeIORequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
+        params.put(&format!("{}{}", prefix, "VolumeId"),
+                   &obj.volume_id.replace("+", "%2B"));
 
     }
 }
@@ -17002,7 +17368,8 @@ impl EnableVpcClassicLinkDnsSupportRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.vpc_id {
-            params.put(&format!("{}{}", prefix, "VpcId"), &field_value);
+            params.put(&format!("{}{}", prefix, "VpcId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -17078,9 +17445,11 @@ impl EnableVpcClassicLinkRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -17505,16 +17874,20 @@ impl ExportToS3TaskSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.container_format {
-            params.put(&format!("{}{}", prefix, "ContainerFormat"), &field_value);
+            params.put(&format!("{}{}", prefix, "ContainerFormat"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.disk_image_format {
-            params.put(&format!("{}{}", prefix, "DiskImageFormat"), &field_value);
+            params.put(&format!("{}{}", prefix, "DiskImageFormat"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.s3_bucket {
-            params.put(&format!("{}{}", prefix, "S3Bucket"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3Bucket"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.s3_prefix {
-            params.put(&format!("{}{}", prefix, "S3Prefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3Prefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -17540,7 +17913,8 @@ impl FilterSerializer {
         }
 
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "Name"), &field_value);
+            params.put(&format!("{}{}", prefix, "Name"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.values {
             ValueStringListSerializer::serialize(params,
@@ -18011,9 +18385,11 @@ impl GetConsoleOutputRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
 
     }
 }
@@ -18101,11 +18477,14 @@ impl GetConsoleScreenshotRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.wake_up {
-            params.put(&format!("{}{}", prefix, "WakeUp"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "WakeUp"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -18187,7 +18566,8 @@ impl GetHostReservationPurchasePreviewRequestSerializer {
         RequestHostIdSetSerializer::serialize(params,
                                               &format!("{}{}", prefix, "HostIdSet"),
                                               &obj.host_id_set);
-        params.put(&format!("{}{}", prefix, "OfferingId"), &obj.offering_id);
+        params.put(&format!("{}{}", prefix, "OfferingId"),
+                   &obj.offering_id.replace("+", "%2B"));
 
     }
 }
@@ -18282,9 +18662,11 @@ impl GetPasswordDataRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
 
     }
 }
@@ -18372,7 +18754,8 @@ impl GetReservedInstancesExchangeQuoteRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         ReservedInstanceIdSetSerializer::serialize(params,
                                                    &format!("{}{}", prefix, "ReservedInstanceId"),
@@ -18567,10 +18950,12 @@ impl GroupIdentifierSerializer {
         }
 
         if let Some(ref field_value) = obj.group_id {
-            params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -19632,10 +20017,12 @@ impl IamInstanceProfileSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.arn {
-            params.put(&format!("{}{}", prefix, "Arn"), &field_value);
+            params.put(&format!("{}{}", prefix, "Arn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "Name"), &field_value);
+            params.put(&format!("{}{}", prefix, "Name"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -19705,10 +20092,12 @@ impl IcmpTypeCodeSerializer {
         }
 
         if let Some(ref field_value) = obj.code {
-            params.put(&format!("{}{}", prefix, "Code"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Code"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.type_ {
-            params.put(&format!("{}{}", prefix, "Type"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Type"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -20140,19 +20529,24 @@ impl ImageDiskContainerSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.device_name {
-            params.put(&format!("{}{}", prefix, "DeviceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DeviceName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.format {
-            params.put(&format!("{}{}", prefix, "Format"), &field_value);
+            params.put(&format!("{}{}", prefix, "Format"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_id {
-            params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.url {
-            params.put(&format!("{}{}", prefix, "Url"), &field_value);
+            params.put(&format!("{}{}", prefix, "Url"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_bucket {
             UserBucketSerializer::serialize(params,
@@ -20292,7 +20686,8 @@ impl ImportImageRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.architecture {
-            params.put(&format!("{}{}", prefix, "Architecture"), &field_value);
+            params.put(&format!("{}{}", prefix, "Architecture"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.client_data {
             ClientDataSerializer::serialize(params,
@@ -20300,10 +20695,12 @@ impl ImportImageRequestSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.disk_containers {
             ImageDiskContainerListSerializer::serialize(params,
@@ -20311,19 +20708,24 @@ impl ImportImageRequestSerializer {
                                                         field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.hypervisor {
-            params.put(&format!("{}{}", prefix, "Hypervisor"), &field_value);
+            params.put(&format!("{}{}", prefix, "Hypervisor"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.license_type {
-            params.put(&format!("{}{}", prefix, "LicenseType"), &field_value);
+            params.put(&format!("{}{}", prefix, "LicenseType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.platform {
-            params.put(&format!("{}{}", prefix, "Platform"), &field_value);
+            params.put(&format!("{}{}", prefix, "Platform"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.role_name {
-            params.put(&format!("{}{}", prefix, "RoleName"), &field_value);
+            params.put(&format!("{}{}", prefix, "RoleName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -20628,10 +21030,12 @@ impl ImportInstanceLaunchSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.additional_info {
-            params.put(&format!("{}{}", prefix, "AdditionalInfo"), &field_value);
+            params.put(&format!("{}{}", prefix, "AdditionalInfo"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.architecture {
-            params.put(&format!("{}{}", prefix, "Architecture"), &field_value);
+            params.put(&format!("{}{}", prefix, "Architecture"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_ids {
             SecurityGroupIdStringListSerializer::serialize(params,
@@ -20645,14 +21049,15 @@ impl ImportInstanceLaunchSpecificationSerializer {
         }
         if let Some(ref field_value) = obj.instance_initiated_shutdown_behavior {
             params.put(&format!("{}{}", prefix, "InstanceInitiatedShutdownBehavior"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_type {
-            params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring {
             params.put(&format!("{}{}", prefix, "Monitoring"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.placement {
             PlacementSerializer::serialize(params,
@@ -20660,10 +21065,12 @@ impl ImportInstanceLaunchSpecificationSerializer {
                                            field_value);
         }
         if let Some(ref field_value) = obj.private_ip_address {
-            params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrivateIpAddress"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.subnet_id {
-            params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubnetId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_data {
             UserDataSerializer::serialize(params,
@@ -20700,7 +21107,8 @@ impl ImportInstanceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.disk_images {
             DiskImageListSerializer::serialize(params,
@@ -20708,7 +21116,8 @@ impl ImportInstanceRequestSerializer {
                                                field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.launch_specification {
             ImportInstanceLaunchSpecificationSerializer::serialize(params,
@@ -20717,7 +21126,8 @@ impl ImportInstanceRequestSerializer {
                                                                            "LaunchSpecification"),
                                                                    field_value);
         }
-        params.put(&format!("{}{}", prefix, "Platform"), &obj.platform);
+        params.put(&format!("{}{}", prefix, "Platform"),
+                   &obj.platform.replace("+", "%2B"));
 
     }
 }
@@ -20990,11 +21400,15 @@ impl ImportKeyPairRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "KeyName"), &obj.key_name);
+        params.put(&format!("{}{}", prefix, "KeyName"),
+                   &obj.key_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "PublicKeyMaterial"),
-                   ::std::str::from_utf8(&obj.public_key_material).unwrap());
+                   ::std::str::from_utf8(&obj.public_key_material)
+                       .unwrap()
+                       .replace("+", "%2B"));
 
     }
 }
@@ -21088,10 +21502,12 @@ impl ImportSnapshotRequestSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.disk_container {
             SnapshotDiskContainerSerializer::serialize(params,
@@ -21099,10 +21515,12 @@ impl ImportSnapshotRequestSerializer {
                                                        field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.role_name {
-            params.put(&format!("{}{}", prefix, "RoleName"), &field_value);
+            params.put(&format!("{}{}", prefix, "RoleName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -21311,12 +21729,14 @@ impl ImportVolumeRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AvailabilityZone"),
-                   &obj.availability_zone);
+                   &obj.availability_zone.replace("+", "%2B"));
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         DiskImageDetailSerializer::serialize(params, &format!("{}{}", prefix, "Image"), &obj.image);
         VolumeDetailSerializer::serialize(params, &format!("{}{}", prefix, "Volume"), &obj.volume);
@@ -22008,7 +22428,8 @@ impl InstanceBlockDeviceMappingSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.device_name {
-            params.put(&format!("{}{}", prefix, "DeviceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DeviceName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ebs {
             EbsInstanceBlockDeviceSpecificationSerializer::serialize(params,
@@ -22018,10 +22439,12 @@ impl InstanceBlockDeviceMappingSpecificationSerializer {
                                                                      field_value);
         }
         if let Some(ref field_value) = obj.no_device {
-            params.put(&format!("{}{}", prefix, "NoDevice"), &field_value);
+            params.put(&format!("{}{}", prefix, "NoDevice"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.virtual_name {
-            params.put(&format!("{}{}", prefix, "VirtualName"), &field_value);
+            params.put(&format!("{}{}", prefix, "VirtualName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -22384,7 +22807,8 @@ impl InstanceIpv6AddressSerializer {
         }
 
         if let Some(ref field_value) = obj.ipv_6_address {
-            params.put(&format!("{}{}", prefix, "Ipv6Address"), &field_value);
+            params.put(&format!("{}{}", prefix, "Ipv6Address"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -23044,18 +23468,19 @@ impl InstanceNetworkInterfaceSpecificationSerializer {
 
         if let Some(ref field_value) = obj.associate_public_ip_address {
             params.put(&format!("{}{}", prefix, "AssociatePublicIpAddress"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(&format!("{}{}", prefix, "DeleteOnTermination"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.device_index {
             params.put(&format!("{}{}", prefix, "DeviceIndex"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.groups {
             SecurityGroupIdStringListSerializer::serialize(params,
@@ -23066,7 +23491,7 @@ impl InstanceNetworkInterfaceSpecificationSerializer {
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
             params.put(&format!("{}{}", prefix, "Ipv6AddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             InstanceIpv6AddressListSerializer::serialize(params,
@@ -23076,10 +23501,12 @@ impl InstanceNetworkInterfaceSpecificationSerializer {
                                                          field_value);
         }
         if let Some(ref field_value) = obj.network_interface_id {
-            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.private_ip_address {
-            params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrivateIpAddress"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.private_ip_addresses {
             PrivateIpAddressSpecificationListSerializer::serialize(params,
@@ -23090,10 +23517,11 @@ impl InstanceNetworkInterfaceSpecificationSerializer {
         }
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(&format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.subnet_id {
-            params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubnetId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -24183,10 +24611,11 @@ impl IpPermissionSerializer {
 
         if let Some(ref field_value) = obj.from_port {
             params.put(&format!("{}{}", prefix, "FromPort"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ip_protocol {
-            params.put(&format!("{}{}", prefix, "IpProtocol"), &field_value);
+            params.put(&format!("{}{}", prefix, "IpProtocol"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ip_ranges {
             IpRangeListSerializer::serialize(params,
@@ -24204,7 +24633,8 @@ impl IpPermissionSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_id_group_pairs {
             UserIdGroupPairListSerializer::serialize(params,
@@ -24328,7 +24758,8 @@ impl IpRangeSerializer {
         }
 
         if let Some(ref field_value) = obj.cidr_ip {
-            params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "CidrIp"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -24631,7 +25062,8 @@ impl Ipv6RangeSerializer {
         }
 
         if let Some(ref field_value) = obj.cidr_ipv_6 {
-            params.put(&format!("{}{}", prefix, "CidrIpv6"), &field_value);
+            params.put(&format!("{}{}", prefix, "CidrIpv6"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -24927,10 +25359,12 @@ impl LaunchPermissionSerializer {
         }
 
         if let Some(ref field_value) = obj.group {
-            params.put(&format!("{}{}", prefix, "Group"), &field_value);
+            params.put(&format!("{}{}", prefix, "Group"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_id {
-            params.put(&format!("{}{}", prefix, "UserId"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -25272,7 +25706,7 @@ impl ModifyHostsRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AutoPlacement"),
-                   &obj.auto_placement);
+                   &obj.auto_placement.replace("+", "%2B"));
         RequestHostIdListSerializer::serialize(params,
                                                &format!("{}{}", prefix, "HostId"),
                                                &obj.host_ids);
@@ -25356,9 +25790,10 @@ impl ModifyIdFormatRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Resource"), &obj.resource);
+        params.put(&format!("{}{}", prefix, "Resource"),
+                   &obj.resource.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "UseLongIds"),
-                   &obj.use_long_ids.to_string());
+                   &obj.use_long_ids.to_string().replace("+", "%2B"));
 
     }
 }
@@ -25384,10 +25819,12 @@ impl ModifyIdentityIdFormatRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PrincipalArn"), &obj.principal_arn);
-        params.put(&format!("{}{}", prefix, "Resource"), &obj.resource);
+        params.put(&format!("{}{}", prefix, "PrincipalArn"),
+                   &obj.principal_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Resource"),
+                   &obj.resource.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "UseLongIds"),
-                   &obj.use_long_ids.to_string());
+                   &obj.use_long_ids.to_string().replace("+", "%2B"));
 
     }
 }
@@ -25428,7 +25865,8 @@ impl ModifyImageAttributeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.attribute {
-            params.put(&format!("{}{}", prefix, "Attribute"), &field_value);
+            params.put(&format!("{}{}", prefix, "Attribute"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
             AttributeValueSerializer::serialize(params,
@@ -25436,9 +25874,11 @@ impl ModifyImageAttributeRequestSerializer {
                                                 field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
+        params.put(&format!("{}{}", prefix, "ImageId"),
+                   &obj.image_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.launch_permission {
             LaunchPermissionModificationsSerializer::serialize(params,
                                                                &format!("{}{}",
@@ -25447,7 +25887,8 @@ impl ModifyImageAttributeRequestSerializer {
                                                                field_value);
         }
         if let Some(ref field_value) = obj.operation_type {
-            params.put(&format!("{}{}", prefix, "OperationType"), &field_value);
+            params.put(&format!("{}{}", prefix, "OperationType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.product_codes {
             ProductCodeStringListSerializer::serialize(params,
@@ -25465,7 +25906,8 @@ impl ModifyImageAttributeRequestSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -25519,7 +25961,8 @@ impl ModifyInstanceAttributeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.attribute {
-            params.put(&format!("{}{}", prefix, "Attribute"), &field_value);
+            params.put(&format!("{}{}", prefix, "Attribute"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.block_device_mappings {
             InstanceBlockDeviceMappingSpecificationListSerializer::serialize(params,
@@ -25536,7 +25979,8 @@ impl ModifyInstanceAttributeRequestSerializer {
                                                        field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ebs_optimized {
             AttributeBooleanValueSerializer::serialize(params,
@@ -25553,7 +25997,8 @@ impl ModifyInstanceAttributeRequestSerializer {
                                                    &format!("{}{}", prefix, "GroupId"),
                                                    field_value);
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_initiated_shutdown_behavior {
             AttributeValueSerializer::serialize(params,
                                                 &format!("{}{}",
@@ -25592,7 +26037,8 @@ impl ModifyInstanceAttributeRequestSerializer {
                                                     field_value);
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -25622,14 +26068,18 @@ impl ModifyInstancePlacementRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.affinity {
-            params.put(&format!("{}{}", prefix, "Affinity"), &field_value);
+            params.put(&format!("{}{}", prefix, "Affinity"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.host_id {
-            params.put(&format!("{}{}", prefix, "HostId"), &field_value);
+            params.put(&format!("{}{}", prefix, "HostId"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tenancy {
-            params.put(&format!("{}{}", prefix, "Tenancy"), &field_value);
+            params.put(&format!("{}{}", prefix, "Tenancy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -25724,7 +26174,8 @@ impl ModifyNetworkInterfaceAttributeRequestSerializer {
                                                 field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.groups {
             SecurityGroupIdStringListSerializer::serialize(params,
@@ -25734,7 +26185,7 @@ impl ModifyNetworkInterfaceAttributeRequestSerializer {
                                                            field_value);
         }
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.source_dest_check {
             AttributeBooleanValueSerializer::serialize(params,
                                                        &format!("{}{}", prefix, "SourceDestCheck"),
@@ -25766,7 +26217,8 @@ impl ModifyReservedInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         ReservedInstancesIdStringListSerializer::serialize(params,
                                                            &format!("{}{}",
@@ -25862,7 +26314,8 @@ impl ModifySnapshotAttributeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.attribute {
-            params.put(&format!("{}{}", prefix, "Attribute"), &field_value);
+            params.put(&format!("{}{}", prefix, "Attribute"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.create_volume_permission {
             CreateVolumePermissionModificationsSerializer::serialize(params,
@@ -25872,7 +26325,8 @@ impl ModifySnapshotAttributeRequestSerializer {
                                                                      field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_names {
             GroupNameStringListSerializer::serialize(params,
@@ -25880,9 +26334,11 @@ impl ModifySnapshotAttributeRequestSerializer {
                                                      field_value);
         }
         if let Some(ref field_value) = obj.operation_type {
-            params.put(&format!("{}{}", prefix, "OperationType"), &field_value);
+            params.put(&format!("{}{}", prefix, "OperationType"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SnapshotId"), &obj.snapshot_id);
+        params.put(&format!("{}{}", prefix, "SnapshotId"),
+                   &obj.snapshot_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_ids {
             UserIdStringListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "UserId"),
@@ -25915,13 +26371,13 @@ impl ModifySpotFleetRequestRequestSerializer {
 
         if let Some(ref field_value) = obj.excess_capacity_termination_policy {
             params.put(&format!("{}{}", prefix, "ExcessCapacityTerminationPolicy"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SpotFleetRequestId"),
-                   &obj.spot_fleet_request_id);
+                   &obj.spot_fleet_request_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.target_capacity {
             params.put(&format!("{}{}", prefix, "TargetCapacity"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -26011,7 +26467,8 @@ impl ModifySubnetAttributeRequestSerializer {
                                                                "MapPublicIpOnLaunch"),
                                                        field_value);
         }
-        params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
+        params.put(&format!("{}{}", prefix, "SubnetId"),
+                   &obj.subnet_id.replace("+", "%2B"));
 
     }
 }
@@ -26043,9 +26500,11 @@ impl ModifyVolumeAttributeRequestSerializer {
                                                        field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
+        params.put(&format!("{}{}", prefix, "VolumeId"),
+                   &obj.volume_id.replace("+", "%2B"));
 
     }
 }
@@ -26074,17 +26533,22 @@ impl ModifyVolumeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.size {
-            params.put(&format!("{}{}", prefix, "Size"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Size"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
+        params.put(&format!("{}{}", prefix, "VolumeId"),
+                   &obj.volume_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.volume_type {
-            params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "VolumeType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -26174,7 +26638,8 @@ impl ModifyVpcAttributeRequestSerializer {
                                                                "EnableDnsSupport"),
                                                        field_value);
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -26212,10 +26677,12 @@ impl ModifyVpcEndpointRequestSerializer {
                                                  field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.policy_document {
-            params.put(&format!("{}{}", prefix, "PolicyDocument"), &field_value);
+            params.put(&format!("{}{}", prefix, "PolicyDocument"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.remove_route_table_ids {
             ValueStringListSerializer::serialize(params,
@@ -26224,10 +26691,10 @@ impl ModifyVpcEndpointRequestSerializer {
         }
         if let Some(ref field_value) = obj.reset_policy {
             params.put(&format!("{}{}", prefix, "ResetPolicy"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "VpcEndpointId"),
-                   &obj.vpc_endpoint_id);
+                   &obj.vpc_endpoint_id.replace("+", "%2B"));
 
     }
 }
@@ -26311,7 +26778,8 @@ impl ModifyVpcPeeringConnectionOptionsRequestSerializer {
                                                                  field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.requester_peering_connection_options {
             PeeringConnectionOptionsRequestSerializer::serialize(params,
@@ -26321,7 +26789,7 @@ impl ModifyVpcPeeringConnectionOptionsRequestSerializer {
                                                                  field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcPeeringConnectionId"),
-                   &obj.vpc_peering_connection_id);
+                   &obj.vpc_peering_connection_id.replace("+", "%2B"));
 
     }
 }
@@ -26399,7 +26867,8 @@ impl MonitorInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         InstanceIdStringListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "InstanceId"),
@@ -26541,9 +27010,11 @@ impl MoveAddressToVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PublicIp"), &obj.public_ip);
+        params.put(&format!("{}{}", prefix, "PublicIp"),
+                   &obj.public_ip.replace("+", "%2B"));
 
     }
 }
@@ -27691,11 +28162,12 @@ impl NetworkInterfaceAttachmentChangesSerializer {
         }
 
         if let Some(ref field_value) = obj.attachment_id {
-            params.put(&format!("{}{}", prefix, "AttachmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "AttachmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(&format!("{}{}", prefix, "DeleteOnTermination"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -28207,7 +28679,8 @@ impl NewDhcpConfigurationSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.values {
             ValueStringListSerializer::serialize(params,
@@ -28506,15 +28979,15 @@ impl PeeringConnectionOptionsRequestSerializer {
 
         if let Some(ref field_value) = obj.allow_dns_resolution_from_remote_vpc {
             params.put(&format!("{}{}", prefix, "AllowDnsResolutionFromRemoteVpc"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.allow_egress_from_local_classic_link_to_remote_vpc {
             params.put(&format!("{}{}", prefix, "AllowEgressFromLocalClassicLinkToRemoteVpc"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.allow_egress_from_local_vpc_to_remote_classic_link {
             params.put(&format!("{}{}", prefix, "AllowEgressFromLocalVpcToRemoteClassicLink"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -28625,22 +29098,28 @@ impl PlacementSerializer {
         }
 
         if let Some(ref field_value) = obj.affinity {
-            params.put(&format!("{}{}", prefix, "Affinity"), &field_value);
+            params.put(&format!("{}{}", prefix, "Affinity"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.host_id {
-            params.put(&format!("{}{}", prefix, "HostId"), &field_value);
+            params.put(&format!("{}{}", prefix, "HostId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.spread_domain {
-            params.put(&format!("{}{}", prefix, "SpreadDomain"), &field_value);
+            params.put(&format!("{}{}", prefix, "SpreadDomain"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tenancy {
-            params.put(&format!("{}{}", prefix, "Tenancy"), &field_value);
+            params.put(&format!("{}{}", prefix, "Tenancy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -28868,10 +29347,12 @@ impl PortRangeSerializer {
         }
 
         if let Some(ref field_value) = obj.from {
-            params.put(&format!("{}{}", prefix, "From"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "From"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.to {
-            params.put(&format!("{}{}", prefix, "To"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "To"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -28999,7 +29480,8 @@ impl PrefixListIdSerializer {
         }
 
         if let Some(ref field_value) = obj.prefix_list_id {
-            params.put(&format!("{}{}", prefix, "PrefixListId"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrefixListId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -29269,13 +29751,16 @@ impl PriceScheduleSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.currency_code {
-            params.put(&format!("{}{}", prefix, "CurrencyCode"), &field_value);
+            params.put(&format!("{}{}", prefix, "CurrencyCode"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.price {
-            params.put(&format!("{}{}", prefix, "Price"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Price"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.term {
-            params.put(&format!("{}{}", prefix, "Term"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Term"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -29469,10 +29954,10 @@ impl PrivateIpAddressSpecificationSerializer {
 
         if let Some(ref field_value) = obj.primary {
             params.put(&format!("{}{}", prefix, "Primary"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "PrivateIpAddress"),
-                   &obj.private_ip_address);
+                   &obj.private_ip_address.replace("+", "%2B"));
 
     }
 }
@@ -29975,18 +30460,22 @@ impl PurchaseHostReservationRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.currency_code {
-            params.put(&format!("{}{}", prefix, "CurrencyCode"), &field_value);
+            params.put(&format!("{}{}", prefix, "CurrencyCode"),
+                       &field_value.replace("+", "%2B"));
         }
         RequestHostIdSetSerializer::serialize(params,
                                               &format!("{}{}", prefix, "HostIdSet"),
                                               &obj.host_id_set);
         if let Some(ref field_value) = obj.limit_price {
-            params.put(&format!("{}{}", prefix, "LimitPrice"), &field_value);
+            params.put(&format!("{}{}", prefix, "LimitPrice"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "OfferingId"), &obj.offering_id);
+        params.put(&format!("{}{}", prefix, "OfferingId"),
+                   &obj.offering_id.replace("+", "%2B"));
 
     }
 }
@@ -30086,9 +30575,9 @@ impl PurchaseRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "InstanceCount"),
-                   &obj.instance_count.to_string());
+                   &obj.instance_count.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "PurchaseToken"),
-                   &obj.purchase_token);
+                   &obj.purchase_token.replace("+", "%2B"));
 
     }
 }
@@ -30129,17 +30618,18 @@ impl PurchaseReservedInstancesOfferingRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "InstanceCount"),
-                   &obj.instance_count.to_string());
+                   &obj.instance_count.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.limit_price {
             ReservedInstanceLimitPriceSerializer::serialize(params,
                                                             &format!("{}{}", prefix, "LimitPrice"),
                                                             field_value);
         }
         params.put(&format!("{}{}", prefix, "ReservedInstancesOfferingId"),
-                   &obj.reserved_instances_offering_id);
+                   &obj.reserved_instances_offering_id.replace("+", "%2B"));
 
     }
 }
@@ -30217,10 +30707,12 @@ impl PurchaseScheduledInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         PurchaseRequestSetSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "PurchaseRequest"),
@@ -30406,7 +30898,8 @@ impl RebootInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         InstanceIdStringListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "InstanceId"),
@@ -30674,7 +31167,8 @@ impl RegisterImageRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.architecture {
-            params.put(&format!("{}{}", prefix, "Architecture"), &field_value);
+            params.put(&format!("{}{}", prefix, "Architecture"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.billing_products {
             BillingProductListSerializer::serialize(params,
@@ -30689,33 +31183,42 @@ impl RegisterImageRequestSerializer {
                                                                field_value);
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ena_support {
             params.put(&format!("{}{}", prefix, "EnaSupport"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.image_location {
-            params.put(&format!("{}{}", prefix, "ImageLocation"), &field_value);
+            params.put(&format!("{}{}", prefix, "ImageLocation"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kernel_id {
-            params.put(&format!("{}{}", prefix, "KernelId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KernelId"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ramdisk_id {
-            params.put(&format!("{}{}", prefix, "RamdiskId"), &field_value);
+            params.put(&format!("{}{}", prefix, "RamdiskId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.root_device_name {
-            params.put(&format!("{}{}", prefix, "RootDeviceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "RootDeviceName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sriov_net_support {
-            params.put(&format!("{}{}", prefix, "SriovNetSupport"), &field_value);
+            params.put(&format!("{}{}", prefix, "SriovNetSupport"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.virtualization_type {
-            params.put(&format!("{}{}", prefix, "VirtualizationType"), &field_value);
+            params.put(&format!("{}{}", prefix, "VirtualizationType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -30790,10 +31293,11 @@ impl RejectVpcPeeringConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "VpcPeeringConnectionId"),
-                   &obj.vpc_peering_connection_id);
+                   &obj.vpc_peering_connection_id.replace("+", "%2B"));
 
     }
 }
@@ -30870,13 +31374,16 @@ impl ReleaseAddressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.allocation_id {
-            params.put(&format!("{}{}", prefix, "AllocationId"), &field_value);
+            params.put(&format!("{}{}", prefix, "AllocationId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.public_ip {
-            params.put(&format!("{}{}", prefix, "PublicIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "PublicIp"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -30984,7 +31491,7 @@ impl ReplaceIamInstanceProfileAssociationRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AssociationId"),
-                   &obj.association_id);
+                   &obj.association_id.replace("+", "%2B"));
         IamInstanceProfileSpecificationSerializer::serialize(params,
                                                              &format!("{}{}",
                                                                      prefix,
@@ -31064,12 +31571,13 @@ impl ReplaceNetworkAclAssociationRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AssociationId"),
-                   &obj.association_id);
+                   &obj.association_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkAclId"),
-                   &obj.network_acl_id);
+                   &obj.network_acl_id.replace("+", "%2B"));
 
     }
 }
@@ -31161,31 +31669,37 @@ impl ReplaceNetworkAclEntryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.cidr_block {
-            params.put(&format!("{}{}", prefix, "CidrBlock"), &field_value);
+            params.put(&format!("{}{}", prefix, "CidrBlock"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress.to_string());
+        params.put(&format!("{}{}", prefix, "Egress"),
+                   &obj.egress.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.icmp_type_code {
             IcmpTypeCodeSerializer::serialize(params,
                                               &format!("{}{}", prefix, "Icmp"),
                                               field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_cidr_block {
-            params.put(&format!("{}{}", prefix, "Ipv6CidrBlock"), &field_value);
+            params.put(&format!("{}{}", prefix, "Ipv6CidrBlock"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkAclId"),
-                   &obj.network_acl_id);
+                   &obj.network_acl_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.port_range {
             PortRangeSerializer::serialize(params,
                                            &format!("{}{}", prefix, "PortRange"),
                                            field_value);
         }
-        params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
-        params.put(&format!("{}{}", prefix, "RuleAction"), &obj.rule_action);
+        params.put(&format!("{}{}", prefix, "Protocol"),
+                   &obj.protocol.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RuleAction"),
+                   &obj.rule_action.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "RuleNumber"),
-                   &obj.rule_number.to_string());
+                   &obj.rule_number.to_string().replace("+", "%2B"));
 
     }
 }
@@ -31227,36 +31741,41 @@ impl ReplaceRouteRequestSerializer {
 
         if let Some(ref field_value) = obj.destination_cidr_block {
             params.put(&format!("{}{}", prefix, "DestinationCidrBlock"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.destination_ipv_6_cidr_block {
             params.put(&format!("{}{}", prefix, "DestinationIpv6CidrBlock"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.egress_only_internet_gateway_id {
             params.put(&format!("{}{}", prefix, "EgressOnlyInternetGatewayId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.gateway_id {
-            params.put(&format!("{}{}", prefix, "GatewayId"), &field_value);
+            params.put(&format!("{}{}", prefix, "GatewayId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.nat_gateway_id {
-            params.put(&format!("{}{}", prefix, "NatGatewayId"), &field_value);
+            params.put(&format!("{}{}", prefix, "NatGatewayId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.network_interface_id {
-            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "RouteTableId"),
-                   &obj.route_table_id);
+                   &obj.route_table_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.vpc_peering_connection_id {
             params.put(&format!("{}{}", prefix, "VpcPeeringConnectionId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -31284,12 +31803,13 @@ impl ReplaceRouteTableAssociationRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AssociationId"),
-                   &obj.association_id);
+                   &obj.association_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "RouteTableId"),
-                   &obj.route_table_id);
+                   &obj.route_table_id.replace("+", "%2B"));
 
     }
 }
@@ -31375,13 +31895,16 @@ impl ReportInstanceStatusRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         InstanceIdStringListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "InstanceId"),
@@ -31390,9 +31913,11 @@ impl ReportInstanceStatusRequestSerializer {
                                              &format!("{}{}", prefix, "ReasonCode"),
                                              &obj.reason_codes);
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Status"), &obj.status);
+        params.put(&format!("{}{}", prefix, "Status"),
+                   &obj.status.replace("+", "%2B"));
 
     }
 }
@@ -31441,7 +31966,8 @@ impl RequestSpotFleetRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         SpotFleetRequestConfigDataSerializer::serialize(params,
                                                         &format!("{}{}",
@@ -31540,24 +32066,27 @@ impl RequestSpotInstancesRequestSerializer {
 
         if let Some(ref field_value) = obj.availability_zone_group {
             params.put(&format!("{}{}", prefix, "AvailabilityZoneGroup"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.block_duration_minutes {
             params.put(&format!("{}{}", prefix, "BlockDurationMinutes"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_count {
             params.put(&format!("{}{}", prefix, "InstanceCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.launch_group {
-            params.put(&format!("{}{}", prefix, "LaunchGroup"), &field_value);
+            params.put(&format!("{}{}", prefix, "LaunchGroup"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.launch_specification {
             RequestSpotLaunchSpecificationSerializer::serialize(params,
@@ -31566,15 +32095,19 @@ impl RequestSpotInstancesRequestSerializer {
                                                                         "LaunchSpecification"),
                                                                 field_value);
         }
-        params.put(&format!("{}{}", prefix, "SpotPrice"), &obj.spot_price);
+        params.put(&format!("{}{}", prefix, "SpotPrice"),
+                   &obj.spot_price.replace("+", "%2B"));
         if let Some(ref field_value) = obj.type_ {
-            params.put(&format!("{}{}", prefix, "Type"), &field_value);
+            params.put(&format!("{}{}", prefix, "Type"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.valid_from {
-            params.put(&format!("{}{}", prefix, "ValidFrom"), &field_value);
+            params.put(&format!("{}{}", prefix, "ValidFrom"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.valid_until {
-            params.put(&format!("{}{}", prefix, "ValidUntil"), &field_value);
+            params.put(&format!("{}{}", prefix, "ValidUntil"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -31678,7 +32211,8 @@ impl RequestSpotLaunchSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.addressing_type {
-            params.put(&format!("{}{}", prefix, "AddressingType"), &field_value);
+            params.put(&format!("{}{}", prefix, "AddressingType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.block_device_mappings {
             BlockDeviceMappingListSerializer::serialize(params,
@@ -31689,7 +32223,7 @@ impl RequestSpotLaunchSpecificationSerializer {
         }
         if let Some(ref field_value) = obj.ebs_optimized {
             params.put(&format!("{}{}", prefix, "EbsOptimized"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iam_instance_profile {
             IamInstanceProfileSpecificationSerializer::serialize(params,
@@ -31699,16 +32233,20 @@ impl RequestSpotLaunchSpecificationSerializer {
                                                                  field_value);
         }
         if let Some(ref field_value) = obj.image_id {
-            params.put(&format!("{}{}", prefix, "ImageId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ImageId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_type {
-            params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kernel_id {
-            params.put(&format!("{}{}", prefix, "KernelId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KernelId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.key_name {
-            params.put(&format!("{}{}", prefix, "KeyName"), &field_value);
+            params.put(&format!("{}{}", prefix, "KeyName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring {
             RunInstancesMonitoringEnabledSerializer::serialize(params,
@@ -31730,7 +32268,8 @@ impl RequestSpotLaunchSpecificationSerializer {
                                                field_value);
         }
         if let Some(ref field_value) = obj.ramdisk_id {
-            params.put(&format!("{}{}", prefix, "RamdiskId"), &field_value);
+            params.put(&format!("{}{}", prefix, "RamdiskId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_group_ids {
             ValueStringListSerializer::serialize(params,
@@ -31743,10 +32282,12 @@ impl RequestSpotLaunchSpecificationSerializer {
                                                  field_value);
         }
         if let Some(ref field_value) = obj.subnet_id {
-            params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubnetId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_data {
-            params.put(&format!("{}{}", prefix, "UserData"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserData"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -31977,10 +32518,12 @@ impl ReservedInstanceLimitPriceSerializer {
         }
 
         if let Some(ref field_value) = obj.amount {
-            params.put(&format!("{}{}", prefix, "Amount"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Amount"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.currency_code {
-            params.put(&format!("{}{}", prefix, "CurrencyCode"), &field_value);
+            params.put(&format!("{}{}", prefix, "CurrencyCode"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -32346,20 +32889,24 @@ impl ReservedInstancesConfigurationSerializer {
         }
 
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_count {
             params.put(&format!("{}{}", prefix, "InstanceCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_type {
-            params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.platform {
-            params.put(&format!("{}{}", prefix, "Platform"), &field_value);
+            params.put(&format!("{}{}", prefix, "Platform"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.scope {
-            params.put(&format!("{}{}", prefix, "Scope"), &field_value);
+            params.put(&format!("{}{}", prefix, "Scope"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -33138,11 +33685,14 @@ impl ResetImageAttributeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
+        params.put(&format!("{}{}", prefix, "Attribute"),
+                   &obj.attribute.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
+        params.put(&format!("{}{}", prefix, "ImageId"),
+                   &obj.image_id.replace("+", "%2B"));
 
     }
 }
@@ -33168,11 +33718,14 @@ impl ResetInstanceAttributeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
+        params.put(&format!("{}{}", prefix, "Attribute"),
+                   &obj.attribute.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
+        params.put(&format!("{}{}", prefix, "InstanceId"),
+                   &obj.instance_id.replace("+", "%2B"));
 
     }
 }
@@ -33199,12 +33752,14 @@ impl ResetNetworkInterfaceAttributeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.source_dest_check {
-            params.put(&format!("{}{}", prefix, "SourceDestCheck"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceDestCheck"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -33231,11 +33786,14 @@ impl ResetSnapshotAttributeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
+        params.put(&format!("{}{}", prefix, "Attribute"),
+                   &obj.attribute.replace("+", "%2B"));
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SnapshotId"), &obj.snapshot_id);
+        params.put(&format!("{}{}", prefix, "SnapshotId"),
+                   &obj.snapshot_id.replace("+", "%2B"));
 
     }
 }
@@ -33380,9 +33938,11 @@ impl RestoreAddressToClassicRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PublicIp"), &obj.public_ip);
+        params.put(&format!("{}{}", prefix, "PublicIp"),
+                   &obj.public_ip.replace("+", "%2B"));
 
     }
 }
@@ -33476,34 +34036,39 @@ impl RevokeSecurityGroupEgressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.cidr_ip {
-            params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "CidrIp"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.from_port {
             params.put(&format!("{}{}", prefix, "FromPort"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "GroupId"), &obj.group_id);
+        params.put(&format!("{}{}", prefix, "GroupId"),
+                   &obj.group_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ip_permissions {
             IpPermissionListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "IpPermissions"),
                                                   field_value);
         }
         if let Some(ref field_value) = obj.ip_protocol {
-            params.put(&format!("{}{}", prefix, "IpProtocol"), &field_value);
+            params.put(&format!("{}{}", prefix, "IpProtocol"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_security_group_name {
             params.put(&format!("{}{}", prefix, "SourceSecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_security_group_owner_id {
             params.put(&format!("{}{}", prefix, "SourceSecurityGroupOwnerId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -33545,20 +34110,24 @@ impl RevokeSecurityGroupIngressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.cidr_ip {
-            params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "CidrIp"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.from_port {
             params.put(&format!("{}{}", prefix, "FromPort"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_id {
-            params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ip_permissions {
             IpPermissionListSerializer::serialize(params,
@@ -33566,18 +34135,20 @@ impl RevokeSecurityGroupIngressRequestSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.ip_protocol {
-            params.put(&format!("{}{}", prefix, "IpProtocol"), &field_value);
+            params.put(&format!("{}{}", prefix, "IpProtocol"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_security_group_name {
             params.put(&format!("{}{}", prefix, "SourceSecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_security_group_owner_id {
             params.put(&format!("{}{}", prefix, "SourceSecurityGroupOwnerId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -34076,7 +34647,7 @@ impl RunInstancesMonitoringEnabledSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "Enabled"),
-                   &obj.enabled.to_string());
+                   &obj.enabled.to_string().replace("+", "%2B"));
 
     }
 }
@@ -34151,7 +34722,8 @@ impl RunInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.additional_info {
-            params.put(&format!("{}{}", prefix, "AdditionalInfo"), &field_value);
+            params.put(&format!("{}{}", prefix, "AdditionalInfo"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.block_device_mappings {
             BlockDeviceMappingRequestListSerializer::serialize(params,
@@ -34161,18 +34733,20 @@ impl RunInstancesRequestSerializer {
                                                                field_value);
         }
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.disable_api_termination {
             params.put(&format!("{}{}", prefix, "DisableApiTermination"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ebs_optimized {
             params.put(&format!("{}{}", prefix, "EbsOptimized"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.elastic_gpu_specification {
             ElasticGpuSpecificationsSerializer::serialize(params,
@@ -34188,17 +34762,19 @@ impl RunInstancesRequestSerializer {
                                                                          "IamInstanceProfile"),
                                                                  field_value);
         }
-        params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
+        params.put(&format!("{}{}", prefix, "ImageId"),
+                   &obj.image_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_initiated_shutdown_behavior {
             params.put(&format!("{}{}", prefix, "InstanceInitiatedShutdownBehavior"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_type {
-            params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
             params.put(&format!("{}{}", prefix, "Ipv6AddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             InstanceIpv6AddressListSerializer::serialize(params,
@@ -34206,15 +34782,17 @@ impl RunInstancesRequestSerializer {
                                                          field_value);
         }
         if let Some(ref field_value) = obj.kernel_id {
-            params.put(&format!("{}{}", prefix, "KernelId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KernelId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.key_name {
-            params.put(&format!("{}{}", prefix, "KeyName"), &field_value);
+            params.put(&format!("{}{}", prefix, "KeyName"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "MaxCount"),
-                   &obj.max_count.to_string());
+                   &obj.max_count.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "MinCount"),
-                   &obj.min_count.to_string());
+                   &obj.min_count.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.monitoring {
             RunInstancesMonitoringEnabledSerializer::serialize(params,
                                                                &format!("{}{}",
@@ -34235,10 +34813,12 @@ impl RunInstancesRequestSerializer {
                                            field_value);
         }
         if let Some(ref field_value) = obj.private_ip_address {
-            params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrivateIpAddress"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ramdisk_id {
-            params.put(&format!("{}{}", prefix, "RamdiskId"), &field_value);
+            params.put(&format!("{}{}", prefix, "RamdiskId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_group_ids {
             SecurityGroupIdStringListSerializer::serialize(params,
@@ -34253,7 +34833,8 @@ impl RunInstancesRequestSerializer {
                                                          field_value);
         }
         if let Some(ref field_value) = obj.subnet_id {
-            params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubnetId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_specifications {
             TagSpecificationListSerializer::serialize(params,
@@ -34261,7 +34842,8 @@ impl RunInstancesRequestSerializer {
                                                       field_value);
         }
         if let Some(ref field_value) = obj.user_data {
-            params.put(&format!("{}{}", prefix, "UserData"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserData"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -34293,14 +34875,16 @@ impl RunScheduledInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_count {
             params.put(&format!("{}{}", prefix, "InstanceCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         ScheduledInstancesLaunchSpecificationSerializer::serialize(params,
                                                                    &format!("{}{}",
@@ -34308,7 +34892,7 @@ impl RunScheduledInstancesRequestSerializer {
                                                                            "LaunchSpecification"),
                                                                    &obj.launch_specification);
         params.put(&format!("{}{}", prefix, "ScheduledInstanceId"),
-                   &obj.scheduled_instance_id);
+                   &obj.scheduled_instance_id.replace("+", "%2B"));
 
     }
 }
@@ -34449,21 +35033,26 @@ impl S3StorageSerializer {
         }
 
         if let Some(ref field_value) = obj.aws_access_key_id {
-            params.put(&format!("{}{}", prefix, "AWSAccessKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "AWSAccessKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.bucket {
-            params.put(&format!("{}{}", prefix, "Bucket"), &field_value);
+            params.put(&format!("{}{}", prefix, "Bucket"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.prefix {
-            params.put(&format!("{}{}", prefix, "Prefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "Prefix"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.upload_policy {
             params.put(&format!("{}{}", prefix, "UploadPolicy"),
-                       ::std::str::from_utf8(&field_value).unwrap());
+                       ::std::str::from_utf8(&field_value)
+                           .unwrap()
+                           .replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.upload_policy_signature {
             params.put(&format!("{}{}", prefix, "UploadPolicySignature"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -34894,11 +35483,12 @@ impl ScheduledInstanceRecurrenceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.frequency {
-            params.put(&format!("{}{}", prefix, "Frequency"), &field_value);
+            params.put(&format!("{}{}", prefix, "Frequency"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.interval {
             params.put(&format!("{}{}", prefix, "Interval"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.occurrence_days {
             OccurrenceDayRequestSetSerializer::serialize(params,
@@ -34907,10 +35497,11 @@ impl ScheduledInstanceRecurrenceRequestSerializer {
         }
         if let Some(ref field_value) = obj.occurrence_relative_to_end {
             params.put(&format!("{}{}", prefix, "OccurrenceRelativeToEnd"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.occurrence_unit {
-            params.put(&format!("{}{}", prefix, "OccurrenceUnit"), &field_value);
+            params.put(&format!("{}{}", prefix, "OccurrenceUnit"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -34981,7 +35572,8 @@ impl ScheduledInstancesBlockDeviceMappingSerializer {
         }
 
         if let Some(ref field_value) = obj.device_name {
-            params.put(&format!("{}{}", prefix, "DeviceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DeviceName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ebs {
             ScheduledInstancesEbsSerializer::serialize(params,
@@ -34989,10 +35581,12 @@ impl ScheduledInstancesBlockDeviceMappingSerializer {
                                                        field_value);
         }
         if let Some(ref field_value) = obj.no_device {
-            params.put(&format!("{}{}", prefix, "NoDevice"), &field_value);
+            params.put(&format!("{}{}", prefix, "NoDevice"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.virtual_name {
-            params.put(&format!("{}{}", prefix, "VirtualName"), &field_value);
+            params.put(&format!("{}{}", prefix, "VirtualName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -35041,24 +35635,27 @@ impl ScheduledInstancesEbsSerializer {
 
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(&format!("{}{}", prefix, "DeleteOnTermination"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.encrypted {
             params.put(&format!("{}{}", prefix, "Encrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_id {
-            params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_size {
             params.put(&format!("{}{}", prefix, "VolumeSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.volume_type {
-            params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "VolumeType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -35084,10 +35681,12 @@ impl ScheduledInstancesIamInstanceProfileSerializer {
         }
 
         if let Some(ref field_value) = obj.arn {
-            params.put(&format!("{}{}", prefix, "Arn"), &field_value);
+            params.put(&format!("{}{}", prefix, "Arn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "Name"), &field_value);
+            params.put(&format!("{}{}", prefix, "Name"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -35111,7 +35710,8 @@ impl ScheduledInstancesIpv6AddressSerializer {
         }
 
         if let Some(ref field_value) = obj.ipv_6_address {
-            params.put(&format!("{}{}", prefix, "Ipv6Address"), &field_value);
+            params.put(&format!("{}{}", prefix, "Ipv6Address"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -35181,7 +35781,7 @@ impl ScheduledInstancesLaunchSpecificationSerializer {
         }
         if let Some(ref field_value) = obj.ebs_optimized {
             params.put(&format!("{}{}", prefix, "EbsOptimized"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iam_instance_profile {
             ScheduledInstancesIamInstanceProfileSerializer::serialize(params,
@@ -35190,15 +35790,19 @@ impl ScheduledInstancesLaunchSpecificationSerializer {
                                                                               "IamInstanceProfile"),
                                                                       field_value);
         }
-        params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
+        params.put(&format!("{}{}", prefix, "ImageId"),
+                   &obj.image_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_type {
-            params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kernel_id {
-            params.put(&format!("{}{}", prefix, "KernelId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KernelId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.key_name {
-            params.put(&format!("{}{}", prefix, "KeyName"), &field_value);
+            params.put(&format!("{}{}", prefix, "KeyName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring {
             ScheduledInstancesMonitoringSerializer::serialize(params,
@@ -35220,7 +35824,8 @@ impl ScheduledInstancesLaunchSpecificationSerializer {
                                                              field_value);
         }
         if let Some(ref field_value) = obj.ramdisk_id {
-            params.put(&format!("{}{}", prefix, "RamdiskId"), &field_value);
+            params.put(&format!("{}{}", prefix, "RamdiskId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_group_ids {
             ScheduledInstancesSecurityGroupIdSetSerializer::serialize(params,
@@ -35230,10 +35835,12 @@ impl ScheduledInstancesLaunchSpecificationSerializer {
                                                                       field_value);
         }
         if let Some(ref field_value) = obj.subnet_id {
-            params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubnetId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_data {
-            params.put(&format!("{}{}", prefix, "UserData"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserData"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -35258,7 +35865,7 @@ impl ScheduledInstancesMonitoringSerializer {
 
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -35305,18 +35912,19 @@ impl ScheduledInstancesNetworkInterfaceSerializer {
 
         if let Some(ref field_value) = obj.associate_public_ip_address {
             params.put(&format!("{}{}", prefix, "AssociatePublicIpAddress"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(&format!("{}{}", prefix, "DeleteOnTermination"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.device_index {
             params.put(&format!("{}{}", prefix, "DeviceIndex"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.groups {
             ScheduledInstancesSecurityGroupIdSetSerializer::serialize(params,
@@ -35327,7 +35935,7 @@ impl ScheduledInstancesNetworkInterfaceSerializer {
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
             params.put(&format!("{}{}", prefix, "Ipv6AddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             ScheduledInstancesIpv6AddressListSerializer::serialize(params,
@@ -35337,10 +35945,12 @@ impl ScheduledInstancesNetworkInterfaceSerializer {
                                                                    field_value);
         }
         if let Some(ref field_value) = obj.network_interface_id {
-            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.private_ip_address {
-            params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrivateIpAddress"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.private_ip_address_configs {
             PrivateIpAddressConfigSetSerializer::serialize(params,
@@ -35351,10 +35961,11 @@ impl ScheduledInstancesNetworkInterfaceSerializer {
         }
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(&format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.subnet_id {
-            params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubnetId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -35392,10 +36003,12 @@ impl ScheduledInstancesPlacementSerializer {
         }
 
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -35422,10 +36035,11 @@ impl ScheduledInstancesPrivateIpAddressConfigSerializer {
 
         if let Some(ref field_value) = obj.primary {
             params.put(&format!("{}{}", prefix, "Primary"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.private_ip_address {
-            params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrivateIpAddress"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -35778,8 +36392,10 @@ impl SlotDateTimeRangeRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "EarliestTime"), &obj.earliest_time);
-        params.put(&format!("{}{}", prefix, "LatestTime"), &obj.latest_time);
+        params.put(&format!("{}{}", prefix, "EarliestTime"),
+                   &obj.earliest_time.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "LatestTime"),
+                   &obj.latest_time.replace("+", "%2B"));
 
     }
 }
@@ -35804,10 +36420,12 @@ impl SlotStartTimeRangeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.earliest_time {
-            params.put(&format!("{}{}", prefix, "EarliestTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EarliestTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.latest_time {
-            params.put(&format!("{}{}", prefix, "LatestTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "LatestTime"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -36109,13 +36727,16 @@ impl SnapshotDiskContainerSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.format {
-            params.put(&format!("{}{}", prefix, "Format"), &field_value);
+            params.put(&format!("{}{}", prefix, "Format"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.url {
-            params.put(&format!("{}{}", prefix, "Url"), &field_value);
+            params.put(&format!("{}{}", prefix, "Url"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_bucket {
             UserBucketSerializer::serialize(params,
@@ -36529,7 +37150,8 @@ impl SpotFleetLaunchSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.addressing_type {
-            params.put(&format!("{}{}", prefix, "AddressingType"), &field_value);
+            params.put(&format!("{}{}", prefix, "AddressingType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.block_device_mappings {
             BlockDeviceMappingListSerializer::serialize(params,
@@ -36540,7 +37162,7 @@ impl SpotFleetLaunchSpecificationSerializer {
         }
         if let Some(ref field_value) = obj.ebs_optimized {
             params.put(&format!("{}{}", prefix, "EbsOptimized"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iam_instance_profile {
             IamInstanceProfileSpecificationSerializer::serialize(params,
@@ -36550,16 +37172,20 @@ impl SpotFleetLaunchSpecificationSerializer {
                                                                  field_value);
         }
         if let Some(ref field_value) = obj.image_id {
-            params.put(&format!("{}{}", prefix, "ImageId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ImageId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.instance_type {
-            params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kernel_id {
-            params.put(&format!("{}{}", prefix, "KernelId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KernelId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.key_name {
-            params.put(&format!("{}{}", prefix, "KeyName"), &field_value);
+            params.put(&format!("{}{}", prefix, "KeyName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring {
             SpotFleetMonitoringSerializer::serialize(params,
@@ -36579,7 +37205,8 @@ impl SpotFleetLaunchSpecificationSerializer {
                                                field_value);
         }
         if let Some(ref field_value) = obj.ramdisk_id {
-            params.put(&format!("{}{}", prefix, "RamdiskId"), &field_value);
+            params.put(&format!("{}{}", prefix, "RamdiskId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_groups {
             GroupIdentifierListSerializer::serialize(params,
@@ -36587,10 +37214,12 @@ impl SpotFleetLaunchSpecificationSerializer {
                                                      field_value);
         }
         if let Some(ref field_value) = obj.spot_price {
-            params.put(&format!("{}{}", prefix, "SpotPrice"), &field_value);
+            params.put(&format!("{}{}", prefix, "SpotPrice"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.subnet_id {
-            params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubnetId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_specifications {
             SpotFleetTagSpecificationListSerializer::serialize(params,
@@ -36600,11 +37229,12 @@ impl SpotFleetLaunchSpecificationSerializer {
                                                                field_value);
         }
         if let Some(ref field_value) = obj.user_data {
-            params.put(&format!("{}{}", prefix, "UserData"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserData"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.weighted_capacity {
             params.put(&format!("{}{}", prefix, "WeightedCapacity"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -36671,7 +37301,7 @@ impl SpotFleetMonitoringSerializer {
 
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -36889,43 +37519,49 @@ impl SpotFleetRequestConfigDataSerializer {
         }
 
         if let Some(ref field_value) = obj.allocation_strategy {
-            params.put(&format!("{}{}", prefix, "AllocationStrategy"), &field_value);
+            params.put(&format!("{}{}", prefix, "AllocationStrategy"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.client_token {
-            params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClientToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.excess_capacity_termination_policy {
             params.put(&format!("{}{}", prefix, "ExcessCapacityTerminationPolicy"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.fulfilled_capacity {
             params.put(&format!("{}{}", prefix, "FulfilledCapacity"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "IamFleetRole"),
-                   &obj.iam_fleet_role);
+                   &obj.iam_fleet_role.replace("+", "%2B"));
         LaunchSpecsListSerializer::serialize(params,
                                              &format!("{}{}", prefix, "LaunchSpecifications"),
                                              &obj.launch_specifications);
         if let Some(ref field_value) = obj.replace_unhealthy_instances {
             params.put(&format!("{}{}", prefix, "ReplaceUnhealthyInstances"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SpotPrice"), &obj.spot_price);
+        params.put(&format!("{}{}", prefix, "SpotPrice"),
+                   &obj.spot_price.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "TargetCapacity"),
-                   &obj.target_capacity.to_string());
+                   &obj.target_capacity.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.terminate_instances_with_expiration {
             params.put(&format!("{}{}", prefix, "TerminateInstancesWithExpiration"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.type_ {
-            params.put(&format!("{}{}", prefix, "Type"), &field_value);
+            params.put(&format!("{}{}", prefix, "Type"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.valid_from {
-            params.put(&format!("{}{}", prefix, "ValidFrom"), &field_value);
+            params.put(&format!("{}{}", prefix, "ValidFrom"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.valid_until {
-            params.put(&format!("{}{}", prefix, "ValidUntil"), &field_value);
+            params.put(&format!("{}{}", prefix, "ValidUntil"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -37039,7 +37675,8 @@ impl SpotFleetTagSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.resource_type {
-            params.put(&format!("{}{}", prefix, "ResourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tag"), field_value);
@@ -37532,13 +38169,16 @@ impl SpotPlacementSerializer {
         }
 
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tenancy {
-            params.put(&format!("{}{}", prefix, "Tenancy"), &field_value);
+            params.put(&format!("{}{}", prefix, "Tenancy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -37926,10 +38566,12 @@ impl StartInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.additional_info {
-            params.put(&format!("{}{}", prefix, "AdditionalInfo"), &field_value);
+            params.put(&format!("{}{}", prefix, "AdditionalInfo"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         InstanceIdStringListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "InstanceId"),
@@ -38120,10 +38762,12 @@ impl StopInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         InstanceIdStringListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "InstanceId"),
@@ -38267,10 +38911,12 @@ impl StorageLocationSerializer {
         }
 
         if let Some(ref field_value) = obj.bucket {
-            params.put(&format!("{}{}", prefix, "Bucket"), &field_value);
+            params.put(&format!("{}{}", prefix, "Bucket"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -38719,10 +39365,12 @@ impl TagSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -38908,7 +39556,8 @@ impl TagSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.resource_type {
-            params.put(&format!("{}{}", prefix, "ResourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tag"), field_value);
@@ -39006,9 +39655,10 @@ impl TargetConfigurationRequestSerializer {
 
         if let Some(ref field_value) = obj.instance_count {
             params.put(&format!("{}{}", prefix, "InstanceCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "OfferingId"), &obj.offering_id);
+        params.put(&format!("{}{}", prefix, "OfferingId"),
+                   &obj.offering_id.replace("+", "%2B"));
 
     }
 }
@@ -39172,7 +39822,8 @@ impl TerminateInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         InstanceIdStringListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "InstanceId"),
@@ -39267,7 +39918,7 @@ impl UnassignIpv6AddressesRequestSerializer {
                                              &format!("{}{}", prefix, "Ipv6Addresses"),
                                              &obj.ipv_6_addresses);
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
 
     }
 }
@@ -39348,7 +39999,7 @@ impl UnassignPrivateIpAddressesRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "NetworkInterfaceId"),
-                   &obj.network_interface_id);
+                   &obj.network_interface_id.replace("+", "%2B"));
         PrivateIpAddressStringListSerializer::serialize(params,
                                                         &format!("{}{}",
                                                                 prefix,
@@ -39378,7 +40029,8 @@ impl UnmonitorInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         InstanceIdStringListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "InstanceId"),
@@ -39647,10 +40299,12 @@ impl UserBucketSerializer {
         }
 
         if let Some(ref field_value) = obj.s3_bucket {
-            params.put(&format!("{}{}", prefix, "S3Bucket"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3Bucket"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.s3_key {
-            params.put(&format!("{}{}", prefix, "S3Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3Key"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -39729,7 +40383,8 @@ impl UserDataSerializer {
         }
 
         if let Some(ref field_value) = obj.data {
-            params.put(&format!("{}{}", prefix, "Data"), &field_value);
+            params.put(&format!("{}{}", prefix, "Data"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -39838,23 +40493,28 @@ impl UserIdGroupPairSerializer {
         }
 
         if let Some(ref field_value) = obj.group_id {
-            params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.peering_status {
-            params.put(&format!("{}{}", prefix, "PeeringStatus"), &field_value);
+            params.put(&format!("{}{}", prefix, "PeeringStatus"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_id {
-            params.put(&format!("{}{}", prefix, "UserId"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_id {
-            params.put(&format!("{}{}", prefix, "VpcId"), &field_value);
+            params.put(&format!("{}{}", prefix, "VpcId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_peering_connection_id {
             params.put(&format!("{}{}", prefix, "VpcPeeringConnectionId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -40420,7 +41080,8 @@ impl VolumeDetailSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Size"), &obj.size.to_string());
+        params.put(&format!("{}{}", prefix, "Size"),
+                   &obj.size.to_string().replace("+", "%2B"));
 
     }
 }
@@ -42430,7 +43091,7 @@ impl VpnConnectionOptionsSpecificationSerializer {
 
         if let Some(ref field_value) = obj.static_routes_only {
             params.put(&format!("{}{}", prefix, "StaticRoutesOnly"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -58,7 +58,8 @@ impl AddTagsToResourceMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ResourceName"), &obj.resource_name);
+        params.put(&format!("{}{}", prefix, "ResourceName"),
+                   &obj.resource_name.replace("+", "%2B"));
         TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), &obj.tags);
 
     }
@@ -139,11 +140,11 @@ impl AuthorizeCacheSecurityGroupIngressMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheSecurityGroupName"),
-                   &obj.cache_security_group_name);
+                   &obj.cache_security_group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "EC2SecurityGroupName"),
-                   &obj.ec2_security_group_name);
+                   &obj.ec2_security_group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "EC2SecurityGroupOwnerId"),
-                   &obj.ec2_security_group_owner_id);
+                   &obj.ec2_security_group_owner_id.replace("+", "%2B"));
 
     }
 }
@@ -2069,12 +2070,13 @@ impl CopySnapshotMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SourceSnapshotName"),
-                   &obj.source_snapshot_name);
+                   &obj.source_snapshot_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.target_bucket {
-            params.put(&format!("{}{}", prefix, "TargetBucket"), &field_value);
+            params.put(&format!("{}{}", prefix, "TargetBucket"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "TargetSnapshotName"),
-                   &obj.target_snapshot_name);
+                   &obj.target_snapshot_name.replace("+", "%2B"));
 
     }
 }
@@ -2188,23 +2190,26 @@ impl CreateCacheClusterMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.az_mode {
-            params.put(&format!("{}{}", prefix, "AZMode"), &field_value);
+            params.put(&format!("{}{}", prefix, "AZMode"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.auth_token {
-            params.put(&format!("{}{}", prefix, "AuthToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "AuthToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "CacheClusterId"),
-                   &obj.cache_cluster_id);
+                   &obj.cache_cluster_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.cache_node_type {
-            params.put(&format!("{}{}", prefix, "CacheNodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheNodeType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_parameter_group_name {
             params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_security_group_names {
             CacheSecurityGroupNameListSerializer::serialize(params,
@@ -2215,28 +2220,31 @@ impl CreateCacheClusterMessageSerializer {
         }
         if let Some(ref field_value) = obj.cache_subnet_group_name {
             params.put(&format!("{}{}", prefix, "CacheSubnetGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine {
-            params.put(&format!("{}{}", prefix, "Engine"), &field_value);
+            params.put(&format!("{}{}", prefix, "Engine"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_topic_arn {
             params.put(&format!("{}{}", prefix, "NotificationTopicArn"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.num_cache_nodes {
             params.put(&format!("{}{}", prefix, "NumCacheNodes"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_availability_zone {
             params.put(&format!("{}{}", prefix, "PreferredAvailabilityZone"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_availability_zones {
             PreferredAvailabilityZoneListSerializer::serialize(params,
@@ -2247,10 +2255,11 @@ impl CreateCacheClusterMessageSerializer {
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replication_group_id {
-            params.put(&format!("{}{}", prefix, "ReplicationGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_group_ids {
             SecurityGroupIdsListSerializer::serialize(params,
@@ -2263,14 +2272,16 @@ impl CreateCacheClusterMessageSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.snapshot_name {
-            params.put(&format!("{}{}", prefix, "SnapshotName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_retention_limit {
             params.put(&format!("{}{}", prefix, "SnapshotRetentionLimit"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_window {
-            params.put(&format!("{}{}", prefix, "SnapshotWindow"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotWindow"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
@@ -2349,10 +2360,11 @@ impl CreateCacheParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheParameterGroupFamily"),
-                   &obj.cache_parameter_group_family);
+                   &obj.cache_parameter_group_family.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                   &obj.cache_parameter_group_name);
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
+                   &obj.cache_parameter_group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
 
     }
 }
@@ -2426,8 +2438,9 @@ impl CreateCacheSecurityGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheSecurityGroupName"),
-                   &obj.cache_security_group_name);
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
+                   &obj.cache_security_group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
 
     }
 }
@@ -2502,9 +2515,9 @@ impl CreateCacheSubnetGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheSubnetGroupDescription"),
-                   &obj.cache_subnet_group_description);
+                   &obj.cache_subnet_group_description.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "CacheSubnetGroupName"),
-                   &obj.cache_subnet_group_name);
+                   &obj.cache_subnet_group_name.replace("+", "%2B"));
         SubnetIdentifierListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "SubnetIds"),
                                                   &obj.subnet_ids);
@@ -2628,22 +2641,24 @@ impl CreateReplicationGroupMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.auth_token {
-            params.put(&format!("{}{}", prefix, "AuthToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "AuthToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.automatic_failover_enabled {
             params.put(&format!("{}{}", prefix, "AutomaticFailoverEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_node_type {
-            params.put(&format!("{}{}", prefix, "CacheNodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheNodeType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_parameter_group_name {
             params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_security_group_names {
             CacheSecurityGroupNameListSerializer::serialize(params,
@@ -2654,13 +2669,15 @@ impl CreateReplicationGroupMessageSerializer {
         }
         if let Some(ref field_value) = obj.cache_subnet_group_name {
             params.put(&format!("{}{}", prefix, "CacheSubnetGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine {
-            params.put(&format!("{}{}", prefix, "Engine"), &field_value);
+            params.put(&format!("{}{}", prefix, "Engine"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.node_group_configuration {
             NodeGroupConfigurationListSerializer::serialize(params,
@@ -2671,18 +2688,19 @@ impl CreateReplicationGroupMessageSerializer {
         }
         if let Some(ref field_value) = obj.notification_topic_arn {
             params.put(&format!("{}{}", prefix, "NotificationTopicArn"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.num_cache_clusters {
             params.put(&format!("{}{}", prefix, "NumCacheClusters"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.num_node_groups {
             params.put(&format!("{}{}", prefix, "NumNodeGroups"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_cache_cluster_a_zs {
             AvailabilityZonesListSerializer::serialize(params,
@@ -2693,19 +2711,20 @@ impl CreateReplicationGroupMessageSerializer {
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.primary_cluster_id {
-            params.put(&format!("{}{}", prefix, "PrimaryClusterId"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrimaryClusterId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replicas_per_node_group {
             params.put(&format!("{}{}", prefix, "ReplicasPerNodeGroup"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ReplicationGroupDescription"),
-                   &obj.replication_group_description);
+                   &obj.replication_group_description.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
-                   &obj.replication_group_id);
+                   &obj.replication_group_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.security_group_ids {
             SecurityGroupIdsListSerializer::serialize(params,
                                                       &format!("{}{}", prefix, "SecurityGroupIds"),
@@ -2717,14 +2736,16 @@ impl CreateReplicationGroupMessageSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.snapshot_name {
-            params.put(&format!("{}{}", prefix, "SnapshotName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_retention_limit {
             params.put(&format!("{}{}", prefix, "SnapshotRetentionLimit"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_window {
-            params.put(&format!("{}{}", prefix, "SnapshotWindow"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotWindow"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
@@ -2803,12 +2824,15 @@ impl CreateSnapshotMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cache_cluster_id {
-            params.put(&format!("{}{}", prefix, "CacheClusterId"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheClusterId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replication_group_id {
-            params.put(&format!("{}{}", prefix, "ReplicationGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SnapshotName"), &obj.snapshot_name);
+        params.put(&format!("{}{}", prefix, "SnapshotName"),
+                   &obj.snapshot_name.replace("+", "%2B"));
 
     }
 }
@@ -2880,10 +2904,10 @@ impl DeleteCacheClusterMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheClusterId"),
-                   &obj.cache_cluster_id);
+                   &obj.cache_cluster_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.final_snapshot_identifier {
             params.put(&format!("{}{}", prefix, "FinalSnapshotIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2955,7 +2979,7 @@ impl DeleteCacheParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                   &obj.cache_parameter_group_name);
+                   &obj.cache_parameter_group_name.replace("+", "%2B"));
 
     }
 }
@@ -2978,7 +3002,7 @@ impl DeleteCacheSecurityGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheSecurityGroupName"),
-                   &obj.cache_security_group_name);
+                   &obj.cache_security_group_name.replace("+", "%2B"));
 
     }
 }
@@ -3001,7 +3025,7 @@ impl DeleteCacheSubnetGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheSubnetGroupName"),
-                   &obj.cache_subnet_group_name);
+                   &obj.cache_subnet_group_name.replace("+", "%2B"));
 
     }
 }
@@ -3029,13 +3053,13 @@ impl DeleteReplicationGroupMessageSerializer {
 
         if let Some(ref field_value) = obj.final_snapshot_identifier {
             params.put(&format!("{}{}", prefix, "FinalSnapshotIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
-                   &obj.replication_group_id);
+                   &obj.replication_group_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.retain_primary_cluster {
             params.put(&format!("{}{}", prefix, "RetainPrimaryCluster"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3106,7 +3130,8 @@ impl DeleteSnapshotMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "SnapshotName"), &obj.snapshot_name);
+        params.put(&format!("{}{}", prefix, "SnapshotName"),
+                   &obj.snapshot_name.replace("+", "%2B"));
 
     }
 }
@@ -3184,22 +3209,24 @@ impl DescribeCacheClustersMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cache_cluster_id {
-            params.put(&format!("{}{}", prefix, "CacheClusterId"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheClusterId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.show_cache_clusters_not_in_replication_groups {
             params.put(&format!("{}{}", prefix, "ShowCacheClustersNotInReplicationGroups"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.show_cache_node_info {
             params.put(&format!("{}{}", prefix, "ShowCacheNodeInfo"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3234,24 +3261,27 @@ impl DescribeCacheEngineVersionsMessageSerializer {
 
         if let Some(ref field_value) = obj.cache_parameter_group_family {
             params.put(&format!("{}{}", prefix, "CacheParameterGroupFamily"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.default_only {
             params.put(&format!("{}{}", prefix, "DefaultOnly"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine {
-            params.put(&format!("{}{}", prefix, "Engine"), &field_value);
+            params.put(&format!("{}{}", prefix, "Engine"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3280,14 +3310,15 @@ impl DescribeCacheParameterGroupsMessageSerializer {
 
         if let Some(ref field_value) = obj.cache_parameter_group_name {
             params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3317,16 +3348,18 @@ impl DescribeCacheParametersMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                   &obj.cache_parameter_group_name);
+                   &obj.cache_parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source {
-            params.put(&format!("{}{}", prefix, "Source"), &field_value);
+            params.put(&format!("{}{}", prefix, "Source"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3355,14 +3388,15 @@ impl DescribeCacheSecurityGroupsMessageSerializer {
 
         if let Some(ref field_value) = obj.cache_security_group_name {
             params.put(&format!("{}{}", prefix, "CacheSecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3391,14 +3425,15 @@ impl DescribeCacheSubnetGroupsMessageSerializer {
 
         if let Some(ref field_value) = obj.cache_subnet_group_name {
             params.put(&format!("{}{}", prefix, "CacheSubnetGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3426,13 +3461,14 @@ impl DescribeEngineDefaultParametersMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheParameterGroupFamily"),
-                   &obj.cache_parameter_group_family);
+                   &obj.cache_parameter_group_family.replace("+", "%2B"));
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3518,26 +3554,31 @@ impl DescribeEventsMessageSerializer {
 
         if let Some(ref field_value) = obj.duration {
             params.put(&format!("{}{}", prefix, "Duration"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_identifier {
-            params.put(&format!("{}{}", prefix, "SourceIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3565,14 +3606,16 @@ impl DescribeReplicationGroupsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replication_group_id {
-            params.put(&format!("{}{}", prefix, "ReplicationGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3610,31 +3653,36 @@ impl DescribeReservedCacheNodesMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cache_node_type {
-            params.put(&format!("{}{}", prefix, "CacheNodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheNodeType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.duration {
-            params.put(&format!("{}{}", prefix, "Duration"), &field_value);
+            params.put(&format!("{}{}", prefix, "Duration"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.offering_type {
-            params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.product_description {
-            params.put(&format!("{}{}", prefix, "ProductDescription"), &field_value);
+            params.put(&format!("{}{}", prefix, "ProductDescription"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_cache_node_id {
             params.put(&format!("{}{}", prefix, "ReservedCacheNodeId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_cache_nodes_offering_id {
             params.put(&format!("{}{}", prefix, "ReservedCacheNodesOfferingId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3672,27 +3720,32 @@ impl DescribeReservedCacheNodesOfferingsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cache_node_type {
-            params.put(&format!("{}{}", prefix, "CacheNodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheNodeType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.duration {
-            params.put(&format!("{}{}", prefix, "Duration"), &field_value);
+            params.put(&format!("{}{}", prefix, "Duration"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.offering_type {
-            params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.product_description {
-            params.put(&format!("{}{}", prefix, "ProductDescription"), &field_value);
+            params.put(&format!("{}{}", prefix, "ProductDescription"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_cache_nodes_offering_id {
             params.put(&format!("{}{}", prefix, "ReservedCacheNodesOfferingId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3784,27 +3837,32 @@ impl DescribeSnapshotsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cache_cluster_id {
-            params.put(&format!("{}{}", prefix, "CacheClusterId"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheClusterId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replication_group_id {
-            params.put(&format!("{}{}", prefix, "ReplicationGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.show_node_group_config {
             params.put(&format!("{}{}", prefix, "ShowNodeGroupConfig"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_name {
-            params.put(&format!("{}{}", prefix, "SnapshotName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_source {
-            params.put(&format!("{}{}", prefix, "SnapshotSource"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotSource"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4275,10 +4333,12 @@ impl ListAllowedNodeTypeModificationsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cache_cluster_id {
-            params.put(&format!("{}{}", prefix, "CacheClusterId"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheClusterId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replication_group_id {
-            params.put(&format!("{}{}", prefix, "ReplicationGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4301,7 +4361,8 @@ impl ListTagsForResourceMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ResourceName"), &obj.resource_name);
+        params.put(&format!("{}{}", prefix, "ResourceName"),
+                   &obj.resource_name.replace("+", "%2B"));
 
     }
 }
@@ -4356,29 +4417,31 @@ impl ModifyCacheClusterMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.az_mode {
-            params.put(&format!("{}{}", prefix, "AZMode"), &field_value);
+            params.put(&format!("{}{}", prefix, "AZMode"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.apply_immediately {
             params.put(&format!("{}{}", prefix, "ApplyImmediately"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "CacheClusterId"),
-                   &obj.cache_cluster_id);
+                   &obj.cache_cluster_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.cache_node_ids_to_remove {
             CacheNodeIdsListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "CacheNodeIdsToRemove"),
                                                   field_value);
         }
         if let Some(ref field_value) = obj.cache_node_type {
-            params.put(&format!("{}{}", prefix, "CacheNodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheNodeType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_parameter_group_name {
             params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_security_group_names {
             CacheSecurityGroupNameListSerializer::serialize(params,
@@ -4388,7 +4451,8 @@ impl ModifyCacheClusterMessageSerializer {
                                                             field_value);
         }
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.new_availability_zones {
             PreferredAvailabilityZoneListSerializer::serialize(params,
@@ -4399,19 +4463,19 @@ impl ModifyCacheClusterMessageSerializer {
         }
         if let Some(ref field_value) = obj.notification_topic_arn {
             params.put(&format!("{}{}", prefix, "NotificationTopicArn"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_topic_status {
             params.put(&format!("{}{}", prefix, "NotificationTopicStatus"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.num_cache_nodes {
             params.put(&format!("{}{}", prefix, "NumCacheNodes"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_group_ids {
             SecurityGroupIdsListSerializer::serialize(params,
@@ -4420,10 +4484,11 @@ impl ModifyCacheClusterMessageSerializer {
         }
         if let Some(ref field_value) = obj.snapshot_retention_limit {
             params.put(&format!("{}{}", prefix, "SnapshotRetentionLimit"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_window {
-            params.put(&format!("{}{}", prefix, "SnapshotWindow"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotWindow"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4497,7 +4562,7 @@ impl ModifyCacheParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                   &obj.cache_parameter_group_name);
+                   &obj.cache_parameter_group_name.replace("+", "%2B"));
         ParameterNameValueListSerializer::serialize(params,
                                                     &format!("{}{}",
                                                             prefix,
@@ -4530,10 +4595,10 @@ impl ModifyCacheSubnetGroupMessageSerializer {
 
         if let Some(ref field_value) = obj.cache_subnet_group_description {
             params.put(&format!("{}{}", prefix, "CacheSubnetGroupDescription"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "CacheSubnetGroupName"),
-                   &obj.cache_subnet_group_name);
+                   &obj.cache_subnet_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.subnet_ids {
             SubnetIdentifierListSerializer::serialize(params,
                                                       &format!("{}{}", prefix, "SubnetIds"),
@@ -4644,22 +4709,23 @@ impl ModifyReplicationGroupMessageSerializer {
 
         if let Some(ref field_value) = obj.apply_immediately {
             params.put(&format!("{}{}", prefix, "ApplyImmediately"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.automatic_failover_enabled {
             params.put(&format!("{}{}", prefix, "AutomaticFailoverEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_node_type {
-            params.put(&format!("{}{}", prefix, "CacheNodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "CacheNodeType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_parameter_group_name {
             params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cache_security_group_names {
             CacheSecurityGroupNameListSerializer::serialize(params,
@@ -4669,32 +4735,35 @@ impl ModifyReplicationGroupMessageSerializer {
                                                             field_value);
         }
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.node_group_id {
-            params.put(&format!("{}{}", prefix, "NodeGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "NodeGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_topic_arn {
             params.put(&format!("{}{}", prefix, "NotificationTopicArn"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.notification_topic_status {
             params.put(&format!("{}{}", prefix, "NotificationTopicStatus"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.primary_cluster_id {
-            params.put(&format!("{}{}", prefix, "PrimaryClusterId"), &field_value);
+            params.put(&format!("{}{}", prefix, "PrimaryClusterId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replication_group_description {
             params.put(&format!("{}{}", prefix, "ReplicationGroupDescription"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
-                   &obj.replication_group_id);
+                   &obj.replication_group_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.security_group_ids {
             SecurityGroupIdsListSerializer::serialize(params,
                                                       &format!("{}{}", prefix, "SecurityGroupIds"),
@@ -4702,14 +4771,15 @@ impl ModifyReplicationGroupMessageSerializer {
         }
         if let Some(ref field_value) = obj.snapshot_retention_limit {
             params.put(&format!("{}{}", prefix, "SnapshotRetentionLimit"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_window {
-            params.put(&format!("{}{}", prefix, "SnapshotWindow"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotWindow"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshotting_cluster_id {
             params.put(&format!("{}{}", prefix, "SnapshottingClusterId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4918,7 +4988,7 @@ impl NodeGroupConfigurationSerializer {
 
         if let Some(ref field_value) = obj.primary_availability_zone {
             params.put(&format!("{}{}", prefix, "PrimaryAvailabilityZone"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replica_availability_zones {
             AvailabilityZonesListSerializer::serialize(params,
@@ -4929,10 +4999,11 @@ impl NodeGroupConfigurationSerializer {
         }
         if let Some(ref field_value) = obj.replica_count {
             params.put(&format!("{}{}", prefix, "ReplicaCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.slots {
-            params.put(&format!("{}{}", prefix, "Slots"), &field_value);
+            params.put(&format!("{}{}", prefix, "Slots"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5455,10 +5526,12 @@ impl ParameterNameValueSerializer {
         }
 
         if let Some(ref field_value) = obj.parameter_name {
-            params.put(&format!("{}{}", prefix, "ParameterName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameter_value {
-            params.put(&format!("{}{}", prefix, "ParameterValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterValue"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5637,14 +5710,14 @@ impl PurchaseReservedCacheNodesOfferingMessageSerializer {
 
         if let Some(ref field_value) = obj.cache_node_count {
             params.put(&format!("{}{}", prefix, "CacheNodeCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_cache_node_id {
             params.put(&format!("{}{}", prefix, "ReservedCacheNodeId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ReservedCacheNodesOfferingId"),
-                   &obj.reserved_cache_nodes_offering_id);
+                   &obj.reserved_cache_nodes_offering_id.replace("+", "%2B"));
 
     }
 }
@@ -5718,7 +5791,7 @@ impl RebootCacheClusterMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheClusterId"),
-                   &obj.cache_cluster_id);
+                   &obj.cache_cluster_id.replace("+", "%2B"));
         CacheNodeIdsListSerializer::serialize(params,
                                               &format!("{}{}", prefix, "CacheNodeIdsToReboot"),
                                               &obj.cache_node_ids_to_reboot);
@@ -5892,7 +5965,8 @@ impl RemoveTagsFromResourceMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ResourceName"), &obj.resource_name);
+        params.put(&format!("{}{}", prefix, "ResourceName"),
+                   &obj.resource_name.replace("+", "%2B"));
         KeyListSerializer::serialize(params, &format!("{}{}", prefix, "TagKeys"), &obj.tag_keys);
 
     }
@@ -6610,7 +6684,7 @@ impl ResetCacheParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheParameterGroupName"),
-                   &obj.cache_parameter_group_name);
+                   &obj.cache_parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.parameter_name_values {
             ParameterNameValueListSerializer::serialize(params,
                                                         &format!("{}{}",
@@ -6620,7 +6694,7 @@ impl ResetCacheParameterGroupMessageSerializer {
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
             params.put(&format!("{}{}", prefix, "ResetAllParameters"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6648,11 +6722,11 @@ impl RevokeCacheSecurityGroupIngressMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CacheSecurityGroupName"),
-                   &obj.cache_security_group_name);
+                   &obj.cache_security_group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "EC2SecurityGroupName"),
-                   &obj.ec2_security_group_name);
+                   &obj.ec2_security_group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "EC2SecurityGroupOwnerId"),
-                   &obj.ec2_security_group_owner_id);
+                   &obj.ec2_security_group_owner_id.replace("+", "%2B"));
 
     }
 }
@@ -7289,10 +7363,12 @@ impl TagSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7418,9 +7494,10 @@ impl TestFailoverMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "NodeGroupId"), &obj.node_group_id);
+        params.put(&format!("{}{}", prefix, "NodeGroupId"),
+                   &obj.node_group_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ReplicationGroupId"),
-                   &obj.replication_group_id);
+                   &obj.replication_group_id.replace("+", "%2B"));
 
     }
 }

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -73,10 +73,12 @@ impl AbortEnvironmentUpdateMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -528,7 +530,8 @@ impl ApplicationResourceLifecycleConfigSerializer {
         }
 
         if let Some(ref field_value) = obj.service_role {
-            params.put(&format!("{}{}", prefix, "ServiceRole"), &field_value);
+            params.put(&format!("{}{}", prefix, "ServiceRole"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.version_lifecycle_config {
             ApplicationVersionLifecycleConfigSerializer::serialize(params,
@@ -962,12 +965,15 @@ impl ApplyEnvironmentManagedActionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ActionId"), &obj.action_id);
+        params.put(&format!("{}{}", prefix, "ActionId"),
+                   &obj.action_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1270,17 +1276,20 @@ impl BuildConfigurationSerializer {
         }
 
         if let Some(ref field_value) = obj.artifact_name {
-            params.put(&format!("{}{}", prefix, "ArtifactName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ArtifactName"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "CodeBuildServiceRole"),
-                   &obj.code_build_service_role);
+                   &obj.code_build_service_role.replace("+", "%2B"));
         if let Some(ref field_value) = obj.compute_type {
-            params.put(&format!("{}{}", prefix, "ComputeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ComputeType"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Image"), &obj.image);
+        params.put(&format!("{}{}", prefix, "Image"),
+                   &obj.image.replace("+", "%2B"));
         if let Some(ref field_value) = obj.timeout_in_minutes {
             params.put(&format!("{}{}", prefix, "TimeoutInMinutes"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1493,7 +1502,8 @@ impl CheckDNSAvailabilityMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "CNAMEPrefix"), &obj.cname_prefix);
+        params.put(&format!("{}{}", prefix, "CNAMEPrefix"),
+                   &obj.cname_prefix.replace("+", "%2B"));
 
     }
 }
@@ -1592,10 +1602,12 @@ impl ComposeEnvironmentsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.application_name {
-            params.put(&format!("{}{}", prefix, "ApplicationName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplicationName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.version_labels {
             VersionLabelsSerializer::serialize(params,
@@ -1931,16 +1943,20 @@ impl ConfigurationOptionSettingSerializer {
         }
 
         if let Some(ref field_value) = obj.namespace {
-            params.put(&format!("{}{}", prefix, "Namespace"), &field_value);
+            params.put(&format!("{}{}", prefix, "Namespace"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_name {
-            params.put(&format!("{}{}", prefix, "OptionName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_name {
-            params.put(&format!("{}{}", prefix, "ResourceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2434,9 +2450,10 @@ impl CreateApplicationMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_lifecycle_config {
             ApplicationResourceLifecycleConfigSerializer::serialize(params,
@@ -2481,10 +2498,10 @@ impl CreateApplicationVersionMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.auto_create_application {
             params.put(&format!("{}{}", prefix, "AutoCreateApplication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.build_configuration {
             BuildConfigurationSerializer::serialize(params,
@@ -2492,11 +2509,12 @@ impl CreateApplicationVersionMessageSerializer {
                                                     field_value);
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.process {
             params.put(&format!("{}{}", prefix, "Process"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_build_information {
             SourceBuildInformationSerializer::serialize(params,
@@ -2510,7 +2528,8 @@ impl CreateApplicationVersionMessageSerializer {
                                             &format!("{}{}", prefix, "SourceBundle"),
                                             field_value);
         }
-        params.put(&format!("{}{}", prefix, "VersionLabel"), &obj.version_label);
+        params.put(&format!("{}{}", prefix, "VersionLabel"),
+                   &obj.version_label.replace("+", "%2B"));
 
     }
 }
@@ -2547,12 +2566,14 @@ impl CreateConfigurationTemplateMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_settings {
             ConfigurationOptionSettingsListSerializer::serialize(params,
@@ -2562,10 +2583,12 @@ impl CreateConfigurationTemplateMessageSerializer {
                                                                  field_value);
         }
         if let Some(ref field_value) = obj.platform_arn {
-            params.put(&format!("{}{}", prefix, "PlatformArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlatformArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.solution_stack_name {
-            params.put(&format!("{}{}", prefix, "SolutionStackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SolutionStackName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_configuration {
             SourceConfigurationSerializer::serialize(params,
@@ -2574,7 +2597,8 @@ impl CreateConfigurationTemplateMessageSerializer {
                                                              "SourceConfiguration"),
                                                      field_value);
         }
-        params.put(&format!("{}{}", prefix, "TemplateName"), &obj.template_name);
+        params.put(&format!("{}{}", prefix, "TemplateName"),
+                   &obj.template_name.replace("+", "%2B"));
 
     }
 }
@@ -2621,18 +2645,22 @@ impl CreateEnvironmentMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.cname_prefix {
-            params.put(&format!("{}{}", prefix, "CNAMEPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "CNAMEPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_settings {
             ConfigurationOptionSettingsListSerializer::serialize(params,
@@ -2647,16 +2675,19 @@ impl CreateEnvironmentMessageSerializer {
                                                       field_value);
         }
         if let Some(ref field_value) = obj.platform_arn {
-            params.put(&format!("{}{}", prefix, "PlatformArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlatformArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.solution_stack_name {
-            params.put(&format!("{}{}", prefix, "SolutionStackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SolutionStackName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagsSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.template_name {
-            params.put(&format!("{}{}", prefix, "TemplateName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tier {
             EnvironmentTierSerializer::serialize(params,
@@ -2664,7 +2695,8 @@ impl CreateEnvironmentMessageSerializer {
                                                  field_value);
         }
         if let Some(ref field_value) = obj.version_label {
-            params.put(&format!("{}{}", prefix, "VersionLabel"), &field_value);
+            params.put(&format!("{}{}", prefix, "VersionLabel"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2696,7 +2728,8 @@ impl CreatePlatformVersionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_settings {
             ConfigurationOptionSettingsListSerializer::serialize(params,
@@ -2708,9 +2741,10 @@ impl CreatePlatformVersionRequestSerializer {
         S3LocationSerializer::serialize(params,
                                         &format!("{}{}", prefix, "PlatformDefinitionBundle"),
                                         &obj.platform_definition_bundle);
-        params.put(&format!("{}{}", prefix, "PlatformName"), &obj.platform_name);
+        params.put(&format!("{}{}", prefix, "PlatformName"),
+                   &obj.platform_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "PlatformVersion"),
-                   &obj.platform_version);
+                   &obj.platform_version.replace("+", "%2B"));
 
     }
 }
@@ -2965,10 +2999,10 @@ impl DeleteApplicationMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.terminate_env_by_force {
             params.put(&format!("{}{}", prefix, "TerminateEnvByForce"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -2996,12 +3030,13 @@ impl DeleteApplicationVersionMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.delete_source_bundle {
             params.put(&format!("{}{}", prefix, "DeleteSourceBundle"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VersionLabel"), &obj.version_label);
+        params.put(&format!("{}{}", prefix, "VersionLabel"),
+                   &obj.version_label.replace("+", "%2B"));
 
     }
 }
@@ -3026,8 +3061,9 @@ impl DeleteConfigurationTemplateMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
-        params.put(&format!("{}{}", prefix, "TemplateName"), &obj.template_name);
+                   &obj.application_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "TemplateName"),
+                   &obj.template_name.replace("+", "%2B"));
 
     }
 }
@@ -3052,9 +3088,9 @@ impl DeleteEnvironmentConfigurationMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "EnvironmentName"),
-                   &obj.environment_name);
+                   &obj.environment_name.replace("+", "%2B"));
 
     }
 }
@@ -3076,7 +3112,8 @@ impl DeletePlatformVersionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.platform_arn {
-            params.put(&format!("{}{}", prefix, "PlatformArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlatformArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3238,14 +3275,16 @@ impl DescribeApplicationVersionsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.application_name {
-            params.put(&format!("{}{}", prefix, "ApplicationName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplicationName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.version_labels {
             VersionLabelsListSerializer::serialize(params,
@@ -3310,10 +3349,12 @@ impl DescribeConfigurationOptionsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.application_name {
-            params.put(&format!("{}{}", prefix, "ApplicationName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplicationName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.options {
             OptionsSpecifierListSerializer::serialize(params,
@@ -3321,13 +3362,16 @@ impl DescribeConfigurationOptionsMessageSerializer {
                                                       field_value);
         }
         if let Some(ref field_value) = obj.platform_arn {
-            params.put(&format!("{}{}", prefix, "PlatformArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlatformArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.solution_stack_name {
-            params.put(&format!("{}{}", prefix, "SolutionStackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SolutionStackName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_name {
-            params.put(&format!("{}{}", prefix, "TemplateName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3355,12 +3399,14 @@ impl DescribeConfigurationSettingsMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_name {
-            params.put(&format!("{}{}", prefix, "TemplateName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3395,10 +3441,12 @@ impl DescribeEnvironmentHealthRequestSerializer {
                                                              field_value);
         }
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3526,17 +3574,20 @@ impl DescribeEnvironmentManagedActionHistoryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3619,13 +3670,16 @@ impl DescribeEnvironmentManagedActionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.status {
-            params.put(&format!("{}{}", prefix, "Status"), &field_value);
+            params.put(&format!("{}{}", prefix, "Status"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3702,10 +3756,12 @@ impl DescribeEnvironmentResourcesMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3743,7 +3799,8 @@ impl DescribeEnvironmentsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.application_name {
-            params.put(&format!("{}{}", prefix, "ApplicationName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplicationName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_ids {
             EnvironmentIdListSerializer::serialize(params,
@@ -3757,21 +3814,23 @@ impl DescribeEnvironmentsMessageSerializer {
         }
         if let Some(ref field_value) = obj.include_deleted {
             params.put(&format!("{}{}", prefix, "IncludeDeleted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.included_deleted_back_to {
             params.put(&format!("{}{}", prefix, "IncludedDeletedBackTo"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.version_label {
-            params.put(&format!("{}{}", prefix, "VersionLabel"), &field_value);
+            params.put(&format!("{}{}", prefix, "VersionLabel"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3817,41 +3876,52 @@ impl DescribeEventsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.application_name {
-            params.put(&format!("{}{}", prefix, "ApplicationName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplicationName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.platform_arn {
-            params.put(&format!("{}{}", prefix, "PlatformArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlatformArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.request_id {
-            params.put(&format!("{}{}", prefix, "RequestId"), &field_value);
+            params.put(&format!("{}{}", prefix, "RequestId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.severity {
-            params.put(&format!("{}{}", prefix, "Severity"), &field_value);
+            params.put(&format!("{}{}", prefix, "Severity"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_name {
-            params.put(&format!("{}{}", prefix, "TemplateName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.version_label {
-            params.put(&format!("{}{}", prefix, "VersionLabel"), &field_value);
+            params.put(&format!("{}{}", prefix, "VersionLabel"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3888,13 +3958,16 @@ impl DescribeInstancesHealthRequestSerializer {
                                                            field_value);
         }
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3980,7 +4053,8 @@ impl DescribePlatformVersionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.platform_arn {
-            params.put(&format!("{}{}", prefix, "PlatformArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlatformArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4952,13 +5026,16 @@ impl EnvironmentTierSerializer {
         }
 
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "Name"), &field_value);
+            params.put(&format!("{}{}", prefix, "Name"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.type_ {
-            params.put(&format!("{}{}", prefix, "Type"), &field_value);
+            params.put(&format!("{}{}", prefix, "Type"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.version {
-            params.put(&format!("{}{}", prefix, "Version"), &field_value);
+            params.put(&format!("{}{}", prefix, "Version"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5791,10 +5868,11 @@ impl ListPlatformVersionsRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6502,13 +6580,13 @@ impl MaxAgeRuleSerializer {
 
         if let Some(ref field_value) = obj.delete_source_from_s3 {
             params.put(&format!("{}{}", prefix, "DeleteSourceFromS3"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "Enabled"),
-                   &obj.enabled.to_string());
+                   &obj.enabled.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.max_age_in_days {
             params.put(&format!("{}{}", prefix, "MaxAgeInDays"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6588,13 +6666,13 @@ impl MaxCountRuleSerializer {
 
         if let Some(ref field_value) = obj.delete_source_from_s3 {
             params.put(&format!("{}{}", prefix, "DeleteSourceFromS3"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "Enabled"),
-                   &obj.enabled.to_string());
+                   &obj.enabled.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.max_count {
             params.put(&format!("{}{}", prefix, "MaxCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6831,13 +6909,16 @@ impl OptionSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.namespace {
-            params.put(&format!("{}{}", prefix, "Namespace"), &field_value);
+            params.put(&format!("{}{}", prefix, "Namespace"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_name {
-            params.put(&format!("{}{}", prefix, "OptionName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_name {
-            params.put(&format!("{}{}", prefix, "ResourceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7071,10 +7152,12 @@ impl PlatformFilterSerializer {
         }
 
         if let Some(ref field_value) = obj.operator {
-            params.put(&format!("{}{}", prefix, "Operator"), &field_value);
+            params.put(&format!("{}{}", prefix, "Operator"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.type_ {
-            params.put(&format!("{}{}", prefix, "Type"), &field_value);
+            params.put(&format!("{}{}", prefix, "Type"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.values {
             PlatformFilterValueListSerializer::serialize(params,
@@ -7610,10 +7693,12 @@ impl RebuildEnvironmentMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7697,12 +7782,15 @@ impl RequestEnvironmentInfoMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InfoType"), &obj.info_type);
+        params.put(&format!("{}{}", prefix, "InfoType"),
+                   &obj.info_type.replace("+", "%2B"));
 
     }
 }
@@ -7769,10 +7857,12 @@ impl RestartAppServerMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7800,12 +7890,15 @@ impl RetrieveEnvironmentInfoMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "InfoType"), &obj.info_type);
+        params.put(&format!("{}{}", prefix, "InfoType"),
+                   &obj.info_type.replace("+", "%2B"));
 
     }
 }
@@ -7952,10 +8045,12 @@ impl S3LocationSerializer {
         }
 
         if let Some(ref field_value) = obj.s3_bucket {
-            params.put(&format!("{}{}", prefix, "S3Bucket"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3Bucket"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.s3_key {
-            params.put(&format!("{}{}", prefix, "S3Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3Key"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8265,10 +8360,11 @@ impl SourceBuildInformationSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SourceLocation"),
-                   &obj.source_location);
+                   &obj.source_location.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SourceRepository"),
-                   &obj.source_repository);
-        params.put(&format!("{}{}", prefix, "SourceType"), &obj.source_type);
+                   &obj.source_repository.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "SourceType"),
+                   &obj.source_type.replace("+", "%2B"));
 
     }
 }
@@ -8293,10 +8389,12 @@ impl SourceConfigurationSerializer {
         }
 
         if let Some(ref field_value) = obj.application_name {
-            params.put(&format!("{}{}", prefix, "ApplicationName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplicationName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_name {
-            params.put(&format!("{}{}", prefix, "TemplateName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8564,19 +8662,19 @@ impl SwapEnvironmentCNAMEsMessageSerializer {
 
         if let Some(ref field_value) = obj.destination_environment_id {
             params.put(&format!("{}{}", prefix, "DestinationEnvironmentId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.destination_environment_name {
             params.put(&format!("{}{}", prefix, "DestinationEnvironmentName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_environment_id {
             params.put(&format!("{}{}", prefix, "SourceEnvironmentId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_environment_name {
             params.put(&format!("{}{}", prefix, "SourceEnvironmentName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8659,10 +8757,12 @@ impl TagSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8704,18 +8804,20 @@ impl TerminateEnvironmentMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.force_terminate {
             params.put(&format!("{}{}", prefix, "ForceTerminate"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.terminate_resources {
             params.put(&format!("{}{}", prefix, "TerminateResources"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8859,9 +8961,10 @@ impl UpdateApplicationMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8888,7 +8991,7 @@ impl UpdateApplicationResourceLifecycleMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         ApplicationResourceLifecycleConfigSerializer::serialize(params,
                                                                 &format!("{}{}",
                                                                         prefix,
@@ -8920,11 +9023,13 @@ impl UpdateApplicationVersionMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VersionLabel"), &obj.version_label);
+        params.put(&format!("{}{}", prefix, "VersionLabel"),
+                   &obj.version_label.replace("+", "%2B"));
 
     }
 }
@@ -8955,9 +9060,10 @@ impl UpdateConfigurationTemplateMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_settings {
             ConfigurationOptionSettingsListSerializer::serialize(params,
@@ -8971,7 +9077,8 @@ impl UpdateConfigurationTemplateMessageSerializer {
                                                       &format!("{}{}", prefix, "OptionsToRemove"),
                                                       field_value);
         }
-        params.put(&format!("{}{}", prefix, "TemplateName"), &obj.template_name);
+        params.put(&format!("{}{}", prefix, "TemplateName"),
+                   &obj.template_name.replace("+", "%2B"));
 
     }
 }
@@ -9030,19 +9137,24 @@ impl UpdateEnvironmentMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.application_name {
-            params.put(&format!("{}{}", prefix, "ApplicationName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplicationName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_id {
-            params.put(&format!("{}{}", prefix, "EnvironmentId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.group_name {
-            params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "GroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_settings {
             ConfigurationOptionSettingsListSerializer::serialize(params,
@@ -9057,13 +9169,16 @@ impl UpdateEnvironmentMessageSerializer {
                                                       field_value);
         }
         if let Some(ref field_value) = obj.platform_arn {
-            params.put(&format!("{}{}", prefix, "PlatformArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "PlatformArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.solution_stack_name {
-            params.put(&format!("{}{}", prefix, "SolutionStackName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SolutionStackName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.template_name {
-            params.put(&format!("{}{}", prefix, "TemplateName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tier {
             EnvironmentTierSerializer::serialize(params,
@@ -9071,7 +9186,8 @@ impl UpdateEnvironmentMessageSerializer {
                                                  field_value);
         }
         if let Some(ref field_value) = obj.version_label {
-            params.put(&format!("{}{}", prefix, "VersionLabel"), &field_value);
+            params.put(&format!("{}{}", prefix, "VersionLabel"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9115,9 +9231,10 @@ impl ValidateConfigurationSettingsMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ApplicationName"),
-                   &obj.application_name);
+                   &obj.application_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.environment_name {
-            params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EnvironmentName"),
+                       &field_value.replace("+", "%2B"));
         }
         ConfigurationOptionSettingsListSerializer::serialize(params,
                                                              &format!("{}{}",
@@ -9125,7 +9242,8 @@ impl ValidateConfigurationSettingsMessageSerializer {
                                                                      "OptionSettings"),
                                                              &obj.option_settings);
         if let Some(ref field_value) = obj.template_name {
-            params.put(&format!("{}{}", prefix, "TemplateName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TemplateName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -121,15 +121,17 @@ impl AccessLogSerializer {
 
         if let Some(ref field_value) = obj.emit_interval {
             params.put(&format!("{}{}", prefix, "EmitInterval"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "Enabled"),
-                   &obj.enabled.to_string());
+                   &obj.enabled.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.s3_bucket_name {
-            params.put(&format!("{}{}", prefix, "S3BucketName"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3BucketName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.s3_bucket_prefix {
-            params.put(&format!("{}{}", prefix, "S3BucketPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3BucketPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -228,7 +230,7 @@ impl AddAvailabilityZonesInputSerializer {
                                                &format!("{}{}", prefix, "AvailabilityZones"),
                                                &obj.availability_zones);
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -396,10 +398,12 @@ impl AdditionalAttributeSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -606,7 +610,7 @@ impl ApplySecurityGroupsToLoadBalancerInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         SecurityGroupsSerializer::serialize(params,
                                             &format!("{}{}", prefix, "SecurityGroups"),
                                             &obj.security_groups);
@@ -685,7 +689,7 @@ impl AttachLoadBalancerToSubnetsInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         SubnetsSerializer::serialize(params, &format!("{}{}", prefix, "Subnets"), &obj.subnets);
 
     }
@@ -986,7 +990,7 @@ impl ConfigureHealthCheckInputSerializer {
                                          &format!("{}{}", prefix, "HealthCheck"),
                                          &obj.health_check);
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -1107,10 +1111,10 @@ impl ConnectionDrainingSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "Enabled"),
-                   &obj.enabled.to_string());
+                   &obj.enabled.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.timeout {
             params.put(&format!("{}{}", prefix, "Timeout"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1204,7 +1208,7 @@ impl ConnectionSettingsSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "IdleTimeout"),
-                   &obj.idle_timeout.to_string());
+                   &obj.idle_timeout.to_string().replace("+", "%2B"));
 
     }
 }
@@ -1275,9 +1279,10 @@ impl CreateAccessPointInputSerializer {
                                        &format!("{}{}", prefix, "Listeners"),
                                        &obj.listeners);
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.scheme {
-            params.put(&format!("{}{}", prefix, "Scheme"), &field_value);
+            params.put(&format!("{}{}", prefix, "Scheme"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_groups {
             SecurityGroupsSerializer::serialize(params,
@@ -1364,10 +1369,12 @@ impl CreateAppCookieStickinessPolicyInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "CookieName"), &obj.cookie_name);
+        params.put(&format!("{}{}", prefix, "CookieName"),
+                   &obj.cookie_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -1416,11 +1423,12 @@ impl CreateLBCookieStickinessPolicyInputSerializer {
 
         if let Some(ref field_value) = obj.cookie_expiration_period {
             params.put(&format!("{}{}", prefix, "CookieExpirationPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -1469,7 +1477,7 @@ impl CreateLoadBalancerListenerInputSerializer {
                                        &format!("{}{}", prefix, "Listeners"),
                                        &obj.listeners);
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -1519,15 +1527,16 @@ impl CreateLoadBalancerPolicyInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.policy_attributes {
             PolicyAttributesSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "PolicyAttributes"),
                                                   field_value);
         }
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "PolicyTypeName"),
-                   &obj.policy_type_name);
+                   &obj.policy_type_name.replace("+", "%2B"));
 
     }
 }
@@ -1627,7 +1636,7 @@ impl CrossZoneLoadBalancingSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "Enabled"),
-                   &obj.enabled.to_string());
+                   &obj.enabled.to_string().replace("+", "%2B"));
 
     }
 }
@@ -1692,7 +1701,7 @@ impl DeleteAccessPointInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -1737,7 +1746,7 @@ impl DeleteLoadBalancerListenerInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         PortsSerializer::serialize(params,
                                    &format!("{}{}", prefix, "LoadBalancerPorts"),
                                    &obj.load_balancer_ports);
@@ -1786,8 +1795,9 @@ impl DeleteLoadBalancerPolicyInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -1835,7 +1845,7 @@ impl DeregisterEndPointsInputSerializer {
                                        &format!("{}{}", prefix, "Instances"),
                                        &obj.instances);
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -1916,11 +1926,12 @@ impl DescribeAccessPointsInputSerializer {
                                                    field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.page_size {
             params.put(&format!("{}{}", prefix, "PageSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1999,11 +2010,12 @@ impl DescribeAccountLimitsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.page_size {
             params.put(&format!("{}{}", prefix, "PageSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -2088,7 +2100,7 @@ impl DescribeEndPointStateInputSerializer {
                                            field_value);
         }
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -2161,7 +2173,7 @@ impl DescribeLoadBalancerAttributesInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -2237,7 +2249,8 @@ impl DescribeLoadBalancerPoliciesInputSerializer {
         }
 
         if let Some(ref field_value) = obj.load_balancer_name {
-            params.put(&format!("{}{}", prefix, "LoadBalancerName"), &field_value);
+            params.put(&format!("{}{}", prefix, "LoadBalancerName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.policy_names {
             PolicyNamesSerializer::serialize(params,
@@ -2484,7 +2497,7 @@ impl DetachLoadBalancerFromSubnetsInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         SubnetsSerializer::serialize(params, &format!("{}{}", prefix, "Subnets"), &obj.subnets);
 
     }
@@ -2627,14 +2640,15 @@ impl HealthCheckSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "HealthyThreshold"),
-                   &obj.healthy_threshold.to_string());
+                   &obj.healthy_threshold.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "Interval"),
-                   &obj.interval.to_string());
-        params.put(&format!("{}{}", prefix, "Target"), &obj.target);
+                   &obj.interval.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Target"),
+                   &obj.target.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "Timeout"),
-                   &obj.timeout.to_string());
+                   &obj.timeout.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "UnhealthyThreshold"),
-                   &obj.unhealthy_threshold.to_string());
+                   &obj.unhealthy_threshold.to_string().replace("+", "%2B"));
 
     }
 }
@@ -2770,7 +2784,8 @@ impl InstanceSerializer {
         }
 
         if let Some(ref field_value) = obj.instance_id {
-            params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3247,15 +3262,18 @@ impl ListenerSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "InstancePort"),
-                   &obj.instance_port.to_string());
+                   &obj.instance_port.to_string().replace("+", "%2B"));
         if let Some(ref field_value) = obj.instance_protocol {
-            params.put(&format!("{}{}", prefix, "InstanceProtocol"), &field_value);
+            params.put(&format!("{}{}", prefix, "InstanceProtocol"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "LoadBalancerPort"),
-                   &obj.load_balancer_port.to_string());
-        params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
+                   &obj.load_balancer_port.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Protocol"),
+                   &obj.protocol.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ssl_certificate_id {
-            params.put(&format!("{}{}", prefix, "SSLCertificateId"), &field_value);
+            params.put(&format!("{}{}", prefix, "SSLCertificateId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3771,7 +3789,7 @@ impl ModifyLoadBalancerAttributesInputSerializer {
                                                             "LoadBalancerAttributes"),
                                                     &obj.load_balancer_attributes);
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -3928,10 +3946,12 @@ impl PolicyAttributeSerializer {
         }
 
         if let Some(ref field_value) = obj.attribute_name {
-            params.put(&format!("{}{}", prefix, "AttributeName"), &field_value);
+            params.put(&format!("{}{}", prefix, "AttributeName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.attribute_value {
-            params.put(&format!("{}{}", prefix, "AttributeValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "AttributeValue"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4532,7 +4552,7 @@ impl RegisterEndPointsInputSerializer {
                                        &format!("{}{}", prefix, "Instances"),
                                        &obj.instances);
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -4609,7 +4629,7 @@ impl RemoveAvailabilityZonesInputSerializer {
                                                &format!("{}{}", prefix, "AvailabilityZones"),
                                                &obj.availability_zones);
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
 
     }
 }
@@ -4858,11 +4878,11 @@ impl SetLoadBalancerListenerSSLCertificateInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "LoadBalancerPort"),
-                   &obj.load_balancer_port.to_string());
+                   &obj.load_balancer_port.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SSLCertificateId"),
-                   &obj.ssl_certificate_id);
+                   &obj.ssl_certificate_id.replace("+", "%2B"));
 
     }
 }
@@ -4912,9 +4932,9 @@ impl SetLoadBalancerPoliciesForBackendServerInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "InstancePort"),
-                   &obj.instance_port.to_string());
+                   &obj.instance_port.to_string().replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         PolicyNamesSerializer::serialize(params,
                                          &format!("{}{}", prefix, "PolicyNames"),
                                          &obj.policy_names);
@@ -4965,9 +4985,9 @@ impl SetLoadBalancerPoliciesOfListenerInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerName"),
-                   &obj.load_balancer_name);
+                   &obj.load_balancer_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "LoadBalancerPort"),
-                   &obj.load_balancer_port.to_string());
+                   &obj.load_balancer_port.to_string().replace("+", "%2B"));
         PolicyNamesSerializer::serialize(params,
                                          &format!("{}{}", prefix, "PolicyNames"),
                                          &obj.policy_names);
@@ -5198,9 +5218,11 @@ impl TagSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Key"), &obj.key);
+        params.put(&format!("{}{}", prefix, "Key"),
+                   &obj.key.replace("+", "%2B"));
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5346,7 +5368,8 @@ impl TagKeyOnlySerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -106,8 +106,9 @@ impl ActionSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "TargetGroupArn"),
-                   &obj.target_group_arn);
-        params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
+                   &obj.target_group_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Type"),
+                   &obj.type_.replace("+", "%2B"));
 
     }
 }
@@ -395,7 +396,8 @@ impl CertificateSerializer {
         }
 
         if let Some(ref field_value) = obj.certificate_arn {
-            params.put(&format!("{}{}", prefix, "CertificateArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "CertificateArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -642,11 +644,14 @@ impl CreateListenerInputSerializer {
                                      &format!("{}{}", prefix, "DefaultActions"),
                                      &obj.default_actions);
         params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
-                   &obj.load_balancer_arn);
-        params.put(&format!("{}{}", prefix, "Port"), &obj.port.to_string());
-        params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
+                   &obj.load_balancer_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Port"),
+                   &obj.port.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Protocol"),
+                   &obj.protocol.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ssl_policy {
-            params.put(&format!("{}{}", prefix, "SslPolicy"), &field_value);
+            params.put(&format!("{}{}", prefix, "SslPolicy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -727,11 +732,14 @@ impl CreateLoadBalancerInputSerializer {
         }
 
         if let Some(ref field_value) = obj.ip_address_type {
-            params.put(&format!("{}{}", prefix, "IpAddressType"), &field_value);
+            params.put(&format!("{}{}", prefix, "IpAddressType"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.scheme {
-            params.put(&format!("{}{}", prefix, "Scheme"), &field_value);
+            params.put(&format!("{}{}", prefix, "Scheme"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.security_groups {
             SecurityGroupsSerializer::serialize(params,
@@ -821,9 +829,10 @@ impl CreateRuleInputSerializer {
         RuleConditionListSerializer::serialize(params,
                                                &format!("{}{}", prefix, "Conditions"),
                                                &obj.conditions);
-        params.put(&format!("{}{}", prefix, "ListenerArn"), &obj.listener_arn);
+        params.put(&format!("{}{}", prefix, "ListenerArn"),
+                   &obj.listener_arn.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "Priority"),
-                   &obj.priority.to_string());
+                   &obj.priority.to_string().replace("+", "%2B"));
 
     }
 }
@@ -915,37 +924,43 @@ impl CreateTargetGroupInputSerializer {
 
         if let Some(ref field_value) = obj.health_check_interval_seconds {
             params.put(&format!("{}{}", prefix, "HealthCheckIntervalSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_path {
-            params.put(&format!("{}{}", prefix, "HealthCheckPath"), &field_value);
+            params.put(&format!("{}{}", prefix, "HealthCheckPath"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_port {
-            params.put(&format!("{}{}", prefix, "HealthCheckPort"), &field_value);
+            params.put(&format!("{}{}", prefix, "HealthCheckPort"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_protocol {
             params.put(&format!("{}{}", prefix, "HealthCheckProtocol"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_timeout_seconds {
             params.put(&format!("{}{}", prefix, "HealthCheckTimeoutSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.healthy_threshold_count {
             params.put(&format!("{}{}", prefix, "HealthyThresholdCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.matcher {
             MatcherSerializer::serialize(params, &format!("{}{}", prefix, "Matcher"), field_value);
         }
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
-        params.put(&format!("{}{}", prefix, "Port"), &obj.port.to_string());
-        params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Port"),
+                   &obj.port.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Protocol"),
+                   &obj.protocol.replace("+", "%2B"));
         if let Some(ref field_value) = obj.unhealthy_threshold_count {
             params.put(&format!("{}{}", prefix, "UnhealthyThresholdCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
+        params.put(&format!("{}{}", prefix, "VpcId"),
+                   &obj.vpc_id.replace("+", "%2B"));
 
     }
 }
@@ -1043,7 +1058,8 @@ impl DeleteListenerInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ListenerArn"), &obj.listener_arn);
+        params.put(&format!("{}{}", prefix, "ListenerArn"),
+                   &obj.listener_arn.replace("+", "%2B"));
 
     }
 }
@@ -1084,7 +1100,7 @@ impl DeleteLoadBalancerInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
-                   &obj.load_balancer_arn);
+                   &obj.load_balancer_arn.replace("+", "%2B"));
 
     }
 }
@@ -1124,7 +1140,8 @@ impl DeleteRuleInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "RuleArn"), &obj.rule_arn);
+        params.put(&format!("{}{}", prefix, "RuleArn"),
+                   &obj.rule_arn.replace("+", "%2B"));
 
     }
 }
@@ -1165,7 +1182,7 @@ impl DeleteTargetGroupInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "TargetGroupArn"),
-                   &obj.target_group_arn);
+                   &obj.target_group_arn.replace("+", "%2B"));
 
     }
 }
@@ -1208,7 +1225,7 @@ impl DeregisterTargetsInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "TargetGroupArn"),
-                   &obj.target_group_arn);
+                   &obj.target_group_arn.replace("+", "%2B"));
         TargetDescriptionsSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "Targets"),
                                                 &obj.targets);
@@ -1254,11 +1271,12 @@ impl DescribeAccountLimitsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.page_size {
             params.put(&format!("{}{}", prefix, "PageSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1346,14 +1364,16 @@ impl DescribeListenersInputSerializer {
                                               field_value);
         }
         if let Some(ref field_value) = obj.load_balancer_arn {
-            params.put(&format!("{}{}", prefix, "LoadBalancerArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.page_size {
             params.put(&format!("{}{}", prefix, "PageSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1430,7 +1450,7 @@ impl DescribeLoadBalancerAttributesInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
-                   &obj.load_balancer_arn);
+                   &obj.load_balancer_arn.replace("+", "%2B"));
 
     }
 }
@@ -1513,7 +1533,8 @@ impl DescribeLoadBalancersInputSerializer {
                                                   field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.names {
             LoadBalancerNamesSerializer::serialize(params,
@@ -1522,7 +1543,7 @@ impl DescribeLoadBalancersInputSerializer {
         }
         if let Some(ref field_value) = obj.page_size {
             params.put(&format!("{}{}", prefix, "PageSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1606,14 +1627,16 @@ impl DescribeRulesInputSerializer {
         }
 
         if let Some(ref field_value) = obj.listener_arn {
-            params.put(&format!("{}{}", prefix, "ListenerArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "ListenerArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.page_size {
             params.put(&format!("{}{}", prefix, "PageSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.rule_arns {
             RuleArnsSerializer::serialize(params,
@@ -1698,7 +1721,8 @@ impl DescribeSSLPoliciesInputSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.names {
             SslPolicyNamesSerializer::serialize(params,
@@ -1707,7 +1731,7 @@ impl DescribeSSLPoliciesInputSerializer {
         }
         if let Some(ref field_value) = obj.page_size {
             params.put(&format!("{}{}", prefix, "PageSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1857,7 +1881,7 @@ impl DescribeTargetGroupAttributesInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "TargetGroupArn"),
-                   &obj.target_group_arn);
+                   &obj.target_group_arn.replace("+", "%2B"));
 
     }
 }
@@ -1937,10 +1961,12 @@ impl DescribeTargetGroupsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.load_balancer_arn {
-            params.put(&format!("{}{}", prefix, "LoadBalancerArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.names {
             TargetGroupNamesSerializer::serialize(params,
@@ -1949,7 +1975,7 @@ impl DescribeTargetGroupsInputSerializer {
         }
         if let Some(ref field_value) = obj.page_size {
             params.put(&format!("{}{}", prefix, "PageSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.target_group_arns {
             TargetGroupArnsSerializer::serialize(params,
@@ -2034,7 +2060,7 @@ impl DescribeTargetHealthInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "TargetGroupArn"),
-                   &obj.target_group_arn);
+                   &obj.target_group_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.targets {
             TargetDescriptionsSerializer::serialize(params,
                                                     &format!("{}{}", prefix, "Targets"),
@@ -2761,10 +2787,12 @@ impl LoadBalancerAttributeSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3090,7 +3118,8 @@ impl MatcherSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "HttpCode"), &obj.http_code);
+        params.put(&format!("{}{}", prefix, "HttpCode"),
+                   &obj.http_code.replace("+", "%2B"));
 
     }
 }
@@ -3145,15 +3174,19 @@ impl ModifyListenerInputSerializer {
                                          &format!("{}{}", prefix, "DefaultActions"),
                                          field_value);
         }
-        params.put(&format!("{}{}", prefix, "ListenerArn"), &obj.listener_arn);
+        params.put(&format!("{}{}", prefix, "ListenerArn"),
+                   &obj.listener_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.protocol {
-            params.put(&format!("{}{}", prefix, "Protocol"), &field_value);
+            params.put(&format!("{}{}", prefix, "Protocol"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ssl_policy {
-            params.put(&format!("{}{}", prefix, "SslPolicy"), &field_value);
+            params.put(&format!("{}{}", prefix, "SslPolicy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3229,7 +3262,7 @@ impl ModifyLoadBalancerAttributesInputSerializer {
                                                     &format!("{}{}", prefix, "Attributes"),
                                                     &obj.attributes);
         params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
-                   &obj.load_balancer_arn);
+                   &obj.load_balancer_arn.replace("+", "%2B"));
 
     }
 }
@@ -3312,7 +3345,8 @@ impl ModifyRuleInputSerializer {
                                                    &format!("{}{}", prefix, "Conditions"),
                                                    field_value);
         }
-        params.put(&format!("{}{}", prefix, "RuleArn"), &obj.rule_arn);
+        params.put(&format!("{}{}", prefix, "RuleArn"),
+                   &obj.rule_arn.replace("+", "%2B"));
 
     }
 }
@@ -3386,7 +3420,7 @@ impl ModifyTargetGroupAttributesInputSerializer {
                                                    &format!("{}{}", prefix, "Attributes"),
                                                    &obj.attributes);
         params.put(&format!("{}{}", prefix, "TargetGroupArn"),
-                   &obj.target_group_arn);
+                   &obj.target_group_arn.replace("+", "%2B"));
 
     }
 }
@@ -3475,34 +3509,36 @@ impl ModifyTargetGroupInputSerializer {
 
         if let Some(ref field_value) = obj.health_check_interval_seconds {
             params.put(&format!("{}{}", prefix, "HealthCheckIntervalSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_path {
-            params.put(&format!("{}{}", prefix, "HealthCheckPath"), &field_value);
+            params.put(&format!("{}{}", prefix, "HealthCheckPath"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_port {
-            params.put(&format!("{}{}", prefix, "HealthCheckPort"), &field_value);
+            params.put(&format!("{}{}", prefix, "HealthCheckPort"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_protocol {
             params.put(&format!("{}{}", prefix, "HealthCheckProtocol"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.health_check_timeout_seconds {
             params.put(&format!("{}{}", prefix, "HealthCheckTimeoutSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.healthy_threshold_count {
             params.put(&format!("{}{}", prefix, "HealthyThresholdCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.matcher {
             MatcherSerializer::serialize(params, &format!("{}{}", prefix, "Matcher"), field_value);
         }
         params.put(&format!("{}{}", prefix, "TargetGroupArn"),
-                   &obj.target_group_arn);
+                   &obj.target_group_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.unhealthy_threshold_count {
             params.put(&format!("{}{}", prefix, "UnhealthyThresholdCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3632,7 +3668,7 @@ impl RegisterTargetsInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "TargetGroupArn"),
-                   &obj.target_group_arn);
+                   &obj.target_group_arn.replace("+", "%2B"));
         TargetDescriptionsSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "Targets"),
                                                 &obj.targets);
@@ -3897,7 +3933,8 @@ impl RuleConditionSerializer {
         }
 
         if let Some(ref field_value) = obj.field {
-            params.put(&format!("{}{}", prefix, "Field"), &field_value);
+            params.put(&format!("{}{}", prefix, "Field"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.values {
             ListOfStringSerializer::serialize(params,
@@ -3994,10 +4031,11 @@ impl RulePriorityPairSerializer {
 
         if let Some(ref field_value) = obj.priority {
             params.put(&format!("{}{}", prefix, "Priority"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.rule_arn {
-            params.put(&format!("{}{}", prefix, "RuleArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "RuleArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4130,9 +4168,9 @@ impl SetIpAddressTypeInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "IpAddressType"),
-                   &obj.ip_address_type);
+                   &obj.ip_address_type.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
-                   &obj.load_balancer_arn);
+                   &obj.load_balancer_arn.replace("+", "%2B"));
 
     }
 }
@@ -4275,7 +4313,7 @@ impl SetSecurityGroupsInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
-                   &obj.load_balancer_arn);
+                   &obj.load_balancer_arn.replace("+", "%2B"));
         SecurityGroupsSerializer::serialize(params,
                                             &format!("{}{}", prefix, "SecurityGroups"),
                                             &obj.security_groups);
@@ -4351,7 +4389,7 @@ impl SetSubnetsInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "LoadBalancerArn"),
-                   &obj.load_balancer_arn);
+                   &obj.load_balancer_arn.replace("+", "%2B"));
         SubnetsSerializer::serialize(params, &format!("{}{}", prefix, "Subnets"), &obj.subnets);
 
     }
@@ -4722,9 +4760,11 @@ impl TagSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Key"), &obj.key);
+        params.put(&format!("{}{}", prefix, "Key"),
+                   &obj.key.replace("+", "%2B"));
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4982,9 +5022,10 @@ impl TargetDescriptionSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Id"), &obj.id);
+        params.put(&format!("{}{}", prefix, "Id"), &obj.id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -5220,10 +5261,12 @@ impl TargetGroupAttributeSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -412,9 +412,10 @@ impl AddClientIDToOpenIDConnectProviderRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ClientID"), &obj.client_id);
+        params.put(&format!("{}{}", prefix, "ClientID"),
+                   &obj.client_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "OpenIDConnectProviderArn"),
-                   &obj.open_id_connect_provider_arn);
+                   &obj.open_id_connect_provider_arn.replace("+", "%2B"));
 
     }
 }
@@ -438,8 +439,9 @@ impl AddRoleToInstanceProfileRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "InstanceProfileName"),
-                   &obj.instance_profile_name);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+                   &obj.instance_profile_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -462,8 +464,10 @@ impl AddUserToGroupRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -500,8 +504,10 @@ impl AttachGroupPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
 
     }
 }
@@ -524,8 +530,10 @@ impl AttachRolePolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -548,8 +556,10 @@ impl AttachUserPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -808,8 +818,10 @@ impl ChangePasswordRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "NewPassword"), &obj.new_password);
-        params.put(&format!("{}{}", prefix, "OldPassword"), &obj.old_password);
+        params.put(&format!("{}{}", prefix, "NewPassword"),
+                   &obj.new_password.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "OldPassword"),
+                   &obj.old_password.replace("+", "%2B"));
 
     }
 }
@@ -917,10 +929,12 @@ impl ContextEntrySerializer {
         }
 
         if let Some(ref field_value) = obj.context_key_name {
-            params.put(&format!("{}{}", prefix, "ContextKeyName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ContextKeyName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.context_key_type {
-            params.put(&format!("{}{}", prefix, "ContextKeyType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ContextKeyType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.context_key_values {
             ContextKeyValueListTypeSerializer::serialize(params,
@@ -1030,7 +1044,8 @@ impl CreateAccessKeyRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1101,7 +1116,8 @@ impl CreateAccountAliasRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "AccountAlias"), &obj.account_alias);
+        params.put(&format!("{}{}", prefix, "AccountAlias"),
+                   &obj.account_alias.replace("+", "%2B"));
 
     }
 }
@@ -1124,9 +1140,11 @@ impl CreateGroupRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.path {
-            params.put(&format!("{}{}", prefix, "Path"), &field_value);
+            params.put(&format!("{}{}", prefix, "Path"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1199,9 +1217,10 @@ impl CreateInstanceProfileRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "InstanceProfileName"),
-                   &obj.instance_profile_name);
+                   &obj.instance_profile_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.path {
-            params.put(&format!("{}{}", prefix, "Path"), &field_value);
+            params.put(&format!("{}{}", prefix, "Path"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1277,12 +1296,14 @@ impl CreateLoginProfileRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Password"), &obj.password);
+        params.put(&format!("{}{}", prefix, "Password"),
+                   &obj.password.replace("+", "%2B"));
         if let Some(ref field_value) = obj.password_reset_required {
             params.put(&format!("{}{}", prefix, "PasswordResetRequired"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -1364,7 +1385,8 @@ impl CreateOpenIDConnectProviderRequestSerializer {
         ThumbprintListTypeSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "ThumbprintList"),
                                                 &obj.thumbprint_list);
-        params.put(&format!("{}{}", prefix, "Url"), &obj.url);
+        params.put(&format!("{}{}", prefix, "Url"),
+                   &obj.url.replace("+", "%2B"));
 
     }
 }
@@ -1443,14 +1465,17 @@ impl CreatePolicyRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path {
-            params.put(&format!("{}{}", prefix, "Path"), &field_value);
+            params.put(&format!("{}{}", prefix, "Path"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "PolicyDocument"),
-                   &obj.policy_document);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+                   &obj.policy_document.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -1524,12 +1549,13 @@ impl CreatePolicyVersionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "PolicyDocument"),
-                   &obj.policy_document);
+                   &obj.policy_document.replace("+", "%2B"));
         if let Some(ref field_value) = obj.set_as_default {
             params.put(&format!("{}{}", prefix, "SetAsDefault"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1608,14 +1634,17 @@ impl CreateRoleRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AssumeRolePolicyDocument"),
-                   &obj.assume_role_policy_document);
+                   &obj.assume_role_policy_document.replace("+", "%2B"));
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path {
-            params.put(&format!("{}{}", prefix, "Path"), &field_value);
+            params.put(&format!("{}{}", prefix, "Path"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -1686,9 +1715,10 @@ impl CreateSAMLProviderRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SAMLMetadataDocument"),
-                   &obj.saml_metadata_document);
+                   &obj.saml_metadata_document.replace("+", "%2B"));
 
     }
 }
@@ -1764,12 +1794,14 @@ impl CreateServiceLinkedRoleRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AWSServiceName"),
-                   &obj.aws_service_name);
+                   &obj.aws_service_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.custom_suffix {
-            params.put(&format!("{}{}", prefix, "CustomSuffix"), &field_value);
+            params.put(&format!("{}{}", prefix, "CustomSuffix"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1841,8 +1873,10 @@ impl CreateServiceSpecificCredentialRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ServiceName"), &obj.service_name);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "ServiceName"),
+                   &obj.service_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -1914,9 +1948,11 @@ impl CreateUserRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.path {
-            params.put(&format!("{}{}", prefix, "Path"), &field_value);
+            params.put(&format!("{}{}", prefix, "Path"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -1988,10 +2024,11 @@ impl CreateVirtualMFADeviceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.path {
-            params.put(&format!("{}{}", prefix, "Path"), &field_value);
+            params.put(&format!("{}{}", prefix, "Path"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "VirtualMFADeviceName"),
-                   &obj.virtual_mfa_device_name);
+                   &obj.virtual_mfa_device_name.replace("+", "%2B"));
 
     }
 }
@@ -2078,8 +2115,10 @@ impl DeactivateMFADeviceRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "SerialNumber"), &obj.serial_number);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "SerialNumber"),
+                   &obj.serial_number.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -2102,9 +2141,11 @@ impl DeleteAccessKeyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "AccessKeyId"), &obj.access_key_id);
+        params.put(&format!("{}{}", prefix, "AccessKeyId"),
+                   &obj.access_key_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2126,7 +2167,8 @@ impl DeleteAccountAliasRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "AccountAlias"), &obj.account_alias);
+        params.put(&format!("{}{}", prefix, "AccountAlias"),
+                   &obj.account_alias.replace("+", "%2B"));
 
     }
 }
@@ -2149,8 +2191,10 @@ impl DeleteGroupPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -2171,7 +2215,8 @@ impl DeleteGroupRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
 
     }
 }
@@ -2193,7 +2238,7 @@ impl DeleteInstanceProfileRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "InstanceProfileName"),
-                   &obj.instance_profile_name);
+                   &obj.instance_profile_name.replace("+", "%2B"));
 
     }
 }
@@ -2214,7 +2259,8 @@ impl DeleteLoginProfileRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -2236,7 +2282,7 @@ impl DeleteOpenIDConnectProviderRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "OpenIDConnectProviderArn"),
-                   &obj.open_id_connect_provider_arn);
+                   &obj.open_id_connect_provider_arn.replace("+", "%2B"));
 
     }
 }
@@ -2257,7 +2303,8 @@ impl DeletePolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
 
     }
 }
@@ -2280,8 +2327,10 @@ impl DeletePolicyVersionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
-        params.put(&format!("{}{}", prefix, "VersionId"), &obj.version_id);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VersionId"),
+                   &obj.version_id.replace("+", "%2B"));
 
     }
 }
@@ -2304,8 +2353,10 @@ impl DeleteRolePolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -2326,7 +2377,8 @@ impl DeleteRoleRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -2348,7 +2400,7 @@ impl DeleteSAMLProviderRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SAMLProviderArn"),
-                   &obj.saml_provider_arn);
+                   &obj.saml_provider_arn.replace("+", "%2B"));
 
     }
 }
@@ -2372,8 +2424,9 @@ impl DeleteSSHPublicKeyRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SSHPublicKeyId"),
-                   &obj.ssh_public_key_id);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+                   &obj.ssh_public_key_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -2395,7 +2448,7 @@ impl DeleteServerCertificateRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ServerCertificateName"),
-                   &obj.server_certificate_name);
+                   &obj.server_certificate_name.replace("+", "%2B"));
 
     }
 }
@@ -2419,9 +2472,10 @@ impl DeleteServiceSpecificCredentialRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ServiceSpecificCredentialId"),
-                   &obj.service_specific_credential_id);
+                   &obj.service_specific_credential_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2446,9 +2500,10 @@ impl DeleteSigningCertificateRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CertificateId"),
-                   &obj.certificate_id);
+                   &obj.certificate_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -2472,8 +2527,10 @@ impl DeleteUserPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -2494,7 +2551,8 @@ impl DeleteUserRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -2515,7 +2573,8 @@ impl DeleteVirtualMFADeviceRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "SerialNumber"), &obj.serial_number);
+        params.put(&format!("{}{}", prefix, "SerialNumber"),
+                   &obj.serial_number.replace("+", "%2B"));
 
     }
 }
@@ -2538,8 +2597,10 @@ impl DetachGroupPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
 
     }
 }
@@ -2562,8 +2623,10 @@ impl DetachRolePolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -2586,8 +2649,10 @@ impl DetachUserPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -2615,11 +2680,13 @@ impl EnableMFADeviceRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AuthenticationCode1"),
-                   &obj.authentication_code_1);
+                   &obj.authentication_code_1.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "AuthenticationCode2"),
-                   &obj.authentication_code_2);
-        params.put(&format!("{}{}", prefix, "SerialNumber"), &obj.serial_number);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+                   &obj.authentication_code_2.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "SerialNumber"),
+                   &obj.serial_number.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -2893,7 +2960,8 @@ impl GetAccessKeyLastUsedRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "AccessKeyId"), &obj.access_key_id);
+        params.put(&format!("{}{}", prefix, "AccessKeyId"),
+                   &obj.access_key_id.replace("+", "%2B"));
 
     }
 }
@@ -2981,11 +3049,12 @@ impl GetAccountAuthorizationDetailsRequestSerializer {
                                                 field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3273,7 +3342,7 @@ impl GetContextKeysForPrincipalPolicyRequestSerializer {
                                                           field_value);
         }
         params.put(&format!("{}{}", prefix, "PolicySourceArn"),
-                   &obj.policy_source_arn);
+                   &obj.policy_source_arn.replace("+", "%2B"));
 
     }
 }
@@ -3360,8 +3429,10 @@ impl GetGroupPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -3448,13 +3519,15 @@ impl GetGroupRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3543,7 +3616,7 @@ impl GetInstanceProfileRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "InstanceProfileName"),
-                   &obj.instance_profile_name);
+                   &obj.instance_profile_name.replace("+", "%2B"));
 
     }
 }
@@ -3614,7 +3687,8 @@ impl GetLoginProfileRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -3685,7 +3759,7 @@ impl GetOpenIDConnectProviderRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "OpenIDConnectProviderArn"),
-                   &obj.open_id_connect_provider_arn);
+                   &obj.open_id_connect_provider_arn.replace("+", "%2B"));
 
     }
 }
@@ -3775,7 +3849,8 @@ impl GetPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
 
     }
 }
@@ -3847,8 +3922,10 @@ impl GetPolicyVersionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
-        params.put(&format!("{}{}", prefix, "VersionId"), &obj.version_id);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VersionId"),
+                   &obj.version_id.replace("+", "%2B"));
 
     }
 }
@@ -3921,8 +3998,10 @@ impl GetRolePolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -4005,7 +4084,8 @@ impl GetRoleRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -4075,7 +4155,7 @@ impl GetSAMLProviderRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SAMLProviderArn"),
-                   &obj.saml_provider_arn);
+                   &obj.saml_provider_arn.replace("+", "%2B"));
 
     }
 }
@@ -4160,10 +4240,12 @@ impl GetSSHPublicKeyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Encoding"), &obj.encoding);
+        params.put(&format!("{}{}", prefix, "Encoding"),
+                   &obj.encoding.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SSHPublicKeyId"),
-                   &obj.ssh_public_key_id);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+                   &obj.ssh_public_key_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -4235,7 +4317,7 @@ impl GetServerCertificateRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ServerCertificateName"),
-                   &obj.server_certificate_name);
+                   &obj.server_certificate_name.replace("+", "%2B"));
 
     }
 }
@@ -4308,8 +4390,10 @@ impl GetUserPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -4394,7 +4478,8 @@ impl GetUserRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4919,14 +5004,16 @@ impl ListAccessKeysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5014,11 +5101,12 @@ impl ListAccountAliasesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -5109,16 +5197,19 @@ impl ListAttachedGroupPoliciesRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5209,16 +5300,19 @@ impl ListAttachedRolePoliciesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -5308,16 +5402,19 @@ impl ListAttachedUserPoliciesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -5409,19 +5506,23 @@ impl ListEntitiesForPolicyRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.entity_filter {
-            params.put(&format!("{}{}", prefix, "EntityFilter"), &field_value);
+            params.put(&format!("{}{}", prefix, "EntityFilter"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
 
     }
 }
@@ -5523,13 +5624,15 @@ impl ListGroupPoliciesRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -5619,13 +5722,15 @@ impl ListGroupsForUserRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -5713,14 +5818,16 @@ impl ListGroupsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5809,13 +5916,15 @@ impl ListInstanceProfilesForRoleRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -5905,14 +6014,16 @@ impl ListInstanceProfilesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6002,14 +6113,16 @@ impl ListMFADevicesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6170,21 +6283,24 @@ impl ListPoliciesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.only_attached {
             params.put(&format!("{}{}", prefix, "OnlyAttached"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.scope {
-            params.put(&format!("{}{}", prefix, "Scope"), &field_value);
+            params.put(&format!("{}{}", prefix, "Scope"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6274,13 +6390,15 @@ impl ListPolicyVersionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
 
     }
 }
@@ -6367,13 +6485,15 @@ impl ListRolePoliciesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -6462,14 +6582,16 @@ impl ListRolesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6625,14 +6747,16 @@ impl ListSSHPublicKeysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6722,14 +6846,16 @@ impl ListServerCertificatesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6815,10 +6941,12 @@ impl ListServiceSpecificCredentialsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.service_name {
-            params.put(&format!("{}{}", prefix, "ServiceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ServiceName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6893,14 +7021,16 @@ impl ListSigningCertificatesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6991,13 +7121,15 @@ impl ListUserPoliciesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -7086,14 +7218,16 @@ impl ListUsersRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path_prefix {
-            params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "PathPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7181,14 +7315,16 @@ impl ListVirtualMFADevicesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.assignment_status {
-            params.put(&format!("{}{}", prefix, "AssignmentStatus"), &field_value);
+            params.put(&format!("{}{}", prefix, "AssignmentStatus"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8824,10 +8960,12 @@ impl PutGroupPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "PolicyDocument"),
-                   &obj.policy_document);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+                   &obj.policy_document.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -8853,9 +8991,11 @@ impl PutRolePolicyRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "PolicyDocument"),
-                   &obj.policy_document);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+                   &obj.policy_document.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -8881,9 +9021,11 @@ impl PutUserPolicyRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "PolicyDocument"),
-                   &obj.policy_document);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+                   &obj.policy_document.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -8908,9 +9050,10 @@ impl RemoveClientIDFromOpenIDConnectProviderRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ClientID"), &obj.client_id);
+        params.put(&format!("{}{}", prefix, "ClientID"),
+                   &obj.client_id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "OpenIDConnectProviderArn"),
-                   &obj.open_id_connect_provider_arn);
+                   &obj.open_id_connect_provider_arn.replace("+", "%2B"));
 
     }
 }
@@ -8934,8 +9077,9 @@ impl RemoveRoleFromInstanceProfileRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "InstanceProfileName"),
-                   &obj.instance_profile_name);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+                   &obj.instance_profile_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -8958,8 +9102,10 @@ impl RemoveUserFromGroupRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -9039,9 +9185,10 @@ impl ResetServiceSpecificCredentialRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ServiceSpecificCredentialId"),
-                   &obj.service_specific_credential_id);
+                   &obj.service_specific_credential_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9262,11 +9409,13 @@ impl ResyncMFADeviceRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AuthenticationCode1"),
-                   &obj.authentication_code_1);
+                   &obj.authentication_code_1.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "AuthenticationCode2"),
-                   &obj.authentication_code_2);
-        params.put(&format!("{}{}", prefix, "SerialNumber"), &obj.serial_number);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+                   &obj.authentication_code_2.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "SerialNumber"),
+                   &obj.serial_number.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -10364,8 +10513,10 @@ impl SetDefaultPolicyVersionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
-        params.put(&format!("{}{}", prefix, "VersionId"), &obj.version_id);
+        params.put(&format!("{}{}", prefix, "PolicyArn"),
+                   &obj.policy_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "VersionId"),
+                   &obj.version_id.replace("+", "%2B"));
 
     }
 }
@@ -10482,7 +10633,8 @@ impl SimulateCustomPolicyRequestSerializer {
                                                 &format!("{}{}", prefix, "ActionNames"),
                                                 &obj.action_names);
         if let Some(ref field_value) = obj.caller_arn {
-            params.put(&format!("{}{}", prefix, "CallerArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "CallerArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.context_entries {
             ContextEntryListTypeSerializer::serialize(params,
@@ -10490,11 +10642,12 @@ impl SimulateCustomPolicyRequestSerializer {
                                                       field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         SimulationPolicyListTypeSerializer::serialize(params,
                                                       &format!("{}{}", prefix, "PolicyInputList"),
@@ -10506,13 +10659,15 @@ impl SimulateCustomPolicyRequestSerializer {
         }
         if let Some(ref field_value) = obj.resource_handling_option {
             params.put(&format!("{}{}", prefix, "ResourceHandlingOption"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_owner {
-            params.put(&format!("{}{}", prefix, "ResourceOwner"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceOwner"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_policy {
-            params.put(&format!("{}{}", prefix, "ResourcePolicy"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourcePolicy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10619,7 +10774,8 @@ impl SimulatePrincipalPolicyRequestSerializer {
                                                 &format!("{}{}", prefix, "ActionNames"),
                                                 &obj.action_names);
         if let Some(ref field_value) = obj.caller_arn {
-            params.put(&format!("{}{}", prefix, "CallerArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "CallerArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.context_entries {
             ContextEntryListTypeSerializer::serialize(params,
@@ -10627,11 +10783,12 @@ impl SimulatePrincipalPolicyRequestSerializer {
                                                       field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.policy_input_list {
             SimulationPolicyListTypeSerializer::serialize(params,
@@ -10641,7 +10798,7 @@ impl SimulatePrincipalPolicyRequestSerializer {
                                                           field_value);
         }
         params.put(&format!("{}{}", prefix, "PolicySourceArn"),
-                   &obj.policy_source_arn);
+                   &obj.policy_source_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.resource_arns {
             ResourceNameListTypeSerializer::serialize(params,
                                                       &format!("{}{}", prefix, "ResourceArns"),
@@ -10649,13 +10806,15 @@ impl SimulatePrincipalPolicyRequestSerializer {
         }
         if let Some(ref field_value) = obj.resource_handling_option {
             params.put(&format!("{}{}", prefix, "ResourceHandlingOption"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_owner {
-            params.put(&format!("{}{}", prefix, "ResourceOwner"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceOwner"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_policy {
-            params.put(&format!("{}{}", prefix, "ResourcePolicy"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourcePolicy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10951,10 +11110,13 @@ impl UpdateAccessKeyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "AccessKeyId"), &obj.access_key_id);
-        params.put(&format!("{}{}", prefix, "Status"), &obj.status);
+        params.put(&format!("{}{}", prefix, "AccessKeyId"),
+                   &obj.access_key_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Status"),
+                   &obj.status.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10994,39 +11156,39 @@ impl UpdateAccountPasswordPolicyRequestSerializer {
 
         if let Some(ref field_value) = obj.allow_users_to_change_password {
             params.put(&format!("{}{}", prefix, "AllowUsersToChangePassword"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.hard_expiry {
             params.put(&format!("{}{}", prefix, "HardExpiry"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_password_age {
             params.put(&format!("{}{}", prefix, "MaxPasswordAge"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.minimum_password_length {
             params.put(&format!("{}{}", prefix, "MinimumPasswordLength"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.password_reuse_prevention {
             params.put(&format!("{}{}", prefix, "PasswordReusePrevention"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.require_lowercase_characters {
             params.put(&format!("{}{}", prefix, "RequireLowercaseCharacters"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.require_numbers {
             params.put(&format!("{}{}", prefix, "RequireNumbers"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.require_symbols {
             params.put(&format!("{}{}", prefix, "RequireSymbols"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.require_uppercase_characters {
             params.put(&format!("{}{}", prefix, "RequireUppercaseCharacters"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -11051,8 +11213,9 @@ impl UpdateAssumeRolePolicyRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "PolicyDocument"),
-                   &obj.policy_document);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+                   &obj.policy_document.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -11077,12 +11240,15 @@ impl UpdateGroupRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
+        params.put(&format!("{}{}", prefix, "GroupName"),
+                   &obj.group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.new_group_name {
-            params.put(&format!("{}{}", prefix, "NewGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "NewGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.new_path {
-            params.put(&format!("{}{}", prefix, "NewPath"), &field_value);
+            params.put(&format!("{}{}", prefix, "NewPath"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -11109,13 +11275,15 @@ impl UpdateLoginProfileRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.password {
-            params.put(&format!("{}{}", prefix, "Password"), &field_value);
+            params.put(&format!("{}{}", prefix, "Password"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.password_reset_required {
             params.put(&format!("{}{}", prefix, "PasswordResetRequired"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -11141,7 +11309,7 @@ impl UpdateOpenIDConnectProviderThumbprintRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "OpenIDConnectProviderArn"),
-                   &obj.open_id_connect_provider_arn);
+                   &obj.open_id_connect_provider_arn.replace("+", "%2B"));
         ThumbprintListTypeSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "ThumbprintList"),
                                                 &obj.thumbprint_list);
@@ -11167,8 +11335,10 @@ impl UpdateRoleDescriptionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
-        params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleName"),
+                   &obj.role_name.replace("+", "%2B"));
 
     }
 }
@@ -11239,9 +11409,9 @@ impl UpdateSAMLProviderRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SAMLMetadataDocument"),
-                   &obj.saml_metadata_document);
+                   &obj.saml_metadata_document.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SAMLProviderArn"),
-                   &obj.saml_provider_arn);
+                   &obj.saml_provider_arn.replace("+", "%2B"));
 
     }
 }
@@ -11317,9 +11487,11 @@ impl UpdateSSHPublicKeyRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SSHPublicKeyId"),
-                   &obj.ssh_public_key_id);
-        params.put(&format!("{}{}", prefix, "Status"), &obj.status);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+                   &obj.ssh_public_key_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Status"),
+                   &obj.status.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -11345,14 +11517,15 @@ impl UpdateServerCertificateRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.new_path {
-            params.put(&format!("{}{}", prefix, "NewPath"), &field_value);
+            params.put(&format!("{}{}", prefix, "NewPath"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.new_server_certificate_name {
             params.put(&format!("{}{}", prefix, "NewServerCertificateName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ServerCertificateName"),
-                   &obj.server_certificate_name);
+                   &obj.server_certificate_name.replace("+", "%2B"));
 
     }
 }
@@ -11378,10 +11551,12 @@ impl UpdateServiceSpecificCredentialRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ServiceSpecificCredentialId"),
-                   &obj.service_specific_credential_id);
-        params.put(&format!("{}{}", prefix, "Status"), &obj.status);
+                   &obj.service_specific_credential_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Status"),
+                   &obj.status.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -11408,10 +11583,12 @@ impl UpdateSigningCertificateRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CertificateId"),
-                   &obj.certificate_id);
-        params.put(&format!("{}{}", prefix, "Status"), &obj.status);
+                   &obj.certificate_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Status"),
+                   &obj.status.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -11438,12 +11615,15 @@ impl UpdateUserRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.new_path {
-            params.put(&format!("{}{}", prefix, "NewPath"), &field_value);
+            params.put(&format!("{}{}", prefix, "NewPath"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.new_user_name {
-            params.put(&format!("{}{}", prefix, "NewUserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "NewUserName"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -11467,8 +11647,9 @@ impl UploadSSHPublicKeyRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SSHPublicKeyBody"),
-                   &obj.ssh_public_key_body);
-        params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
+                   &obj.ssh_public_key_body.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "UserName"),
+                   &obj.user_name.replace("+", "%2B"));
 
     }
 }
@@ -11548,16 +11729,19 @@ impl UploadServerCertificateRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CertificateBody"),
-                   &obj.certificate_body);
+                   &obj.certificate_body.replace("+", "%2B"));
         if let Some(ref field_value) = obj.certificate_chain {
-            params.put(&format!("{}{}", prefix, "CertificateChain"), &field_value);
+            params.put(&format!("{}{}", prefix, "CertificateChain"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.path {
-            params.put(&format!("{}{}", prefix, "Path"), &field_value);
+            params.put(&format!("{}{}", prefix, "Path"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PrivateKey"), &obj.private_key);
+        params.put(&format!("{}{}", prefix, "PrivateKey"),
+                   &obj.private_key.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ServerCertificateName"),
-                   &obj.server_certificate_name);
+                   &obj.server_certificate_name.replace("+", "%2B"));
 
     }
 }
@@ -11630,9 +11814,10 @@ impl UploadSigningCertificateRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "CertificateBody"),
-                   &obj.certificate_body);
+                   &obj.certificate_body.replace("+", "%2B"));
         if let Some(ref field_value) = obj.user_name {
-            params.put(&format!("{}{}", prefix, "UserName"), &field_value);
+            params.put(&format!("{}{}", prefix, "UserName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -151,9 +151,11 @@ impl CancelJobInputSerializer {
         }
 
         if let Some(ref field_value) = obj.api_version {
-            params.put(&format!("{}{}", prefix, "APIVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "APIVersion"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "JobId"), &obj.job_id);
+        params.put(&format!("{}{}", prefix, "JobId"),
+                   &obj.job_id.replace("+", "%2B"));
 
     }
 }
@@ -241,15 +243,19 @@ impl CreateJobInputSerializer {
         }
 
         if let Some(ref field_value) = obj.api_version {
-            params.put(&format!("{}{}", prefix, "APIVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "APIVersion"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "JobType"), &obj.job_type);
-        params.put(&format!("{}{}", prefix, "Manifest"), &obj.manifest);
+        params.put(&format!("{}{}", prefix, "JobType"),
+                   &obj.job_type.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Manifest"),
+                   &obj.manifest.replace("+", "%2B"));
         if let Some(ref field_value) = obj.manifest_addendum {
-            params.put(&format!("{}{}", prefix, "ManifestAddendum"), &field_value);
+            params.put(&format!("{}{}", prefix, "ManifestAddendum"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ValidateOnly"),
-                   &obj.validate_only.to_string());
+                   &obj.validate_only.to_string().replace("+", "%2B"));
 
     }
 }
@@ -426,38 +432,49 @@ impl GetShippingLabelInputSerializer {
         }
 
         if let Some(ref field_value) = obj.api_version {
-            params.put(&format!("{}{}", prefix, "APIVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "APIVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.city {
-            params.put(&format!("{}{}", prefix, "city"), &field_value);
+            params.put(&format!("{}{}", prefix, "city"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.company {
-            params.put(&format!("{}{}", prefix, "company"), &field_value);
+            params.put(&format!("{}{}", prefix, "company"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.country {
-            params.put(&format!("{}{}", prefix, "country"), &field_value);
+            params.put(&format!("{}{}", prefix, "country"),
+                       &field_value.replace("+", "%2B"));
         }
         JobIdListSerializer::serialize(params, &format!("{}{}", prefix, "jobIds"), &obj.job_ids);
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "name"), &field_value);
+            params.put(&format!("{}{}", prefix, "name"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.phone_number {
-            params.put(&format!("{}{}", prefix, "phoneNumber"), &field_value);
+            params.put(&format!("{}{}", prefix, "phoneNumber"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.postal_code {
-            params.put(&format!("{}{}", prefix, "postalCode"), &field_value);
+            params.put(&format!("{}{}", prefix, "postalCode"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.state_or_province {
-            params.put(&format!("{}{}", prefix, "stateOrProvince"), &field_value);
+            params.put(&format!("{}{}", prefix, "stateOrProvince"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.street_1 {
-            params.put(&format!("{}{}", prefix, "street1"), &field_value);
+            params.put(&format!("{}{}", prefix, "street1"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.street_2 {
-            params.put(&format!("{}{}", prefix, "street2"), &field_value);
+            params.put(&format!("{}{}", prefix, "street2"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.street_3 {
-            params.put(&format!("{}{}", prefix, "street3"), &field_value);
+            params.put(&format!("{}{}", prefix, "street3"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -534,9 +551,11 @@ impl GetStatusInputSerializer {
         }
 
         if let Some(ref field_value) = obj.api_version {
-            params.put(&format!("{}{}", prefix, "APIVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "APIVersion"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "JobId"), &obj.job_id);
+        params.put(&format!("{}{}", prefix, "JobId"),
+                   &obj.job_id.replace("+", "%2B"));
 
     }
 }
@@ -865,14 +884,16 @@ impl ListJobsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.api_version {
-            params.put(&format!("{}{}", prefix, "APIVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "APIVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_jobs {
             params.put(&format!("{}{}", prefix, "MaxJobs"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1106,13 +1127,17 @@ impl UpdateJobInputSerializer {
         }
 
         if let Some(ref field_value) = obj.api_version {
-            params.put(&format!("{}{}", prefix, "APIVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "APIVersion"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "JobId"), &obj.job_id);
-        params.put(&format!("{}{}", prefix, "JobType"), &obj.job_type);
-        params.put(&format!("{}{}", prefix, "Manifest"), &obj.manifest);
+        params.put(&format!("{}{}", prefix, "JobId"),
+                   &obj.job_id.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "JobType"),
+                   &obj.job_type.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Manifest"),
+                   &obj.manifest.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ValidateOnly"),
-                   &obj.validate_only.to_string());
+                   &obj.validate_only.to_string().replace("+", "%2B"));
 
     }
 }

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -210,8 +210,9 @@ impl AddRoleToDBClusterMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
-        params.put(&format!("{}{}", prefix, "RoleArn"), &obj.role_arn);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleArn"),
+                   &obj.role_arn.replace("+", "%2B"));
 
     }
 }
@@ -236,9 +237,9 @@ impl AddSourceIdentifierToSubscriptionMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SourceIdentifier"),
-                   &obj.source_identifier);
+                   &obj.source_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SubscriptionName"),
-                   &obj.subscription_name);
+                   &obj.subscription_name.replace("+", "%2B"));
 
     }
 }
@@ -311,7 +312,8 @@ impl AddTagsToResourceMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ResourceName"), &obj.resource_name);
+        params.put(&format!("{}{}", prefix, "ResourceName"),
+                   &obj.resource_name.replace("+", "%2B"));
         TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), &obj.tags);
 
     }
@@ -352,10 +354,12 @@ impl ApplyPendingMaintenanceActionMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ApplyAction"), &obj.apply_action);
-        params.put(&format!("{}{}", prefix, "OptInType"), &obj.opt_in_type);
+        params.put(&format!("{}{}", prefix, "ApplyAction"),
+                   &obj.apply_action.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "OptInType"),
+                   &obj.opt_in_type.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ResourceIdentifier"),
-                   &obj.resource_identifier);
+                   &obj.resource_identifier.replace("+", "%2B"));
 
     }
 }
@@ -486,20 +490,22 @@ impl AuthorizeDBSecurityGroupIngressMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cidrip {
-            params.put(&format!("{}{}", prefix, "CIDRIP"), &field_value);
+            params.put(&format!("{}{}", prefix, "CIDRIP"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBSecurityGroupName"),
-                   &obj.db_security_group_name);
+                   &obj.db_security_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ec2_security_group_id {
-            params.put(&format!("{}{}", prefix, "EC2SecurityGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EC2SecurityGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ec2_security_group_name {
             params.put(&format!("{}{}", prefix, "EC2SecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ec2_security_group_owner_id {
             params.put(&format!("{}{}", prefix, "EC2SecurityGroupOwnerId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -983,14 +989,17 @@ impl CopyDBClusterParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SourceDBClusterParameterGroupIdentifier"),
-                   &obj.source_db_cluster_parameter_group_identifier);
+                   &obj.source_db_cluster_parameter_group_identifier
+                        .replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         params.put(&format!("{}{}", prefix, "TargetDBClusterParameterGroupDescription"),
-                   &obj.target_db_cluster_parameter_group_description);
+                   &obj.target_db_cluster_parameter_group_description
+                        .replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "TargetDBClusterParameterGroupIdentifier"),
-                   &obj.target_db_cluster_parameter_group_identifier);
+                   &obj.target_db_cluster_parameter_group_identifier
+                        .replace("+", "%2B"));
 
     }
 }
@@ -1072,21 +1081,25 @@ impl CopyDBClusterSnapshotMessageSerializer {
 
         if let Some(ref field_value) = obj.copy_tags {
             params.put(&format!("{}{}", prefix, "CopyTags"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.pre_signed_url {
-            params.put(&format!("{}{}", prefix, "PreSignedUrl"), &field_value);
+            params.put(&format!("{}{}", prefix, "PreSignedUrl"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SourceDBClusterSnapshotIdentifier"),
-                   &obj.source_db_cluster_snapshot_identifier);
+                   &obj.source_db_cluster_snapshot_identifier
+                        .replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         params.put(&format!("{}{}", prefix, "TargetDBClusterSnapshotIdentifier"),
-                   &obj.target_db_cluster_snapshot_identifier);
+                   &obj.target_db_cluster_snapshot_identifier
+                        .replace("+", "%2B"));
 
     }
 }
@@ -1162,14 +1175,15 @@ impl CopyDBParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SourceDBParameterGroupIdentifier"),
-                   &obj.source_db_parameter_group_identifier);
+                   &obj.source_db_parameter_group_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         params.put(&format!("{}{}", prefix, "TargetDBParameterGroupDescription"),
-                   &obj.target_db_parameter_group_description);
+                   &obj.target_db_parameter_group_description
+                        .replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "TargetDBParameterGroupIdentifier"),
-                   &obj.target_db_parameter_group_identifier);
+                   &obj.target_db_parameter_group_identifier.replace("+", "%2B"));
 
     }
 }
@@ -1252,24 +1266,27 @@ impl CopyDBSnapshotMessageSerializer {
 
         if let Some(ref field_value) = obj.copy_tags {
             params.put(&format!("{}{}", prefix, "CopyTags"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.pre_signed_url {
-            params.put(&format!("{}{}", prefix, "PreSignedUrl"), &field_value);
+            params.put(&format!("{}{}", prefix, "PreSignedUrl"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SourceDBSnapshotIdentifier"),
-                   &obj.source_db_snapshot_identifier);
+                   &obj.source_db_snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         params.put(&format!("{}{}", prefix, "TargetDBSnapshotIdentifier"),
-                   &obj.target_db_snapshot_identifier);
+                   &obj.target_db_snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -1345,14 +1362,14 @@ impl CopyOptionGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SourceOptionGroupIdentifier"),
-                   &obj.source_option_group_identifier);
+                   &obj.source_option_group_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         params.put(&format!("{}{}", prefix, "TargetOptionGroupDescription"),
-                   &obj.target_option_group_description);
+                   &obj.target_option_group_description.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "TargetOptionGroupIdentifier"),
-                   &obj.target_option_group_identifier);
+                   &obj.target_option_group_identifier.replace("+", "%2B"));
 
     }
 }
@@ -1470,64 +1487,75 @@ impl CreateDBClusterMessageSerializer {
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(&format!("{}{}", prefix, "BackupRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.character_set_name {
-            params.put(&format!("{}{}", prefix, "CharacterSetName"), &field_value);
+            params.put(&format!("{}{}", prefix, "CharacterSetName"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_cluster_parameter_group_name {
             params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.database_name {
-            params.put(&format!("{}{}", prefix, "DatabaseName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DatabaseName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
+        params.put(&format!("{}{}", prefix, "Engine"),
+                   &obj.engine.replace("+", "%2B"));
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.master_user_password {
-            params.put(&format!("{}{}", prefix, "MasterUserPassword"), &field_value);
+            params.put(&format!("{}{}", prefix, "MasterUserPassword"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.master_username {
-            params.put(&format!("{}{}", prefix, "MasterUsername"), &field_value);
+            params.put(&format!("{}{}", prefix, "MasterUsername"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.pre_signed_url {
-            params.put(&format!("{}{}", prefix, "PreSignedUrl"), &field_value);
+            params.put(&format!("{}{}", prefix, "PreSignedUrl"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(&format!("{}{}", prefix, "PreferredBackupWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.replication_source_identifier {
             params.put(&format!("{}{}", prefix, "ReplicationSourceIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.storage_encrypted {
             params.put(&format!("{}{}", prefix, "StorageEncrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
@@ -1566,10 +1594,11 @@ impl CreateDBClusterParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                   &obj.db_cluster_parameter_group_name);
+                   &obj.db_cluster_parameter_group_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBParameterGroupFamily"),
-                   &obj.db_parameter_group_family);
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
+                   &obj.db_parameter_group_family.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -1695,9 +1724,9 @@ impl CreateDBClusterSnapshotMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBClusterSnapshotIdentifier"),
-                   &obj.db_cluster_snapshot_identifier);
+                   &obj.db_cluster_snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -1847,40 +1876,43 @@ impl CreateDBInstanceMessageSerializer {
 
         if let Some(ref field_value) = obj.allocated_storage {
             params.put(&format!("{}{}", prefix, "AllocatedStorage"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(&format!("{}{}", prefix, "BackupRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.character_set_name {
-            params.put(&format!("{}{}", prefix, "CharacterSetName"), &field_value);
+            params.put(&format!("{}{}", prefix, "CharacterSetName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
             params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_cluster_identifier {
             params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBInstanceClass"),
-                   &obj.db_instance_class);
+                   &obj.db_instance_class.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_name {
-            params.put(&format!("{}{}", prefix, "DBName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_parameter_group_name {
             params.put(&format!("{}{}", prefix, "DBParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_security_groups {
             DBSecurityGroupNameListSerializer::serialize(params,
@@ -1890,89 +1922,105 @@ impl CreateDBInstanceMessageSerializer {
                                                          field_value);
         }
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain {
-            params.put(&format!("{}{}", prefix, "Domain"), &field_value);
+            params.put(&format!("{}{}", prefix, "Domain"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain_iam_role_name {
-            params.put(&format!("{}{}", prefix, "DomainIAMRoleName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DomainIAMRoleName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
+        params.put(&format!("{}{}", prefix, "Engine"),
+                   &obj.engine.replace("+", "%2B"));
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.license_model {
-            params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
+            params.put(&format!("{}{}", prefix, "LicenseModel"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.master_user_password {
-            params.put(&format!("{}{}", prefix, "MasterUserPassword"), &field_value);
+            params.put(&format!("{}{}", prefix, "MasterUserPassword"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.master_username {
-            params.put(&format!("{}{}", prefix, "MasterUsername"), &field_value);
+            params.put(&format!("{}{}", prefix, "MasterUsername"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring_interval {
             params.put(&format!("{}{}", prefix, "MonitoringInterval"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
-            params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "MonitoringRoleArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.multi_az {
             params.put(&format!("{}{}", prefix, "MultiAZ"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(&format!("{}{}", prefix, "PreferredBackupWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.promotion_tier {
             params.put(&format!("{}{}", prefix, "PromotionTier"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.publicly_accessible {
             params.put(&format!("{}{}", prefix, "PubliclyAccessible"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.storage_encrypted {
             params.put(&format!("{}{}", prefix, "StorageEncrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.storage_type {
-            params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
+            params.put(&format!("{}{}", prefix, "StorageType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.tde_credential_arn {
-            params.put(&format!("{}{}", prefix, "TdeCredentialArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TdeCredentialArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tde_credential_password {
             params.put(&format!("{}{}", prefix, "TdeCredentialPassword"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.timezone {
-            params.put(&format!("{}{}", prefix, "Timezone"), &field_value);
+            params.put(&format!("{}{}", prefix, "Timezone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
             VpcSecurityGroupIdListSerializer::serialize(params,
@@ -2036,57 +2084,67 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
 
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
             params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_instance_class {
-            params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBInstanceClass"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring_interval {
             params.put(&format!("{}{}", prefix, "MonitoringInterval"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
-            params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "MonitoringRoleArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.pre_signed_url {
-            params.put(&format!("{}{}", prefix, "PreSignedUrl"), &field_value);
+            params.put(&format!("{}{}", prefix, "PreSignedUrl"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.publicly_accessible {
             params.put(&format!("{}{}", prefix, "PubliclyAccessible"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SourceDBInstanceIdentifier"),
-                   &obj.source_db_instance_identifier);
+                   &obj.source_db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.storage_type {
-            params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
+            params.put(&format!("{}{}", prefix, "StorageType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
@@ -2215,10 +2273,11 @@ impl CreateDBParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBParameterGroupFamily"),
-                   &obj.db_parameter_group_family);
+                   &obj.db_parameter_group_family.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBParameterGroupName"),
-                   &obj.db_parameter_group_name);
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
+                   &obj.db_parameter_group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -2295,9 +2354,9 @@ impl CreateDBSecurityGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBSecurityGroupDescription"),
-                   &obj.db_security_group_description);
+                   &obj.db_security_group_description.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBSecurityGroupName"),
-                   &obj.db_security_group_name);
+                   &obj.db_security_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -2374,9 +2433,9 @@ impl CreateDBSnapshotMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBSnapshotIdentifier"),
-                   &obj.db_snapshot_identifier);
+                   &obj.db_snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -2455,9 +2514,9 @@ impl CreateDBSubnetGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBSubnetGroupDescription"),
-                   &obj.db_subnet_group_description);
+                   &obj.db_subnet_group_description.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
-                   &obj.db_subnet_group_name);
+                   &obj.db_subnet_group_name.replace("+", "%2B"));
         SubnetIdentifierListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "SubnetIds"),
                                                   &obj.subnet_ids);
@@ -2546,24 +2605,26 @@ impl CreateEventSubscriptionMessageSerializer {
 
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(params,
                                                      &format!("{}{}", prefix, "EventCategories"),
                                                      field_value);
         }
-        params.put(&format!("{}{}", prefix, "SnsTopicArn"), &obj.sns_topic_arn);
+        params.put(&format!("{}{}", prefix, "SnsTopicArn"),
+                   &obj.sns_topic_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.source_ids {
             SourceIdsListSerializer::serialize(params,
                                                &format!("{}{}", prefix, "SourceIds"),
                                                field_value);
         }
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SubscriptionName"),
-                   &obj.subscription_name);
+                   &obj.subscription_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -2643,13 +2704,14 @@ impl CreateOptionGroupMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "EngineName"), &obj.engine_name);
+        params.put(&format!("{}{}", prefix, "EngineName"),
+                   &obj.engine_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "MajorEngineVersion"),
-                   &obj.major_engine_version);
+                   &obj.major_engine_version.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "OptionGroupDescription"),
-                   &obj.option_group_description);
+                   &obj.option_group_description.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "OptionGroupName"),
-                   &obj.option_group_name);
+                   &obj.option_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -6175,14 +6237,14 @@ impl DeleteDBClusterMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.final_db_snapshot_identifier {
             params.put(&format!("{}{}", prefix, "FinalDBSnapshotIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.skip_final_snapshot {
             params.put(&format!("{}{}", prefix, "SkipFinalSnapshot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6206,7 +6268,7 @@ impl DeleteDBClusterParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                   &obj.db_cluster_parameter_group_name);
+                   &obj.db_cluster_parameter_group_name.replace("+", "%2B"));
 
     }
 }
@@ -6276,7 +6338,7 @@ impl DeleteDBClusterSnapshotMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterSnapshotIdentifier"),
-                   &obj.db_cluster_snapshot_identifier);
+                   &obj.db_cluster_snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -6351,14 +6413,14 @@ impl DeleteDBInstanceMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.final_db_snapshot_identifier {
             params.put(&format!("{}{}", prefix, "FinalDBSnapshotIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.skip_final_snapshot {
             params.put(&format!("{}{}", prefix, "SkipFinalSnapshot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6430,7 +6492,7 @@ impl DeleteDBParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBParameterGroupName"),
-                   &obj.db_parameter_group_name);
+                   &obj.db_parameter_group_name.replace("+", "%2B"));
 
     }
 }
@@ -6453,7 +6515,7 @@ impl DeleteDBSecurityGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBSecurityGroupName"),
-                   &obj.db_security_group_name);
+                   &obj.db_security_group_name.replace("+", "%2B"));
 
     }
 }
@@ -6476,7 +6538,7 @@ impl DeleteDBSnapshotMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBSnapshotIdentifier"),
-                   &obj.db_snapshot_identifier);
+                   &obj.db_snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -6547,7 +6609,7 @@ impl DeleteDBSubnetGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
-                   &obj.db_subnet_group_name);
+                   &obj.db_subnet_group_name.replace("+", "%2B"));
 
     }
 }
@@ -6570,7 +6632,7 @@ impl DeleteEventSubscriptionMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SubscriptionName"),
-                   &obj.subscription_name);
+                   &obj.subscription_name.replace("+", "%2B"));
 
     }
 }
@@ -6641,7 +6703,7 @@ impl DeleteOptionGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "OptionGroupName"),
-                   &obj.option_group_name);
+                   &obj.option_group_name.replace("+", "%2B"));
 
     }
 }
@@ -6690,7 +6752,7 @@ impl DescribeCertificatesMessageSerializer {
 
         if let Some(ref field_value) = obj.certificate_identifier {
             params.put(&format!("{}{}", prefix, "CertificateIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -6698,11 +6760,12 @@ impl DescribeCertificatesMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6733,7 +6796,7 @@ impl DescribeDBClusterParameterGroupsMessageSerializer {
 
         if let Some(ref field_value) = obj.db_cluster_parameter_group_name {
             params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -6741,11 +6804,12 @@ impl DescribeDBClusterParameterGroupsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6777,21 +6841,23 @@ impl DescribeDBClusterParametersMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                   &obj.db_cluster_parameter_group_name);
+                   &obj.db_cluster_parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Filters"),
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source {
-            params.put(&format!("{}{}", prefix, "Source"), &field_value);
+            params.put(&format!("{}{}", prefix, "Source"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6817,7 +6883,7 @@ impl DescribeDBClusterSnapshotAttributesMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterSnapshotIdentifier"),
-                   &obj.db_cluster_snapshot_identifier);
+                   &obj.db_cluster_snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -6902,11 +6968,11 @@ impl DescribeDBClusterSnapshotsMessageSerializer {
 
         if let Some(ref field_value) = obj.db_cluster_identifier {
             params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_cluster_snapshot_identifier {
             params.put(&format!("{}{}", prefix, "DBClusterSnapshotIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -6915,21 +6981,23 @@ impl DescribeDBClusterSnapshotsMessageSerializer {
         }
         if let Some(ref field_value) = obj.include_public {
             params.put(&format!("{}{}", prefix, "IncludePublic"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.include_shared {
             params.put(&format!("{}{}", prefix, "IncludeShared"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_type {
-            params.put(&format!("{}{}", prefix, "SnapshotType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6960,7 +7028,7 @@ impl DescribeDBClustersMessageSerializer {
 
         if let Some(ref field_value) = obj.db_cluster_identifier {
             params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -6968,11 +7036,12 @@ impl DescribeDBClustersMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7012,17 +7081,19 @@ impl DescribeDBEngineVersionsMessageSerializer {
 
         if let Some(ref field_value) = obj.db_parameter_group_family {
             params.put(&format!("{}{}", prefix, "DBParameterGroupFamily"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.default_only {
             params.put(&format!("{}{}", prefix, "DefaultOnly"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine {
-            params.put(&format!("{}{}", prefix, "Engine"), &field_value);
+            params.put(&format!("{}{}", prefix, "Engine"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -7031,18 +7102,19 @@ impl DescribeDBEngineVersionsMessageSerializer {
         }
         if let Some(ref field_value) = obj.list_supported_character_sets {
             params.put(&format!("{}{}", prefix, "ListSupportedCharacterSets"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.list_supported_timezones {
             params.put(&format!("{}{}", prefix, "ListSupportedTimezones"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7073,7 +7145,7 @@ impl DescribeDBInstancesMessageSerializer {
 
         if let Some(ref field_value) = obj.db_instance_identifier {
             params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -7081,11 +7153,12 @@ impl DescribeDBInstancesMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7222,17 +7295,18 @@ impl DescribeDBLogFilesMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.file_last_written {
             params.put(&format!("{}{}", prefix, "FileLastWritten"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.file_size {
             params.put(&format!("{}{}", prefix, "FileSize"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filename_contains {
-            params.put(&format!("{}{}", prefix, "FilenameContains"), &field_value);
+            params.put(&format!("{}{}", prefix, "FilenameContains"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -7240,11 +7314,12 @@ impl DescribeDBLogFilesMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7331,7 +7406,7 @@ impl DescribeDBParameterGroupsMessageSerializer {
 
         if let Some(ref field_value) = obj.db_parameter_group_name {
             params.put(&format!("{}{}", prefix, "DBParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -7339,11 +7414,12 @@ impl DescribeDBParameterGroupsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7374,21 +7450,23 @@ impl DescribeDBParametersMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBParameterGroupName"),
-                   &obj.db_parameter_group_name);
+                   &obj.db_parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Filters"),
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source {
-            params.put(&format!("{}{}", prefix, "Source"), &field_value);
+            params.put(&format!("{}{}", prefix, "Source"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7419,7 +7497,7 @@ impl DescribeDBSecurityGroupsMessageSerializer {
 
         if let Some(ref field_value) = obj.db_security_group_name {
             params.put(&format!("{}{}", prefix, "DBSecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -7427,11 +7505,12 @@ impl DescribeDBSecurityGroupsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7455,7 +7534,7 @@ impl DescribeDBSnapshotAttributesMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBSnapshotIdentifier"),
-                   &obj.db_snapshot_identifier);
+                   &obj.db_snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -7540,11 +7619,11 @@ impl DescribeDBSnapshotsMessageSerializer {
 
         if let Some(ref field_value) = obj.db_instance_identifier {
             params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_snapshot_identifier {
             params.put(&format!("{}{}", prefix, "DBSnapshotIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -7553,21 +7632,23 @@ impl DescribeDBSnapshotsMessageSerializer {
         }
         if let Some(ref field_value) = obj.include_public {
             params.put(&format!("{}{}", prefix, "IncludePublic"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.include_shared {
             params.put(&format!("{}{}", prefix, "IncludeShared"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_type {
-            params.put(&format!("{}{}", prefix, "SnapshotType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7597,7 +7678,8 @@ impl DescribeDBSubnetGroupsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -7605,11 +7687,12 @@ impl DescribeDBSubnetGroupsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7641,18 +7724,19 @@ impl DescribeEngineDefaultClusterParametersMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBParameterGroupFamily"),
-                   &obj.db_parameter_group_family);
+                   &obj.db_parameter_group_family.replace("+", "%2B"));
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Filters"),
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7731,18 +7815,19 @@ impl DescribeEngineDefaultParametersMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBParameterGroupFamily"),
-                   &obj.db_parameter_group_family);
+                   &obj.db_parameter_group_family.replace("+", "%2B"));
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Filters"),
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -7822,7 +7907,8 @@ impl DescribeEventCategoriesMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7857,14 +7943,16 @@ impl DescribeEventSubscriptionsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.subscription_name {
-            params.put(&format!("{}{}", prefix, "SubscriptionName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubscriptionName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7905,10 +7993,11 @@ impl DescribeEventsMessageSerializer {
 
         if let Some(ref field_value) = obj.duration {
             params.put(&format!("{}{}", prefix, "Duration"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(params,
@@ -7921,20 +8010,24 @@ impl DescribeEventsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_identifier {
-            params.put(&format!("{}{}", prefix, "SourceIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7965,21 +8058,24 @@ impl DescribeOptionGroupOptionsMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "EngineName"), &obj.engine_name);
+        params.put(&format!("{}{}", prefix, "EngineName"),
+                   &obj.engine_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Filters"),
                                             field_value);
         }
         if let Some(ref field_value) = obj.major_engine_version {
-            params.put(&format!("{}{}", prefix, "MajorEngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "MajorEngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8013,7 +8109,8 @@ impl DescribeOptionGroupsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.engine_name {
-            params.put(&format!("{}{}", prefix, "EngineName"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -8021,17 +8118,20 @@ impl DescribeOptionGroupsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.major_engine_version {
-            params.put(&format!("{}{}", prefix, "MajorEngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "MajorEngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8071,11 +8171,14 @@ impl DescribeOrderableDBInstanceOptionsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.db_instance_class {
-            params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBInstanceClass"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
+        params.put(&format!("{}{}", prefix, "Engine"),
+                   &obj.engine.replace("+", "%2B"));
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -8083,17 +8186,20 @@ impl DescribeOrderableDBInstanceOptionsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.license_model {
-            params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
+            params.put(&format!("{}{}", prefix, "LicenseModel"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc {
-            params.put(&format!("{}{}", prefix, "Vpc"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Vpc"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8128,14 +8234,16 @@ impl DescribePendingMaintenanceActionsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_identifier {
-            params.put(&format!("{}{}", prefix, "ResourceIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8177,10 +8285,12 @@ impl DescribeReservedDBInstancesMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.db_instance_class {
-            params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBInstanceClass"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.duration {
-            params.put(&format!("{}{}", prefix, "Duration"), &field_value);
+            params.put(&format!("{}{}", prefix, "Duration"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -8188,29 +8298,32 @@ impl DescribeReservedDBInstancesMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.multi_az {
             params.put(&format!("{}{}", prefix, "MultiAZ"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.offering_type {
-            params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.product_description {
-            params.put(&format!("{}{}", prefix, "ProductDescription"), &field_value);
+            params.put(&format!("{}{}", prefix, "ProductDescription"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_db_instance_id {
             params.put(&format!("{}{}", prefix, "ReservedDBInstanceId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_db_instances_offering_id {
             params.put(&format!("{}{}", prefix, "ReservedDBInstancesOfferingId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8252,10 +8365,12 @@ impl DescribeReservedDBInstancesOfferingsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.db_instance_class {
-            params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBInstanceClass"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.duration {
-            params.put(&format!("{}{}", prefix, "Duration"), &field_value);
+            params.put(&format!("{}{}", prefix, "Duration"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(params,
@@ -8263,25 +8378,28 @@ impl DescribeReservedDBInstancesOfferingsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.multi_az {
             params.put(&format!("{}{}", prefix, "MultiAZ"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.offering_type {
-            params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
+            params.put(&format!("{}{}", prefix, "OfferingType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.product_description {
-            params.put(&format!("{}{}", prefix, "ProductDescription"), &field_value);
+            params.put(&format!("{}{}", prefix, "ProductDescription"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_db_instances_offering_id {
             params.put(&format!("{}{}", prefix, "ReservedDBInstancesOfferingId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8316,14 +8434,16 @@ impl DescribeSourceRegionsMessageSerializer {
                                             field_value);
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.region_name {
-            params.put(&format!("{}{}", prefix, "RegionName"), &field_value);
+            params.put(&format!("{}{}", prefix, "RegionName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8538,14 +8658,16 @@ impl DownloadDBLogFilePortionMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
-        params.put(&format!("{}{}", prefix, "LogFileName"), &obj.log_file_name);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "LogFileName"),
+                   &obj.log_file_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.number_of_lines {
             params.put(&format!("{}{}", prefix, "NumberOfLines"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -9389,11 +9511,11 @@ impl FailoverDBClusterMessageSerializer {
 
         if let Some(ref field_value) = obj.db_cluster_identifier {
             params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.target_db_instance_identifier {
             params.put(&format!("{}{}", prefix, "TargetDBInstanceIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -9465,7 +9587,8 @@ impl FilterSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         FilterValueListSerializer::serialize(params,
                                              &format!("{}{}", prefix, "Values"),
                                              &obj.values);
@@ -9657,7 +9780,8 @@ impl ListTagsForResourceMessageSerializer {
                                             &format!("{}{}", prefix, "Filters"),
                                             field_value);
         }
-        params.put(&format!("{}{}", prefix, "ResourceName"), &obj.resource_name);
+        params.put(&format!("{}{}", prefix, "ResourceName"),
+                   &obj.resource_name.replace("+", "%2B"));
 
     }
 }
@@ -9717,42 +9841,45 @@ impl ModifyDBClusterMessageSerializer {
 
         if let Some(ref field_value) = obj.apply_immediately {
             params.put(&format!("{}{}", prefix, "ApplyImmediately"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(&format!("{}{}", prefix, "BackupRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_cluster_parameter_group_name {
             params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.master_user_password {
-            params.put(&format!("{}{}", prefix, "MasterUserPassword"), &field_value);
+            params.put(&format!("{}{}", prefix, "MasterUserPassword"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.new_db_cluster_identifier {
             params.put(&format!("{}{}", prefix, "NewDBClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(&format!("{}{}", prefix, "PreferredBackupWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
             VpcSecurityGroupIdListSerializer::serialize(params,
@@ -9785,7 +9912,7 @@ impl ModifyDBClusterParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                   &obj.db_cluster_parameter_group_name);
+                   &obj.db_cluster_parameter_group_name.replace("+", "%2B"));
         ParametersListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Parameters"),
                                             &obj.parameters);
@@ -9864,9 +9991,9 @@ impl ModifyDBClusterSnapshotAttributeMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AttributeName"),
-                   &obj.attribute_name);
+                   &obj.attribute_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBClusterSnapshotIdentifier"),
-                   &obj.db_cluster_snapshot_identifier);
+                   &obj.db_cluster_snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.values_to_add {
             AttributeValueListSerializer::serialize(params,
                                                     &format!("{}{}", prefix, "ValuesToAdd"),
@@ -10011,44 +10138,45 @@ impl ModifyDBInstanceMessageSerializer {
 
         if let Some(ref field_value) = obj.allocated_storage {
             params.put(&format!("{}{}", prefix, "AllocatedStorage"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.allow_major_version_upgrade {
             params.put(&format!("{}{}", prefix, "AllowMajorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.apply_immediately {
             params.put(&format!("{}{}", prefix, "ApplyImmediately"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(&format!("{}{}", prefix, "BackupRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ca_certificate_identifier {
             params.put(&format!("{}{}", prefix, "CACertificateIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
             params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_instance_class {
-            params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBInstanceClass"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_parameter_group_name {
             params.put(&format!("{}{}", prefix, "DBParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_port_number {
             params.put(&format!("{}{}", prefix, "DBPortNumber"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_security_groups {
             DBSecurityGroupNameListSerializer::serialize(params,
@@ -10058,73 +10186,84 @@ impl ModifyDBInstanceMessageSerializer {
                                                          field_value);
         }
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain {
-            params.put(&format!("{}{}", prefix, "Domain"), &field_value);
+            params.put(&format!("{}{}", prefix, "Domain"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain_iam_role_name {
-            params.put(&format!("{}{}", prefix, "DomainIAMRoleName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DomainIAMRoleName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.license_model {
-            params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
+            params.put(&format!("{}{}", prefix, "LicenseModel"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.master_user_password {
-            params.put(&format!("{}{}", prefix, "MasterUserPassword"), &field_value);
+            params.put(&format!("{}{}", prefix, "MasterUserPassword"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring_interval {
             params.put(&format!("{}{}", prefix, "MonitoringInterval"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
-            params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "MonitoringRoleArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.multi_az {
             params.put(&format!("{}{}", prefix, "MultiAZ"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.new_db_instance_identifier {
             params.put(&format!("{}{}", prefix, "NewDBInstanceIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(&format!("{}{}", prefix, "PreferredBackupWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.promotion_tier {
             params.put(&format!("{}{}", prefix, "PromotionTier"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.publicly_accessible {
             params.put(&format!("{}{}", prefix, "PubliclyAccessible"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.storage_type {
-            params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
+            params.put(&format!("{}{}", prefix, "StorageType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tde_credential_arn {
-            params.put(&format!("{}{}", prefix, "TdeCredentialArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TdeCredentialArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tde_credential_password {
             params.put(&format!("{}{}", prefix, "TdeCredentialPassword"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
             VpcSecurityGroupIdListSerializer::serialize(params,
@@ -10205,7 +10344,7 @@ impl ModifyDBParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBParameterGroupName"),
-                   &obj.db_parameter_group_name);
+                   &obj.db_parameter_group_name.replace("+", "%2B"));
         ParametersListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Parameters"),
                                             &obj.parameters);
@@ -10237,9 +10376,9 @@ impl ModifyDBSnapshotAttributeMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AttributeName"),
-                   &obj.attribute_name);
+                   &obj.attribute_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DBSnapshotIdentifier"),
-                   &obj.db_snapshot_identifier);
+                   &obj.db_snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.values_to_add {
             AttributeValueListSerializer::serialize(params,
                                                     &format!("{}{}", prefix, "ValuesToAdd"),
@@ -10320,9 +10459,10 @@ impl ModifyDBSnapshotMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBSnapshotIdentifier"),
-                   &obj.db_snapshot_identifier);
+                   &obj.db_snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -10399,10 +10539,10 @@ impl ModifyDBSubnetGroupMessageSerializer {
 
         if let Some(ref field_value) = obj.db_subnet_group_description {
             params.put(&format!("{}{}", prefix, "DBSubnetGroupDescription"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
-                   &obj.db_subnet_group_name);
+                   &obj.db_subnet_group_name.replace("+", "%2B"));
         SubnetIdentifierListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "SubnetIds"),
                                                   &obj.subnet_ids);
@@ -10485,7 +10625,7 @@ impl ModifyEventSubscriptionMessageSerializer {
 
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(params,
@@ -10493,13 +10633,15 @@ impl ModifyEventSubscriptionMessageSerializer {
                                                      field_value);
         }
         if let Some(ref field_value) = obj.sns_topic_arn {
-            params.put(&format!("{}{}", prefix, "SnsTopicArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnsTopicArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SubscriptionName"),
-                   &obj.subscription_name);
+                   &obj.subscription_name.replace("+", "%2B"));
 
     }
 }
@@ -10577,10 +10719,10 @@ impl ModifyOptionGroupMessageSerializer {
 
         if let Some(ref field_value) = obj.apply_immediately {
             params.put(&format!("{}{}", prefix, "ApplyImmediately"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "OptionGroupName"),
-                   &obj.option_group_name);
+                   &obj.option_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.options_to_include {
             OptionConfigurationListSerializer::serialize(params,
                                                          &format!("{}{}",
@@ -10774,17 +10916,20 @@ impl OptionConfigurationSerializer {
                                                                  "DBSecurityGroupMemberships"),
                                                          field_value);
         }
-        params.put(&format!("{}{}", prefix, "OptionName"), &obj.option_name);
+        params.put(&format!("{}{}", prefix, "OptionName"),
+                   &obj.option_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.option_settings {
             OptionSettingsListSerializer::serialize(params,
                                                     &format!("{}{}", prefix, "OptionSettings"),
                                                     field_value);
         }
         if let Some(ref field_value) = obj.option_version {
-            params.put(&format!("{}{}", prefix, "OptionVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_security_group_memberships {
             VpcSecurityGroupIdListSerializer::serialize(params,
@@ -11619,33 +11764,40 @@ impl OptionSettingSerializer {
         }
 
         if let Some(ref field_value) = obj.allowed_values {
-            params.put(&format!("{}{}", prefix, "AllowedValues"), &field_value);
+            params.put(&format!("{}{}", prefix, "AllowedValues"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.apply_type {
-            params.put(&format!("{}{}", prefix, "ApplyType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplyType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.data_type {
-            params.put(&format!("{}{}", prefix, "DataType"), &field_value);
+            params.put(&format!("{}{}", prefix, "DataType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.default_value {
-            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "DefaultValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.is_collection {
             params.put(&format!("{}{}", prefix, "IsCollection"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.is_modifiable {
             params.put(&format!("{}{}", prefix, "IsModifiable"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "Name"), &field_value);
+            params.put(&format!("{}{}", prefix, "Name"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -12224,36 +12376,44 @@ impl ParameterSerializer {
         }
 
         if let Some(ref field_value) = obj.allowed_values {
-            params.put(&format!("{}{}", prefix, "AllowedValues"), &field_value);
+            params.put(&format!("{}{}", prefix, "AllowedValues"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.apply_method {
-            params.put(&format!("{}{}", prefix, "ApplyMethod"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplyMethod"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.apply_type {
-            params.put(&format!("{}{}", prefix, "ApplyType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplyType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.data_type {
-            params.put(&format!("{}{}", prefix, "DataType"), &field_value);
+            params.put(&format!("{}{}", prefix, "DataType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.is_modifiable {
             params.put(&format!("{}{}", prefix, "IsModifiable"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.minimum_engine_version {
             params.put(&format!("{}{}", prefix, "MinimumEngineVersion"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameter_name {
-            params.put(&format!("{}{}", prefix, "ParameterName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameter_value {
-            params.put(&format!("{}{}", prefix, "ParameterValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source {
-            params.put(&format!("{}{}", prefix, "Source"), &field_value);
+            params.put(&format!("{}{}", prefix, "Source"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -12679,7 +12839,7 @@ impl PromoteReadReplicaDBClusterMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
 
     }
 }
@@ -12755,13 +12915,13 @@ impl PromoteReadReplicaMessageSerializer {
 
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(&format!("{}{}", prefix, "BackupRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(&format!("{}{}", prefix, "PreferredBackupWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -12841,14 +13001,14 @@ impl PurchaseReservedDBInstancesOfferingMessageSerializer {
 
         if let Some(ref field_value) = obj.db_instance_count {
             params.put(&format!("{}{}", prefix, "DBInstanceCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_db_instance_id {
             params.put(&format!("{}{}", prefix, "ReservedDBInstanceId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ReservedDBInstancesOfferingId"),
-                   &obj.reserved_db_instances_offering_id);
+                   &obj.reserved_db_instances_offering_id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -13049,10 +13209,10 @@ impl RebootDBInstanceMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.force_failover {
             params.put(&format!("{}{}", prefix, "ForceFailover"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -13224,8 +13384,9 @@ impl RemoveRoleFromDBClusterMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
-        params.put(&format!("{}{}", prefix, "RoleArn"), &obj.role_arn);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleArn"),
+                   &obj.role_arn.replace("+", "%2B"));
 
     }
 }
@@ -13252,9 +13413,9 @@ impl RemoveSourceIdentifierFromSubscriptionMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SourceIdentifier"),
-                   &obj.source_identifier);
+                   &obj.source_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SubscriptionName"),
-                   &obj.subscription_name);
+                   &obj.subscription_name.replace("+", "%2B"));
 
     }
 }
@@ -13327,7 +13488,8 @@ impl RemoveTagsFromResourceMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ResourceName"), &obj.resource_name);
+        params.put(&format!("{}{}", prefix, "ResourceName"),
+                   &obj.resource_name.replace("+", "%2B"));
         KeyListSerializer::serialize(params, &format!("{}{}", prefix, "TagKeys"), &obj.tag_keys);
 
     }
@@ -13795,7 +13957,7 @@ impl ResetDBClusterParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                   &obj.db_cluster_parameter_group_name);
+                   &obj.db_cluster_parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.parameters {
             ParametersListSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "Parameters"),
@@ -13803,7 +13965,7 @@ impl ResetDBClusterParameterGroupMessageSerializer {
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
             params.put(&format!("{}{}", prefix, "ResetAllParameters"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -13831,7 +13993,7 @@ impl ResetDBParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBParameterGroupName"),
-                   &obj.db_parameter_group_name);
+                   &obj.db_parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.parameters {
             ParametersListSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "Parameters"),
@@ -13839,7 +14001,7 @@ impl ResetDBParameterGroupMessageSerializer {
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
             params.put(&format!("{}{}", prefix, "ResetAllParameters"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -13971,65 +14133,75 @@ impl RestoreDBClusterFromS3MessageSerializer {
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(&format!("{}{}", prefix, "BackupRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.character_set_name {
-            params.put(&format!("{}{}", prefix, "CharacterSetName"), &field_value);
+            params.put(&format!("{}{}", prefix, "CharacterSetName"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_cluster_parameter_group_name {
             params.put(&format!("{}{}", prefix, "DBClusterParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.database_name {
-            params.put(&format!("{}{}", prefix, "DatabaseName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DatabaseName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
+        params.put(&format!("{}{}", prefix, "Engine"),
+                   &obj.engine.replace("+", "%2B"));
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "MasterUserPassword"),
-                   &obj.master_user_password);
+                   &obj.master_user_password.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "MasterUsername"),
-                   &obj.master_username);
+                   &obj.master_username.replace("+", "%2B"));
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(&format!("{}{}", prefix, "PreferredBackupWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "S3BucketName"),
-                   &obj.s3_bucket_name);
+                   &obj.s3_bucket_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "S3IngestionRoleArn"),
-                   &obj.s3_ingestion_role_arn);
+                   &obj.s3_ingestion_role_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.s3_prefix {
-            params.put(&format!("{}{}", prefix, "S3Prefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3Prefix"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SourceEngine"), &obj.source_engine);
+        params.put(&format!("{}{}", prefix, "SourceEngine"),
+                   &obj.source_engine.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SourceEngineVersion"),
-                   &obj.source_engine_version);
+                   &obj.source_engine_version.replace("+", "%2B"));
         if let Some(ref field_value) = obj.storage_encrypted {
             params.put(&format!("{}{}", prefix, "StorageEncrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
@@ -14139,32 +14311,39 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
                                                    field_value);
         }
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.database_name {
-            params.put(&format!("{}{}", prefix, "DatabaseName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DatabaseName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
+        params.put(&format!("{}{}", prefix, "Engine"),
+                   &obj.engine.replace("+", "%2B"));
         if let Some(ref field_value) = obj.engine_version {
-            params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "EngineVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SnapshotIdentifier"),
-                   &obj.snapshot_identifier);
+                   &obj.snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -14266,37 +14445,43 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBClusterIdentifier"),
-                   &obj.db_cluster_identifier);
+                   &obj.db_cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.restore_to_time {
-            params.put(&format!("{}{}", prefix, "RestoreToTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "RestoreToTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.restore_type {
-            params.put(&format!("{}{}", prefix, "RestoreType"), &field_value);
+            params.put(&format!("{}{}", prefix, "RestoreType"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SourceDBClusterIdentifier"),
-                   &obj.source_db_cluster_identifier);
+                   &obj.source_db_cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.use_latest_restorable_time {
             params.put(&format!("{}{}", prefix, "UseLatestRestorableTime"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
             VpcSecurityGroupIdListSerializer::serialize(params,
@@ -14417,73 +14602,86 @@ impl RestoreDBInstanceFromDBSnapshotMessageSerializer {
 
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
             params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_instance_class {
-            params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBInstanceClass"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_name {
-            params.put(&format!("{}{}", prefix, "DBName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBName"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBSnapshotIdentifier"),
-                   &obj.db_snapshot_identifier);
+                   &obj.db_snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain {
-            params.put(&format!("{}{}", prefix, "Domain"), &field_value);
+            params.put(&format!("{}{}", prefix, "Domain"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain_iam_role_name {
-            params.put(&format!("{}{}", prefix, "DomainIAMRoleName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DomainIAMRoleName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine {
-            params.put(&format!("{}{}", prefix, "Engine"), &field_value);
+            params.put(&format!("{}{}", prefix, "Engine"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.license_model {
-            params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
+            params.put(&format!("{}{}", prefix, "LicenseModel"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.multi_az {
             params.put(&format!("{}{}", prefix, "MultiAZ"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.publicly_accessible {
             params.put(&format!("{}{}", prefix, "PubliclyAccessible"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.storage_type {
-            params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
+            params.put(&format!("{}{}", prefix, "StorageType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         if let Some(ref field_value) = obj.tde_credential_arn {
-            params.put(&format!("{}{}", prefix, "TdeCredentialArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TdeCredentialArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tde_credential_password {
             params.put(&format!("{}{}", prefix, "TdeCredentialPassword"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -14602,80 +14800,94 @@ impl RestoreDBInstanceToPointInTimeMessageSerializer {
 
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(&format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
             params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_instance_class {
-            params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBInstanceClass"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_name {
-            params.put(&format!("{}{}", prefix, "DBName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_subnet_group_name {
-            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBSubnetGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain {
-            params.put(&format!("{}{}", prefix, "Domain"), &field_value);
+            params.put(&format!("{}{}", prefix, "Domain"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.domain_iam_role_name {
-            params.put(&format!("{}{}", prefix, "DomainIAMRoleName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DomainIAMRoleName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(&format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.engine {
-            params.put(&format!("{}{}", prefix, "Engine"), &field_value);
+            params.put(&format!("{}{}", prefix, "Engine"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.license_model {
-            params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
+            params.put(&format!("{}{}", prefix, "LicenseModel"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.multi_az {
             params.put(&format!("{}{}", prefix, "MultiAZ"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.option_group_name {
-            params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "OptionGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.publicly_accessible {
             params.put(&format!("{}{}", prefix, "PubliclyAccessible"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.restore_time {
-            params.put(&format!("{}{}", prefix, "RestoreTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "RestoreTime"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SourceDBInstanceIdentifier"),
-                   &obj.source_db_instance_identifier);
+                   &obj.source_db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.storage_type {
-            params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
+            params.put(&format!("{}{}", prefix, "StorageType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
         params.put(&format!("{}{}", prefix, "TargetDBInstanceIdentifier"),
-                   &obj.target_db_instance_identifier);
+                   &obj.target_db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tde_credential_arn {
-            params.put(&format!("{}{}", prefix, "TdeCredentialArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TdeCredentialArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tde_credential_password {
             params.put(&format!("{}{}", prefix, "TdeCredentialPassword"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.use_latest_restorable_time {
             params.put(&format!("{}{}", prefix, "UseLatestRestorableTime"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -14756,20 +14968,22 @@ impl RevokeDBSecurityGroupIngressMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cidrip {
-            params.put(&format!("{}{}", prefix, "CIDRIP"), &field_value);
+            params.put(&format!("{}{}", prefix, "CIDRIP"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "DBSecurityGroupName"),
-                   &obj.db_security_group_name);
+                   &obj.db_security_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ec2_security_group_id {
-            params.put(&format!("{}{}", prefix, "EC2SecurityGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "EC2SecurityGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ec2_security_group_name {
             params.put(&format!("{}{}", prefix, "EC2SecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ec2_security_group_owner_id {
             params.put(&format!("{}{}", prefix, "EC2SecurityGroupOwnerId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -15067,7 +15281,7 @@ impl StartDBInstanceMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
 
     }
 }
@@ -15139,10 +15353,10 @@ impl StopDBInstanceMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DBInstanceIdentifier"),
-                   &obj.db_instance_identifier);
+                   &obj.db_instance_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_snapshot_identifier {
             params.put(&format!("{}{}", prefix, "DBSnapshotIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -15486,10 +15700,12 @@ impl TagSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -161,17 +161,18 @@ impl AuthorizeClusterSecurityGroupIngressMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cidrip {
-            params.put(&format!("{}{}", prefix, "CIDRIP"), &field_value);
+            params.put(&format!("{}{}", prefix, "CIDRIP"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ClusterSecurityGroupName"),
-                   &obj.cluster_security_group_name);
+                   &obj.cluster_security_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ec2_security_group_name {
             params.put(&format!("{}{}", prefix, "EC2SecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ec2_security_group_owner_id {
             params.put(&format!("{}{}", prefix, "EC2SecurityGroupOwnerId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -248,13 +249,13 @@ impl AuthorizeSnapshotAccessMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AccountWithRestoreAccess"),
-                   &obj.account_with_restore_access);
+                   &obj.account_with_restore_access.replace("+", "%2B"));
         if let Some(ref field_value) = obj.snapshot_cluster_identifier {
             params.put(&format!("{}{}", prefix, "SnapshotClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SnapshotIdentifier"),
-                   &obj.snapshot_identifier);
+                   &obj.snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -2190,12 +2191,12 @@ impl CopyClusterSnapshotMessageSerializer {
 
         if let Some(ref field_value) = obj.source_snapshot_cluster_identifier {
             params.put(&format!("{}{}", prefix, "SourceSnapshotClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SourceSnapshotIdentifier"),
-                   &obj.source_snapshot_identifier);
+                   &obj.source_snapshot_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "TargetSnapshotIdentifier"),
-                   &obj.target_snapshot_identifier);
+                   &obj.target_snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -2317,24 +2318,26 @@ impl CreateClusterMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.additional_info {
-            params.put(&format!("{}{}", prefix, "AdditionalInfo"), &field_value);
+            params.put(&format!("{}{}", prefix, "AdditionalInfo"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.allow_version_upgrade {
             params.put(&format!("{}{}", prefix, "AllowVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.automated_snapshot_retention_period {
             params.put(&format!("{}{}", prefix, "AutomatedSnapshotRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.cluster_parameter_group_name {
             params.put(&format!("{}{}", prefix, "ClusterParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cluster_security_groups {
             ClusterSecurityGroupNameListSerializer::serialize(params,
@@ -2345,35 +2348,39 @@ impl CreateClusterMessageSerializer {
         }
         if let Some(ref field_value) = obj.cluster_subnet_group_name {
             params.put(&format!("{}{}", prefix, "ClusterSubnetGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cluster_type {
-            params.put(&format!("{}{}", prefix, "ClusterType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cluster_version {
-            params.put(&format!("{}{}", prefix, "ClusterVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.db_name {
-            params.put(&format!("{}{}", prefix, "DBName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DBName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.elastic_ip {
-            params.put(&format!("{}{}", prefix, "ElasticIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "ElasticIp"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.encrypted {
             params.put(&format!("{}{}", prefix, "Encrypted"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enhanced_vpc_routing {
             params.put(&format!("{}{}", prefix, "EnhancedVpcRouting"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.hsm_client_certificate_identifier {
             params.put(&format!("{}{}", prefix, "HsmClientCertificateIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.hsm_configuration_identifier {
             params.put(&format!("{}{}", prefix, "HsmConfigurationIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iam_roles {
             IamRoleArnListSerializer::serialize(params,
@@ -2381,27 +2388,30 @@ impl CreateClusterMessageSerializer {
                                                 field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "MasterUserPassword"),
-                   &obj.master_user_password);
+                   &obj.master_user_password.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "MasterUsername"),
-                   &obj.master_username);
-        params.put(&format!("{}{}", prefix, "NodeType"), &obj.node_type);
+                   &obj.master_username.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "NodeType"),
+                   &obj.node_type.replace("+", "%2B"));
         if let Some(ref field_value) = obj.number_of_nodes {
             params.put(&format!("{}{}", prefix, "NumberOfNodes"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.publicly_accessible {
             params.put(&format!("{}{}", prefix, "PubliclyAccessible"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
@@ -2440,11 +2450,12 @@ impl CreateClusterParameterGroupMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ParameterGroupFamily"),
-                   &obj.parameter_group_family);
+                   &obj.parameter_group_family.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ParameterGroupName"),
-                   &obj.parameter_group_name);
+                   &obj.parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -2570,8 +2581,9 @@ impl CreateClusterSecurityGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterSecurityGroupName"),
-                   &obj.cluster_security_group_name);
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
+                   &obj.cluster_security_group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -2650,9 +2662,9 @@ impl CreateClusterSnapshotMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SnapshotIdentifier"),
-                   &obj.snapshot_identifier);
+                   &obj.snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -2731,8 +2743,9 @@ impl CreateClusterSubnetGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterSubnetGroupName"),
-                   &obj.cluster_subnet_group_name);
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
+                   &obj.cluster_subnet_group_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
         SubnetIdentifierListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "SubnetIds"),
                                                   &obj.subnet_ids);
@@ -2824,7 +2837,7 @@ impl CreateEventSubscriptionMessageSerializer {
 
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(params,
@@ -2832,19 +2845,22 @@ impl CreateEventSubscriptionMessageSerializer {
                                                      field_value);
         }
         if let Some(ref field_value) = obj.severity {
-            params.put(&format!("{}{}", prefix, "Severity"), &field_value);
+            params.put(&format!("{}{}", prefix, "Severity"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "SnsTopicArn"), &obj.sns_topic_arn);
+        params.put(&format!("{}{}", prefix, "SnsTopicArn"),
+                   &obj.sns_topic_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.source_ids {
             SourceIdsListSerializer::serialize(params,
                                                &format!("{}{}", prefix, "SourceIds"),
                                                field_value);
         }
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SubscriptionName"),
-                   &obj.subscription_name);
+                   &obj.subscription_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -2920,7 +2936,7 @@ impl CreateHsmClientCertificateMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "HsmClientCertificateIdentifier"),
-                   &obj.hsm_client_certificate_identifier);
+                   &obj.hsm_client_certificate_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -3006,17 +3022,18 @@ impl CreateHsmConfigurationMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Description"), &obj.description);
+        params.put(&format!("{}{}", prefix, "Description"),
+                   &obj.description.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "HsmConfigurationIdentifier"),
-                   &obj.hsm_configuration_identifier);
+                   &obj.hsm_configuration_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "HsmIpAddress"),
-                   &obj.hsm_ip_address);
+                   &obj.hsm_ip_address.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "HsmPartitionName"),
-                   &obj.hsm_partition_name);
+                   &obj.hsm_partition_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "HsmPartitionPassword"),
-                   &obj.hsm_partition_password);
+                   &obj.hsm_partition_password.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "HsmServerPublicCertificate"),
-                   &obj.hsm_server_public_certificate);
+                   &obj.hsm_server_public_certificate.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -3094,10 +3111,11 @@ impl CreateSnapshotCopyGrantMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SnapshotCopyGrantName"),
-                   &obj.snapshot_copy_grant_name);
+                   &obj.snapshot_copy_grant_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), field_value);
         }
@@ -3172,7 +3190,8 @@ impl CreateTagsMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ResourceName"), &obj.resource_name);
+        params.put(&format!("{}{}", prefix, "ResourceName"),
+                   &obj.resource_name.replace("+", "%2B"));
         TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), &obj.tags);
 
     }
@@ -3275,14 +3294,14 @@ impl DeleteClusterMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.final_cluster_snapshot_identifier {
             params.put(&format!("{}{}", prefix, "FinalClusterSnapshotIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.skip_final_cluster_snapshot {
             params.put(&format!("{}{}", prefix, "SkipFinalClusterSnapshot"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3306,7 +3325,7 @@ impl DeleteClusterParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ParameterGroupName"),
-                   &obj.parameter_group_name);
+                   &obj.parameter_group_name.replace("+", "%2B"));
 
     }
 }
@@ -3376,7 +3395,7 @@ impl DeleteClusterSecurityGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterSecurityGroupName"),
-                   &obj.cluster_security_group_name);
+                   &obj.cluster_security_group_name.replace("+", "%2B"));
 
     }
 }
@@ -3402,10 +3421,10 @@ impl DeleteClusterSnapshotMessageSerializer {
 
         if let Some(ref field_value) = obj.snapshot_cluster_identifier {
             params.put(&format!("{}{}", prefix, "SnapshotClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SnapshotIdentifier"),
-                   &obj.snapshot_identifier);
+                   &obj.snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -3475,7 +3494,7 @@ impl DeleteClusterSubnetGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterSubnetGroupName"),
-                   &obj.cluster_subnet_group_name);
+                   &obj.cluster_subnet_group_name.replace("+", "%2B"));
 
     }
 }
@@ -3498,7 +3517,7 @@ impl DeleteEventSubscriptionMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SubscriptionName"),
-                   &obj.subscription_name);
+                   &obj.subscription_name.replace("+", "%2B"));
 
     }
 }
@@ -3521,7 +3540,7 @@ impl DeleteHsmClientCertificateMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "HsmClientCertificateIdentifier"),
-                   &obj.hsm_client_certificate_identifier);
+                   &obj.hsm_client_certificate_identifier.replace("+", "%2B"));
 
     }
 }
@@ -3544,7 +3563,7 @@ impl DeleteHsmConfigurationMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "HsmConfigurationIdentifier"),
-                   &obj.hsm_configuration_identifier);
+                   &obj.hsm_configuration_identifier.replace("+", "%2B"));
 
     }
 }
@@ -3567,7 +3586,7 @@ impl DeleteSnapshotCopyGrantMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SnapshotCopyGrantName"),
-                   &obj.snapshot_copy_grant_name);
+                   &obj.snapshot_copy_grant_name.replace("+", "%2B"));
 
     }
 }
@@ -3591,7 +3610,8 @@ impl DeleteTagsMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "ResourceName"), &obj.resource_name);
+        params.put(&format!("{}{}", prefix, "ResourceName"),
+                   &obj.resource_name.replace("+", "%2B"));
         TagKeyListSerializer::serialize(params, &format!("{}{}", prefix, "TagKeys"), &obj.tag_keys);
 
     }
@@ -3623,14 +3643,16 @@ impl DescribeClusterParameterGroupsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameter_group_name {
-            params.put(&format!("{}{}", prefix, "ParameterGroupName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterGroupName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -3670,16 +3692,18 @@ impl DescribeClusterParametersMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ParameterGroupName"),
-                   &obj.parameter_group_name);
+                   &obj.parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.source {
-            params.put(&format!("{}{}", prefix, "Source"), &field_value);
+            params.put(&format!("{}{}", prefix, "Source"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3712,14 +3736,15 @@ impl DescribeClusterSecurityGroupsMessageSerializer {
 
         if let Some(ref field_value) = obj.cluster_security_group_name {
             params.put(&format!("{}{}", prefix, "ClusterSecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -3771,29 +3796,36 @@ impl DescribeClusterSnapshotsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cluster_identifier {
-            params.put(&format!("{}{}", prefix, "ClusterIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.owner_account {
-            params.put(&format!("{}{}", prefix, "OwnerAccount"), &field_value);
+            params.put(&format!("{}{}", prefix, "OwnerAccount"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_identifier {
-            params.put(&format!("{}{}", prefix, "SnapshotIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_type {
-            params.put(&format!("{}{}", prefix, "SnapshotType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnapshotType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -3836,14 +3868,15 @@ impl DescribeClusterSubnetGroupsMessageSerializer {
 
         if let Some(ref field_value) = obj.cluster_subnet_group_name {
             params.put(&format!("{}{}", prefix, "ClusterSubnetGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -3884,17 +3917,19 @@ impl DescribeClusterVersionsMessageSerializer {
 
         if let Some(ref field_value) = obj.cluster_parameter_group_family {
             params.put(&format!("{}{}", prefix, "ClusterParameterGroupFamily"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cluster_version {
-            params.put(&format!("{}{}", prefix, "ClusterVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -3926,14 +3961,16 @@ impl DescribeClustersMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cluster_identifier {
-            params.put(&format!("{}{}", prefix, "ClusterIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -3971,14 +4008,15 @@ impl DescribeDefaultClusterParametersMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ParameterGroupFamily"),
-                   &obj.parameter_group_family);
+                   &obj.parameter_group_family.replace("+", "%2B"));
 
     }
 }
@@ -4048,7 +4086,8 @@ impl DescribeEventCategoriesMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4076,14 +4115,16 @@ impl DescribeEventSubscriptionsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.subscription_name {
-            params.put(&format!("{}{}", prefix, "SubscriptionName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SubscriptionName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4120,26 +4161,31 @@ impl DescribeEventsMessageSerializer {
 
         if let Some(ref field_value) = obj.duration {
             params.put(&format!("{}{}", prefix, "Duration"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.end_time {
-            params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "EndTime"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_identifier {
-            params.put(&format!("{}{}", prefix, "SourceIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.start_time {
-            params.put(&format!("{}{}", prefix, "StartTime"), &field_value);
+            params.put(&format!("{}{}", prefix, "StartTime"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4172,14 +4218,15 @@ impl DescribeHsmClientCertificatesMessageSerializer {
 
         if let Some(ref field_value) = obj.hsm_client_certificate_identifier {
             params.put(&format!("{}{}", prefix, "HsmClientCertificateIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -4222,14 +4269,15 @@ impl DescribeHsmConfigurationsMessageSerializer {
 
         if let Some(ref field_value) = obj.hsm_configuration_identifier {
             params.put(&format!("{}{}", prefix, "HsmConfigurationIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -4263,7 +4311,7 @@ impl DescribeLoggingStatusMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
 
     }
 }
@@ -4292,17 +4340,20 @@ impl DescribeOrderableClusterOptionsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cluster_version {
-            params.put(&format!("{}{}", prefix, "ClusterVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.node_type {
-            params.put(&format!("{}{}", prefix, "NodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "NodeType"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4330,15 +4381,16 @@ impl DescribeReservedNodeOfferingsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_node_offering_id {
             params.put(&format!("{}{}", prefix, "ReservedNodeOfferingId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4366,14 +4418,16 @@ impl DescribeReservedNodesMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.reserved_node_id {
-            params.put(&format!("{}{}", prefix, "ReservedNodeId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReservedNodeId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4397,7 +4451,7 @@ impl DescribeResizeMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
 
     }
 }
@@ -4428,15 +4482,16 @@ impl DescribeSnapshotCopyGrantsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_copy_grant_name {
             params.put(&format!("{}{}", prefix, "SnapshotCopyGrantName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -4476,18 +4531,20 @@ impl DescribeTableRestoreStatusMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cluster_identifier {
-            params.put(&format!("{}{}", prefix, "ClusterIdentifier"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.table_restore_request_id {
             params.put(&format!("{}{}", prefix, "TableRestoreRequestId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4521,17 +4578,20 @@ impl DescribeTagsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.marker {
-            params.put(&format!("{}{}", prefix, "Marker"), &field_value);
+            params.put(&format!("{}{}", prefix, "Marker"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_records {
             params.put(&format!("{}{}", prefix, "MaxRecords"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_name {
-            params.put(&format!("{}{}", prefix, "ResourceName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.resource_type {
-            params.put(&format!("{}{}", prefix, "ResourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ResourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(params,
@@ -4565,7 +4625,7 @@ impl DisableLoggingMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
 
     }
 }
@@ -4588,7 +4648,7 @@ impl DisableSnapshotCopyMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
 
     }
 }
@@ -4854,11 +4914,13 @@ impl EnableLoggingMessageSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "BucketName"), &obj.bucket_name);
+        params.put(&format!("{}{}", prefix, "BucketName"),
+                   &obj.bucket_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.s3_key_prefix {
-            params.put(&format!("{}{}", prefix, "S3KeyPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "S3KeyPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4888,16 +4950,16 @@ impl EnableSnapshotCopyMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DestinationRegion"),
-                   &obj.destination_region);
+                   &obj.destination_region.replace("+", "%2B"));
         if let Some(ref field_value) = obj.retention_period {
             params.put(&format!("{}{}", prefix, "RetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_copy_grant_name {
             params.put(&format!("{}{}", prefix, "SnapshotCopyGrantName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5736,22 +5798,24 @@ impl GetClusterCredentialsMessageSerializer {
 
         if let Some(ref field_value) = obj.auto_create {
             params.put(&format!("{}{}", prefix, "AutoCreate"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.db_groups {
             DbGroupListSerializer::serialize(params,
                                              &format!("{}{}", prefix, "DbGroups"),
                                              field_value);
         }
         if let Some(ref field_value) = obj.db_name {
-            params.put(&format!("{}{}", prefix, "DbName"), &field_value);
+            params.put(&format!("{}{}", prefix, "DbName"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DbUser"), &obj.db_user);
+        params.put(&format!("{}{}", prefix, "DbUser"),
+                   &obj.db_user.replace("+", "%2B"));
         if let Some(ref field_value) = obj.duration_seconds {
             params.put(&format!("{}{}", prefix, "DurationSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -6551,7 +6615,7 @@ impl ModifyClusterIamRolesMessageSerializer {
                                                 field_value);
         }
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.remove_iam_roles {
             IamRoleArnListSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "RemoveIamRoles"),
@@ -6661,17 +6725,17 @@ impl ModifyClusterMessageSerializer {
 
         if let Some(ref field_value) = obj.allow_version_upgrade {
             params.put(&format!("{}{}", prefix, "AllowVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.automated_snapshot_retention_period {
             params.put(&format!("{}{}", prefix, "AutomatedSnapshotRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.cluster_parameter_group_name {
             params.put(&format!("{}{}", prefix, "ClusterParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cluster_security_groups {
             ClusterSecurityGroupNameListSerializer::serialize(params,
@@ -6681,47 +6745,52 @@ impl ModifyClusterMessageSerializer {
                                                               field_value);
         }
         if let Some(ref field_value) = obj.cluster_type {
-            params.put(&format!("{}{}", prefix, "ClusterType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cluster_version {
-            params.put(&format!("{}{}", prefix, "ClusterVersion"), &field_value);
+            params.put(&format!("{}{}", prefix, "ClusterVersion"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.elastic_ip {
-            params.put(&format!("{}{}", prefix, "ElasticIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "ElasticIp"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enhanced_vpc_routing {
             params.put(&format!("{}{}", prefix, "EnhancedVpcRouting"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.hsm_client_certificate_identifier {
             params.put(&format!("{}{}", prefix, "HsmClientCertificateIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.hsm_configuration_identifier {
             params.put(&format!("{}{}", prefix, "HsmConfigurationIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.master_user_password {
-            params.put(&format!("{}{}", prefix, "MasterUserPassword"), &field_value);
+            params.put(&format!("{}{}", prefix, "MasterUserPassword"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.new_cluster_identifier {
             params.put(&format!("{}{}", prefix, "NewClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.node_type {
-            params.put(&format!("{}{}", prefix, "NodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "NodeType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.number_of_nodes {
             params.put(&format!("{}{}", prefix, "NumberOfNodes"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.publicly_accessible {
             params.put(&format!("{}{}", prefix, "PubliclyAccessible"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
             VpcSecurityGroupIdListSerializer::serialize(params,
@@ -6754,7 +6823,7 @@ impl ModifyClusterParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ParameterGroupName"),
-                   &obj.parameter_group_name);
+                   &obj.parameter_group_name.replace("+", "%2B"));
         ParametersListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Parameters"),
                                             &obj.parameters);
@@ -6831,9 +6900,10 @@ impl ModifyClusterSubnetGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterSubnetGroupName"),
-                   &obj.cluster_subnet_group_name);
+                   &obj.cluster_subnet_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         SubnetIdentifierListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "SubnetIds"),
@@ -6921,7 +6991,7 @@ impl ModifyEventSubscriptionMessageSerializer {
 
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(params,
@@ -6929,10 +6999,12 @@ impl ModifyEventSubscriptionMessageSerializer {
                                                      field_value);
         }
         if let Some(ref field_value) = obj.severity {
-            params.put(&format!("{}{}", prefix, "Severity"), &field_value);
+            params.put(&format!("{}{}", prefix, "Severity"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.sns_topic_arn {
-            params.put(&format!("{}{}", prefix, "SnsTopicArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnsTopicArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_ids {
             SourceIdsListSerializer::serialize(params,
@@ -6940,10 +7012,11 @@ impl ModifyEventSubscriptionMessageSerializer {
                                                field_value);
         }
         if let Some(ref field_value) = obj.source_type {
-            params.put(&format!("{}{}", prefix, "SourceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceType"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SubscriptionName"),
-                   &obj.subscription_name);
+                   &obj.subscription_name.replace("+", "%2B"));
 
     }
 }
@@ -7016,9 +7089,9 @@ impl ModifySnapshotCopyRetentionPeriodMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "RetentionPeriod"),
-                   &obj.retention_period.to_string());
+                   &obj.retention_period.to_string().replace("+", "%2B"));
 
     }
 }
@@ -7346,33 +7419,40 @@ impl ParameterSerializer {
         }
 
         if let Some(ref field_value) = obj.allowed_values {
-            params.put(&format!("{}{}", prefix, "AllowedValues"), &field_value);
+            params.put(&format!("{}{}", prefix, "AllowedValues"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.apply_type {
-            params.put(&format!("{}{}", prefix, "ApplyType"), &field_value);
+            params.put(&format!("{}{}", prefix, "ApplyType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.data_type {
-            params.put(&format!("{}{}", prefix, "DataType"), &field_value);
+            params.put(&format!("{}{}", prefix, "DataType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.description {
-            params.put(&format!("{}{}", prefix, "Description"), &field_value);
+            params.put(&format!("{}{}", prefix, "Description"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.is_modifiable {
             params.put(&format!("{}{}", prefix, "IsModifiable"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.minimum_engine_version {
             params.put(&format!("{}{}", prefix, "MinimumEngineVersion"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameter_name {
-            params.put(&format!("{}{}", prefix, "ParameterName"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.parameter_value {
-            params.put(&format!("{}{}", prefix, "ParameterValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "ParameterValue"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source {
-            params.put(&format!("{}{}", prefix, "Source"), &field_value);
+            params.put(&format!("{}{}", prefix, "Source"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -7611,10 +7691,10 @@ impl PurchaseReservedNodeOfferingMessageSerializer {
 
         if let Some(ref field_value) = obj.node_count {
             params.put(&format!("{}{}", prefix, "NodeCount"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ReservedNodeOfferingId"),
-                   &obj.reserved_node_offering_id);
+                   &obj.reserved_node_offering_id.replace("+", "%2B"));
 
     }
 }
@@ -7686,7 +7766,7 @@ impl RebootClusterMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
 
     }
 }
@@ -8262,7 +8342,7 @@ impl ResetClusterParameterGroupMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ParameterGroupName"),
-                   &obj.parameter_group_name);
+                   &obj.parameter_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.parameters {
             ParametersListSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "Parameters"),
@@ -8270,7 +8350,7 @@ impl ResetClusterParameterGroupMessageSerializer {
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
             params.put(&format!("{}{}", prefix, "ResetAllParameters"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -8503,24 +8583,26 @@ impl RestoreFromClusterSnapshotMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.additional_info {
-            params.put(&format!("{}{}", prefix, "AdditionalInfo"), &field_value);
+            params.put(&format!("{}{}", prefix, "AdditionalInfo"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.allow_version_upgrade {
             params.put(&format!("{}{}", prefix, "AllowVersionUpgrade"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.automated_snapshot_retention_period {
             params.put(&format!("{}{}", prefix, "AutomatedSnapshotRetentionPeriod"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.availability_zone {
-            params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
+            params.put(&format!("{}{}", prefix, "AvailabilityZone"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.cluster_parameter_group_name {
             params.put(&format!("{}{}", prefix, "ClusterParameterGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.cluster_security_groups {
             ClusterSecurityGroupNameListSerializer::serialize(params,
@@ -8531,22 +8613,23 @@ impl RestoreFromClusterSnapshotMessageSerializer {
         }
         if let Some(ref field_value) = obj.cluster_subnet_group_name {
             params.put(&format!("{}{}", prefix, "ClusterSubnetGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.elastic_ip {
-            params.put(&format!("{}{}", prefix, "ElasticIp"), &field_value);
+            params.put(&format!("{}{}", prefix, "ElasticIp"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.enhanced_vpc_routing {
             params.put(&format!("{}{}", prefix, "EnhancedVpcRouting"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.hsm_client_certificate_identifier {
             params.put(&format!("{}{}", prefix, "HsmClientCertificateIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.hsm_configuration_identifier {
             params.put(&format!("{}{}", prefix, "HsmConfigurationIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.iam_roles {
             IamRoleArnListSerializer::serialize(params,
@@ -8554,31 +8637,35 @@ impl RestoreFromClusterSnapshotMessageSerializer {
                                                 field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
-            params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.node_type {
-            params.put(&format!("{}{}", prefix, "NodeType"), &field_value);
+            params.put(&format!("{}{}", prefix, "NodeType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.owner_account {
-            params.put(&format!("{}{}", prefix, "OwnerAccount"), &field_value);
+            params.put(&format!("{}{}", prefix, "OwnerAccount"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(&format!("{}{}", prefix, "PreferredMaintenanceWindow"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.publicly_accessible {
             params.put(&format!("{}{}", prefix, "PubliclyAccessible"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.snapshot_cluster_identifier {
             params.put(&format!("{}{}", prefix, "SnapshotClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SnapshotIdentifier"),
-                   &obj.snapshot_identifier);
+                   &obj.snapshot_identifier.replace("+", "%2B"));
         if let Some(ref field_value) = obj.vpc_security_group_ids {
             VpcSecurityGroupIdListSerializer::serialize(params,
                                                         &format!("{}{}",
@@ -8754,23 +8841,26 @@ impl RestoreTableFromClusterSnapshotMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "NewTableName"),
-                   &obj.new_table_name);
+                   &obj.new_table_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SnapshotIdentifier"),
-                   &obj.snapshot_identifier);
+                   &obj.snapshot_identifier.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SourceDatabaseName"),
-                   &obj.source_database_name);
+                   &obj.source_database_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.source_schema_name {
-            params.put(&format!("{}{}", prefix, "SourceSchemaName"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceSchemaName"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SourceTableName"),
-                   &obj.source_table_name);
+                   &obj.source_table_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.target_database_name {
-            params.put(&format!("{}{}", prefix, "TargetDatabaseName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TargetDatabaseName"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.target_schema_name {
-            params.put(&format!("{}{}", prefix, "TargetSchemaName"), &field_value);
+            params.put(&format!("{}{}", prefix, "TargetSchemaName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8849,17 +8939,18 @@ impl RevokeClusterSecurityGroupIngressMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cidrip {
-            params.put(&format!("{}{}", prefix, "CIDRIP"), &field_value);
+            params.put(&format!("{}{}", prefix, "CIDRIP"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "ClusterSecurityGroupName"),
-                   &obj.cluster_security_group_name);
+                   &obj.cluster_security_group_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.ec2_security_group_name {
             params.put(&format!("{}{}", prefix, "EC2SecurityGroupName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.ec2_security_group_owner_id {
             params.put(&format!("{}{}", prefix, "EC2SecurityGroupOwnerId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -8936,13 +9027,13 @@ impl RevokeSnapshotAccessMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AccountWithRestoreAccess"),
-                   &obj.account_with_restore_access);
+                   &obj.account_with_restore_access.replace("+", "%2B"));
         if let Some(ref field_value) = obj.snapshot_cluster_identifier {
             params.put(&format!("{}{}", prefix, "SnapshotClusterIdentifier"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SnapshotIdentifier"),
-                   &obj.snapshot_identifier);
+                   &obj.snapshot_identifier.replace("+", "%2B"));
 
     }
 }
@@ -9012,7 +9103,7 @@ impl RotateEncryptionKeyMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ClusterIdentifier"),
-                   &obj.cluster_identifier);
+                   &obj.cluster_identifier.replace("+", "%2B"));
 
     }
 }
@@ -10087,10 +10178,12 @@ impl TagSerializer {
         }
 
         if let Some(ref field_value) = obj.key {
-            params.put(&format!("{}{}", prefix, "Key"), &field_value);
+            params.put(&format!("{}{}", prefix, "Key"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -118,14 +118,16 @@ impl AttributeSerializer {
 
         if let Some(ref field_value) = obj.alternate_name_encoding {
             params.put(&format!("{}{}", prefix, "AlternateNameEncoding"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.alternate_value_encoding {
             params.put(&format!("{}{}", prefix, "AlternateValueEncoding"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
-        params.put(&format!("{}{}", prefix, "Value"), &obj.value);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Value"),
+                   &obj.value.replace("+", "%2B"));
 
     }
 }
@@ -200,7 +202,8 @@ impl BatchDeleteAttributesRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         DeletableItemListSerializer::serialize(params,
                                                &format!("{}{}", prefix, "Items"),
                                                &obj.items);
@@ -226,7 +229,8 @@ impl BatchPutAttributesRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         ReplaceableItemListSerializer::serialize(params,
                                                  &format!("{}{}", prefix, "Items"),
                                                  &obj.items);
@@ -250,7 +254,8 @@ impl CreateDomainRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -276,7 +281,8 @@ impl DeletableItemSerializer {
                                                &format!("{}{}", prefix, "Attributes"),
                                                field_value);
         }
-        params.put(&format!("{}{}", prefix, "ItemName"), &obj.name);
+        params.put(&format!("{}{}", prefix, "ItemName"),
+                   &obj.name.replace("+", "%2B"));
 
     }
 }
@@ -320,13 +326,15 @@ impl DeleteAttributesRequestSerializer {
                                                &format!("{}{}", prefix, "Attributes"),
                                                field_value);
         }
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.expected {
             UpdateConditionSerializer::serialize(params,
                                                  &format!("{}{}", prefix, "Expected"),
                                                  field_value);
         }
-        params.put(&format!("{}{}", prefix, "ItemName"), &obj.item_name);
+        params.put(&format!("{}{}", prefix, "ItemName"),
+                   &obj.item_name.replace("+", "%2B"));
 
     }
 }
@@ -347,7 +355,8 @@ impl DeleteDomainRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -368,7 +377,8 @@ impl DomainMetadataRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
 
     }
 }
@@ -519,10 +529,12 @@ impl GetAttributesRequestSerializer {
         }
         if let Some(ref field_value) = obj.consistent_read {
             params.put(&format!("{}{}", prefix, "ConsistentRead"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
-        params.put(&format!("{}{}", prefix, "ItemName"), &obj.item_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "ItemName"),
+                   &obj.item_name.replace("+", "%2B"));
 
     }
 }
@@ -699,10 +711,11 @@ impl ListDomainsRequestSerializer {
 
         if let Some(ref field_value) = obj.max_number_of_domains {
             params.put(&format!("{}{}", prefix, "MaxNumberOfDomains"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -802,13 +815,15 @@ impl PutAttributesRequestSerializer {
         ReplaceableAttributeListSerializer::serialize(params,
                                                       &format!("{}{}", prefix, "Attributes"),
                                                       &obj.attributes);
-        params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
+        params.put(&format!("{}{}", prefix, "DomainName"),
+                   &obj.domain_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.expected {
             UpdateConditionSerializer::serialize(params,
                                                  &format!("{}{}", prefix, "Expected"),
                                                  field_value);
         }
-        params.put(&format!("{}{}", prefix, "ItemName"), &obj.item_name);
+        params.put(&format!("{}{}", prefix, "ItemName"),
+                   &obj.item_name.replace("+", "%2B"));
 
     }
 }
@@ -834,12 +849,14 @@ impl ReplaceableAttributeSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.replace {
             params.put(&format!("{}{}", prefix, "Replace"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Value"), &obj.value);
+        params.put(&format!("{}{}", prefix, "Value"),
+                   &obj.value.replace("+", "%2B"));
 
     }
 }
@@ -878,7 +895,8 @@ impl ReplaceableItemSerializer {
         ReplaceableAttributeListSerializer::serialize(params,
                                                       &format!("{}{}", prefix, "Attributes"),
                                                       &obj.attributes);
-        params.put(&format!("{}{}", prefix, "ItemName"), &obj.name);
+        params.put(&format!("{}{}", prefix, "ItemName"),
+                   &obj.name.replace("+", "%2B"));
 
     }
 }
@@ -917,13 +935,14 @@ impl SelectRequestSerializer {
 
         if let Some(ref field_value) = obj.consistent_read {
             params.put(&format!("{}{}", prefix, "ConsistentRead"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SelectExpression"),
-                   &obj.select_expression);
+                   &obj.select_expression.replace("+", "%2B"));
 
     }
 }
@@ -1018,13 +1037,16 @@ impl UpdateConditionSerializer {
         }
 
         if let Some(ref field_value) = obj.exists {
-            params.put(&format!("{}{}", prefix, "Exists"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Exists"),
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.name {
-            params.put(&format!("{}{}", prefix, "Name"), &field_value);
+            params.put(&format!("{}{}", prefix, "Name"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value);
+            params.put(&format!("{}{}", prefix, "Value"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -104,8 +104,10 @@ impl AddHeaderActionSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "HeaderName"), &obj.header_name);
-        params.put(&format!("{}{}", prefix, "HeaderValue"), &obj.header_value);
+        params.put(&format!("{}{}", prefix, "HeaderName"),
+                   &obj.header_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "HeaderValue"),
+                   &obj.header_value.replace("+", "%2B"));
 
     }
 }
@@ -319,15 +321,19 @@ impl BounceActionSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Message"), &obj.message);
-        params.put(&format!("{}{}", prefix, "Sender"), &obj.sender);
+        params.put(&format!("{}{}", prefix, "Message"),
+                   &obj.message.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Sender"),
+                   &obj.sender.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SmtpReplyCode"),
-                   &obj.smtp_reply_code);
+                   &obj.smtp_reply_code.replace("+", "%2B"));
         if let Some(ref field_value) = obj.status_code {
-            params.put(&format!("{}{}", prefix, "StatusCode"), &field_value);
+            params.put(&format!("{}{}", prefix, "StatusCode"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.topic_arn {
-            params.put(&format!("{}{}", prefix, "TopicArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TopicArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -399,11 +405,14 @@ impl BouncedRecipientInfoSerializer {
         }
 
         if let Some(ref field_value) = obj.bounce_type {
-            params.put(&format!("{}{}", prefix, "BounceType"), &field_value);
+            params.put(&format!("{}{}", prefix, "BounceType"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Recipient"), &obj.recipient);
+        params.put(&format!("{}{}", prefix, "Recipient"),
+                   &obj.recipient.replace("+", "%2B"));
         if let Some(ref field_value) = obj.recipient_arn {
-            params.put(&format!("{}{}", prefix, "RecipientArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "RecipientArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.recipient_dsn_fields {
             RecipientDsnFieldsSerializer::serialize(params,
@@ -460,8 +469,9 @@ impl CloneReceiptRuleSetRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "OriginalRuleSetName"),
-                   &obj.original_rule_set_name);
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+                   &obj.original_rule_set_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -629,11 +639,11 @@ impl CloudWatchDimensionConfigurationSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DefaultDimensionValue"),
-                   &obj.default_dimension_value);
+                   &obj.default_dimension_value.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DimensionName"),
-                   &obj.dimension_name);
+                   &obj.dimension_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "DimensionValueSource"),
-                   &obj.dimension_value_source);
+                   &obj.dimension_value_source.replace("+", "%2B"));
 
     }
 }
@@ -751,7 +761,8 @@ impl ConfigurationSetSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
 
     }
 }
@@ -843,9 +854,11 @@ impl ContentSerializer {
         }
 
         if let Some(ref field_value) = obj.charset {
-            params.put(&format!("{}{}", prefix, "Charset"), &field_value);
+            params.put(&format!("{}{}", prefix, "Charset"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Data"), &obj.data);
+        params.put(&format!("{}{}", prefix, "Data"),
+                   &obj.data.replace("+", "%2B"));
 
     }
 }
@@ -886,7 +899,7 @@ impl CreateConfigurationSetEventDestinationRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ConfigurationSetName"),
-                   &obj.configuration_set_name);
+                   &obj.configuration_set_name.replace("+", "%2B"));
         EventDestinationSerializer::serialize(params,
                                               &format!("{}{}", prefix, "EventDestination"),
                                               &obj.event_destination);
@@ -1023,10 +1036,12 @@ impl CreateReceiptRuleRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.after {
-            params.put(&format!("{}{}", prefix, "After"), &field_value);
+            params.put(&format!("{}{}", prefix, "After"),
+                       &field_value.replace("+", "%2B"));
         }
         ReceiptRuleSerializer::serialize(params, &format!("{}{}", prefix, "Rule"), &obj.rule);
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1068,7 +1083,8 @@ impl CreateReceiptRuleSetRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1143,9 +1159,9 @@ impl DeleteConfigurationSetEventDestinationRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ConfigurationSetName"),
-                   &obj.configuration_set_name);
+                   &obj.configuration_set_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "EventDestinationName"),
-                   &obj.event_destination_name);
+                   &obj.event_destination_name.replace("+", "%2B"));
 
     }
 }
@@ -1189,7 +1205,7 @@ impl DeleteConfigurationSetRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ConfigurationSetName"),
-                   &obj.configuration_set_name);
+                   &obj.configuration_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1233,8 +1249,10 @@ impl DeleteIdentityPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -1276,7 +1294,8 @@ impl DeleteIdentityRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
 
     }
 }
@@ -1318,7 +1337,8 @@ impl DeleteReceiptFilterRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "FilterName"), &obj.filter_name);
+        params.put(&format!("{}{}", prefix, "FilterName"),
+                   &obj.filter_name.replace("+", "%2B"));
 
     }
 }
@@ -1362,8 +1382,10 @@ impl DeleteReceiptRuleRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "RuleName"), &obj.rule_name);
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleName"),
+                   &obj.rule_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1405,7 +1427,8 @@ impl DeleteReceiptRuleSetRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1447,7 +1470,8 @@ impl DeleteVerifiedEmailAddressRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "EmailAddress"), &obj.email_address);
+        params.put(&format!("{}{}", prefix, "EmailAddress"),
+                   &obj.email_address.replace("+", "%2B"));
 
     }
 }
@@ -1556,7 +1580,7 @@ impl DescribeConfigurationSetRequestSerializer {
                                                                field_value);
         }
         params.put(&format!("{}{}", prefix, "ConfigurationSetName"),
-                   &obj.configuration_set_name);
+                   &obj.configuration_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1638,8 +1662,10 @@ impl DescribeReceiptRuleRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "RuleName"), &obj.rule_name);
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleName"),
+                   &obj.rule_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1710,7 +1736,8 @@ impl DescribeReceiptRuleSetRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -1978,7 +2005,7 @@ impl EventDestinationSerializer {
         }
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.kinesis_firehose_destination {
             KinesisFirehoseDestinationSerializer::serialize(params,
@@ -1990,7 +2017,8 @@ impl EventDestinationSerializer {
         EventTypesSerializer::serialize(params,
                                         &format!("{}{}", prefix, "MatchingEventTypes"),
                                         &obj.matching_event_types);
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.sns_destination {
             SNSDestinationSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "SNSDestination"),
@@ -2141,8 +2169,10 @@ impl ExtensionFieldSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
-        params.put(&format!("{}{}", prefix, "Value"), &obj.value);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Value"),
+                   &obj.value.replace("+", "%2B"));
 
     }
 }
@@ -2407,7 +2437,8 @@ impl GetIdentityPoliciesRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
         PolicyNameListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "PolicyNames"),
                                             &obj.policy_names);
@@ -3107,8 +3138,9 @@ impl KinesisFirehoseDestinationSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DeliveryStreamARN"),
-                   &obj.delivery_stream_arn);
-        params.put(&format!("{}{}", prefix, "IAMRoleARN"), &obj.iam_role_arn);
+                   &obj.delivery_stream_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "IAMRoleARN"),
+                   &obj.iam_role_arn.replace("+", "%2B"));
 
     }
 }
@@ -3187,12 +3219,15 @@ impl LambdaActionSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "FunctionArn"), &obj.function_arn);
+        params.put(&format!("{}{}", prefix, "FunctionArn"),
+                   &obj.function_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.invocation_type {
-            params.put(&format!("{}{}", prefix, "InvocationType"), &field_value);
+            params.put(&format!("{}{}", prefix, "InvocationType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.topic_arn {
-            params.put(&format!("{}{}", prefix, "TopicArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TopicArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3219,10 +3254,11 @@ impl ListConfigurationSetsRequestSerializer {
 
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3306,14 +3342,16 @@ impl ListIdentitiesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.identity_type {
-            params.put(&format!("{}{}", prefix, "IdentityType"), &field_value);
+            params.put(&format!("{}{}", prefix, "IdentityType"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.max_items {
             params.put(&format!("{}{}", prefix, "MaxItems"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3391,7 +3429,8 @@ impl ListIdentityPoliciesRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
 
     }
 }
@@ -3532,7 +3571,8 @@ impl ListReceiptRuleSetsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -3760,14 +3800,16 @@ impl MessageDsnSerializer {
         }
 
         if let Some(ref field_value) = obj.arrival_date {
-            params.put(&format!("{}{}", prefix, "ArrivalDate"), &field_value);
+            params.put(&format!("{}{}", prefix, "ArrivalDate"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.extension_fields {
             ExtensionFieldListSerializer::serialize(params,
                                                     &format!("{}{}", prefix, "ExtensionFields"),
                                                     field_value);
         }
-        params.put(&format!("{}{}", prefix, "ReportingMta"), &obj.reporting_mta);
+        params.put(&format!("{}{}", prefix, "ReportingMta"),
+                   &obj.reporting_mta.replace("+", "%2B"));
 
     }
 }
@@ -3805,8 +3847,10 @@ impl MessageTagSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
-        params.put(&format!("{}{}", prefix, "Value"), &obj.value);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Value"),
+                   &obj.value.replace("+", "%2B"));
 
     }
 }
@@ -4003,9 +4047,12 @@ impl PutIdentityPolicyRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
-        params.put(&format!("{}{}", prefix, "Policy"), &obj.policy);
-        params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Policy"),
+                   &obj.policy.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "PolicyName"),
+                   &obj.policy_name.replace("+", "%2B"));
 
     }
 }
@@ -4048,7 +4095,9 @@ impl RawMessageSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "Data"),
-                   ::std::str::from_utf8(&obj.data).unwrap());
+                   ::std::str::from_utf8(&obj.data)
+                       .unwrap()
+                       .replace("+", "%2B"));
 
     }
 }
@@ -4313,7 +4362,8 @@ impl ReceiptFilterSerializer {
         ReceiptIpFilterSerializer::serialize(params,
                                              &format!("{}{}", prefix, "IpFilter"),
                                              &obj.ip_filter);
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
 
     }
 }
@@ -4451,8 +4501,10 @@ impl ReceiptIpFilterSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Cidr"), &obj.cidr);
-        params.put(&format!("{}{}", prefix, "Policy"), &obj.policy);
+        params.put(&format!("{}{}", prefix, "Cidr"),
+                   &obj.cidr.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Policy"),
+                   &obj.policy.replace("+", "%2B"));
 
     }
 }
@@ -4555,9 +4607,10 @@ impl ReceiptRuleSerializer {
         }
         if let Some(ref field_value) = obj.enabled {
             params.put(&format!("{}{}", prefix, "Enabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.recipients {
             RecipientsListSerializer::serialize(params,
                                                 &format!("{}{}", prefix, "Recipients"),
@@ -4565,10 +4618,11 @@ impl ReceiptRuleSerializer {
         }
         if let Some(ref field_value) = obj.scan_enabled {
             params.put(&format!("{}{}", prefix, "ScanEnabled"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tls_policy {
-            params.put(&format!("{}{}", prefix, "TlsPolicy"), &field_value);
+            params.put(&format!("{}{}", prefix, "TlsPolicy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -4797,9 +4851,11 @@ impl RecipientDsnFieldsSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Action"), &obj.action);
+        params.put(&format!("{}{}", prefix, "Action"),
+                   &obj.action.replace("+", "%2B"));
         if let Some(ref field_value) = obj.diagnostic_code {
-            params.put(&format!("{}{}", prefix, "DiagnosticCode"), &field_value);
+            params.put(&format!("{}{}", prefix, "DiagnosticCode"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.extension_fields {
             ExtensionFieldListSerializer::serialize(params,
@@ -4807,15 +4863,19 @@ impl RecipientDsnFieldsSerializer {
                                                     field_value);
         }
         if let Some(ref field_value) = obj.final_recipient {
-            params.put(&format!("{}{}", prefix, "FinalRecipient"), &field_value);
+            params.put(&format!("{}{}", prefix, "FinalRecipient"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.last_attempt_date {
-            params.put(&format!("{}{}", prefix, "LastAttemptDate"), &field_value);
+            params.put(&format!("{}{}", prefix, "LastAttemptDate"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.remote_mta {
-            params.put(&format!("{}{}", prefix, "RemoteMta"), &field_value);
+            params.put(&format!("{}{}", prefix, "RemoteMta"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Status"), &obj.status);
+        params.put(&format!("{}{}", prefix, "Status"),
+                   &obj.status.replace("+", "%2B"));
 
     }
 }
@@ -4895,7 +4955,8 @@ impl ReorderReceiptRuleSetRequestSerializer {
         ReceiptRuleNamesListSerializer::serialize(params,
                                                   &format!("{}{}", prefix, "RuleNames"),
                                                   &obj.rule_names);
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -5000,15 +5061,19 @@ impl S3ActionSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "BucketName"), &obj.bucket_name);
+        params.put(&format!("{}{}", prefix, "BucketName"),
+                   &obj.bucket_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.kms_key_arn {
-            params.put(&format!("{}{}", prefix, "KmsKeyArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "KmsKeyArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.object_key_prefix {
-            params.put(&format!("{}{}", prefix, "ObjectKeyPrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "ObjectKeyPrefix"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.topic_arn {
-            params.put(&format!("{}{}", prefix, "TopicArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TopicArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5110,9 +5175,11 @@ impl SNSActionSerializer {
         }
 
         if let Some(ref field_value) = obj.encoding {
-            params.put(&format!("{}{}", prefix, "Encoding"), &field_value);
+            params.put(&format!("{}{}", prefix, "Encoding"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -5191,7 +5258,8 @@ impl SNSDestinationSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "TopicARN"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "TopicARN"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -5223,9 +5291,11 @@ impl SendBounceRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "BounceSender"), &obj.bounce_sender);
+        params.put(&format!("{}{}", prefix, "BounceSender"),
+                   &obj.bounce_sender.replace("+", "%2B"));
         if let Some(ref field_value) = obj.bounce_sender_arn {
-            params.put(&format!("{}{}", prefix, "BounceSenderArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "BounceSenderArn"),
+                       &field_value.replace("+", "%2B"));
         }
         BouncedRecipientInfoListSerializer::serialize(params,
                                                       &format!("{}{}",
@@ -5233,7 +5303,8 @@ impl SendBounceRequestSerializer {
                                                               "BouncedRecipientInfoList"),
                                                       &obj.bounced_recipient_info_list);
         if let Some(ref field_value) = obj.explanation {
-            params.put(&format!("{}{}", prefix, "Explanation"), &field_value);
+            params.put(&format!("{}{}", prefix, "Explanation"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.message_dsn {
             MessageDsnSerializer::serialize(params,
@@ -5241,7 +5312,7 @@ impl SendBounceRequestSerializer {
                                             field_value);
         }
         params.put(&format!("{}{}", prefix, "OriginalMessageId"),
-                   &obj.original_message_id);
+                   &obj.original_message_id.replace("+", "%2B"));
 
     }
 }
@@ -5445,7 +5516,7 @@ impl SendEmailRequestSerializer {
 
         if let Some(ref field_value) = obj.configuration_set_name {
             params.put(&format!("{}{}", prefix, "ConfigurationSetName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         DestinationSerializer::serialize(params,
                                          &format!("{}{}", prefix, "Destination"),
@@ -5457,14 +5528,18 @@ impl SendEmailRequestSerializer {
                                              field_value);
         }
         if let Some(ref field_value) = obj.return_path {
-            params.put(&format!("{}{}", prefix, "ReturnPath"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReturnPath"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.return_path_arn {
-            params.put(&format!("{}{}", prefix, "ReturnPathArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReturnPathArn"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Source"), &obj.source);
+        params.put(&format!("{}{}", prefix, "Source"),
+                   &obj.source.replace("+", "%2B"));
         if let Some(ref field_value) = obj.source_arn {
-            params.put(&format!("{}{}", prefix, "SourceArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             MessageTagListSerializer::serialize(params,
@@ -5557,7 +5632,7 @@ impl SendRawEmailRequestSerializer {
 
         if let Some(ref field_value) = obj.configuration_set_name {
             params.put(&format!("{}{}", prefix, "ConfigurationSetName"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.destinations {
             AddressListSerializer::serialize(params,
@@ -5565,19 +5640,23 @@ impl SendRawEmailRequestSerializer {
                                              field_value);
         }
         if let Some(ref field_value) = obj.from_arn {
-            params.put(&format!("{}{}", prefix, "FromArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "FromArn"),
+                       &field_value.replace("+", "%2B"));
         }
         RawMessageSerializer::serialize(params,
                                         &format!("{}{}", prefix, "RawMessage"),
                                         &obj.raw_message);
         if let Some(ref field_value) = obj.return_path_arn {
-            params.put(&format!("{}{}", prefix, "ReturnPathArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "ReturnPathArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source {
-            params.put(&format!("{}{}", prefix, "Source"), &field_value);
+            params.put(&format!("{}{}", prefix, "Source"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.source_arn {
-            params.put(&format!("{}{}", prefix, "SourceArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "SourceArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.tags {
             MessageTagListSerializer::serialize(params,
@@ -5669,7 +5748,8 @@ impl SetActiveReceiptRuleSetRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.rule_set_name {
-            params.put(&format!("{}{}", prefix, "RuleSetName"), &field_value);
+            params.put(&format!("{}{}", prefix, "RuleSetName"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5716,8 +5796,9 @@ impl SetIdentityDkimEnabledRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DkimEnabled"),
-                   &obj.dkim_enabled.to_string());
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
+                   &obj.dkim_enabled.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
 
     }
 }
@@ -5764,8 +5845,9 @@ impl SetIdentityFeedbackForwardingEnabledRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ForwardingEnabled"),
-                   &obj.forwarding_enabled.to_string());
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
+                   &obj.forwarding_enabled.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
 
     }
 }
@@ -5815,10 +5897,11 @@ impl SetIdentityHeadersInNotificationsEnabledRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "Enabled"),
-                   &obj.enabled.to_string());
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
+                   &obj.enabled.to_string().replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "NotificationType"),
-                   &obj.notification_type);
+                   &obj.notification_type.replace("+", "%2B"));
 
     }
 }
@@ -5867,11 +5950,13 @@ impl SetIdentityMailFromDomainRequestSerializer {
 
         if let Some(ref field_value) = obj.behavior_on_mx_failure {
             params.put(&format!("{}{}", prefix, "BehaviorOnMXFailure"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
         if let Some(ref field_value) = obj.mail_from_domain {
-            params.put(&format!("{}{}", prefix, "MailFromDomain"), &field_value);
+            params.put(&format!("{}{}", prefix, "MailFromDomain"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5919,11 +6004,13 @@ impl SetIdentityNotificationTopicRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
+        params.put(&format!("{}{}", prefix, "Identity"),
+                   &obj.identity.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "NotificationType"),
-                   &obj.notification_type);
+                   &obj.notification_type.replace("+", "%2B"));
         if let Some(ref field_value) = obj.sns_topic {
-            params.put(&format!("{}{}", prefix, "SnsTopic"), &field_value);
+            params.put(&format!("{}{}", prefix, "SnsTopic"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -5972,10 +6059,13 @@ impl SetReceiptRulePositionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.after {
-            params.put(&format!("{}{}", prefix, "After"), &field_value);
+            params.put(&format!("{}{}", prefix, "After"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "RuleName"), &obj.rule_name);
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleName"),
+                   &obj.rule_name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -6065,9 +6155,11 @@ impl StopActionSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Scope"), &obj.scope);
+        params.put(&format!("{}{}", prefix, "Scope"),
+                   &obj.scope.replace("+", "%2B"));
         if let Some(ref field_value) = obj.topic_arn {
-            params.put(&format!("{}{}", prefix, "TopicArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TopicArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -6137,7 +6229,7 @@ impl UpdateConfigurationSetEventDestinationRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "ConfigurationSetName"),
-                   &obj.configuration_set_name);
+                   &obj.configuration_set_name.replace("+", "%2B"));
         EventDestinationSerializer::serialize(params,
                                               &format!("{}{}", prefix, "EventDestination"),
                                               &obj.event_destination);
@@ -6186,7 +6278,8 @@ impl UpdateReceiptRuleRequestSerializer {
         }
 
         ReceiptRuleSerializer::serialize(params, &format!("{}{}", prefix, "Rule"), &obj.rule);
-        params.put(&format!("{}{}", prefix, "RuleSetName"), &obj.rule_set_name);
+        params.put(&format!("{}{}", prefix, "RuleSetName"),
+                   &obj.rule_set_name.replace("+", "%2B"));
 
     }
 }
@@ -6323,7 +6416,8 @@ impl VerifyDomainDkimRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Domain"), &obj.domain);
+        params.put(&format!("{}{}", prefix, "Domain"),
+                   &obj.domain.replace("+", "%2B"));
 
     }
 }
@@ -6395,7 +6489,8 @@ impl VerifyDomainIdentityRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Domain"), &obj.domain);
+        params.put(&format!("{}{}", prefix, "Domain"),
+                   &obj.domain.replace("+", "%2B"));
 
     }
 }
@@ -6467,7 +6562,8 @@ impl VerifyEmailAddressRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "EmailAddress"), &obj.email_address);
+        params.put(&format!("{}{}", prefix, "EmailAddress"),
+                   &obj.email_address.replace("+", "%2B"));
 
     }
 }
@@ -6489,7 +6585,8 @@ impl VerifyEmailIdentityRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "EmailAddress"), &obj.email_address);
+        params.put(&format!("{}{}", prefix, "EmailAddress"),
+                   &obj.email_address.replace("+", "%2B"));
 
     }
 }
@@ -6582,9 +6679,10 @@ impl WorkmailActionSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "OrganizationArn"),
-                   &obj.organization_arn);
+                   &obj.organization_arn.replace("+", "%2B"));
         if let Some(ref field_value) = obj.topic_arn {
-            params.put(&format!("{}{}", prefix, "TopicArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TopicArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -93,8 +93,10 @@ impl AddPermissionInputSerializer {
         ActionsListSerializer::serialize(params,
                                          &format!("{}{}", prefix, "ActionName"),
                                          &obj.action_name);
-        params.put(&format!("{}{}", prefix, "Label"), &obj.label);
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "Label"),
+                   &obj.label.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -158,7 +160,8 @@ impl CheckIfPhoneNumberIsOptedOutInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "phoneNumber"), &obj.phone_number);
+        params.put(&format!("{}{}", prefix, "phoneNumber"),
+                   &obj.phone_number.replace("+", "%2B"));
 
     }
 }
@@ -236,10 +239,12 @@ impl ConfirmSubscriptionInputSerializer {
 
         if let Some(ref field_value) = obj.authenticate_on_unsubscribe {
             params.put(&format!("{}{}", prefix, "AuthenticateOnUnsubscribe"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Token"), &obj.token);
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "Token"),
+                   &obj.token.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -367,8 +372,10 @@ impl CreatePlatformApplicationInputSerializer {
         MapStringToStringSerializer::serialize(params,
                                                &format!("{}{}", prefix, "Attributes"),
                                                &obj.attributes);
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
-        params.put(&format!("{}{}", prefix, "Platform"), &obj.platform);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Platform"),
+                   &obj.platform.replace("+", "%2B"));
 
     }
 }
@@ -453,11 +460,13 @@ impl CreatePlatformEndpointInputSerializer {
                                                    field_value);
         }
         if let Some(ref field_value) = obj.custom_user_data {
-            params.put(&format!("{}{}", prefix, "CustomUserData"), &field_value);
+            params.put(&format!("{}{}", prefix, "CustomUserData"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "PlatformApplicationArn"),
-                   &obj.platform_application_arn);
-        params.put(&format!("{}{}", prefix, "Token"), &obj.token);
+                   &obj.platform_application_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "Token"),
+                   &obj.token.replace("+", "%2B"));
 
     }
 }
@@ -479,7 +488,8 @@ impl CreateTopicInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
 
     }
 }
@@ -562,7 +572,8 @@ impl DeleteEndpointInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "EndpointArn"), &obj.endpoint_arn);
+        params.put(&format!("{}{}", prefix, "EndpointArn"),
+                   &obj.endpoint_arn.replace("+", "%2B"));
 
     }
 }
@@ -585,7 +596,7 @@ impl DeletePlatformApplicationInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "PlatformApplicationArn"),
-                   &obj.platform_application_arn);
+                   &obj.platform_application_arn.replace("+", "%2B"));
 
     }
 }
@@ -606,7 +617,8 @@ impl DeleteTopicInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -642,7 +654,8 @@ impl GetEndpointAttributesInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "EndpointArn"), &obj.endpoint_arn);
+        params.put(&format!("{}{}", prefix, "EndpointArn"),
+                   &obj.endpoint_arn.replace("+", "%2B"));
 
     }
 }
@@ -715,7 +728,7 @@ impl GetPlatformApplicationAttributesInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "PlatformApplicationArn"),
-                   &obj.platform_application_arn);
+                   &obj.platform_application_arn.replace("+", "%2B"));
 
     }
 }
@@ -865,7 +878,7 @@ impl GetSubscriptionAttributesInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SubscriptionArn"),
-                   &obj.subscription_arn);
+                   &obj.subscription_arn.replace("+", "%2B"));
 
     }
 }
@@ -936,7 +949,8 @@ impl GetTopicAttributesInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -1011,10 +1025,11 @@ impl ListEndpointsByPlatformApplicationInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "PlatformApplicationArn"),
-                   &obj.platform_application_arn);
+                   &obj.platform_application_arn.replace("+", "%2B"));
 
     }
 }
@@ -1177,7 +1192,8 @@ impl ListPhoneNumbersOptedOutInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "nextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "nextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1258,7 +1274,8 @@ impl ListPlatformApplicationsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1351,9 +1368,11 @@ impl ListSubscriptionsByTopicInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -1433,7 +1452,8 @@ impl ListSubscriptionsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1512,7 +1532,8 @@ impl ListTopicsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.next_token {
-            params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
+            params.put(&format!("{}{}", prefix, "NextToken"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1652,11 +1673,15 @@ impl MessageAttributeValueSerializer {
 
         if let Some(ref field_value) = obj.binary_value {
             params.put(&format!("{}{}", prefix, "BinaryValue"),
-                       ::std::str::from_utf8(&field_value).unwrap());
+                       ::std::str::from_utf8(&field_value)
+                           .unwrap()
+                           .replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DataType"), &obj.data_type);
+        params.put(&format!("{}{}", prefix, "DataType"),
+                   &obj.data_type.replace("+", "%2B"));
         if let Some(ref field_value) = obj.string_value {
-            params.put(&format!("{}{}", prefix, "StringValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "StringValue"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1707,7 +1732,8 @@ impl OptInPhoneNumberInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "phoneNumber"), &obj.phone_number);
+        params.put(&format!("{}{}", prefix, "phoneNumber"),
+                   &obj.phone_number.replace("+", "%2B"));
 
     }
 }
@@ -1887,26 +1913,32 @@ impl PublishInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Message"), &obj.message);
+        params.put(&format!("{}{}", prefix, "Message"),
+                   &obj.message.replace("+", "%2B"));
         if let Some(ref field_value) = obj.message_attributes {
             MessageAttributeMapSerializer::serialize(params,
                                                      &format!("{}{}", prefix, "MessageAttributes"),
                                                      field_value);
         }
         if let Some(ref field_value) = obj.message_structure {
-            params.put(&format!("{}{}", prefix, "MessageStructure"), &field_value);
+            params.put(&format!("{}{}", prefix, "MessageStructure"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.phone_number {
-            params.put(&format!("{}{}", prefix, "PhoneNumber"), &field_value);
+            params.put(&format!("{}{}", prefix, "PhoneNumber"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.subject {
-            params.put(&format!("{}{}", prefix, "Subject"), &field_value);
+            params.put(&format!("{}{}", prefix, "Subject"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.target_arn {
-            params.put(&format!("{}{}", prefix, "TargetArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TargetArn"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.topic_arn {
-            params.put(&format!("{}{}", prefix, "TopicArn"), &field_value);
+            params.put(&format!("{}{}", prefix, "TopicArn"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1980,8 +2012,10 @@ impl RemovePermissionInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Label"), &obj.label);
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "Label"),
+                   &obj.label.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -2008,7 +2042,8 @@ impl SetEndpointAttributesInputSerializer {
         MapStringToStringSerializer::serialize(params,
                                                &format!("{}{}", prefix, "Attributes"),
                                                &obj.attributes);
-        params.put(&format!("{}{}", prefix, "EndpointArn"), &obj.endpoint_arn);
+        params.put(&format!("{}{}", prefix, "EndpointArn"),
+                   &obj.endpoint_arn.replace("+", "%2B"));
 
     }
 }
@@ -2036,7 +2071,7 @@ impl SetPlatformApplicationAttributesInputSerializer {
                                                &format!("{}{}", prefix, "Attributes"),
                                                &obj.attributes);
         params.put(&format!("{}{}", prefix, "PlatformApplicationArn"),
-                   &obj.platform_application_arn);
+                   &obj.platform_application_arn.replace("+", "%2B"));
 
     }
 }
@@ -2107,12 +2142,13 @@ impl SetSubscriptionAttributesInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AttributeName"),
-                   &obj.attribute_name);
+                   &obj.attribute_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.attribute_value {
-            params.put(&format!("{}{}", prefix, "AttributeValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "AttributeValue"),
+                       &field_value.replace("+", "%2B"));
         }
         params.put(&format!("{}{}", prefix, "SubscriptionArn"),
-                   &obj.subscription_arn);
+                   &obj.subscription_arn.replace("+", "%2B"));
 
     }
 }
@@ -2139,11 +2175,13 @@ impl SetTopicAttributesInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "AttributeName"),
-                   &obj.attribute_name);
+                   &obj.attribute_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.attribute_value {
-            params.put(&format!("{}{}", prefix, "AttributeValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "AttributeValue"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -2184,10 +2222,13 @@ impl SubscribeInputSerializer {
         }
 
         if let Some(ref field_value) = obj.endpoint {
-            params.put(&format!("{}{}", prefix, "Endpoint"), &field_value);
+            params.put(&format!("{}{}", prefix, "Endpoint"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
-        params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);
+        params.put(&format!("{}{}", prefix, "Protocol"),
+                   &obj.protocol.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "TopicArn"),
+                   &obj.topic_arn.replace("+", "%2B"));
 
     }
 }
@@ -2541,7 +2582,7 @@ impl UnsubscribeInputSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "SubscriptionArn"),
-                   &obj.subscription_arn);
+                   &obj.subscription_arn.replace("+", "%2B"));
 
     }
 }

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -92,8 +92,10 @@ impl AddPermissionRequestSerializer {
         ActionNameListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "Actions"),
                                             &obj.actions);
-        params.put(&format!("{}{}", prefix, "Label"), &obj.label);
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "Label"),
+                   &obj.label.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -308,7 +310,8 @@ impl ChangeMessageVisibilityBatchRequestSerializer {
                                                                                   prefix,
                                                                                   "Entries"),
                                                                           &obj.entries);
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -334,12 +337,12 @@ impl ChangeMessageVisibilityBatchRequestEntrySerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Id"), &obj.id);
+        params.put(&format!("{}{}", prefix, "Id"), &obj.id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ReceiptHandle"),
-                   &obj.receipt_handle);
+                   &obj.receipt_handle.replace("+", "%2B"));
         if let Some(ref field_value) = obj.visibility_timeout {
             params.put(&format!("{}{}", prefix, "VisibilityTimeout"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -513,11 +516,12 @@ impl ChangeMessageVisibilityRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ReceiptHandle"),
-                   &obj.receipt_handle);
+                   &obj.receipt_handle.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "VisibilityTimeout"),
-                   &obj.visibility_timeout.to_string());
+                   &obj.visibility_timeout.to_string().replace("+", "%2B"));
 
     }
 }
@@ -546,7 +550,8 @@ impl CreateQueueRequestSerializer {
                                                    &format!("{}{}", prefix, "Attribute"),
                                                    field_value);
         }
-        params.put(&format!("{}{}", prefix, "QueueName"), &obj.queue_name);
+        params.put(&format!("{}{}", prefix, "QueueName"),
+                   &obj.queue_name.replace("+", "%2B"));
 
     }
 }
@@ -624,7 +629,8 @@ impl DeleteMessageBatchRequestSerializer {
                                                                         prefix,
                                                                         "Entries"),
                                                                 &obj.entries);
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -648,9 +654,9 @@ impl DeleteMessageBatchRequestEntrySerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Id"), &obj.id);
+        params.put(&format!("{}{}", prefix, "Id"), &obj.id.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ReceiptHandle"),
-                   &obj.receipt_handle);
+                   &obj.receipt_handle.replace("+", "%2B"));
 
     }
 }
@@ -819,9 +825,10 @@ impl DeleteMessageRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "ReceiptHandle"),
-                   &obj.receipt_handle);
+                   &obj.receipt_handle.replace("+", "%2B"));
 
     }
 }
@@ -843,7 +850,8 @@ impl DeleteQueueRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -872,7 +880,8 @@ impl GetQueueAttributesRequestSerializer {
                                                    &format!("{}{}", prefix, "AttributeNames"),
                                                    field_value);
         }
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -946,10 +955,11 @@ impl GetQueueUrlRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "QueueName"), &obj.queue_name);
+        params.put(&format!("{}{}", prefix, "QueueName"),
+                   &obj.queue_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.queue_owner_aws_account_id {
             params.put(&format!("{}{}", prefix, "QueueOwnerAWSAccountId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1021,7 +1031,8 @@ impl ListDeadLetterSourceQueuesRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -1094,7 +1105,8 @@ impl ListQueuesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.queue_name_prefix {
-            params.put(&format!("{}{}", prefix, "QueueNamePrefix"), &field_value);
+            params.put(&format!("{}{}", prefix, "QueueNamePrefix"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1339,16 +1351,20 @@ impl MessageAttributeValueSerializer {
         }
         if let Some(ref field_value) = obj.binary_value {
             params.put(&format!("{}{}", prefix, "BinaryValue"),
-                       ::std::str::from_utf8(&field_value).unwrap());
+                       ::std::str::from_utf8(&field_value)
+                           .unwrap()
+                           .replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "DataType"), &obj.data_type);
+        params.put(&format!("{}{}", prefix, "DataType"),
+                   &obj.data_type.replace("+", "%2B"));
         if let Some(ref field_value) = obj.string_list_values {
             StringListSerializer::serialize(params,
                                             &format!("{}{}", prefix, "StringListValue"),
                                             field_value);
         }
         if let Some(ref field_value) = obj.string_value {
-            params.put(&format!("{}{}", prefix, "StringValue"), &field_value);
+            params.put(&format!("{}{}", prefix, "StringValue"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1472,7 +1488,8 @@ impl PurgeQueueRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -1591,7 +1608,7 @@ impl ReceiveMessageRequestSerializer {
         }
         if let Some(ref field_value) = obj.max_number_of_messages {
             params.put(&format!("{}{}", prefix, "MaxNumberOfMessages"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.message_attribute_names {
             MessageAttributeNameListSerializer::serialize(params,
@@ -1600,18 +1617,19 @@ impl ReceiveMessageRequestSerializer {
                                                                   "MessageAttributeNames"),
                                                           field_value);
         }
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
         if let Some(ref field_value) = obj.receive_request_attempt_id {
             params.put(&format!("{}{}", prefix, "ReceiveRequestAttemptId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.visibility_timeout {
             params.put(&format!("{}{}", prefix, "VisibilityTimeout"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.wait_time_seconds {
             params.put(&format!("{}{}", prefix, "WaitTimeSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
 
     }
@@ -1685,8 +1703,10 @@ impl RemovePermissionRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Label"), &obj.label);
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "Label"),
+                   &obj.label.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -1713,7 +1733,8 @@ impl SendMessageBatchRequestSerializer {
         SendMessageBatchRequestEntryListSerializer::serialize(params,
                                                               &format!("{}{}", prefix, "Entries"),
                                                               &obj.entries);
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -1747,9 +1768,9 @@ impl SendMessageBatchRequestEntrySerializer {
 
         if let Some(ref field_value) = obj.delay_seconds {
             params.put(&format!("{}{}", prefix, "DelaySeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Id"), &obj.id);
+        params.put(&format!("{}{}", prefix, "Id"), &obj.id.replace("+", "%2B"));
         if let Some(ref field_value) = obj.message_attributes {
             MessageBodyAttributeMapSerializer::serialize(params,
                                                          &format!("{}{}",
@@ -1757,13 +1778,15 @@ impl SendMessageBatchRequestEntrySerializer {
                                                                  "MessageAttribute"),
                                                          field_value);
         }
-        params.put(&format!("{}{}", prefix, "MessageBody"), &obj.message_body);
+        params.put(&format!("{}{}", prefix, "MessageBody"),
+                   &obj.message_body.replace("+", "%2B"));
         if let Some(ref field_value) = obj.message_deduplication_id {
             params.put(&format!("{}{}", prefix, "MessageDeduplicationId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.message_group_id {
-            params.put(&format!("{}{}", prefix, "MessageGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "MessageGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -1969,7 +1992,7 @@ impl SendMessageRequestSerializer {
 
         if let Some(ref field_value) = obj.delay_seconds {
             params.put(&format!("{}{}", prefix, "DelaySeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.message_attributes {
             MessageBodyAttributeMapSerializer::serialize(params,
@@ -1978,15 +2001,18 @@ impl SendMessageRequestSerializer {
                                                                  "MessageAttribute"),
                                                          field_value);
         }
-        params.put(&format!("{}{}", prefix, "MessageBody"), &obj.message_body);
+        params.put(&format!("{}{}", prefix, "MessageBody"),
+                   &obj.message_body.replace("+", "%2B"));
         if let Some(ref field_value) = obj.message_deduplication_id {
             params.put(&format!("{}{}", prefix, "MessageDeduplicationId"),
-                       &field_value);
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.message_group_id {
-            params.put(&format!("{}{}", prefix, "MessageGroupId"), &field_value);
+            params.put(&format!("{}{}", prefix, "MessageGroupId"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }
@@ -2083,7 +2109,8 @@ impl SetQueueAttributesRequestSerializer {
         QueueAttributeMapSerializer::serialize(params,
                                                &format!("{}{}", prefix, "Attribute"),
                                                &obj.attributes);
-        params.put(&format!("{}{}", prefix, "QueueUrl"), &obj.queue_url);
+        params.put(&format!("{}{}", prefix, "QueueUrl"),
+                   &obj.queue_url.replace("+", "%2B"));
 
     }
 }

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -125,22 +125,27 @@ impl AssumeRoleRequestSerializer {
 
         if let Some(ref field_value) = obj.duration_seconds {
             params.put(&format!("{}{}", prefix, "DurationSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.external_id {
-            params.put(&format!("{}{}", prefix, "ExternalId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ExternalId"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.policy {
-            params.put(&format!("{}{}", prefix, "Policy"), &field_value);
+            params.put(&format!("{}{}", prefix, "Policy"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "RoleArn"), &obj.role_arn);
+        params.put(&format!("{}{}", prefix, "RoleArn"),
+                   &obj.role_arn.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "RoleSessionName"),
-                   &obj.role_session_name);
+                   &obj.role_session_name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.serial_number {
-            params.put(&format!("{}{}", prefix, "SerialNumber"), &field_value);
+            params.put(&format!("{}{}", prefix, "SerialNumber"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.token_code {
-            params.put(&format!("{}{}", prefix, "TokenCode"), &field_value);
+            params.put(&format!("{}{}", prefix, "TokenCode"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -236,15 +241,18 @@ impl AssumeRoleWithSAMLRequestSerializer {
 
         if let Some(ref field_value) = obj.duration_seconds {
             params.put(&format!("{}{}", prefix, "DurationSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.policy {
-            params.put(&format!("{}{}", prefix, "Policy"), &field_value);
+            params.put(&format!("{}{}", prefix, "Policy"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "PrincipalArn"), &obj.principal_arn);
-        params.put(&format!("{}{}", prefix, "RoleArn"), &obj.role_arn);
+        params.put(&format!("{}{}", prefix, "PrincipalArn"),
+                   &obj.principal_arn.replace("+", "%2B"));
+        params.put(&format!("{}{}", prefix, "RoleArn"),
+                   &obj.role_arn.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "SAMLAssertion"),
-                   &obj.saml_assertion);
+                   &obj.saml_assertion.replace("+", "%2B"));
 
     }
 }
@@ -373,19 +381,22 @@ impl AssumeRoleWithWebIdentityRequestSerializer {
 
         if let Some(ref field_value) = obj.duration_seconds {
             params.put(&format!("{}{}", prefix, "DurationSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.policy {
-            params.put(&format!("{}{}", prefix, "Policy"), &field_value);
+            params.put(&format!("{}{}", prefix, "Policy"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.provider_id {
-            params.put(&format!("{}{}", prefix, "ProviderId"), &field_value);
+            params.put(&format!("{}{}", prefix, "ProviderId"),
+                       &field_value.replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "RoleArn"), &obj.role_arn);
+        params.put(&format!("{}{}", prefix, "RoleArn"),
+                   &obj.role_arn.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "RoleSessionName"),
-                   &obj.role_session_name);
+                   &obj.role_session_name.replace("+", "%2B"));
         params.put(&format!("{}{}", prefix, "WebIdentityToken"),
-                   &obj.web_identity_token);
+                   &obj.web_identity_token.replace("+", "%2B"));
 
     }
 }
@@ -657,7 +668,7 @@ impl DecodeAuthorizationMessageRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "EncodedMessage"),
-                   &obj.encoded_message);
+                   &obj.encoded_message.replace("+", "%2B"));
 
     }
 }
@@ -896,11 +907,13 @@ impl GetFederationTokenRequestSerializer {
 
         if let Some(ref field_value) = obj.duration_seconds {
             params.put(&format!("{}{}", prefix, "DurationSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
-        params.put(&format!("{}{}", prefix, "Name"), &obj.name);
+        params.put(&format!("{}{}", prefix, "Name"),
+                   &obj.name.replace("+", "%2B"));
         if let Some(ref field_value) = obj.policy {
-            params.put(&format!("{}{}", prefix, "Policy"), &field_value);
+            params.put(&format!("{}{}", prefix, "Policy"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }
@@ -992,13 +1005,15 @@ impl GetSessionTokenRequestSerializer {
 
         if let Some(ref field_value) = obj.duration_seconds {
             params.put(&format!("{}{}", prefix, "DurationSeconds"),
-                       &field_value.to_string());
+                       &field_value.to_string().replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.serial_number {
-            params.put(&format!("{}{}", prefix, "SerialNumber"), &field_value);
+            params.put(&format!("{}{}", prefix, "SerialNumber"),
+                       &field_value.replace("+", "%2B"));
         }
         if let Some(ref field_value) = obj.token_code {
-            params.put(&format!("{}{}", prefix, "TokenCode"), &field_value);
+            params.put(&format!("{}{}", prefix, "TokenCode"),
+                       &field_value.replace("+", "%2B"));
         }
 
     }

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -307,7 +307,7 @@ fn optional_primitive_field_serializer(service: &Service,
     let expression = serialize_primitive_expression(&member_shape.shape_type, "field_value");
 
     format!("if let Some(ref field_value) = obj.{field_name} {{
-                params.put(&format!(\"{{}}{{}}\", prefix, \"{tag_name}\"), {expression});
+                params.put(&format!(\"{{}}{{}}\", prefix, \"{tag_name}\"), {expression}.replace(\"+\", \"%2B\"));
             }}",
             field_name = generate_field_name(member_name),
             expression = expression,
@@ -323,7 +323,7 @@ fn required_primitive_field_serializer(service: &Service,
                                                     &format!("obj.{}",
                                                              generate_field_name(member_name)));
 
-    format!("params.put(&format!(\"{{}}{{}}\", prefix, \"{tag_name}\"), {expression});",
+    format!("params.put(&format!(\"{{}}{{}}\", prefix, \"{tag_name}\"), {expression}.replace(\"+\", \"%2B\"));",
             expression = expression,
             tag_name = member_location(service, member, member_name))
 }


### PR DESCRIPTION
fixes #821

this fixes uri encoding for all services that end up using query
string parameters. the root cause of this issue is actual caused
by fixing our core signature generation.

you see according to multiple RFCS (that I'll point you to the issue
for) query strings are supposed to have '+'s represent ' ', and as
such be encoded as '%20'. This can be seen if you try to encode a
query string with a '+' as '%2B' when using V4 Auth and making a
request to S3.

However, sometimes we actually want a plus. This happens a lot, specifically
with our rust code. we get a return value from AWS, and we want to
physically use that '+' that AWS Returns.

There are two things that first come to mind:
  1. Make all of our signature code be techincally broken, not properly
    handling '+'s inside of query strings.

    - This is super unfortunate. Having funademently broken signing
      is really bad idea.

  2. Encode all of our rust fields inside of params.put() (so we put
    in an already encoded value).

    - This is unfortunate because it means if you actually want the
      signing behavior to handle the encoding of "+"'s for you when
      using the rust types, then you'll be thoroughly dissapointed.

Personally I think #2 is the much better solution. If you actually want
a space, pass in a space. So that's what I went with.

Side note:
  - If you notice I simply am using a "replace()", and not fully
    url encoding it. This has a couple benifits:
      - we don't have to pay the full cost of encoding twice.
        performance win yay?
      - don't have to have any extra imports.

All Integration tests should now pass (though specifically SQS).