### PR TITLE
add metadata to S3 put/copy/create_multipart

### DIFF
--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -157,8 +157,8 @@ impl SignedRequest {
 
     /// Add a value to the array of headers for the specified key.
     /// Headers are kept sorted by key name for use at signing (BTreeMap)
-    pub fn add_header(&mut self, key: &str, value: &str) {
-        let key_lower = key.to_ascii_lowercase().to_string();
+    pub fn add_header<K: ToString>(&mut self, key: K, value: &str) {
+        let key_lower = key.to_string().to_ascii_lowercase();
         let value_vec = value.as_bytes().to_vec();
 
         match self.headers.entry(key_lower) {

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -18862,6 +18862,14 @@ impl<P, D> S3 for S3Client<P, D>
             request.add_header("x-amz-grant-write-acp", &grant_write_acp.to_string());
         }
 
+        if let Some(ref metadata) = input.metadata {
+            for (header_name, header_value) in metadata.iter() {
+                let header = format!("x-amz-meta-{}", header_name);
+                request.add_header(header, header_value);
+            }
+
+        }
+
         if let Some(ref metadata_directive) = input.metadata_directive {
             request.add_header("x-amz-metadata-directive", &metadata_directive.to_string());
         }
@@ -19134,6 +19142,14 @@ impl<P, D> S3 for S3Client<P, D>
 
         if let Some(ref grant_write_acp) = input.grant_write_acp {
             request.add_header("x-amz-grant-write-acp", &grant_write_acp.to_string());
+        }
+
+        if let Some(ref metadata) = input.metadata {
+            for (header_name, header_value) in metadata.iter() {
+                let header = format!("x-amz-meta-{}", header_name);
+                request.add_header(header, header_value);
+            }
+
         }
 
         if let Some(ref request_payer) = input.request_payer {
@@ -22772,6 +22788,14 @@ impl<P, D> S3 for S3Client<P, D>
 
         if let Some(ref grant_write_acp) = input.grant_write_acp {
             request.add_header("x-amz-grant-write-acp", &grant_write_acp.to_string());
+        }
+
+        if let Some(ref metadata) = input.metadata {
+            for (header_name, header_value) in metadata.iter() {
+                let header = format!("x-amz-meta-{}", header_name);
+                request.add_header(header, header_value);
+            }
+
         }
 
         if let Some(ref request_payer) = input.request_payer {

--- a/service_crategen/src/commands/generate/codegen/rest_request_generator.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_request_generator.rs
@@ -37,6 +37,31 @@ pub fn generate_headers(service: &Service, operation: &Operation) -> Option<Stri
                                      location_name = member.location_name.as_ref().unwrap(),
                                      field_name = generate_field_name(member_name)))
                     }
+                },
+                "headers" => {
+                    if shape.required(member_name) {
+                        Some(format!("for (header_name, header_value) in input.{field_name}.iter() {{
+                                              let header = format!(\"{location_name}{{}}\", header_name);
+                                              request.add_header(header,
+                                                                 header_value);
+                                          }}
+                                      ",
+                                     location_name = member.location_name.as_ref().unwrap(),
+                                     field_name = generate_field_name(member_name)))
+                    } else {
+                        Some(format!("
+                        if let Some(ref {field_name}) = 
+                                      input.{field_name} {{
+                                          for (header_name, header_value) in {field_name}.iter() {{
+                                              let header = format!(\"{location_name}{{}}\", header_name);
+                                              request.add_header(header,
+                                                                 header_value);
+                                          }}
+
+                        }}",
+                                     location_name = member.location_name.as_ref().unwrap(),
+                                     field_name = generate_field_name(member_name)))
+                    }
                 }
                 _ => None,
             }


### PR DESCRIPTION
The `metadata` field was already available on the S3 request objects, but it was not being serialized into the request headers. This fixes that. This automatically prepends the `x-amz-meta-` to all keys in the `metadata` hashmap. I haven't done anything on the get object side, which appears to properly have the `z-amz-meta-` stripped from the keys in the `GetObjectOutput` metadata field.

I believe it is correct, and I've tested with my own setup.