### PR TITLE
Fix element name in XML request payload

### DIFF
--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -148,7 +148,7 @@ impl AliasListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize("String", element));
+            parts.push(StringSerializer::serialize("CNAME", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -350,7 +350,7 @@ impl AwsAccountNumberListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize("String", element));
+            parts.push(StringSerializer::serialize("AwsAccountNumber", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -1091,7 +1091,7 @@ impl CookieNameListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize("String", element));
+            parts.push(StringSerializer::serialize("Name", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -3430,7 +3430,7 @@ impl HeaderListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize("String", element));
+            parts.push(StringSerializer::serialize("Name", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -4592,7 +4592,7 @@ impl LocationListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize("String", element));
+            parts.push(StringSerializer::serialize("Location", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5309,7 +5309,7 @@ impl PathListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize("String", element));
+            parts.push(StringSerializer::serialize("Path", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5528,7 +5528,7 @@ impl QueryStringCacheKeysListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(StringSerializer::serialize("String", element));
+            parts.push(StringSerializer::serialize("Name", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -6591,7 +6591,7 @@ impl TagKeyListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagKeySerializer::serialize("TagKey", element));
+            parts.push(TagKeySerializer::serialize("Key", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -683,7 +683,7 @@ impl ChildHealthCheckListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(HealthCheckIdSerializer::serialize("HealthCheckId", element));
+            parts.push(HealthCheckIdSerializer::serialize("ChildHealthCheck", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -3656,7 +3656,7 @@ impl HealthCheckRegionListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(HealthCheckRegionSerializer::serialize("HealthCheckRegion", element));
+            parts.push(HealthCheckRegionSerializer::serialize("Region", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -6549,7 +6549,7 @@ impl TagKeyListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagKeySerializer::serialize("TagKey", element));
+            parts.push(TagKeySerializer::serialize("Key", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -6645,7 +6645,7 @@ impl TagResourceIdListSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TagResourceIdSerializer::serialize("TagResourceId", element));
+            parts.push(TagResourceIdSerializer::serialize("ResourceId", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -264,7 +264,7 @@ impl AllowedHeadersSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(AllowedHeaderSerializer::serialize("AllowedHeader", element));
+            parts.push(AllowedHeaderSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -330,7 +330,7 @@ impl AllowedMethodsSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(AllowedMethodSerializer::serialize("AllowedMethod", element));
+            parts.push(AllowedMethodSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -396,7 +396,7 @@ impl AllowedOriginsSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(AllowedOriginSerializer::serialize("AllowedOrigin", element));
+            parts.push(AllowedOriginSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -1297,7 +1297,7 @@ impl CORSRulesSerializer {
     pub fn serialize(name: &str, obj: &Vec<CORSRule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(CORSRuleSerializer::serialize("CORSRule", element));
+            parts.push(CORSRuleSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -1657,7 +1657,7 @@ impl CompletedPartListSerializer {
     pub fn serialize(name: &str, obj: &Vec<CompletedPart>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(CompletedPartSerializer::serialize("CompletedPart", element));
+            parts.push(CompletedPartSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -3070,7 +3070,7 @@ impl EventListSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(EventSerializer::serialize("Event", element));
+            parts.push(EventSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -3186,7 +3186,7 @@ impl ExposeHeadersSerializer {
     pub fn serialize(name: &str, obj: &Vec<String>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(ExposeHeaderSerializer::serialize("ExposeHeader", element));
+            parts.push(ExposeHeaderSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -3309,7 +3309,7 @@ impl FilterRuleListSerializer {
     pub fn serialize(name: &str, obj: &Vec<FilterRule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(FilterRuleSerializer::serialize("FilterRule", element));
+            parts.push(FilterRuleSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -5408,8 +5408,7 @@ impl InventoryOptionalFieldsSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(InventoryOptionalFieldSerializer::serialize("InventoryOptionalField",
-                                                                   element));
+            parts.push(InventoryOptionalFieldSerializer::serialize("Field", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -5823,7 +5822,7 @@ impl LambdaFunctionConfigurationListSerializer {
     pub fn serialize(name: &str, obj: &Vec<LambdaFunctionConfiguration>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(LambdaFunctionConfigurationSerializer::serialize("LambdaFunctionConfiguration", element));
+            parts.push(LambdaFunctionConfigurationSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -6240,7 +6239,7 @@ impl LifecycleRulesSerializer {
     pub fn serialize(name: &str, obj: &Vec<LifecycleRule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(LifecycleRuleSerializer::serialize("LifecycleRule", element));
+            parts.push(LifecycleRuleSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -8100,7 +8099,7 @@ impl NoncurrentVersionTransitionListSerializer {
     pub fn serialize(name: &str, obj: &Vec<NoncurrentVersionTransition>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(NoncurrentVersionTransitionSerializer::serialize("NoncurrentVersionTransition", element));
+            parts.push(NoncurrentVersionTransitionSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -8453,7 +8452,7 @@ impl ObjectIdentifierListSerializer {
     pub fn serialize(name: &str, obj: &Vec<ObjectIdentifier>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(ObjectIdentifierSerializer::serialize("ObjectIdentifier", element));
+            parts.push(ObjectIdentifierSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -9525,7 +9524,7 @@ impl QueueConfigurationListSerializer {
     pub fn serialize(name: &str, obj: &Vec<QueueConfiguration>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(QueueConfigurationSerializer::serialize("QueueConfiguration", element));
+            parts.push(QueueConfigurationSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -9972,7 +9971,7 @@ impl ReplicationRulesSerializer {
     pub fn serialize(name: &str, obj: &Vec<ReplicationRule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(ReplicationRuleSerializer::serialize("ReplicationRule", element));
+            parts.push(ReplicationRuleSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -10415,7 +10414,7 @@ impl RulesSerializer {
     pub fn serialize(name: &str, obj: &Vec<Rule>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(RuleSerializer::serialize("Rule", element));
+            parts.push(RuleSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -11011,7 +11010,7 @@ impl TargetGrantsSerializer {
         let mut parts: Vec<String> = Vec::new();
         parts.push(format!("<{}>", name));
         for element in obj {
-            parts.push(TargetGrantSerializer::serialize("TargetGrant", element));
+            parts.push(TargetGrantSerializer::serialize("Grant", element));
         }
         parts.push(format!("</{}>", name));
         parts.join("")
@@ -11297,7 +11296,7 @@ impl TopicConfigurationListSerializer {
     pub fn serialize(name: &str, obj: &Vec<TopicConfiguration>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(TopicConfigurationSerializer::serialize("TopicConfiguration", element));
+            parts.push(TopicConfigurationSerializer::serialize(name, element));
         }
         parts.join("")
     }
@@ -11417,7 +11416,7 @@ impl TransitionListSerializer {
     pub fn serialize(name: &str, obj: &Vec<Transition>) -> String {
         let mut parts: Vec<String> = Vec::new();
         for element in obj {
-            parts.push(TransitionSerializer::serialize("Transition", element));
+            parts.push(TransitionSerializer::serialize(name, element));
         }
         parts.join("")
     }

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -17419,7 +17419,7 @@ impl<P, D> S3 for S3Client<P, D>
         request.set_params(params);
         let mut payload: Vec<u8>;
         if input.multipart_upload.is_some() {
-            payload = CompletedMultipartUploadSerializer::serialize("CompletedMultipartUpload",
+            payload = CompletedMultipartUploadSerializer::serialize("CompleteMultipartUpload",
                                                                     input
                                                                         .multipart_upload
                                                                         .as_ref()
@@ -20927,7 +20927,7 @@ impl<P, D> S3 for S3Client<P, D>
         let mut payload: Vec<u8>;
         if input.lifecycle_configuration.is_some() {
             payload =
-                BucketLifecycleConfigurationSerializer::serialize("BucketLifecycleConfiguration",
+                BucketLifecycleConfigurationSerializer::serialize("LifecycleConfiguration",
                                                                   input
                                                                       .lifecycle_configuration
                                                                       .as_ref()

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -242,12 +242,13 @@ fn generate_payload_member_serialization(shape: &Shape) -> String {
                 xml_type = payload_member.shape)
     } else {
         format!("if input.{payload_field}.is_some() {{
-                    payload = {xml_type}Serializer::serialize(\"{xml_type}\", input.{payload_field}.as_ref().unwrap()).into_bytes();
+                    payload = {xml_type}Serializer::serialize(\"{location_name}\", input.{payload_field}.as_ref().unwrap()).into_bytes();
                 }} else {{
                     payload = Vec::new();
                 }}",
                 payload_field = payload_field.to_snake_case(),
-                xml_type = payload_member.shape)
+                xml_type = payload_member.shape,
+                location_name = payload_member.location_name.as_ref().unwrap())
     }
 
 }


### PR DESCRIPTION
Should fix #820 .

`CompleteMultipartUpload` vs. `CompletedMultipartUpload` was broken even before #800 , but S3 accepts both name for the root element.
It should be fixed by the first commit in this PR.

`CompletedPart` vs. `Part` is caused by https://github.com/rusoto/rusoto/commit/b03d5a2371f88f5b7cad44f42cbd91f91bf570be in #800 .
It was totally my mistake. It should use locationName parameter.
It should be fixed by the second commit in this PR.