### PR TITLE
Disable warnings breaking the build.

### DIFF
--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -3,7 +3,6 @@
 #![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 #![cfg_attr(feature = "nightly-testing", allow(cyclomatic_complexity, used_underscore_binding, ptr_arg, suspicious_else_formatting))]
 #![allow(dead_code)]
-#![cfg_attr(not(feature = "unstable"), deny(warnings))]
 #![deny(missing_docs)]
 
 //! Rusoto is an [AWS](https://aws.amazon.com/) SDK for Rust.

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(feature = "nightly-testing", feature(plugin))]
 #![cfg_attr(feature = "nightly-testing", plugin(clippy))]
-#![cfg_attr(not(feature = "unstable"), deny(warnings))]
 #![deny(missing_docs)]
 
 //! Types for loading and managing AWS access credentials for API requests.


### PR DESCRIPTION
Fixes https://github.com/rusoto/rusoto/issues/877 .

Tracking issue for re-enabling warnings breaking the build: https://github.com/rusoto/rusoto/issues/885 .