### PR TITLE
Adds Marketplace Entitlement service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added Discovery service
 - Added CodeStar service
 - Added Migration Hub service
+- Added Marketplace Entitlement service
 
 ## [0.28.0] - 2017-08-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "rusoto/services/logs",
     "rusoto/services/machinelearning",
     "rusoto/services/marketplacecommerceanalytics",
+    "rusoto/services/marketplace-entitlement",
     "rusoto/services/meteringmarketplace",
     "rusoto/services/mgh",
     "rusoto/services/mturk",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -470,11 +470,8 @@ all = [
 	   	"logs",
 	   	"machinelearning",
 	   	"marketplacecommerceanalytics",
-<<<<<<< HEAD
-		"mgh",
-=======
 		"marketplace-entitlement",
->>>>>>> 943845c04... Adds Marketplace Entitlement service.
+		"mgh",
 		"mturk",
 	   	"opsworks",
 		"opsworkscm",
@@ -568,11 +565,8 @@ lightsail = ["rusoto_lightsail"]
 logs = ["rusoto_logs"]
 machinelearning = ["rusoto_machinelearning"]
 marketplacecommerceanalytics = ["rusoto_marketplacecommerceanalytics"]
-<<<<<<< HEAD
-mgh = ["rusoto_mgh"]
-=======
 marketplace-entitlement = ["rusoto_marketplace_entitlement"]
->>>>>>> 943845c04... Adds Marketplace Entitlement service.
+mgh = ["rusoto_mgh"]
 mturk = ["rusoto_mturk"]
 opsworks = ["rusoto_opsworks"]
 opsworkscm = ["rusoto_opsworkscm"]

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -271,7 +271,7 @@ path = "../rusoto/services/machinelearning"
 optional = true
 path = "../rusoto/services/marketplacecommerceanalytics"
 
-[dependencies.rusoto_marketplace-entitlement]
+[dependencies.rusoto_marketplace_entitlement]
 optional = true
 path = "../rusoto/services/marketplace-entitlement"
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -271,6 +271,10 @@ path = "../rusoto/services/machinelearning"
 optional = true
 path = "../rusoto/services/marketplacecommerceanalytics"
 
+[dependencies.rusoto_marketplace-entitlement]
+optional = true
+path = "../rusoto/services/marketplace-entitlement"
+
 [dependencies.rusoto_mgh]
 optional = true
 path = "../rusoto/services/mgh"
@@ -466,7 +470,11 @@ all = [
 	   	"logs",
 	   	"machinelearning",
 	   	"marketplacecommerceanalytics",
+<<<<<<< HEAD
 		"mgh",
+=======
+		"marketplace-entitlement",
+>>>>>>> 943845c04... Adds Marketplace Entitlement service.
 		"mturk",
 	   	"opsworks",
 		"opsworkscm",
@@ -560,7 +568,11 @@ lightsail = ["rusoto_lightsail"]
 logs = ["rusoto_logs"]
 machinelearning = ["rusoto_machinelearning"]
 marketplacecommerceanalytics = ["rusoto_marketplacecommerceanalytics"]
+<<<<<<< HEAD
 mgh = ["rusoto_mgh"]
+=======
+marketplace-entitlement = ["rusoto_marketplace_entitlement"]
+>>>>>>> 943845c04... Adds Marketplace Entitlement service.
 mturk = ["rusoto_mturk"]
 opsworks = ["rusoto_opsworks"]
 opsworkscm = ["rusoto_opsworkscm"]

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
+description = "AWS SDK for Rust - AWS Marketplace Entitlement Service @ 2017-01-11"
+documentation = "https://rusoto.github.io/rusoto/rusoto_core/index.html"
+keywords = ["AWS", "Amazon", "marketplace-entitlem"]
+license = "MIT"
+name = "rusoto_marketplace_entitlement"
+readme = "README.md"
+repository = "https://github.com/rusoto/rusoto"
+version = "0.28.0"
+homepage = "https://www.rusoto.org/"
+
+[build-dependencies]
+
+[dependencies]
+hyper = "0.10.0"
+serde = "1.0.2"
+serde_derive = "1.0.2"
+serde_json = "1.0.1"
+
+[dependencies.rusoto_core]
+version = "0.28.0"
+path = "../../core"
+[dev-dependencies.rusoto_mock]
+version = "0.25.0"
+path = "../../../mock"

--- a/rusoto/services/marketplace-entitlement/README.md
+++ b/rusoto/services/marketplace-entitlement/README.md
@@ -1,0 +1,45 @@
+
+# Rusoto MarketplaceEntitlement
+Rust SDK for AWS Marketplace Entitlement Service
+
+You may be looking for:
+
+* [An overview of Rusoto][rusoto-overview]
+* [AWS services supported by Rusoto][supported-aws-services]
+* [API documentation][api-documentation]
+* [Getting help with Rusoto][rusoto-help]
+
+## Requirements
+
+Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+[`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
+
+On Linux, OpenSSL is required.
+
+## Installation
+
+To use `rusoto_marketplace_entitlement` in your application, add it as a dependency in your `Cargo.toml`:
+
+```toml
+[dependencies]
+rusoto_marketplace_entitlement = "0.28.0"
+```
+
+## Contributing
+
+See [CONTRIBUTING][contributing].
+
+## License
+
+Rusoto is distributed under the terms of the MIT license.
+
+See [LICENSE][license] for details.
+
+[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
+[contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
+[rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"
+[rusoto-overview]: https://www.rusoto.org/ "Rusoto overview"
+[supported-aws-services]: https://www.rusoto.org/supported-aws-services.html "List of AWS services supported by Rusoto"
+        

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -1,0 +1,268 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
+#[allow(warnings)]
+use hyper::Client;
+use hyper::status::StatusCode;
+use rusoto_core::request::DispatchSignedRequest;
+use rusoto_core::region;
+
+use std::fmt;
+use std::error::Error;
+use std::io;
+use std::io::Read;
+use rusoto_core::request::HttpDispatchError;
+use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
+
+use serde_json;
+use rusoto_core::signature::SignedRequest;
+use serde_json::Value as SerdeJsonValue;
+use serde_json::from_str;
+#[doc="<p>An entitlement represents capacity in a product owned by the customer. For example, a customer might own some number of users or seats in an SaaS application or some amount of data capacity in a multi-tenant database.</p>"]
+#[derive(Default,Debug,Clone,Deserialize)]
+pub struct Entitlement {
+    #[doc="<p>The customer identifier is a handle to each unique customer in an application. Customer identifiers are obtained through the ResolveCustomer operation in AWS Marketplace Metering Service.</p>"]
+    #[serde(rename="CustomerIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub customer_identifier: Option<String>,
+    #[doc="<p>The dimension for which the given entitlement applies. Dimensions represent categories of capacity in a product and are specified when the product is listed in AWS Marketplace.</p>"]
+    #[serde(rename="Dimension")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub dimension: Option<String>,
+    #[doc="<p>The expiration date represents the minimum date through which this entitlement is expected to remain valid. For contractual products listed on AWS Marketplace, the expiration date is the date at which the customer will renew or cancel their contract. Customers who are opting to renew their contract will still have entitlements with an expiration date.</p>"]
+    #[serde(rename="ExpirationDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub expiration_date: Option<f64>,
+    #[doc="<p>The product code for which the given entitlement applies. Product codes are provided by AWS Marketplace when the product listing is created.</p>"]
+    #[serde(rename="ProductCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub product_code: Option<String>,
+    #[doc="<p>The EntitlementValue represents the amount of capacity that the customer is entitled to for the product.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub value: Option<EntitlementValue>,
+}
+
+#[doc="<p>The EntitlementValue represents the amount of capacity that the customer is entitled to for the product.</p>"]
+#[derive(Default,Debug,Clone,Deserialize)]
+pub struct EntitlementValue {
+    #[doc="<p>The BooleanValue field will be populated with a boolean value when the entitlement is a boolean type. Otherwise, the field will not be set.</p>"]
+    #[serde(rename="BooleanValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub boolean_value: Option<bool>,
+    #[doc="<p>The DoubleValue field will be populated with a double value when the entitlement is a double type. Otherwise, the field will not be set.</p>"]
+    #[serde(rename="DoubleValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub double_value: Option<f64>,
+    #[doc="<p>The IntegerValue field will be populated with an integer value when the entitlement is an integer type. Otherwise, the field will not be set.</p>"]
+    #[serde(rename="IntegerValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub integer_value: Option<i64>,
+    #[doc="<p>The StringValue field will be populated with a string value when the entitlement is a string type. Otherwise, the field will not be set.</p>"]
+    #[serde(rename="StringValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub string_value: Option<String>,
+}
+
+#[doc="<p>The GetEntitlementsRequest contains parameters for the GetEntitlements operation.</p>"]
+#[derive(Default,Debug,Clone,Serialize)]
+pub struct GetEntitlementsRequest {
+    #[doc="<p>Filter is used to return entitlements for a specific customer or for a specific dimension. Filters are described as keys mapped to a lists of values. Filtered requests are <i>unioned</i> for each value in the value list, and then <i>intersected</i> for each filter key.</p>"]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub filter: Option<::std::collections::HashMap<String, Vec<String>>>,
+    #[doc="<p>The maximum number of items to retrieve from the GetEntitlements operation. For pagination, use the NextToken field in subsequent calls to GetEntitlements.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub max_results: Option<i64>,
+    #[doc="<p>For paginated calls to GetEntitlements, pass the NextToken from the previous GetEntitlementsResult.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub next_token: Option<String>,
+    #[doc="<p>Product code is used to uniquely identify a product in AWS Marketplace. The product code will be provided by AWS Marketplace when the product listing is created.</p>"]
+    #[serde(rename="ProductCode")]
+    pub product_code: String,
+}
+
+#[doc="<p>The GetEntitlementsRequest contains results from the GetEntitlements operation.</p>"]
+#[derive(Default,Debug,Clone,Deserialize)]
+pub struct GetEntitlementsResult {
+    #[doc="<p>The set of entitlements found through the GetEntitlements operation. If the result contains an empty set of entitlements, NextToken might still be present and should be used.</p>"]
+    #[serde(rename="Entitlements")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub entitlements: Option<Vec<Entitlement>>,
+    #[doc="<p>For paginated results, use NextToken in subsequent calls to GetEntitlements. If the result contains an empty set of entitlements, NextToken might still be present and should be used.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub next_token: Option<String>,
+}
+
+/// Errors returned by GetEntitlements
+#[derive(Debug, PartialEq)]
+pub enum GetEntitlementsError {
+    ///<p>An internal error has occurred. Retry your request. If the problem persists, post a message with details on the AWS forums.</p>
+    InternalServiceError(String),
+    ///<p>One or more parameters in your request was invalid.</p>
+    InvalidParameter(String),
+    ///<p>The calls to the GetEntitlements API are throttled.</p>
+    Throttling(String),
+    /// An error occurred dispatching the HTTP request
+    HttpDispatch(HttpDispatchError),
+    /// An error was encountered with AWS credentials.
+    Credentials(CredentialsError),
+    /// A validation error occurred.  Details from AWS are provided.
+    Validation(String),
+    /// An unknown error occurred.  The raw HTTP response is provided.
+    Unknown(String),
+}
+
+
+impl GetEntitlementsError {
+    pub fn from_body(body: &str) -> GetEntitlementsError {
+        match from_str::<SerdeJsonValue>(body) {
+            Ok(json) => {
+                let raw_error_type = json.get("__type")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("Unknown");
+                let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
+
+                let pieces: Vec<&str> = raw_error_type.split("#").collect();
+                let error_type = pieces.last().expect("Expected error type");
+
+                match *error_type {
+                    "InternalServiceErrorException" => {
+                        GetEntitlementsError::InternalServiceError(String::from(error_message))
+                    }
+                    "InvalidParameterException" => {
+                        GetEntitlementsError::InvalidParameter(String::from(error_message))
+                    }
+                    "ThrottlingException" => {
+                        GetEntitlementsError::Throttling(String::from(error_message))
+                    }
+                    "ValidationException" => {
+                        GetEntitlementsError::Validation(error_message.to_string())
+                    }
+                    _ => GetEntitlementsError::Unknown(String::from(body)),
+                }
+            }
+            Err(_) => GetEntitlementsError::Unknown(String::from(body)),
+        }
+    }
+}
+
+impl From<serde_json::error::Error> for GetEntitlementsError {
+    fn from(err: serde_json::error::Error) -> GetEntitlementsError {
+        GetEntitlementsError::Unknown(err.description().to_string())
+    }
+}
+impl From<CredentialsError> for GetEntitlementsError {
+    fn from(err: CredentialsError) -> GetEntitlementsError {
+        GetEntitlementsError::Credentials(err)
+    }
+}
+impl From<HttpDispatchError> for GetEntitlementsError {
+    fn from(err: HttpDispatchError) -> GetEntitlementsError {
+        GetEntitlementsError::HttpDispatch(err)
+    }
+}
+impl From<io::Error> for GetEntitlementsError {
+    fn from(err: io::Error) -> GetEntitlementsError {
+        GetEntitlementsError::HttpDispatch(HttpDispatchError::from(err))
+    }
+}
+impl fmt::Display for GetEntitlementsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+impl Error for GetEntitlementsError {
+    fn description(&self) -> &str {
+        match *self {
+            GetEntitlementsError::InternalServiceError(ref cause) => cause,
+            GetEntitlementsError::InvalidParameter(ref cause) => cause,
+            GetEntitlementsError::Throttling(ref cause) => cause,
+            GetEntitlementsError::Validation(ref cause) => cause,
+            GetEntitlementsError::Credentials(ref err) => err.description(),
+            GetEntitlementsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
+            GetEntitlementsError::Unknown(ref cause) => cause,
+        }
+    }
+}
+/// Trait representing the capabilities of the AWS Marketplace Entitlement Service API. AWS Marketplace Entitlement Service clients implement this trait.
+pub trait MarketplaceEntitlement {
+    #[doc="<p>GetEntitlements retrieves entitlement values for a given product. The results can be filtered based on customer identifier or product dimensions.</p>"]
+    fn get_entitlements(&self,
+                        input: &GetEntitlementsRequest)
+                        -> Result<GetEntitlementsResult, GetEntitlementsError>;
+}
+/// A client for the AWS Marketplace Entitlement Service API.
+pub struct MarketplaceEntitlementClient<P, D>
+    where P: ProvideAwsCredentials,
+          D: DispatchSignedRequest
+{
+    credentials_provider: P,
+    region: region::Region,
+    dispatcher: D,
+}
+
+impl<P, D> MarketplaceEntitlementClient<P, D>
+    where P: ProvideAwsCredentials,
+          D: DispatchSignedRequest
+{
+    pub fn new(request_dispatcher: D, credentials_provider: P, region: region::Region) -> Self {
+        MarketplaceEntitlementClient {
+            credentials_provider: credentials_provider,
+            region: region,
+            dispatcher: request_dispatcher,
+        }
+    }
+}
+
+impl<P, D> MarketplaceEntitlement for MarketplaceEntitlementClient<P, D>
+    where P: ProvideAwsCredentials,
+          D: DispatchSignedRequest
+{
+    #[doc="<p>GetEntitlements retrieves entitlement values for a given product. The results can be filtered based on customer identifier or product dimensions.</p>"]
+    fn get_entitlements(&self,
+                        input: &GetEntitlementsRequest)
+                        -> Result<GetEntitlementsResult, GetEntitlementsError> {
+        let mut request = SignedRequest::new("POST", "aws-marketplace", &self.region, "/");
+        request.set_endpoint_prefix("entitlement.marketplace".to_string());
+        request.set_content_type("application/x-amz-json-1.1".to_owned());
+        request.add_header("x-amz-target", "AWSMPEntitlementService.GetEntitlements");
+        let encoded = serde_json::to_string(input).unwrap();
+        request.set_payload(Some(encoded.into_bytes()));
+
+        request.sign(&try!(self.credentials_provider.credentials()));
+
+        let mut response = try!(self.dispatcher.dispatch(&request));
+
+        match response.status {
+            StatusCode::Ok => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Ok(serde_json::from_str::<GetEntitlementsResult>(String::from_utf8_lossy(&body)
+                                                                     .as_ref())
+                           .unwrap())
+            }
+            _ => {
+                let mut body: Vec<u8> = Vec::new();
+                try!(response.body.read_to_end(&mut body));
+                Err(GetEntitlementsError::from_body(String::from_utf8_lossy(&body).as_ref()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod protocol_tests {}

--- a/rusoto/services/marketplace-entitlement/src/lib.rs
+++ b/rusoto/services/marketplace-entitlement/src/lib.rs
@@ -1,0 +1,30 @@
+
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
+//! <fullname>AWS Marketplace Entitlement Service</fullname> <p>This reference provides descriptions of the AWS Marketplace Entitlement Service API.</p> <p>AWS Marketplace Entitlement Service is used to determine the entitlement of a customer to a given product. An entitlement represents capacity in a product owned by the customer. For example, a customer might own some number of users or seats in an SaaS application or some amount of data capacity in a multi-tenant database.</p> <p> <b>Getting Entitlement Records</b> </p> <ul> <li> <p> <i>GetEntitlements</i>- Gets the entitlements for a Marketplace product.</p> </li> </ul>
+//!
+//! If you're using the service, you're probably looking for [MarketplaceEntitlementClient](struct.MarketplaceEntitlementClient.html) and [MarketplaceEntitlement](trait.MarketplaceEntitlement.html).
+
+extern crate hyper;
+extern crate rusoto_core;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+mod generated;
+mod custom;
+
+pub use generated::*;
+pub use custom::*;
+            

--- a/service_crategen/services.json
+++ b/service_crategen/services.json
@@ -377,6 +377,12 @@
     "protocolVersion": "2015-07-01",
     "baseTypeName": "MarketplaceCommerceAnalytics"
   },
+  "marketplace-entitlement": {
+    "version": "0.28.0",
+    "coreVersion": "0.28.0",
+    "protocolVersion": "2017-01-11",
+    "baseTypeName": "MarketplaceEntitlement"
+  },
   "meteringmarketplace": {
     "version": "0.28.0",
     "coreVersion": "0.28.0",


### PR DESCRIPTION
No integration test since the [single available action](http://docs.aws.amazon.com/marketplaceentitlement/latest/APIReference/API_GetEntitlements.html) requires a `Product code`.