### PR TITLE
Implement Read for StreamingBody

### DIFF
--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -1000,6 +1000,12 @@ impl ::std::ops::DerefMut for StreamingBody {
     }
 }
 
+impl ::std::io::Read for StreamingBody {
+    fn read(&mut self, buf: &mut [u8]) -> ::std::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
 pub struct BodySerializer;
 impl BodySerializer {
     #[allow(unused_variables, warnings)]

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -333,6 +333,12 @@ fn generate_types<P>(writer: &mut FileWriter, service: &Service, protocol_genera
                          fn deref_mut(&mut self) -> &mut Box<Read> {{
                              &mut self.0
                          }}
+                     }}
+
+                     impl ::std::io::Read for {streaming_name} {{
+                         fn read(&mut self, buf: &mut [u8]) -> ::std::io::Result<usize> {{
+                             self.0.read(buf)
+                         }}
                      }}",
                      name = type_name,
                      streaming_name = mutate_type_name_for_streaming(&type_name))?;


### PR DESCRIPTION
Many combinators such as [`BufReader`](https://doc.rust-lang.org/nightly/std/io/struct.BufReader.html) from the standard library are only usable when the wrapped type implements `Read` directly.

There are also methods on `Read` like `chain` or `take` that take ownership of `self`, something that is not feasible with just `&Box<Read>`.

This patch adds an impl of `Read` for `StreamingBody` in order to make it usable with those types of combinators.

Let me know what you think!